### PR TITLE
CC - Fix slow JaCoCo Sensor when analyzing large .exec files.

### DIFF
--- a/sonar-jacoco-plugin/src/main/java/org/sonar/plugins/jacoco/AbstractAnalyzer.java
+++ b/sonar-jacoco-plugin/src/main/java/org/sonar/plugins/jacoco/AbstractAnalyzer.java
@@ -47,6 +47,7 @@ import org.sonar.api.utils.SonarException;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 
 import java.io.File;
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collection;
@@ -128,7 +129,7 @@ public abstract class AbstractAnalyzer {
     } else {
       JaCoCoUtils.LOG.info("Analysing {}", jacocoExecutionData);
 
-      ExecutionDataReader reader = new ExecutionDataReader(new FileInputStream(jacocoExecutionData));
+      ExecutionDataReader reader = new ExecutionDataReader(new BufferedInputStream(new FileInputStream(jacocoExecutionData)));
       reader.setSessionInfoVisitor(executionDataVisitor);
       reader.setExecutionDataVisitor(executionDataVisitor);
       reader.read();


### PR DESCRIPTION
Summary:
JaCoCo Sensor is slow when analyzing large .exec files.

Analysis:
1. Replace JaCoCo binary output in 
\sonar-java\sonar-jacoco-plugin\src\test\resources\org\sonar\plugins\jacoco\JaCoCoSensorTest\jacoco.exec with a large file (eg. 60MB).
2. Run org.sonar.plugins.jacoco.JaCoCoSensorTest
- Baseline: 100s
- Using a profiler, the biggest portion time was spent in AbstractAnalyzer.readExecutionData(); which calls ExecutionDataReader.read().
  (https://github.com/SonarSource/sonar-java/blob/7f5a848a37b84bb8fc2c413aea3a02edbd932d15/sonar-jacoco-plugin/src/main/java/org/sonar/plugins/jacoco/AbstractAnalyzer.java#L122-L135)
- ExecutionDataReader calls InputStream.readByte() in a loop. Which can take a long time for a large file.
  (https://github.com/jacoco/jacoco/blob/283abfa148b749678924b5e75eabd35a2d58f9f8/org.jacoco.core/src/org/jacoco/core/data/ExecutionDataReader.java#L78-L92)

Since AbstractAnalyzer instantiates an ExecutionDataReader and pass in a FileInputStream, each call to read byte(s) will necessitate an file system I/O call. Using a BufferInputStream should improve the performance.

Test:
Run JaCoCoSensorTest
- Baseline (unbuffered):          100s
- BufferedInputStream (default):   30s
- BufferedInputStream (8K):        30s
- BufferedInputStream (16K):       28s
- BufferedInputStream (32K):       28s
