### PR TITLE
SONARJAVA-863 RSPEC-2257 Custom cryptographic algorithm check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -272,7 +272,8 @@ public final class CheckList {
       ClassNamedLikeExceptionCheck.class,
       ProtectedMemberInFinalClassCheck.class,
       SuppressWarningsCheck.class,
-      ImmediateReverseBoxingCheck.class
-    );
+      ImmediateReverseBoxingCheck.class,
+      CustomCryptographicAlgorithmCheck.class
+      );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/CustomCryptographicAlgorithmCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CustomCryptographicAlgorithmCheck.java
@@ -1,0 +1,65 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.model.declaration.ClassTreeImpl;
+import org.sonar.java.resolve.Symbol.TypeSymbol;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+import java.util.List;
+
+@Rule(
+  key = "S2257",
+  priority = Priority.BLOCKER,
+  tags = {"cwe", "owasp-top10", "sans-top25", "security"})
+public class CustomCryptographicAlgorithmCheck extends SubscriptionBaseVisitor {
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Tree.Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    if (hasSemantic()) {
+      ClassTree classTree = (ClassTree) tree;
+      if (isJavaSecurityMessageDigestSubClass(classTree)) {
+        addIssue(classTree, "Use a standard algorithm instead of creating a custom one.");
+      }
+    }
+  }
+
+  private boolean isJavaSecurityMessageDigestSubClass(ClassTree tree) {
+    String qualifiedName = "java.security.MessageDigest";
+    ClassTreeImpl classTreeImpl = (ClassTreeImpl) tree;
+    TypeSymbol classSymbol = classTreeImpl.getSymbol();
+    /*
+     * Corner cases:
+     * - getSymbol is nullable
+     * - A type is a subtype of itself
+     */
+    return classSymbol != null && !classSymbol.getType().is(qualifiedName) && classSymbol.getType().isSubtypeOf(qualifiedName);
+  }
+}

--- a/java-checks/src/main/resources/org/sonar/l10n/java.properties
+++ b/java-checks/src/main/resources/org/sonar/l10n/java.properties
@@ -305,3 +305,4 @@ rule.squid.S2156.name="final" classes should not have "protected" members
 rule.squid.S1309.name=The @SuppressWarnings annotation should not be used
 rule.squid.S1309.param.listOfWarnings=Comma separated list of warnings that can't be suppressed. Example: 'unchecked, cast, all, boxing'. An empty list means that no warning can be suppressed.
 rule.squid.S2153.name=Boxing and unboxing should not be immediately reversed
+rule.squid.S2257.name=Only standard cryptographic algorithms should be used

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2257.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2257.html
@@ -1,0 +1,18 @@
+<p>The use of a non-standard algorithm is dangerous because a determined attacker may be able to break the algorithm and compromise whatever data has been protected. Standard algorithms like <code>SHA-256</code>, <code>SHA-384</code>, <code>SHA-512</code>, ... should be used instead.</p>
+<p>This rule tracks creation of <code>java.security.MessageDigest</code> subclasses.</p>
+
+<h2>Noncompliant code example</h2>
+
+<pre>
+MyCryptographicAlgorithm extends MessageDigest {
+  ...
+}
+</pre>
+
+<h2>See</h2>
+
+<ul>
+  <li><a href="http://cwe.mitre.org/data/definitions/327.html">CWE-327</a> - Use of a Broken or Risky Cryptographic Algorithm</li>
+  <li><a href="https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure">OWASP Top Ten 2013 Category A6 - Sensitive Data Exposure</a></li>
+  <li><a href="http://www.sans.org/top25-software-errors/">SANS TOP 25</a></li>
+</ul>

--- a/java-checks/src/test/files/checks/CustomCryptographicAlgorithmCheck.java
+++ b/java-checks/src/test/files/checks/CustomCryptographicAlgorithmCheck.java
@@ -4,56 +4,23 @@ import java.util.Observable;
 class A { // Compliant
 }
 
