### PR TITLE
SONARJAVA-436 Findbugs analysis should not fail if only package-info.java files are analysed

### DIFF
--- a/sonar-findbugs-plugin/src/main/java/org/sonar/plugins/findbugs/AnalysisNotNeededException.java
+++ b/sonar-findbugs-plugin/src/main/java/org/sonar/plugins/findbugs/AnalysisNotNeededException.java
@@ -1,0 +1,44 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.findbugs;
+
+/**
+ * Exception thrown when configuring Findbugs, and there are non classes to analyse.
+ * This can happen then there are package-info.java files, that should be analysed by source code analysis tools,
+ * but that does not generate any bytocode for Findbugs to analyze.
+ */
+public class AnalysisNotNeededException extends Exception {
+
+  public AnalysisNotNeededException() {
+  }
+
+  public AnalysisNotNeededException(String message) {
+    super(message);
+  }
+
+  public AnalysisNotNeededException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public AnalysisNotNeededException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/sonar-findbugs-plugin/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
+++ b/sonar-findbugs-plugin/src/main/java/org/sonar/plugins/findbugs/FindbugsExecutor.java
@@ -50,6 +50,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -148,6 +149,10 @@ public class FindbugsExecutor implements BatchExtension {
       profiler.stop();
 
       return toReportedBugs(xmlBugReporter.getBugCollection());
+    } catch (AnalysisNotNeededException e) {
+      LOG.info("There are no class files to analyze. Skipping Findbugs analysis");
+      profiler.stop();
+      return Collections.emptyList();
     } catch (TimeoutException e) {
       throw new SonarException("Can not execute Findbugs with a timeout threshold value of " + configuration.getTimeout() + " milliseconds", e);
     } catch (Exception e) {

--- a/sonar-findbugs-plugin/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
+++ b/sonar-findbugs-plugin/src/test/java/org/sonar/plugins/findbugs/FindbugsExecutorTest.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.sonar.api.CoreProperties;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.config.Settings;
 import org.sonar.api.scan.filesystem.ModuleFileSystem;
 import org.sonar.api.utils.SonarException;
@@ -86,10 +87,11 @@ public class FindbugsExecutorTest {
 
   @Test(expected = SonarException.class)
   public void shoulFailIfNoCompiledClasses() throws Exception {
-    ModuleFileSystem fs = mock(ModuleFileSystem.class);
+    FileSystem fs = mock(FileSystem.class);
+    ModuleFileSystem mfs = mock(ModuleFileSystem.class);
     Settings settings = new Settings();
     settings.setProperty(CoreProperties.CORE_VIOLATION_LOCALE_PROPERTY, Locale.getDefault().getDisplayName());
-    FindbugsConfiguration conf = new FindbugsConfiguration(fs, settings, null, null, null, null);
+    FindbugsConfiguration conf = new FindbugsConfiguration(fs, mfs, settings, null, null, null, null);
 
     new FindbugsExecutor(conf).execute();
   }


### PR DESCRIPTION
Intercepts the use case where only package-info.java files (which do not generate any class to be analyzed by Findbugs) are present in the source folders.
