### PR TITLE
UndocumentedApi (squid) does not handle generic methods correctly

### DIFF
--- a/java-checks/src/test/files/checks/UndocumentedApi.java
+++ b/java-checks/src/test/files/checks/UndocumentedApi.java
@@ -168,3 +168,35 @@ public class Foo { // Compliant
     return 0;
   }
 }
+
+/**
+ */
+public class Foo {
+  /**
+   * @param <T> ...
+   * @param value ...
+   * @return ...
+   */
+  public <T> T foo(T value) { // Compliant
+  }
+  
+  /**
+   * @param <T> ...
+   * @param value ...
+   */
+  public <T> T foo(T value) { // Non-Compliant - missing '@return'
+  }
+  
+  /**
+   * @param <T> ...
+   * @param value ...
+   */
+  public <T> void foo(T value) { // Compliant
+  }
+  
+  /**
+   * @param value ...
+   */
+  public <T> void foo(T value) { // Non-Compliant - missing '@param <T>'
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/UndocumentedApiCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UndocumentedApiCheckTest.java
@@ -60,7 +60,9 @@ public class UndocumentedApiCheckTest {
         .next().atLine(139).withMessage("Document the parameter(s): a")
         .next().atLine(162).withMessage("Document the parameter(s): a, b, c")
         .next().atLine(162).withMessage("Document this method return value.")
-        .next().atLine(167).withMessage("Document this public method.");
+        .next().atLine(167).withMessage("Document this public method.")
+        .next().atLine(187).withMessage("Document this method return value.")
+        .next().atLine(200).withMessage("Document the parameter(s): <T>");
   }
 
   @Test


### PR DESCRIPTION
Hello,

we are using Sonar 3.7.1 and have stumbled on what we believe is an error of the UndocumentedApi check, as generic void methods are not processed correctly.

The following two methods report a "Document this method return value." error:

``` java
  /**
   * @param <T> ...
   * @param value ...
   */
  public <T> void foo(T value) { // Compliant
  }

  /**
   * @param value ...
   */
  public <T> void foo(T value) { // Non-Compliant - missing '@param <T>'
  }
```

I added a few test cases to the UndocumentedApi check, but I have not seen an obvious solution to the error and I believe it may be parser related.

Best regards,
    Raúl

PS: I have not been able to create an issue in JIRA (the "SonarQube Java" project does not appear in the list of projects of the create issue dialog), so I'm reporting the issue here.