-class B extends MessageDigest { // Noncompliant
-
+abstract class B extends MessageDigest { // Noncompliant
   protected B(String algorithm) {
     super(algorithm);
   }
-
-  @Override
-  protected void engineUpdate(byte input) {
-  }
-
-  @Override
-  protected void engineUpdate(byte[] input, int offset, int len) {
-  }
-
-  @Override
-  protected byte[] engineDigest() {
-    return null;
-  }
-
-  @Override
-  protected void engineReset() {
-  }
 }
 
-class C extends java.security.MessageDigest { // Noncompliant
-
+abstract class C extends java.security.MessageDigest { // Noncompliant
   protected C(String algorithm) {
     super(algorithm);
   }
+}
 
-  @Override
-  protected void engineUpdate(byte input) {
-  }
-
-  @Override
-  protected void engineUpdate(byte[] input, int offset, int len) {
-  }
-
-  @Override
-  protected byte[] engineDigest() {
-    return null;
-  }
-
-  @Override
-  protected void engineReset() {
+abstract class D extends B { // Noncompliant
+  protected D(String algorithm) {
+    super(algorithm);
   }
 }
 
-class D extends Observable { // Compliant
-}
-
-class E extends C { // Noncompliant
+class E extends Observable { // Compliant
 }

--- a/java-checks/src/test/files/checks/CustomCryptographicAlgorithmCheck.java
+++ b/java-checks/src/test/files/checks/CustomCryptographicAlgorithmCheck.java
@@ -1,0 +1,59 @@
+import java.security.MessageDigest;
+import java.util.Observable;
+
+class A { // Compliant
+}
+
+class B extends MessageDigest { // Noncompliant
+
+  protected B(String algorithm) {
+    super(algorithm);
+  }
+
+  @Override
+  protected void engineUpdate(byte input) {
+  }
+
+  @Override
+  protected void engineUpdate(byte[] input, int offset, int len) {
+  }
+
+  @Override
+  protected byte[] engineDigest() {
+    return null;
+  }
+
+  @Override
+  protected void engineReset() {
+  }
+}
+
+class C extends java.security.MessageDigest { // Noncompliant
+
+  protected C(String algorithm) {
+    super(algorithm);
+  }
+
+  @Override
+  protected void engineUpdate(byte input) {
+  }
+
+  @Override
+  protected void engineUpdate(byte[] input, int offset, int len) {
+  }
+
+  @Override
+  protected byte[] engineDigest() {
+    return null;
+  }
+
+  @Override
+  protected void engineReset() {
+  }
+}
+
+class D extends Observable { // Compliant
+}
+
+class E extends C { // Noncompliant
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/CustomCryptographicAlgorithmCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CustomCryptographicAlgorithmCheckTest.java
@@ -39,8 +39,8 @@ public class CustomCryptographicAlgorithmCheckTest {
       new VisitorsBridge(new CustomCryptographicAlgorithmCheck()));
     checkMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(7).withMessage("Use a standard algorithm instead of creating a custom one.")
-      .next().atLine(31)
-      .next().atLine(58)
+      .next().atLine(13)
+      .next().atLine(19)
       .noMore();
   }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/CustomCryptographicAlgorithmCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CustomCryptographicAlgorithmCheckTest.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class CustomCryptographicAlgorithmCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/CustomCryptographicAlgorithmCheck.java"),
+      new VisitorsBridge(new CustomCryptographicAlgorithmCheck()));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(7).withMessage("Use a standard algorithm instead of creating a custom one.")
+      .next().atLine(31)
+      .next().atLine(58)
+      .noMore();
+  }
+
+}

--- a/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
+++ b/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
@@ -1358,6 +1358,19 @@
       <name>Security features</name>
       <chc>
         <rule-repo>squid</rule-repo>
+        <rule-key>S2257</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>1</val>
+          <txt>d</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>squid</rule-repo>
         <rule-key>S2277</rule-key>
         <prop>
           <key>remediationFunction</key>


### PR DESCRIPTION
Custom cryptographic algorithm check:

- Controls use of a non-standard algorithm, as determined attacker may be able to break the algorithm and compromise whatever data has been protected. Standard algorithms like `SHA-256`, `SHA-384`, `SHA-512`, ... should be used instead.
- Tracks any sub-types of `java.security.MessageDigest`.