### PR TITLE
SONARJAVA-866 RSPEC-2167 CompareTo return value check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -274,7 +274,8 @@ public final class CheckList {
       SuppressWarningsCheck.class,
       ImmediateReverseBoxingCheck.class,
       CustomCryptographicAlgorithmCheck.class,
-      UnusedTypeParameterCheck.class
+      UnusedTypeParameterCheck.class,
+      CompareToReturnValueCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/CompareToReturnValueCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CompareToReturnValueCheck.java
@@ -1,0 +1,83 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.BelongsToProfile;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.model.expression.IdentifierTreeImpl;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.PrimitiveTypeTree;
+import org.sonar.plugins.java.api.tree.ReturnStatementTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+import java.util.List;
+
+@Rule(
+  key = "S2167",
+  priority = Priority.CRITICAL,
+  tags = {"bug"})
+@BelongsToProfile(title = "Sonar way", priority = Priority.CRITICAL)
+public class CompareToReturnValueCheck extends SubscriptionBaseVisitor {
+
+  private boolean insideCompareTo = false;
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.RETURN_STATEMENT, Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    if (tree.is(Kind.METHOD)) {
+      insideCompareTo = isCompareToDeclaration((MethodTree) tree);
+    } else if (insideCompareTo && returnIntegerMinValue((ReturnStatementTree) tree)) {
+      addIssue(tree, "Simply return -1");
+    }
+  }
+
+  @Override
+  public void leaveNode(Tree tree) {
+    if (tree.is(Tree.Kind.METHOD)) {
+      insideCompareTo = false;
+    }
+  }
+
+  private boolean isCompareToDeclaration(MethodTree tree) {
+    Tree returnType = tree.returnType();
+    return "compareTo".equals(tree.simpleName().name()) &&
+      returnType.is(Kind.PRIMITIVE_TYPE) &&
+      "int".equals(((PrimitiveTypeTree) returnType).keyword().text());
+  }
+
+  private boolean returnIntegerMinValue(ReturnStatementTree tree) {
+    ExpressionTree expressionTree = tree.expression();
+    if (expressionTree.is(Kind.MEMBER_SELECT)) {
+      MemberSelectExpressionTree memberSelectExpressionTree = (MemberSelectExpressionTree) expressionTree;
+      return ((IdentifierTreeImpl) memberSelectExpressionTree.expression()).getSymbolType().is("java.lang.Integer") &&
+        "MIN_VALUE".equals(memberSelectExpressionTree.identifier().name());
+    }
+    return false;
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/CompareToReturnValueCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CompareToReturnValueCheck.java
@@ -60,10 +60,10 @@ public class CompareToReturnValueCheck extends SubscriptionBaseVisitor {
   }
 
   private boolean isCompareToDeclaration(MethodTree tree) {
-    return isCalledCompareTo(tree) && hasOneNonPrimitiveParameter(tree) && returnsInt(tree);
+    return isNamedCompareTo(tree) && hasOneNonPrimitiveParameter(tree) && returnsInt(tree);
   }
 
-  private boolean isCalledCompareTo(MethodTree tree) {
+  private boolean isNamedCompareTo(MethodTree tree) {
     return "compareTo".equals(tree.simpleName().name());
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/CompareToReturnValueCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CompareToReturnValueCheck.java
@@ -60,11 +60,11 @@ public class CompareToReturnValueCheck extends SubscriptionBaseVisitor {
   }
 
   private boolean isCompareToDeclaration(MethodTree tree) {
-    return isMethodName(tree, "compareTo") && hasOneNonPrimitiveParameter(tree) && returnsInt(tree);
+    return isCalledCompareTo(tree) && hasOneNonPrimitiveParameter(tree) && returnsInt(tree);
   }
 
-  private boolean isMethodName(MethodTree methodTree, String name) {
-    return name.equals(methodTree.simpleName().name());
+  private boolean isCalledCompareTo(MethodTree tree) {
+    return "compareTo".equals(tree.simpleName().name());
   }
 
   private boolean hasOneNonPrimitiveParameter(MethodTree methodTree) {
@@ -97,7 +97,7 @@ public class CompareToReturnValueCheck extends SubscriptionBaseVisitor {
 
     @Override
     public void visitClass(ClassTree tree) {
-      // Do not visit inner classes as methods of inner class will be visited by main visitor
+      // Do not visit inner classes as methods of inner classes will be visited by main visitor
     }
   }
 }

--- a/java-checks/src/main/resources/org/sonar/l10n/java.properties
+++ b/java-checks/src/main/resources/org/sonar/l10n/java.properties
@@ -307,3 +307,4 @@ rule.squid.S1309.param.listOfWarnings=Comma separated list of warnings that can'
 rule.squid.S2153.name=Boxing and unboxing should not be immediately reversed
 rule.squid.S2257.name=Only standard cryptographic algorithms should be used
 rule.squid.S2326.name=Unused type parameters should be removed
+rule.squid.S2167.name="compareTo" should not return "Integer.MIN_VALUE"

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2167.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2167.html
@@ -1,0 +1,17 @@
+<p>It is the sign, rather than the magnitude of the value returned from <code>compareTo</code> that matters. Returning <code>Integer.MIN_VALUE</code> does not convey a higher degree of inequality, and doing so can cause errors because the return value of <code>compareTo</code> is sometimes inversed, with the expectation that negative values become positive. However, inversing <code>Integer.MIN_VALUE</code> yields <code>Integer.MIN_VALUE</code> rather than <code>Integer.MAX_VALUE</code>.</p>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+public int compareTo(MyClass) {
+  if (condition) {
+    return Integer.MIN_VALUE;  // Noncompliant
+  }
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+public int compareTo(MyClass) {
+  if (condition) {
+    return -1;
+  }
+</pre>

--- a/java-checks/src/test/files/checks/CompareToReturnValueCheck.java
+++ b/java-checks/src/test/files/checks/CompareToReturnValueCheck.java
@@ -73,3 +73,4 @@ class G implements Comparable<G> {
     return Short.MAX_VALUE; // Compliant
   }
 }
+

--- a/java-checks/src/test/files/checks/CompareToReturnValueCheck.java
+++ b/java-checks/src/test/files/checks/CompareToReturnValueCheck.java
@@ -29,3 +29,47 @@ class A implements Comparable<A> {
     return Integer.MAX_VALUE; // Compliant
   }
 }
+
+class B implements Comparable<B> {
+  @Override
+  public int compareTo(B b) {
+    
+    class C implements Comparable<C> {
+      @Override
+      public int compareTo(C c) {
+        
+        class D implements Comparable<D> {
+          @Override
+          public int compareTo(D d) {
+            return Integer.MIN_VALUE; // Noncompliant
+          }
+        }
+        
+        return Integer.MIN_VALUE; // Noncompliant
+      }
+    }
+    
+    return Integer.MIN_VALUE; // Noncompliant
+  }
+}
+
+class E implements Comparable<E> {
+  @Override
+  public int compareTo(E e) {
+    return 0; // Compliant
+  }
+}
+
+class F implements Comparable<F> {
+  @Override
+  public int compareTo(F e) {
+    return Integer.MAX_VALUE; // Compliant
+  }
+}
+
+class G implements Comparable<G> {
+  @Override
+  public int compareTo(G e) {
+    return Short.MAX_VALUE; // Compliant
+  }
+}

--- a/java-checks/src/test/files/checks/CompareToReturnValueCheck.java
+++ b/java-checks/src/test/files/checks/CompareToReturnValueCheck.java
@@ -1,0 +1,31 @@
+class A implements Comparable<A> {
+  @Override
+  public int compareTo(A a) {
+    return Integer.MIN_VALUE; // Noncompliant
+  }
+  
+  public int compareTo() {
+    return Short.MIN_VALUE; // Compliant
+  }
+  
+  public int getMinValue() {
+    return Integer.MIN_VALUE; // Compliant
+  }
+  
+  public int compareTo(int a) {
+    return -1; // Compliant
+  }
+  
+  public boolean compareTo(Boolean a) {
+    return a; // Compliant
+  }
+  
+  public Long compareTo(Long a) {
+    return Long.MIN_VALUE; // Compliant
+  }
+  
+  @Override
+  public int compareTo(Short a) {
+    return Integer.MAX_VALUE; // Compliant
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/CompareToReturnValueCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CompareToReturnValueCheckTest.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class CompareToReturnValueCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/CompareToReturnValueCheck.java"),
+      new VisitorsBridge(new CompareToReturnValueCheck()));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(4).withMessage("Simply return -1")
+      .noMore();
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/CompareToReturnValueCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CompareToReturnValueCheckTest.java
@@ -39,6 +39,9 @@ public class CompareToReturnValueCheckTest {
       new VisitorsBridge(new CompareToReturnValueCheck()));
     checkMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(4).withMessage("Simply return -1")
+      .next().atLine(44)
+      .next().atLine(48)
+      .next().atLine(52)
       .noMore();
   }
 

--- a/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
+++ b/java-squid/src/main/resources/com/sonar/sqale/java-model.xml
@@ -2143,6 +2143,19 @@
       <name>Data</name>
       <chc>
         <rule-repo>squid</rule-repo>
+        <rule-key>S2167</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>5</val>
+          <txt>mn</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>squid</rule-repo>
         <rule-key>S2164</rule-key>
         <prop>
           <key>remediationFunction</key>

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -44,7 +44,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(169);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(170);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
"compareTo" return value check

- It is the sign, rather than the magnitude of the value returned from `compareTo` that matters. Returning `Integer.MIN_VALUE` does not convey a higher degree of inequality, and doing so can cause errors because the return value of `compareTo` is sometimes inversed, with the expectation that negative values become positive. However, inversing `Integer.MIN_VALUE` yields `Integer.MIN_VALUE` rather than `Integer.MAX_VALUE`.
- The rule check the return value of the `compareTo` methods and add an issue if `Integer.MIN_VALUE` is returned.