### PR TITLE
Calling start and end methods to execute custom rules

### DIFF
--- a/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdExecutor.java
+++ b/sonar-pmd-plugin/src/main/java/org/sonar/plugins/pmd/PmdExecutor.java
@@ -93,10 +93,14 @@ public class PmdExecutor implements BatchExtension {
     }
 
     Charset encoding = projectFileSystem.getSourceCharset();
-
+    
+    rulesets.start(ruleContext);
+    
     for (InputFile file : files) {
       pmdFactory.process(file, encoding, rulesets, ruleContext);
     }
+    
+    rulesets.end(ruleContext);
   }
 
   private RuleSets createRulesets(String repositoryKey) {


### PR DESCRIPTION
Hello guys,

I'm using Sonar to get code statistics about the Java projects on my work. We have some custom rules written on PMD according this guide:

http://pmd.sourceforge.net/howtowritearule.html

Especially on this topic “I want to implement a rule that analyse more than the class !”. See the example on this page.

Note the method named "start" and "end" overridden from AbstractJavaRule. I think there is a problem with Sonar PMD Plugin not calling the methods on class PmdExecutor.
