### PR TITLE
SONARJAVA-862 RSPEC-2386 Interface static mutable member check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -274,7 +274,8 @@ public final class CheckList {
       SuppressWarningsCheck.class,
       ImmediateReverseBoxingCheck.class,
       CustomCryptographicAlgorithmCheck.class,
-      UnusedTypeParameterCheck.class
+      UnusedTypeParameterCheck.class,
+      InterfaceStaticMutableMemberCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheck.java
@@ -31,6 +31,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 @Rule(
@@ -40,9 +41,7 @@ import java.util.List;
 @BelongsToProfile(title = "Sonar way", priority = Priority.CRITICAL)
 public class InterfaceStaticMutableMemberCheck extends SubscriptionBaseVisitor {
 
-  private static final String MESSAGE = "Move \"%s\" to a class and lower its visibility";
-  private static final String COLLECTION_QUALIFIED_NAME = "java.util.Collection";
-  private static final String DATE_QUALIFIED_NAME = "java.util.Date";
+  private static final String MESSAGE = "Move \"{0}\" to a class and lower its visibility";
 
   @Override
   public List<Kind> nodesToVisit() {
@@ -55,7 +54,7 @@ public class InterfaceStaticMutableMemberCheck extends SubscriptionBaseVisitor {
       if (member.is(Kind.VARIABLE)) {
         VariableTreeImpl variableTree = (VariableTreeImpl) member;
         if (isStaticMember(variableTree) && isMutableMember(variableTree)) {
-          addIssue(variableTree, String.format(MESSAGE, variableTree.simpleName().name()));
+          addIssue(variableTree, MessageFormat.format(MESSAGE, variableTree.simpleName().name()));
         }
       }
     }
@@ -74,6 +73,6 @@ public class InterfaceStaticMutableMemberCheck extends SubscriptionBaseVisitor {
   }
 
   private boolean isDateOrCollection(Type variableSymbolType) {
-    return variableSymbolType.is(DATE_QUALIFIED_NAME) || variableSymbolType.isSubtypeOf(COLLECTION_QUALIFIED_NAME);
+    return variableSymbolType.is("java.util.Date") || variableSymbolType.isSubtypeOf("java.util.Collection");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheck.java
@@ -1,0 +1,68 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.BelongsToProfile;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.model.declaration.VariableTreeImpl;
+import org.sonar.java.resolve.Symbol.VariableSymbol;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Modifier;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+import java.util.List;
+
+@Rule(
+  key = "S2386",
+  priority = Priority.CRITICAL,
+  tags = {"unpredictable"})
+@BelongsToProfile(title = "Sonar way", priority = Priority.CRITICAL)
+public class InterfaceStaticMutableMemberCheck extends SubscriptionBaseVisitor {
+
+  private static final String MESSAGE = "Move \"xxx\" to a class and lower its visibility";
+  private static final String COLLECTION_QUALIFIED_NAME = "java.util.Collection";
+  private static final String DATE_QUALIFIER_NAME = "java.util.Date";
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.INTERFACE);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    for (Tree member : ((ClassTree) tree).members()) {
+      if (member.is(Kind.VARIABLE)) {
+        VariableTreeImpl variableTree = (VariableTreeImpl) member;
+        if (variableTree.modifiers().modifiers().contains(Modifier.STATIC)) {
+          Tree variableType = variableTree.type();
+          VariableSymbol symbol = variableTree.getSymbol();
+          if (variableType.is(Kind.ARRAY_TYPE) ||
+            (variableType.is(Kind.PARAMETERIZED_TYPE) && symbol.getType().isSubtypeOf(COLLECTION_QUALIFIED_NAME)) ||
+            (variableType.is(Kind.IDENTIFIER) && (symbol.getType().is(DATE_QUALIFIER_NAME) || symbol.getType().isSubtypeOf(COLLECTION_QUALIFIED_NAME)))) {
+            addIssue(variableTree, MESSAGE.replace("xxx", variableTree.simpleName().name()));
+          }
+        }
+      }
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheck.java
@@ -41,8 +41,6 @@ import java.util.List;
 @BelongsToProfile(title = "Sonar way", priority = Priority.CRITICAL)
 public class InterfaceStaticMutableMemberCheck extends SubscriptionBaseVisitor {
 
-  private static final String MESSAGE = "Move \"{0}\" to a class and lower its visibility";
-
   @Override
   public List<Kind> nodesToVisit() {
     return ImmutableList.of(Kind.INTERFACE);
@@ -54,7 +52,7 @@ public class InterfaceStaticMutableMemberCheck extends SubscriptionBaseVisitor {
       if (member.is(Kind.VARIABLE)) {
         VariableTreeImpl variableTree = (VariableTreeImpl) member;
         if (isStaticMember(variableTree) && isMutableMember(variableTree)) {
-          addIssue(variableTree, MessageFormat.format(MESSAGE, variableTree.simpleName().name()));
+          addIssue(variableTree, MessageFormat.format("Move \"{0}\" to a class and lower its visibility", variableTree.simpleName().name()));
         }
       }
     }

--- a/java-checks/src/main/resources/org/sonar/l10n/java.properties
+++ b/java-checks/src/main/resources/org/sonar/l10n/java.properties
@@ -307,3 +307,4 @@ rule.squid.S1309.param.listOfWarnings=Comma separated list of warnings that can'
 rule.squid.S2153.name=Boxing and unboxing should not be immediately reversed
 rule.squid.S2257.name=Only standard cryptographic algorithms should be used
 rule.squid.S2326.name=Unused type parameters should be removed
+rule.squid.S2386.name=Interfaces should not have "public static" mutable fields

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2386.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2386.html
@@ -6,7 +6,7 @@
 <pre>
 public interface MyInterface {
 
-  public static String [] strings; // Noncompliant
+  public static String[] strings; // Noncompliant
 
 }
 </pre>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2386.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2386.html
@@ -1,0 +1,12 @@
+<p>There is no good reason to have a mutable object as the <code>public static</code> member of an <code>interface</code>. Such variables should be moved into classes and their visibility lowered.</p>
+<p>This rule checks that interfaces do not have <code>public static</code> array, <code>Collection</code>, or <code>Date</code> members</p>
+
+<h2>Noncompliant code example</h2>
+
+<pre>
+public interface MyInterface {
+
+  public static String [] strings; // Noncompliant
+
+}
+</pre>

--- a/java-checks/src/test/files/checks/InterfaceStaticMutableMemberCheck.java
+++ b/java-checks/src/test/files/checks/InterfaceStaticMutableMemberCheck.java
@@ -1,0 +1,32 @@
+import java.util.Collection;
+import java.util.List;
+import java.util.Date;
+
+interface A {
+  public static String[] MY_ARRAY = null; // Noncompliant
+  public static Collection<String> MY_COLLECTION = null; // Noncompliant
+  public static Collection MY_2ND_COLLECTION = null; // Noncompliant
+  public static List<String> MY_LIST = null; // Noncompliant
+  public static List MY_2ND_LIST = null; // Noncompliant
+  public static Date MY_DATE = null; // Noncompliant
+  public static int MY_INT = 0; // Compliant
+  public static B<String> MY_PARAMETRIC_TYPE = null; // Compliant
+  public static C MY_FIELD = null; // Compliant
+
+  public Collection<String> myCollection = null; // Compliant
+  public Collection my2ndCollection = null; // Compliant
+  public List<String> myList = null; // Compliant
+  public List my2ndList = null; // Compliant
+  public Date myDate = null; // Compliant
+  public int myInt = 0; // Compliant
+  public B<String> myParametricType = null; // Compliant
+  public C myField = null; // Compliant
+
+  public void doSomething(); // not a field
+}
+
+class B<T> {
+}
+
+class C {
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/InterfaceStaticMutableMemberCheckTest.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifier;
+
+import java.io.File;
+
+public class InterfaceStaticMutableMemberCheckTest {
+
+  @Test
+  public void test() {
+    InterfaceStaticMutableMemberCheck check = new InterfaceStaticMutableMemberCheck();
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/InterfaceStaticMutableMemberCheck.java"), new VisitorsBridge(check));
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(6).withMessage("Move \"MY_ARRAY\" to a class and lower its visibility")
+      .next().atLine(7).withMessage("Move \"MY_COLLECTION\" to a class and lower its visibility")
+      .next().atLine(8).withMessage("Move \"MY_2ND_COLLECTION\" to a class and lower its visibility")
+      .next().atLine(9).withMessage("Move \"MY_LIST\" to a class and lower its visibility")
+      .next().atLine(10).withMessage("Move \"MY_2ND_LIST\" to a class and lower its visibility")
+      .next().atLine(11).withMessage("Move \"MY_DATE\" to a class and lower its visibility")
+      .noMore();
+  }
+
+}

--- a/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
+++ b/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
@@ -2143,6 +2143,19 @@
       <name>Data</name>
       <chc>
         <rule-repo>squid</rule-repo>
+        <rule-key>S2386</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>30</val>
+          <txt>mn</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>squid</rule-repo>
         <rule-key>S2164</rule-key>
         <prop>
           <key>remediationFunction</key>

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -44,7 +44,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(169);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(170);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
Interface static mutable member check :

- There is no good reason to have a mutable object as the `public static` member of an `interface`. Such variables should be moved into classes and their visibility lowered.
- This rule checks that interfaces do not have `public static` array, `Collection`, or `Date` members.