### PR TITLE
Add exceptions for Lombok annotations to UnusedPrivateFieldCheck

### DIFF
--- a/java-checks/src/test/files/checks/UnusedPrivateFieldCheck.java
+++ b/java-checks/src/test/files/checks/UnusedPrivateFieldCheck.java
@@ -41,3 +41,38 @@ interface FooInterface {
   int FOO = 0; // Compliant
 
 }
+
+class Lombok1 {
+  @lombok.Getter
+  private int FOO = 0; // Compliant
+}
+
+@lombok.Getter
+class Lombok2 {
+  private int FOO = 0; // Compliant
+}
+
+@lombok.Data
+class Lombok3 {
+  private int FOO = 0; // Compliant
+}
+
+@lombok.Value
+class Lombok4 {
+  private int FOO = 0; // Compliant
+}
+
+@lombok.Setter
+class Lombok5 {
+  private int FOO = 0; // Compliant (no escape analysis)
+}
+
+class Lombok6 {
+  @lombok.NonNull
+  private int FOO = 0; // Compliant (no escape analysis)
+}
+
+@lombok.AllArgsConstructor
+class Lombok7 {
+  private int FOO = 0; // Compliant (no escape analysis)
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateFieldCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateFieldCheckTest.java
@@ -35,7 +35,9 @@ public class UnusedPrivateFieldCheckTest {
 
   @Test
   public void test() {
-    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UnusedPrivateFieldCheck.java"), new VisitorsBridge(new UnusedPrivateFieldCheck()));
+    File f = new File("java-checks/src/test/files/checks/UnusedPrivateFieldCheck.java");
+    System.out.println(f.getAbsolutePath());
+    SourceFile file = JavaAstScanner.scanSingleFile(f, new VisitorsBridge(new UnusedPrivateFieldCheck()));
     checkMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(3).withMessage("Remove this unused \"unusedField\" private field.")
       .next().atLine(6).withMessage("Remove this unused \"foo\" private field.");


### PR DESCRIPTION
(S1068). Class- and field-level annotations are checked. [Lombok](http://projectlombok.org/) generates methods and constructors from annotations, eliminating boilerplate code. Source-level analysis should take into account Lombok semantics to prevent false positives.

Test case fails for reasons I don't understand. If I drop the "lombok." prefix on the annotation names, I can make the test pass. Why doesn't the annotation's `IdentifierTree.name()` return a fully-qualified annotation name?

An alternative implementation would be to sublass this check and allow Lombok support to be turned on/off on a per-project basis.