### PR TITLE
S1191: Add exclude packages option

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/squidjava.properties
+++ b/java-checks/src/main/resources/org/sonar/l10n/squidjava.properties
@@ -155,6 +155,7 @@ rule.squid.S1190.name="enum" should no longer be used as a name
 rule.squid.S1188.name=Anonymous classes should not have too many lines
 rule.squid.S1188.param.max=Maximum allowed lines in an anonymous class
 rule.squid.S1191.name=Classes from "com.sun.*" and "sun.*" packages should not be used
+rule.squid.S1191.param.exclude=Exclude packages (; separated list) from this rule
 rule.squid.S135.name=Loops should not contain more than a single "break" or "continue" statement
 rule.squid.S1186.name=Methods should not be empty
 rule.squid.S1185.name=Overriding methods should do more than simply call the same method in the super class

--- a/java-checks/src/test/files/checks/SunPackagesUsedCheck.java
+++ b/java-checks/src/test/files/checks/SunPackagesUsedCheck.java
@@ -1,4 +1,5 @@
 import com.sun.imageio.plugins; // Non-Compliant
+import com.sun.jersey.api.client.ClientHandlerException; // Non-Compliant
 import java.util.ArrayList; // Compliant
 
 class A {

--- a/java-checks/src/test/java/org/sonar/java/checks/SunPackagesUsedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/SunPackagesUsedCheckTest.java
@@ -23,23 +23,34 @@ import com.sonar.sslr.squid.checks.CheckMessagesVerifierRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
 import org.sonar.squid.api.SourceFile;
 
 import java.io.File;
 
 public class SunPackagesUsedCheckTest {
 
+  private final SunPackagesUsedCheck check = new SunPackagesUsedCheck();
+
   @Rule
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @Test
   public void detected() {
-    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/SunPackagesUsedCheck.java"), new SunPackagesUsedCheck());
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/SunPackagesUsedCheck.java"), check);
     checkMessagesVerifier.verify(file.getCheckMessages())
         .next().atLine(1).withMessage("Replace this usage of Sun classes by ones from the Java API.")
-        .next().atLine(6)
+        .next().atLine(2)
         .next().atLine(7)
-        .next().atLine(9);
+        .next().atLine(8)
+        .next().atLine(10);
   }
 
+  @Test
+  public void detected2() {
+    check.exclude = "com.sun.imageio;com.sun.jersey";
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/SunPackagesUsedCheck.java"), check);
+    checkMessagesVerifier.verify(file.getCheckMessages())
+        .next().atLine(10).withMessage("Replace this usage of Sun classes by ones from the Java API.");
+  }
 }


### PR DESCRIPTION
Add a way to exlude some package from this check.
For example a project using jersey can use the following import:
icom.sun.jersey
