### PR TITLE
SONARJAVA-865 RSPEC-2183 Ints and longs shift check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -274,7 +274,8 @@ public final class CheckList {
       SuppressWarningsCheck.class,
       ImmediateReverseBoxingCheck.class,
       CustomCryptographicAlgorithmCheck.class,
-      UnusedTypeParameterCheck.class
+      UnusedTypeParameterCheck.class,
+      ShiftOnIntOrLongCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
@@ -76,7 +76,7 @@ public class ShiftOnIntOrLongCheck extends SubscriptionBaseVisitor {
 
     if (shift.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
       String value = ((LiteralTree) shift).value();
-      long numberBits = sign * Long.parseLong(value);
+      long numberBits = sign * Integer.decode(value);
       long reducedNumberBits = numberBits % (expectInt ? 32 : 64);
       String message = getMessage(numberBits, reducedNumberBits, expectInt, identifier);
       if (message != null) {

--- a/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
@@ -76,7 +76,7 @@ public class ShiftOnIntOrLongCheck extends SubscriptionBaseVisitor {
 
     if (shift.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
       String value = ((LiteralTree) shift).value();
-      long numberBits = sign * Integer.decode(value);
+      long numberBits = sign * Long.decode(value);
       long reducedNumberBits = numberBits % (expectInt ? 32 : 64);
       String message = getMessage(numberBits, reducedNumberBits, expectInt, identifier);
       if (message != null) {

--- a/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
@@ -1,0 +1,130 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.BelongsToProfile;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.model.expression.ArrayAccessExpressionTreeImpl;
+import org.sonar.java.model.expression.AssignmentExpressionTreeImpl;
+import org.sonar.java.model.expression.IdentifierTreeImpl;
+import org.sonar.java.model.expression.LiteralTreeImpl;
+import org.sonar.java.model.expression.MethodInvocationTreeImpl;
+import org.sonar.java.model.expression.ParenthesizedTreeImpl;
+import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
+
+import java.util.List;
+
+@Rule(
+  key = "S2183",
+  priority = Priority.CRITICAL,
+  tags = {"bug"})
+@BelongsToProfile(title = "Sonar way", priority = Priority.CRITICAL)
+public class ShiftOnIntOrLongCheck extends SubscriptionBaseVisitor {
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.LEFT_SHIFT, Kind.LEFT_SHIFT_ASSIGNMENT, Kind.RIGHT_SHIFT, Kind.RIGHT_SHIFT_ASSIGNMENT);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ExpressionTree target = null;
+    ExpressionTree shift = null;
+
+    if (tree.is(Kind.LEFT_SHIFT, Kind.RIGHT_SHIFT)) {
+      BinaryExpressionTree binaryExpressionTree = (BinaryExpressionTree) tree;
+      target = binaryExpressionTree.leftOperand();
+      shift = binaryExpressionTree.rightOperand();
+    } else {
+      AssignmentExpressionTreeImpl assignmentExpressionTree = (AssignmentExpressionTreeImpl) tree;
+      target = assignmentExpressionTree.variable();
+      shift = assignmentExpressionTree.expression();
+    }
+
+    String identifier = getIdentifierName(target);
+    boolean expectLong = treeTypeIsLong(target);
+    boolean expectInt = treeTypeIsInt(target);
+    boolean shiftIsMinus = shift.is(Kind.UNARY_MINUS);
+
+    if (shift.is(Kind.UNARY_MINUS, Kind.UNARY_PLUS)) {
+      shift = ((UnaryExpressionTree) shift).expression();
+    }
+
+    if (isShiftEvaluable(shift, expectInt || expectLong)) {
+      String value = ((LiteralTreeImpl) shift).value();
+      long numberBits = (shiftIsMinus ? -1 : 1) * (expectInt ? Integer.parseInt(value) : Long.parseLong(value));
+      long reducedNumberBits = numberBits % (expectLong ? 64 : 32);
+      insertIssue(tree, numberBits, reducedNumberBits, expectInt, identifier);
+    }
+  }
+
+  private void insertIssue(Tree tree, long numberBits, long reducedNumberBits, boolean expectInt, String identifier) {
+    if (reducedNumberBits == 0L) {
+      addIssue(tree, new StringBuilder("Remove this useless shift (multiple of ").append(expectInt ? "32" : "64").append(")").toString());
+    } else if (tooManyBits(numberBits, expectInt)) {
+      if (expectInt) {
+        String identifierMarker = identifier == null ? "use" : new StringBuilder("make \"").append(identifier).append("\"").toString();
+        addIssue(tree, new StringBuilder("Either ").append(identifierMarker).append(" a \"long\" or correct this shift to ").append(reducedNumberBits).toString());
+      } else {
+        addIssue(tree, new StringBuilder("Correct this shift to ").append(reducedNumberBits).toString());
+      }
+    }
+  }
+
+  private boolean tooManyBits(long numberBits, boolean isInt) {
+    long value = Math.abs(numberBits);
+    return (isInt && value >= 32) || (!isInt && value >= 64);
+  }
+
+  private boolean treeTypeIsInt(ExpressionTree tree) {
+    return treeTypeIs(tree, "int") || treeTypeIs(tree, "java.lang.Integer");
+  }
+
+  private boolean treeTypeIsLong(ExpressionTree tree) {
+    return treeTypeIs(tree, "long") || treeTypeIs(tree, "java.lang.Long");
+  }
+
+  private boolean treeTypeIs(ExpressionTree tree, String fullyQualifiedName) {
+    return (tree.is(Kind.IDENTIFIER) && ((IdentifierTreeImpl) tree).getSymbolType().is(fullyQualifiedName)) ||
+      (tree.is(Kind.ARRAY_ACCESS_EXPRESSION) && ((ArrayAccessExpressionTreeImpl) tree).getSymbolType().is(fullyQualifiedName)) ||
+      (tree.is(Kind.PARENTHESIZED_EXPRESSION) && ((ParenthesizedTreeImpl) tree).getSymbolType().is(fullyQualifiedName)) ||
+      (tree.is(Kind.METHOD_INVOCATION) && ((MethodInvocationTreeImpl) tree).getSymbolType().is(fullyQualifiedName));
+  }
+
+  private boolean isShiftEvaluable(ExpressionTree tree, boolean intOrLong) {
+    return intOrLong && tree.is(Kind.INT_LITERAL, Kind.LONG_LITERAL);
+  }
+
+  private String getIdentifierName(ExpressionTree tree) {
+    ExpressionTree expressionTree = tree;
+    if (tree.is(Kind.ARRAY_ACCESS_EXPRESSION)) {
+      expressionTree = ((ArrayAccessExpressionTree) tree).expression();
+    }
+    return expressionTree.is(Kind.IDENTIFIER) ? ((IdentifierTree) expressionTree).name() : null;
+  }
+}

--- a/java-checks/src/main/resources/org/sonar/l10n/java.properties
+++ b/java-checks/src/main/resources/org/sonar/l10n/java.properties
@@ -307,3 +307,4 @@ rule.squid.S1309.param.listOfWarnings=Comma separated list of warnings that can'
 rule.squid.S2153.name=Boxing and unboxing should not be immediately reversed
 rule.squid.S2257.name=Only standard cryptographic algorithms should be used
 rule.squid.S2326.name=Unused type parameters should be removed
+rule.squid.S2183.name=Ints and longs should not be shifted by more than their number of bits-1

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2183.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2183.html
@@ -1,0 +1,17 @@
+<p>Since an <code>int</code> is a 32-bit variable, shifting by more than (-)31 is confusing at best and an error at worst. Shifting an <code>int</code> by 32 is the same as shifting it by 0, and shifting it by 33 is the same as shifting it by 1.</p>
+
+<p>Similarly, shifting a <code>long</code> by (-)64 is the same as shifting it by 0, and shifting it by 65 is the same as shifting it by 1.</p>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+public int shift(int a) {
+  return a << 48;
+}
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+public int shift(int a) {
+  return a << 16;
+}
+</pre>

--- a/java-checks/src/test/files/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/test/files/checks/ShiftOnIntOrLongCheck.java
@@ -1,0 +1,83 @@
+class Shifts {
+  public int shift(int a) {
+    int b;
+    b = a <<  31; // Compliant
+    b = a >> -31; // Compliant
+    b = a <<  32; // Nomcompliant
+    b = a >> -32; // Noncompliant
+    b = a <<  33; // Noncompliant
+    b = a >> -33; // Noncompliant
+
+    a <<=  31; // Compliant
+    a >>= -31; // Compliant
+    a <<=  32; // Noncompliant
+    a >>= -32; // Noncompliant
+    a <<=  33; // Noncompliant
+    a >>= -33; // Noncompliant
+    return b << +48; // Noncompliant
+  }
+
+  public long shift(long a) {
+    long b;
+    b = a >>  63; // Compliant
+    b = a << -63; // Compliant
+    b = a >>  64; // Nomcompliant
+    b = a << -64; // Noncompliant
+    b = a >>  65; // Noncompliant
+    b = a << -65; // Noncompliant
+
+    a >>=  63; // Compliant
+    a <<= -63; // Compliant
+    a >>=  64; // Noncompliant
+    a <<= -64; // Noncompliant
+    a >>=  65; // Noncompliant
+    a <<= -65; // Noncompliant
+    return b >> +96; // Noncompliant
+  }
+
+  public long shiftOtherCases(long a, long b) {
+    long c;
+    long[] d = new long[]{1L};
+    Long[] e = new Long[]{1L};
+    c = a >> b; // Compliant
+    c = a << (b + 3); // Compliant
+    c = a >> returnLong(); //Compliant
+    c = (a - 3) << (b + 3); // Compliant
+    c = (a - 3) >> 63; // Compliant
+    c = (a - 3) << 64; // Noncompliant
+    c = (a - 3) >> 96; // Noncompliant
+    c = returnLong() << 97; // Noncompliant
+    c = d[0] >> 98; // Noncompliant 
+    c = e[0] << 99; //Noncompliant
+    return c;
+  }
+  
+  public int shiftOtherCases(int a, int b) {
+    int c;
+    int[] d = new int[]{1};
+    Integer[] e = new Integer[]{1};
+    c = a << b; // Compliant
+    c = a >> (b + 3); // Compliant
+    c = a << returnInt(); // Compliant
+    c = (a - 3) >> (b + 4); // Compliant
+    c = (a - 3) << 31; // Compliant
+    c = (a - 3) >> 32; // Noncompliant
+    c = (a - 3) << 48; // Noncompliant
+    c = returnInt() >> 49; // Noncompliant
+    c = d[0] << 50; // Noncompliant
+    c = e[0] >> 51; // Noncompliant
+    return c;
+  }
+  
+  public short shift(short a) {
+    return a << 8; // Compliant
+  }
+  
+  public int returnInt() {
+    return 0;
+  }
+  
+  public long returnLong() {
+    return 0L;
+  }
+}

--- a/java-checks/src/test/files/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/test/files/checks/ShiftOnIntOrLongCheck.java
@@ -49,6 +49,8 @@ class Shifts {
     c = returnLong() << 97; // Noncompliant
     c = d[0] >> 98; // Noncompliant 
     c = e[0] << 99; //Noncompliant
+    c = a >> 0x0009; // Compliant
+    c = a << 0x0000; // Noncompliant
     return c;
   }
 
@@ -66,6 +68,8 @@ class Shifts {
     c = returnInt() >> 49; // Noncompliant
     c = d[0] << 50; // Noncompliant
     c = e[0] >> 51; // Noncompliant
+    c = a << 0x0009; // Compliant
+    c = a >> 0x0000; // Noncompliant
     return c;
   }
 

--- a/java-checks/src/test/files/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/test/files/checks/ShiftOnIntOrLongCheck.java
@@ -51,7 +51,7 @@ class Shifts {
     c = e[0] << 99; //Noncompliant
     return c;
   }
-  
+
   public int shiftOtherCases(int a, int b) {
     int c;
     int[] d = new int[]{1};
@@ -68,15 +68,11 @@ class Shifts {
     c = e[0] >> 51; // Noncompliant
     return c;
   }
-  
-  public short shift(short a) {
-    return a << 8; // Compliant
-  }
-  
+
   public int returnInt() {
     return 0;
   }
-  
+
   public long returnLong() {
     return 0L;
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
@@ -26,21 +26,19 @@ import org.sonar.squidbridge.api.SourceFile;
 import org.sonar.squidbridge.checks.CheckMessagesVerifier;
 
 import java.io.File;
+import java.text.MessageFormat;
 
 public class ShiftOnIntOrLongCheckTest {
 
   private static final String REMOVE_SHIFT_32 = "Remove this useless shift (multiple of 32)";
   private static final String REMOVE_SHIFT_64 = "Remove this useless shift (multiple of 64)";
-  private static final String INT_IDENTIFIER_VALUE = "Either make \"%s\" a \"long\" or correct this shift to %s";
-  private static final String INT_VALUE = "Either use a \"long\" or correct this shift to %s";
-  private static final String LONG_VALUE = "Correct this shift to %s";
 
   private String getMessage(String identifier, String value) {
-    return String.format(INT_IDENTIFIER_VALUE, identifier, value);
+    return MessageFormat.format("Either make \"{0}\" a \"long\" or correct this shift to {1}", identifier, value);
   }
 
   private String getMessage(boolean isInt, String value) {
-    return isInt ? String.format(INT_VALUE, value) : String.format(LONG_VALUE, value);
+    return isInt ? MessageFormat.format("Either use a \"long\" or correct this shift to {0}", value) : MessageFormat.format("Correct this shift to {0}", value);
   }
 
   @Test

--- a/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
@@ -54,6 +54,7 @@ public class ShiftOnIntOrLongCheckTest {
       .next().atLine(15).withMessage(getMessage("a", "1"))
       .next().atLine(16).withMessage(getMessage("a", "-1"))
       .next().atLine(17).withMessage(getMessage("b", "16"))
+
       .next().atLine(24).withMessage(REMOVE_SHIFT_64)
       .next().atLine(25).withMessage(REMOVE_SHIFT_64)
       .next().atLine(26).withMessage(getMessage(false, "1"))
@@ -63,16 +64,20 @@ public class ShiftOnIntOrLongCheckTest {
       .next().atLine(33).withMessage(getMessage(false, "1"))
       .next().atLine(34).withMessage(getMessage(false, "-1"))
       .next().atLine(35).withMessage(getMessage(false, "32"))
+
       .next().atLine(47).withMessage(REMOVE_SHIFT_64)
       .next().atLine(48).withMessage(getMessage(false, "32"))
       .next().atLine(49).withMessage(getMessage(false, "33"))
       .next().atLine(50).withMessage(getMessage(false, "34"))
       .next().atLine(51).withMessage(getMessage(false, "35"))
-      .next().atLine(64).withMessage(REMOVE_SHIFT_32)
-      .next().atLine(65).withMessage(getMessage(true, "16"))
-      .next().atLine(66).withMessage(getMessage(true, "17"))
-      .next().atLine(67).withMessage(getMessage("d", "18"))
-      .next().atLine(68).withMessage(getMessage("e", "19"))
+      .next().atLine(53).withMessage(REMOVE_SHIFT_64)
+
+      .next().atLine(66).withMessage(REMOVE_SHIFT_32)
+      .next().atLine(67).withMessage(getMessage(true, "16"))
+      .next().atLine(68).withMessage(getMessage(true, "17"))
+      .next().atLine(69).withMessage(getMessage("d", "18"))
+      .next().atLine(70).withMessage(getMessage("e", "19"))
+      .next().atLine(72).withMessage(REMOVE_SHIFT_32)
       .noMore();
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
@@ -1,0 +1,80 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifier;
+
+import java.io.File;
+
+public class ShiftOnIntOrLongCheckTest {
+
+  private static final String REMOVE_SHIFT_32 = "Remove this useless shift (multiple of 32)";
+  private static final String REMOVE_SHIFT_64 = "Remove this useless shift (multiple of 64)";
+  private static final String INT_IDENTIFIER_VALUE = "Either make \"xxx\" a \"long\" or correct this shift to nnn";
+  private static final String INT_VALUE = "Either use a \"long\" or correct this shift to nnn";
+  private static final String LONG_VALUE = "Correct this shift to nnn";
+
+  private String getMessage(String identifier, String value) {
+    return INT_IDENTIFIER_VALUE.replace("xxx", identifier).replace("nnn", value);
+  }
+
+  private String getMessage(boolean isInt, String value) {
+    return isInt ? INT_VALUE.replace("nnn", value) : LONG_VALUE.replace("nnn", value);
+  }
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/ShiftOnIntOrLongCheck.java"), new VisitorsBridge(new ShiftOnIntOrLongCheck()));
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(6).withMessage(REMOVE_SHIFT_32)
+      .next().atLine(7).withMessage(REMOVE_SHIFT_32)
+      .next().atLine(8).withMessage(getMessage("a", "1"))
+      .next().atLine(9).withMessage(getMessage("a", "-1"))
+      .next().atLine(13).withMessage(REMOVE_SHIFT_32)
+      .next().atLine(14).withMessage(REMOVE_SHIFT_32)
+      .next().atLine(15).withMessage(getMessage("a", "1"))
+      .next().atLine(16).withMessage(getMessage("a", "-1"))
+      .next().atLine(17).withMessage(getMessage("b", "16"))
+      .next().atLine(24).withMessage(REMOVE_SHIFT_64)
+      .next().atLine(25).withMessage(REMOVE_SHIFT_64)
+      .next().atLine(26).withMessage(getMessage(false, "1"))
+      .next().atLine(27).withMessage(getMessage(false, "-1"))
+      .next().atLine(31).withMessage(REMOVE_SHIFT_64)
+      .next().atLine(32).withMessage(REMOVE_SHIFT_64)
+      .next().atLine(33).withMessage(getMessage(false, "1"))
+      .next().atLine(34).withMessage(getMessage(false, "-1"))
+      .next().atLine(35).withMessage(getMessage(false, "32"))
+      .next().atLine(47).withMessage(REMOVE_SHIFT_64)
+      .next().atLine(48).withMessage(getMessage(false, "32"))
+      .next().atLine(49).withMessage(getMessage(false, "33"))
+      .next().atLine(50).withMessage(getMessage(false, "34"))
+      .next().atLine(51).withMessage(getMessage(false, "35"))
+      .next().atLine(64).withMessage(REMOVE_SHIFT_32)
+      .next().atLine(65).withMessage(getMessage(true, "16"))
+      .next().atLine(66).withMessage(getMessage(true, "17"))
+      .next().atLine(67).withMessage(getMessage("d", "18"))
+      .next().atLine(68).withMessage(getMessage("e", "19"))
+      .noMore();
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ShiftOnIntOrLongCheckTest.java
@@ -31,16 +31,16 @@ public class ShiftOnIntOrLongCheckTest {
 
   private static final String REMOVE_SHIFT_32 = "Remove this useless shift (multiple of 32)";
   private static final String REMOVE_SHIFT_64 = "Remove this useless shift (multiple of 64)";
-  private static final String INT_IDENTIFIER_VALUE = "Either make \"xxx\" a \"long\" or correct this shift to nnn";
-  private static final String INT_VALUE = "Either use a \"long\" or correct this shift to nnn";
-  private static final String LONG_VALUE = "Correct this shift to nnn";
+  private static final String INT_IDENTIFIER_VALUE = "Either make \"%s\" a \"long\" or correct this shift to %s";
+  private static final String INT_VALUE = "Either use a \"long\" or correct this shift to %s";
+  private static final String LONG_VALUE = "Correct this shift to %s";
 
   private String getMessage(String identifier, String value) {
-    return INT_IDENTIFIER_VALUE.replace("xxx", identifier).replace("nnn", value);
+    return String.format(INT_IDENTIFIER_VALUE, identifier, value);
   }
 
   private String getMessage(boolean isInt, String value) {
-    return isInt ? INT_VALUE.replace("nnn", value) : LONG_VALUE.replace("nnn", value);
+    return isInt ? String.format(INT_VALUE, value) : String.format(LONG_VALUE, value);
   }
 
   @Test

--- a/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
+++ b/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
@@ -740,6 +740,19 @@
       <name>Understandability</name>
       <chc>
         <rule-repo>squid</rule-repo>
+        <rule-key>S2183</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>remediationFactor</key>
+          <val>5</val>
+          <txt>mn</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>squid</rule-repo>
         <rule-key>S2326</rule-key>
         <prop>
           <key>remediationFunction</key>

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -44,7 +44,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(169);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(170);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
Ints and longs shift check:

- Since an `int` is a 32-bit variable, shifting by more than (-)31 is confusing at best and an error at worst. Shifting an `int` by 32 is the same as shifting it by 0, and shifting it by 33 is the same as shifting it by 1.
- Similarly, shifting a `long` by (-)64 is the same as shifting it by 0, and shifting it by 65 is the same as shifting it by 1.