### PR TITLE
UndocumentedApi : Javadoc {@inheritDoc} tag support

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java.properties
+++ b/java-checks/src/main/resources/org/sonar/l10n/java.properties
@@ -19,6 +19,7 @@ rule.squid.NoSonar.name=Avoid use of //NOSONAR marker
 
 rule.squid.UndocumentedApi.name=Public types, methods and fields (API) should be documented with Javadoc
 rule.squid.UndocumentedApi.param.forClasses=Pattern of classes which should adhere to this constraint. Ex : **.api.**
+rule.squid.UndocumentedApi.param.inheritDocSupport=Javadoc {@inheritDoc} tag considered as consistent
 
 rule.squid.UnusedPrivateMethod.name=Unused private method
 

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/UndocumentedApi.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/UndocumentedApi.html
@@ -47,6 +47,13 @@ public class MyClass&lt;T&gt; implements Runnable {    // Non-Compliant - missin
   public void run() {                            // Compliant - has @Override annotation
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  public void run() {                            // Compliant - if 'inheritDocSupport' rule property set to true
+  }
+
+
   protected void doSomething() {                 // Compliant - not public
   }
 

--- a/java-checks/src/test/files/checks/UndocumentedApiInheritDoc.java
+++ b/java-checks/src/test/files/checks/UndocumentedApiInheritDoc.java
@@ -1,0 +1,17 @@
+/**
+ * Documented
+ */
+public class MyClass implements MyInterface {
+   
+   /**
+    * {@inheritDoc}
+    */
+   public String javadocInheritDoc(String s){
+       return s;
+   }
+   
+   public void fault(){
+       // To verify that the last javadoc error is this one ... and not the inheritDoc below (when inheritDoc is supported)
+   }
+   
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/UndocumentedApiCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UndocumentedApiCheckTest.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.java.checks;
 
-import org.sonar.java.model.VisitorsBridge;
-import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
 import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 
 import java.io.File;
 
@@ -64,9 +64,8 @@ public class UndocumentedApiCheckTest {
       .next().atLine(167).withMessage("Document this public method.")
       .next().atLine(177).withMessage("Document this public method.")
       .next().atLine(183).withMessage("Document this method return value.")
-    //  .next().atLine(193).withMessage("Document this public method.") false negative for getter
-      .next().atLine(208).withMessage("Document this public class.")
-    ;
+      // .next().atLine(193).withMessage("Document this public method.") false negative for getter
+      .next().atLine(208).withMessage("Document this public class.");
   }
 
   @Test
@@ -78,4 +77,27 @@ public class UndocumentedApiCheckTest {
     checkMessagesVerifier.verify(file.getCheckMessages());
   }
 
+  @Test
+  public void inheritDocSupported() {
+    UndocumentedApiCheck check = new UndocumentedApiCheck();
+    check.inheritDocSupport = true;
+    assertThat(check.forClasses).isEqualTo("**");
+    assertThat(check.inheritDocSupport).isEqualTo(true);
+
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UndocumentedApiInheritDoc.java"), new VisitorsBridge(check));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(13);
+  }
+
+  @Test
+  public void inheritDocDefault() {
+    UndocumentedApiCheck check = new UndocumentedApiCheck();
+    assertThat(check.forClasses).isEqualTo("**");
+    assertThat(check.inheritDocSupport).isEqualTo(false);
+
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UndocumentedApiInheritDoc.java"), new VisitorsBridge(check));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(9).withMessage("Document the parameter(s): s").next().atLine(9).withMessage("Document this method return value.").next().atLine(13)
+      .withMessage("Document this public method.");
+  }
 }


### PR DESCRIPTION
Part of [SONARJAVA-70](https://jira.codehaus.org/browse/SONARJAVA-70) : Javadoc [{@inheritDoc}](http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#inheritDoc) tag support = considered as consistent (because it is not since [SONARJAVA-265](https://jira.codehaus.org/browse/SONARJAVA-265)). 
Useful for Java 1.4 / 1.5 (with interface inheritance)

Activation by rule property (false by default).

ML thread : [ squid:UndocumentedApi support inheritDoc Javadoc or not ? ](http://sonarqube.15.x6.nabble.com/squid-UndocumentedApi-support-inheritDoc-Javadoc-or-not-td5027286.html)

Sorry for space format diff ... I can fix.
