### PR TITLE
HardCodedCredentialCheck should not consider empty string literal a violation

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/HardCodedCredentialsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/HardCodedCredentialsCheck.java
@@ -71,9 +71,13 @@ public class HardCodedCredentialsCheck extends SubscriptionBaseVisitor {
   }
 
   private boolean isStringLiteral(ExpressionTree initializer) {
-    return initializer != null && initializer.is(Tree.Kind.STRING_LITERAL);
+    return initializer != null && initializer.is(Tree.Kind.STRING_LITERAL) && !isEmptyStringLiteral((LiteralTree) initializer);
   }
 
+  private boolean isEmptyStringLiteral(LiteralTree initializer){
+	  return "\"\"".equals(initializer.value());
+  }
+  
   private boolean isPasswordVariableName(IdentifierTree identifierTree) {
     return PASSWORD_VARIABLE_PATTERN.matcher(identifierTree.name()).find();
   }

--- a/java-checks/src/test/files/checks/HardCodedCredentialsCheck.java
+++ b/java-checks/src/test/files/checks/HardCodedCredentialsCheck.java
@@ -9,10 +9,16 @@ class A {
 
     String variableNameWithPasswordInIt = "xxx"; // Noncompliant
     String otherVariableNameWithPasswordInIt;
+    String nullInitializedPasswordVariable = null;
+    String emptyInitializedPasswordVariable = "";
     fieldNameWithPasswordInIt = "xx"; // Noncompliant
     fieldNameWithPasswordInIt = retrievePassword();
+    fieldNameWithPasswordInIt = null;
+    fieldNameWithPasswordInIt = "";
     this.fieldNameWithPasswordInIt = "xx"; // Noncompliant
     this.fieldNameWithPasswordInIt = retrievePassword();
+    this.fieldNameWithPasswordInIt = null;
+    this.fieldNameWithPasswordInIt = "";
     variable1 = "xx";
  
     String[] array = {};

--- a/java-checks/src/test/java/org/sonar/java/checks/HardCodedCredentialsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/HardCodedCredentialsCheckTest.java
@@ -40,8 +40,8 @@ public class HardCodedCredentialsCheckTest {
     checkMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(7).withMessage("Remove this hard-coded password.")
       .next().atLine(10)
-      .next().atLine(12)
-      .next().atLine(14);
+      .next().atLine(14)
+      .next().atLine(18);
   }
 
 }


### PR DESCRIPTION
SONARJAVA-788 RSPEC-2068:  HardCodedCredentialCheck should not consider empty string literal as a violation.

I have few false positives where a mutable variable called "password" is initialized to the empty string and it's considered a critical violation. I think the empty string can hardly be seen as hard coded credential and it may happen to have password variable assigned to it.