### PR TITLE
SONARJAVA-649 Bug in enclosing class computation for scala objects

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/resolve/Convert.java
+++ b/java-squid/src/main/java/org/sonar/java/resolve/Convert.java
@@ -44,8 +44,10 @@ public class Convert {
   }
 
   public static String enclosingClassName(String shortName) {
-    int lastDollar = shortName.lastIndexOf('$');
-    return lastDollar < 0 ? "" : shortName.substring(0, lastDollar);
+    //SONARJAVA-649 : Bug in enclosing class computation for scala objects
+    String normalizedShortName = StringUtils.removeEnd(StringUtils.removeEnd(shortName, "$class"), "$");
+    int lastDollar = normalizedShortName.lastIndexOf('$');
+    return lastDollar < 0 ? "" : normalizedShortName.substring(0, lastDollar);
   }
 
   public static String innerClassName(String shortName) {


### PR DESCRIPTION
By removing the last "$" and the last "$class" in the shortName of the class it is allowing inner trait and object to be traited by sonar java plugin. 

Since in Java, there is no way to have an class with no name and with just class as a class name we can safely remove this suffix values in this context.

Not sure however this is the right place to do that.
