### PR TITLE
Fetch bug information from Findbugs before shutting it down in case bugs came from custom plugins

### DIFF
--- a/sonar-findbugs-plugin/src/main/java/org/sonar/plugins/findbugs/ReportedBug.java
+++ b/sonar-findbugs-plugin/src/main/java/org/sonar/plugins/findbugs/ReportedBug.java
@@ -1,0 +1,53 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.findbugs;
+
+import edu.umd.cs.findbugs.BugInstance;
+
+public class ReportedBug {
+
+  private final String type;
+  private final String message;
+  private final String className;
+  private final int startLine;
+
+  public ReportedBug(BugInstance bugInstance) {
+    this.type = bugInstance.getType();
+    this.message = bugInstance.getMessageWithoutPrefix();
+    this.className = bugInstance.getPrimarySourceLineAnnotation().getClassName();
+    this.startLine = bugInstance.getPrimarySourceLineAnnotation().getStartLine();
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public int getStartLine() {
+    return startLine;
+  }
+}

--- a/sonar-findbugs-plugin/src/test/java/org/sonar/plugins/findbugs/FindbugsSensorTest.java
+++ b/sonar-findbugs-plugin/src/test/java/org/sonar/plugins/findbugs/FindbugsSensorTest.java
@@ -20,11 +20,9 @@
 package org.sonar.plugins.findbugs;
 
 import com.google.common.collect.Lists;
-import edu.umd.cs.findbugs.BugCollection;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.ClassAnnotation;
 import edu.umd.cs.findbugs.MethodAnnotation;
-import edu.umd.cs.findbugs.SortedBugCollection;
 import edu.umd.cs.findbugs.SourceLineAnnotation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -43,6 +41,8 @@ import org.sonar.api.rules.Violation;
 import org.sonar.api.test.IsViolation;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Locale;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -120,7 +120,6 @@ public class FindbugsSensorTest extends FindbugsTests {
     FindbugsExecutor executor = mock(FindbugsExecutor.class);
     SensorContext context = mock(SensorContext.class);
 
-    BugCollection collection = new SortedBugCollection();
     BugInstance bugInstance = new BugInstance("AM_CREATES_EMPTY_ZIP_FILE_ENTRY", 2);
     String className = "org.sonar.commons.ZipUtils";
     String sourceFile = "org/sonar/commons/ZipUtils.java";
@@ -130,7 +129,7 @@ public class FindbugsSensorTest extends FindbugsTests {
     MethodAnnotation methodAnnotation = new MethodAnnotation(className, "_zip", "(Ljava/lang/String;Ljava/io/File;Ljava/util/zip/ZipOutputStream;)V", true);
     methodAnnotation.setSourceLines(new SourceLineAnnotation(className, sourceFile, startLine, 0, 0, 0));
     bugInstance.add(methodAnnotation);
-    collection.add(bugInstance);
+    Collection<ReportedBug> collection = Arrays.asList(new ReportedBug(bugInstance));
     when(executor.execute()).thenReturn(collection);
 
     when(context.getResource(any(Resource.class))).thenReturn(new JavaFile("org.sonar.MyClass"));
@@ -153,13 +152,12 @@ public class FindbugsSensorTest extends FindbugsTests {
     SensorContext context = mock(SensorContext.class);
     when(context.getResource(any(Resource.class))).thenReturn(new JavaFile("org.sonar.MyClass"));
 
-    BugCollection collection = new SortedBugCollection();
     BugInstance bugInstance = new BugInstance("UNKNOWN", 2);
     String className = "org.sonar.commons.ZipUtils";
     String sourceFile = "org/sonar/commons/ZipUtils.java";
     ClassAnnotation classAnnotation = new ClassAnnotation(className, sourceFile);
     bugInstance.add(classAnnotation);
-    collection.add(bugInstance);
+    Collection<ReportedBug> collection = Arrays.asList(new ReportedBug(bugInstance));
     when(executor.execute()).thenReturn(collection);
 
     FindbugsSensor analyser = new FindbugsSensor(createRulesProfileWithActiveRules(), FakeRuleFinder.create(), executor);


### PR DESCRIPTION
Hi all,

I've experienced a bug when writing my own custom findbugs plugin where the message being displayed within Sonar was 'Unknown bug pattern...' rather than the actual message. The cause was that custom plugins were being unloaded before the retrieving the bug message but the bug message uses information which was contained within the custom plugin.

To experience this for yourself, try out the 'fb-contrib' plugin which experiences the same problem.

See my emails on the sonar-dev mailing list [1] about the issue.

Cheers,

Will.

1 http://sonar.15.x6.nabble.com/sonar-dev-Custom-FindBugs-rules-FB-Contrib-and-Unknown-bug-pattern-td5013991.html
