### PR TITLE
SONARJAVA-871 SONARJAVA-339 Improve @SuppressWarnings management

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/BytecodeFixture.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/BytecodeFixture.java
@@ -24,6 +24,7 @@ import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.java.DefaultJavaResourceLocator;
 import org.sonar.java.JavaConfiguration;
 import org.sonar.java.JavaSquid;
+import org.sonar.java.filters.SuppressWarningsFilter;
 import org.sonar.squidbridge.api.CodeVisitor;
 import org.sonar.squidbridge.api.SourceCode;
 import org.sonar.squidbridge.api.SourceFile;
@@ -53,9 +54,10 @@ public class BytecodeFixture {
     }
     Project project = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
+    SuppressWarningsFilter filter = mock(SuppressWarningsFilter.class);
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
-    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null);
+    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, filter);
     JavaSquid javaSquid = new JavaSquid(new JavaConfiguration(Charset.forName("UTF-8")), javaResourceLocator, visitor);
     javaSquid.scan(Collections.singleton(file), Collections.<File>emptyList(), Collections.singleton(bytecodeFile));
 

--- a/java-checks/src/test/java/org/sonar/java/checks/BytecodeFixture.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/BytecodeFixture.java
@@ -54,10 +54,9 @@ public class BytecodeFixture {
     }
     Project project = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
-    SuppressWarningsFilter filter = mock(SuppressWarningsFilter.class);
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
-    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, filter);
+    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, new SuppressWarningsFilter());
     JavaSquid javaSquid = new JavaSquid(new JavaConfiguration(Charset.forName("UTF-8")), javaResourceLocator, visitor);
     javaSquid.scan(Collections.singleton(file), Collections.<File>emptyList(), Collections.singleton(bytecodeFile));
 

--- a/java-squid/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
+++ b/java-squid/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
@@ -20,6 +20,7 @@
 package org.sonar.java;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
@@ -50,7 +51,7 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator, JavaFile
   private final Map<String, String> sourceFileByClass;
   private final Map<String, Integer> methodStartLines;
   private final ResourceMapping resourceMapping;
-  SensorContext sensorContext;
+  private SensorContext sensorContext;
 
   public DefaultJavaResourceLocator(Project project, JavaClasspath javaClasspath, SuppressWarningsFilter suppressWarningsFilter) {
     this.project = project;
@@ -120,6 +121,7 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator, JavaFile
 
   @Override
   public void scanFile(JavaFileScannerContext context) {
+    Preconditions.checkNotNull(sensorContext);
     JavaFilesCache javaFilesCache = new JavaFilesCache();
     javaFilesCache.scanFile(context);
     org.sonar.api.resources.File currentResource = org.sonar.api.resources.File.fromIOFile(context.getFile(), project);
@@ -134,7 +136,7 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator, JavaFile
       }
     }
     methodStartLines.putAll(javaFilesCache.getMethodStartLines());
-    if (sensorContext != null && javaFilesCache.hasSuppressWarningLines()) {
+    if (javaFilesCache.hasSuppressWarningLines()) {
       suppressWarningsFilter.addComponent(sensorContext.getResource(currentResource).getEffectiveKey(), javaFilesCache.getSuppressWarningLines());
     }
   }

--- a/java-squid/src/main/java/org/sonar/java/JavaFilesCache.java
+++ b/java-squid/src/main/java/org/sonar/java/JavaFilesCache.java
@@ -24,7 +24,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
@@ -48,7 +47,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class JavaFilesCache extends BaseTreeVisitor implements JavaFileScanner {
 
@@ -58,10 +56,6 @@ public class JavaFilesCache extends BaseTreeVisitor implements JavaFileScanner {
   @VisibleForTesting
   Map<String, Integer> methodStartLines = Maps.newHashMap();
 
-  @VisibleForTesting
-  Set<Integer> ignoredLines = Sets.newHashSet();
-  @VisibleForTesting
-  Multimap<String, Integer> ignoredLinesForRules = HashMultimap.create();
   @VisibleForTesting
   Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
 
@@ -83,6 +77,10 @@ public class JavaFilesCache extends BaseTreeVisitor implements JavaFileScanner {
     return suppressWarningLines;
   }
 
+  public boolean hasSuppressWarningLines() {
+    return !suppressWarningLines.isEmpty();
+  }
+
   @Override
   public void scanFile(JavaFileScannerContext context) {
     JavaTree.CompilationUnitTreeImpl tree = (JavaTree.CompilationUnitTreeImpl) context.getTree();
@@ -91,7 +89,6 @@ public class JavaFilesCache extends BaseTreeVisitor implements JavaFileScanner {
     currentClassKey.clear();
     parent.clear();
     anonymousInnerClassCounter.clear();
-    ignoredLines.clear();
     suppressWarningLines.clear();
     scan(tree);
   }
@@ -200,13 +197,5 @@ public class JavaFilesCache extends BaseTreeVisitor implements JavaFileScanner {
 
   private String trimQuotes(String value) {
     return value.substring(1, value.length() - 1);
-  }
-
-  public Set<Integer> ignoredLines() {
-    return ignoredLines;
-  }
-
-  public Multimap<String, Integer> ignoredLinesForRules() {
-    return ignoredLinesForRules;
   }
 }

--- a/java-squid/src/main/java/org/sonar/java/filters/SuppressWarningsFilter.java
+++ b/java-squid/src/main/java/org/sonar/java/filters/SuppressWarningsFilter.java
@@ -1,0 +1,75 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.filters;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.issue.batch.IssueFilter;
+import org.sonar.api.issue.batch.IssueFilterChain;
+import org.sonar.api.rule.RuleKey;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Issue filter used to ignore issues in the block that follow the <code>@SuppressWarnings</code> annotation.
+ * <p/>
+ * Plugins, via {@link org.sonar.api.BatchExtension}s, must feed this filter by registering the
+ * lines in which are covered by suppress warnings. Note that filters are disabled for the issues reported by
+ * end-users from UI or web services.
+ *
+ * @since 3.6
+ */
+public class SuppressWarningsFilter implements IssueFilter {
+
+  private final Map<String, Multimap<Integer, String>> suppressWarningsLinesByResource = Maps.newHashMap();
+
+  public void addComponent(String componentKey, Multimap<Integer, String> warningLines) {
+    suppressWarningsLinesByResource.put(componentKey, warningLines);
+  }
+
+  @Override
+  public boolean accept(Issue issue, IssueFilterChain chain) {
+    Integer line = issue.line();
+    RuleKey ruleKey = issue.ruleKey();
+    if (line != null) {
+      Multimap<Integer, String> suppressWarningsLines = suppressWarningsLinesByResource.get(issue.componentKey());
+      if (suppressWarningsLines != null && suppressWarningsLines.containsKey(line)) {
+        Collection<String> lineWarnings = suppressWarningsLines.get(line);
+        for (String warning : lineWarnings) {
+          if ((warningIsTheRuleName(warning, ruleKey) || "all".equals(warning)) && !"S1309".equals(ruleKey.rule())) {
+            return false;
+          }
+        }
+      }
+    }
+    return chain.accept(issue);
+  }
+
+  private boolean warningIsTheRuleName(String warning, RuleKey ruleKey) {
+    String[] parts = warning.split(":");
+    if (parts.length != 2) {
+      return false;
+    } else {
+      return parts[0].equals(ruleKey.repository()) && parts[1].equals(ruleKey.rule());
+    }
+  }
+}

--- a/java-squid/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
+++ b/java-squid/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
@@ -20,15 +20,14 @@
 package org.sonar.plugins.java.api;
 
 import com.google.common.annotations.Beta;
-import com.google.common.collect.Multimap;
 import org.sonar.api.BatchExtension;
 import org.sonar.api.resources.Resource;
 import org.sonar.java.bytecode.visitor.ResourceMapping;
 
 import javax.annotation.CheckForNull;
+
 import java.io.File;
 import java.util.Collection;
-import java.util.Map;
 
 @Beta
 public interface JavaResourceLocator extends BatchExtension, JavaFileScanner {
@@ -50,6 +49,4 @@ public interface JavaResourceLocator extends BatchExtension, JavaFileScanner {
   Integer getMethodStartLine(String fullyQualifiedMethodName);
 
   ResourceMapping getResourceMapping();
-
-  Map<String, Multimap<String, Integer>> getIgnoredLinesForRules();
 }

--- a/java-squid/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
+++ b/java-squid/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
@@ -24,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.sonar.api.resources.Project;
 import org.sonar.api.resources.ProjectFileSystem;
+import org.sonar.java.filters.SuppressWarningsFilter;
 import org.sonar.java.model.VisitorsBridge;
 
 import java.io.File;
@@ -34,7 +35,6 @@ import static org.mockito.Mockito.when;
 
 public class DefaultJavaResourceLocatorTest {
 
-
   private static DefaultJavaResourceLocator javaResourceLocator;
 
   @BeforeClass
@@ -43,12 +43,13 @@ public class DefaultJavaResourceLocatorTest {
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
 
     JavaClasspath javaClasspath = mock(JavaClasspath.class);
+    SuppressWarningsFilter suppressWarningsFilter = mock(SuppressWarningsFilter.class);
     when(javaClasspath.getBinaryDirs()).thenReturn(Lists.newArrayList(new File("target/test-classes")));
     when(javaClasspath.getElements()).thenReturn(Lists.newArrayList(new File("target/test-classes")));
     File baseDir = new File("src/test/java");
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
-    DefaultJavaResourceLocator jrl = new DefaultJavaResourceLocator(project, javaClasspath);
+    DefaultJavaResourceLocator jrl = new DefaultJavaResourceLocator(project, javaClasspath, suppressWarningsFilter);
     JavaAstScanner.scanSingleFile(new File("src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java"), new VisitorsBridge(jrl));
     javaResourceLocator = jrl;
   }
@@ -90,7 +91,7 @@ public class DefaultJavaResourceLocatorTest {
     assertThat(javaResourceLocator.classFilesToAnalyze()).hasSize(5);
   }
 
-  static class A { //NOSONAR
+  static class A { // NOSONAR
 
     interface I {
       void foo();

--- a/java-squid/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
+++ b/java-squid/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
@@ -22,6 +22,7 @@ package org.sonar.java;
 import com.google.common.collect.Lists;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.sonar.api.batch.SensorContext;
 import org.sonar.api.resources.Project;
 import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.java.filters.SuppressWarningsFilter;
@@ -41,15 +42,15 @@ public class DefaultJavaResourceLocatorTest {
   public static void setup() {
     Project project = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
-
     JavaClasspath javaClasspath = mock(JavaClasspath.class);
-    SuppressWarningsFilter suppressWarningsFilter = mock(SuppressWarningsFilter.class);
     when(javaClasspath.getBinaryDirs()).thenReturn(Lists.newArrayList(new File("target/test-classes")));
     when(javaClasspath.getElements()).thenReturn(Lists.newArrayList(new File("target/test-classes")));
     File baseDir = new File("src/test/java");
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
-    DefaultJavaResourceLocator jrl = new DefaultJavaResourceLocator(project, javaClasspath, suppressWarningsFilter);
+    SensorContext sensorContext = mock(SensorContext.class);
+    DefaultJavaResourceLocator jrl = new DefaultJavaResourceLocator(project, javaClasspath, new SuppressWarningsFilter());
+    jrl.setSensorContext(sensorContext);
     JavaAstScanner.scanSingleFile(new File("src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java"), new VisitorsBridge(jrl));
     javaResourceLocator = jrl;
   }

--- a/java-squid/src/test/java/org/sonar/java/JavaFilesCacheTest.java
+++ b/java-squid/src/test/java/org/sonar/java/JavaFilesCacheTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.java;
 
+import com.google.common.collect.Lists;
 import org.junit.Test;
 import org.sonar.java.model.VisitorsBridge;
 
@@ -53,23 +54,24 @@ public class JavaFilesCacheTest {
     assertThat(javaFilesCache.methodStartLines.keySet()).contains("org/sonar/java/JavaFilesCacheTest#method_start_lines_mapping()V");
     assertThat(javaFilesCache.methodStartLines.keySet()).contains("org/sonar/java/JavaFilesCacheTest$A#method()V");
     assertThat(javaFilesCache.methodStartLines.keySet()).contains("org/sonar/java/JavaFilesCacheTest#resource_file_mapping()V");
-    assertThat(javaFilesCache.ignoredLines).hasSize(13);
-    assertThat(javaFilesCache.ignoredLines).contains(67);
-    assertThat(javaFilesCache.ignoredLines).contains(68);
-    assertThat(javaFilesCache.ignoredLines).contains(71);
-    assertThat(javaFilesCache.ignoredLines).contains(81);
-    assertThat(javaFilesCache.ignoredLinesForRules.get("foo")).hasSize(5).contains(75,76,77,78,79);
-    assertThat(javaFilesCache.ignoredLinesForRules.get("bar")).hasSize(5).contains(75,76,77,78,79);
+    assertThat(javaFilesCache.suppressWarningLines.keySet()).hasSize(13);
+    for (Integer line : Lists.newArrayList(68, 69, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83)) {
+      assertThat(javaFilesCache.suppressWarningLines.get(line)).contains("all");
+    }
+    for (Integer line : Lists.newArrayList(77, 78, 79, 80, 81)) {
+      assertThat(javaFilesCache.suppressWarningLines.get(line)).contains("foo", "bar");
+    }
   }
 
   static class A {
-    interface I{
+    interface I {
       @SuppressWarnings("all")
       void foo();
     }
+
     private void method() {
       @SuppressWarnings("all")
-      class B{
+      class B {
         Object obj = new I() {
 
           @SuppressWarnings({"foo", "bar"})
@@ -81,6 +83,7 @@ public class JavaFilesCacheTest {
       }
     }
   }
-  @interface plop{}
+  @interface plop {
+  }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
+++ b/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
@@ -20,7 +20,6 @@
 package org.sonar.java;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import org.apache.commons.io.FileUtils;
@@ -118,13 +117,13 @@ public class SquidUserGuideTest {
       public void scanFile(JavaFileScannerContext context) {
         JavaFilesCache javaFilesCache = new JavaFilesCache();
         javaFilesCache.scanFile(context);
-        for (String key : javaFilesCache.resourcesCache.keySet()){
+        for (String key : javaFilesCache.resourcesCache.keySet()) {
           sourceFileCache.put(key, context.getFileKey());
         }
       }
     };
     squid = new JavaSquid(conf, null, measurer, javaResourceLocator, new CodeVisitor[0]);
-    Collection<File> files = FileUtils.listFiles(srcDir, new String[]{"java"}, true);
+    Collection<File> files = FileUtils.listFiles(srcDir, new String[] {"java"}, true);
     squid.scan(files, Collections.<File>emptyList(), Collections.singleton(binDir));
   }
 
@@ -135,8 +134,8 @@ public class SquidUserGuideTest {
     verify(context, atLeastOnce()).saveMeasure(files.capture(), captor.capture());
     Map<String, Double> metrics = new HashMap<String, Double>();
     for (Measure measure : captor.getAllValues()) {
-      if(measure.getValue() != null ){
-        if(metrics.get(measure.getMetricKey())==null) {
+      if (measure.getValue() != null) {
+        if (metrics.get(measure.getMetricKey()) == null) {
           metrics.put(measure.getMetricKey(), measure.getValue());
         } else {
           metrics.put(measure.getMetricKey(), metrics.get(measure.getMetricKey()) + measure.getValue());
@@ -164,9 +163,9 @@ public class SquidUserGuideTest {
     SourceCode collectionsPackage = squid.search("org/apache/commons/collections");
     SourceCode bufferPackage = squid.search("org/apache/commons/collections/buffer");
     SourceCode bidimapPackage = squid.search("org/apache/commons/collections/bidimap");
-//    assertThat(squid.getDependency(bidimapPackage, collectionsPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
-//    assertThat(squid.getDependency(collectionsPackage, bufferPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
-//    assertThat(squid.getDependency(collectionsPackage, bufferPackage).getRootEdges().size()).isEqualTo(7);
+    // assertThat(squid.getDependency(bidimapPackage, collectionsPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
+    // assertThat(squid.getDependency(collectionsPackage, bufferPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
+    // assertThat(squid.getDependency(collectionsPackage, bufferPackage).getRootEdges().size()).isEqualTo(7);
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
+++ b/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
@@ -21,7 +21,6 @@ package org.sonar.java;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
 import org.apache.commons.io.FileUtils;
 import org.fest.assertions.Delta;
 import org.junit.BeforeClass;
@@ -109,21 +108,16 @@ public class SquidUserGuideTest {
       }
 
       @Override
-      public Map<String, Multimap<String, Integer>> getIgnoredLinesForRules() {
-        return Maps.newHashMap();
-      }
-
-      @Override
       public void scanFile(JavaFileScannerContext context) {
         JavaFilesCache javaFilesCache = new JavaFilesCache();
         javaFilesCache.scanFile(context);
-        for (String key : javaFilesCache.resourcesCache.keySet()) {
+        for (String key : javaFilesCache.resourcesCache.keySet()){
           sourceFileCache.put(key, context.getFileKey());
         }
       }
     };
     squid = new JavaSquid(conf, null, measurer, javaResourceLocator, new CodeVisitor[0]);
-    Collection<File> files = FileUtils.listFiles(srcDir, new String[] {"java"}, true);
+    Collection<File> files = FileUtils.listFiles(srcDir, new String[]{"java"}, true);
     squid.scan(files, Collections.<File>emptyList(), Collections.singleton(binDir));
   }
 
@@ -134,8 +128,8 @@ public class SquidUserGuideTest {
     verify(context, atLeastOnce()).saveMeasure(files.capture(), captor.capture());
     Map<String, Double> metrics = new HashMap<String, Double>();
     for (Measure measure : captor.getAllValues()) {
-      if (measure.getValue() != null) {
-        if (metrics.get(measure.getMetricKey()) == null) {
+      if(measure.getValue() != null ){
+        if(metrics.get(measure.getMetricKey())==null) {
           metrics.put(measure.getMetricKey(), measure.getValue());
         } else {
           metrics.put(measure.getMetricKey(), metrics.get(measure.getMetricKey()) + measure.getValue());
@@ -163,9 +157,9 @@ public class SquidUserGuideTest {
     SourceCode collectionsPackage = squid.search("org/apache/commons/collections");
     SourceCode bufferPackage = squid.search("org/apache/commons/collections/buffer");
     SourceCode bidimapPackage = squid.search("org/apache/commons/collections/bidimap");
-    // assertThat(squid.getDependency(bidimapPackage, collectionsPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
-    // assertThat(squid.getDependency(collectionsPackage, bufferPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
-    // assertThat(squid.getDependency(collectionsPackage, bufferPackage).getRootEdges().size()).isEqualTo(7);
+//    assertThat(squid.getDependency(bidimapPackage, collectionsPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
+//    assertThat(squid.getDependency(collectionsPackage, bufferPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
+//    assertThat(squid.getDependency(collectionsPackage, bufferPackage).getRootEdges().size()).isEqualTo(7);
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/bytecode/BytecodeVisitorsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/bytecode/BytecodeVisitorsTest.java
@@ -67,11 +67,10 @@ public class BytecodeVisitorsTest {
     JavaConfiguration conf = new JavaConfiguration(Charset.forName("UTF-8"));
     Project project = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
-    SuppressWarningsFilter swf = mock(SuppressWarningsFilter.class);
     File baseDir = new File("src/test/files/bytecode/src");
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
-    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, swf);
+    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, new SuppressWarningsFilter());
     JavaSquid squid = new JavaSquid(conf, javaResourceLocator);
     Collection<File> files = FileUtils.listFiles(baseDir, new String[] {"java"}, true);
     File binDir = new File("src/test/files/bytecode/bin");

--- a/java-squid/src/test/java/org/sonar/java/bytecode/BytecodeVisitorsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/bytecode/BytecodeVisitorsTest.java
@@ -32,6 +32,7 @@ import org.sonar.java.DefaultJavaResourceLocator;
 import org.sonar.java.JavaConfiguration;
 import org.sonar.java.JavaSquid;
 import org.sonar.java.bytecode.visitor.ResourceMapping;
+import org.sonar.java.filters.SuppressWarningsFilter;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -66,12 +67,13 @@ public class BytecodeVisitorsTest {
     JavaConfiguration conf = new JavaConfiguration(Charset.forName("UTF-8"));
     Project project = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
+    SuppressWarningsFilter swf = mock(SuppressWarningsFilter.class);
     File baseDir = new File("src/test/files/bytecode/src");
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
-    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null);
+    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, swf);
     JavaSquid squid = new JavaSquid(conf, javaResourceLocator);
-    Collection<File> files = FileUtils.listFiles(baseDir, new String[]{"java"}, true);
+    Collection<File> files = FileUtils.listFiles(baseDir, new String[] {"java"}, true);
     File binDir = new File("src/test/files/bytecode/bin");
     squid.scan(files, Collections.<File>emptyList(), Collections.singleton(binDir));
     graph = squid.getGraph();
@@ -171,7 +173,6 @@ public class BytecodeVisitorsTest {
   public void testFileDependencies() {
     assertThat(graph.getEdge(sourceFile, tagException).getUsage()).isEqualTo("USES");
   }
-
 
   private static Resource findResource(String resource) {
     Set<Resource> directories = resourceMapping.directories();

--- a/java-squid/src/test/java/org/sonar/java/bytecode/BytecodeVisitorsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/bytecode/BytecodeVisitorsTest.java
@@ -22,6 +22,10 @@ package org.sonar.java.bytecode;
 import org.apache.commons.io.FileUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.sonar.api.batch.SensorContext;
 import org.sonar.api.design.Dependency;
 import org.sonar.api.resources.Directory;
 import org.sonar.api.resources.Project;
@@ -70,7 +74,17 @@ public class BytecodeVisitorsTest {
     File baseDir = new File("src/test/files/bytecode/src");
     when(project.getFileSystem()).thenReturn(pfs);
     when(pfs.getBasedir()).thenReturn(baseDir);
+    SensorContext sensorContext = mock(SensorContext.class);
+    when(sensorContext.getResource(Matchers.any(org.sonar.api.resources.File.class))).thenAnswer(new Answer<org.sonar.api.resources.File>() {
+      @Override
+      public org.sonar.api.resources.File answer(InvocationOnMock invocation) throws Throwable {
+        org.sonar.api.resources.File response = (org.sonar.api.resources.File) invocation.getArguments()[0];
+        response.setEffectiveKey("");
+        return response;
+      }
+    });
     DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(project, null, new SuppressWarningsFilter());
+    javaResourceLocator.setSensorContext(sensorContext);
     JavaSquid squid = new JavaSquid(conf, javaResourceLocator);
     Collection<File> files = FileUtils.listFiles(baseDir, new String[] {"java"}, true);
     File binDir = new File("src/test/files/bytecode/bin");

--- a/java-squid/src/test/java/org/sonar/java/filters/SuppressWarningsFilterTest.java
+++ b/java-squid/src/test/java/org/sonar/java/filters/SuppressWarningsFilterTest.java
@@ -1,0 +1,179 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.filters;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.issue.Issue;
+import org.sonar.api.issue.batch.IssueFilterChain;
+import org.sonar.api.rule.RuleKey;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SuppressWarningsFilterTest {
+
+  private static final String COMPONENT_KEY = "test:test.MyTest";
+  IssueFilterChain chain = mock(IssueFilterChain.class);
+  SuppressWarningsFilter filter = new SuppressWarningsFilter();
+
+  @Before
+  public void setupChain() {
+    when(chain.accept(isA(Issue.class))).thenReturn(true);
+  }
+
+  @Test
+  public void should_ignore_issue_if_out_of_scope() {
+    Issue issue = mock(Issue.class);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(issue.ruleKey()).thenReturn(RuleKey.of("squid", "firstIssue"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "squid:secondIssue", 12, 16);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    // issue on file
+    when(issue.line()).thenReturn(null);
+    assertTrue(filter.accept(issue, chain));
+
+    // issue on not flagged line
+    when(issue.line()).thenReturn(21);
+    assertTrue(filter.accept(issue, chain));
+  }
+
+  @Test
+  public void should_ignore_issue_if_in_other_component() {
+    Issue issue = mock(Issue.class);
+
+    // issue in other component
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY + "2");
+    when(issue.ruleKey()).thenReturn(RuleKey.of("squid", "firstIssue"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "squid:secondIssue", 12, 16);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    // issue on file
+    when(issue.line()).thenReturn(null);
+    assertTrue(filter.accept(issue, chain));
+
+    // issue on not flagged line
+    when(issue.line()).thenReturn(21);
+    assertTrue(filter.accept(issue, chain));
+  }
+
+  @Test
+  public void should_ignore_issue_if_same_rule_explicitly_mentioned_as_warning_parameter() {
+    Issue issue = mock(Issue.class);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(issue.ruleKey()).thenReturn(RuleKey.of("pmd", "CloseResource"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "pmd:CloseResource", 12, 16);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    // issue on every line covered by @SuppressWarnings, but same as explicitly mentioned
+    for (int i = 12; i <= 16; i++) {
+      when(issue.line()).thenReturn(i);
+      assertFalse(filter.accept(issue, chain));
+    }
+  }
+
+  @Test
+  public void should_accept_issue_if_different_rule_explicitly_mentioned_as_warning_parameter() {
+    Issue issue = mock(Issue.class);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(issue.ruleKey()).thenReturn(RuleKey.of("pmd", "CloseResource"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "pmd:OtherIssue", 12, 16);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    // issue on line covered by @SuppressWarnings, but different from the one explicitly mentioned
+    when(issue.line()).thenReturn(15);
+    assertTrue(filter.accept(issue, chain));
+  }
+
+  @Test
+  public void should_accept_issue_if_suppressWarning_rule_enabled_with_warning_is_all() {
+    Issue issue = mock(Issue.class);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(issue.ruleKey()).thenReturn(RuleKey.of("squid", "S1309"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "all", 12, 16);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    // issue on line covered by @SuppressWarnings
+    when(issue.line()).thenReturn(12);
+    assertTrue(filter.accept(issue, chain));
+  }
+
+  @Test
+  public void should_ignore_issue_if_suppressWarning_rule_enabled_but_explicitly_hidden() {
+    Issue issue = mock(Issue.class);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(issue.ruleKey()).thenReturn(RuleKey.of("squid", "S1309"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "unchecked", 12, 16);
+    addWarning(suppressWarningLines, "cast", 13, 15);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    // issue on line covered by @SuppressWarnings
+    when(issue.line()).thenReturn(12);
+    assertTrue(filter.accept(issue, chain));
+
+    when(issue.line()).thenReturn(14);
+    assertTrue(filter.accept(issue, chain));
+  }
+
+  @Test
+  public void should_ignore_issue_if_suppressWarning_rule_not_enabled() {
+    Issue issue = mock(Issue.class);
+    when(issue.componentKey()).thenReturn(COMPONENT_KEY);
+    when(issue.ruleKey()).thenReturn(RuleKey.of("squid", "firstIssue"));
+
+    Multimap<Integer, String> suppressWarningLines = HashMultimap.create();
+    addWarning(suppressWarningLines, "all", 12, 16);
+
+    filter.addComponent(COMPONENT_KEY, suppressWarningLines);
+
+    when(issue.line()).thenReturn(12);
+    assertFalse(filter.accept(issue, chain));
+  }
+
+  private void addWarning(Multimap<Integer, String> multimap, String warning, int startLine, int endLine) {
+    for (int i = startLine; i <= endLine; i++) {
+      multimap.put(i, warning);
+    }
+  }
+}

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/Bridges.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/Bridges.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.plugins.java;
 
-import com.google.common.collect.Multimap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.CoreProperties;
@@ -39,8 +38,6 @@ import org.sonar.plugins.java.bridges.DesignBridge;
 import org.sonar.squidbridge.api.CodeVisitor;
 import org.sonar.squidbridge.api.SourceFile;
 
-import java.util.Map;
-
 public class Bridges {
 
   private static final Logger LOG = LoggerFactory.getLogger(Bridges.class);
@@ -54,7 +51,7 @@ public class Bridges {
   }
 
   public void save(SensorContext context, Project project, Checks<CodeVisitor> checks, ResourceMapping resourceMapping,
-                   ResourcePerspectives resourcePerspectives, NoSonarFilter noSonarFilter, RulesProfile rulesProfile, Map<String, Multimap<String, Integer>> ignoredLinesForRules) {
+    ResourcePerspectives resourcePerspectives, NoSonarFilter noSonarFilter, RulesProfile rulesProfile) {
     boolean skipPackageDesignAnalysis = settings.getBoolean(CoreProperties.DESIGN_SKIP_PACKAGE_DESIGN_PROPERTY);
     //Design
     if (!skipPackageDesignAnalysis && squid.isBytecodeScanned()) {
@@ -62,7 +59,7 @@ public class Bridges {
       designBridge.saveDesign(project);
     }
     //Report Issues
-    ChecksBridge checksBridge = new ChecksBridge(checks, resourcePerspectives, rulesProfile, ignoredLinesForRules);
+    ChecksBridge checksBridge = new ChecksBridge(checks, resourcePerspectives, rulesProfile);
     reportIssues(resourceMapping, noSonarFilter, checksBridge, project);
   }
 

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaPlugin.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaPlugin.java
@@ -50,44 +50,43 @@ public class JavaPlugin extends SonarPlugin {
     builder.addAll(JaCoCoExtensions.getExtensions());
     builder.addAll(JavaClasspathProperties.getProperties());
     builder.add(
-      JavaClasspath.class,
-      JavaCommonRulesEngine.class,
-      JavaCommonRulesDecorator.class,
-      Java.class,
-      CommonRulesSonarWayProfile.class,
-      PropertyDefinition.builder(Java.FILE_SUFFIXES_KEY)
-        .defaultValue(Java.DEFAULT_FILE_SUFFIXES)
-        .name("File suffixes")
-        .description("Comma-separated list of suffixes for files to analyze. To not filter, leave the list empty.")
-        .subCategory("General")
-        .onQualifiers(Qualifiers.PROJECT)
-        .build(),
-      PropertyDefinition.builder(JavaPlugin.SQUID_ANALYSE_ACCESSORS_PROPERTY)
-        .defaultValue(JavaPlugin.SQUID_ANALYSE_ACCESSORS_DEFAULT_VALUE + "")
-        .category(JAVA_CATEGORY)
-        .subCategory(GENERAL_SUBCATEGORY)
-        .name("Separate Accessors")
-        .description("Flag whether SonarQube should separate accessors (getters/setters) from methods. " +
-          "In that case, accessors are not counted in metrics such as complexity or API documentation.")
-        .type(PropertyType.BOOLEAN)
-        .onQualifiers(Qualifiers.PROJECT)
-        .build(),
-      PropertyDefinition.builder(CoreProperties.DESIGN_SKIP_DESIGN_PROPERTY)
-        .defaultValue(CoreProperties.DESIGN_SKIP_DESIGN_DEFAULT_VALUE + "")
-        .category(JAVA_CATEGORY)
-        .subCategory(GENERAL_SUBCATEGORY)
-        .name("Skip design analysis")
-        .type(PropertyType.BOOLEAN)
-        .hidden()
-        .build(),
+        JavaClasspath.class,
+        JavaCommonRulesEngine.class,
+        JavaCommonRulesDecorator.class,
+        Java.class,
+        CommonRulesSonarWayProfile.class,
+        PropertyDefinition.builder(Java.FILE_SUFFIXES_KEY)
+            .defaultValue(Java.DEFAULT_FILE_SUFFIXES)
+            .name("File suffixes")
+            .description("Comma-separated list of suffixes for files to analyze. To not filter, leave the list empty.")
+            .subCategory("General")
+            .onQualifiers(Qualifiers.PROJECT)
+            .build(),
+        PropertyDefinition.builder(JavaPlugin.SQUID_ANALYSE_ACCESSORS_PROPERTY)
+            .defaultValue(JavaPlugin.SQUID_ANALYSE_ACCESSORS_DEFAULT_VALUE + "")
+            .category(JAVA_CATEGORY)
+            .subCategory(GENERAL_SUBCATEGORY)
+            .name("Separate Accessors")
+            .description("Flag whether SonarQube should separate accessors (getters/setters) from methods. " +
+                "In that case, accessors are not counted in metrics such as complexity or API documentation.")
+            .type(PropertyType.BOOLEAN)
+            .onQualifiers(Qualifiers.PROJECT)
+            .build(),
+        PropertyDefinition.builder(CoreProperties.DESIGN_SKIP_DESIGN_PROPERTY)
+            .defaultValue(CoreProperties.DESIGN_SKIP_DESIGN_DEFAULT_VALUE + "")
+            .category(JAVA_CATEGORY)
+            .subCategory(GENERAL_SUBCATEGORY)
+            .name("Skip design analysis")
+            .type(PropertyType.BOOLEAN)
+            .hidden()
+            .build(),
 
-      JavaRuleRepository.class,
-      JavaSonarWayProfile.class,
-      SonarComponents.class,
-      DefaultJavaResourceLocator.class,
-      JavaSquidSensor.class,
-      SuppressWarningsFilter.class
-      );
+        JavaRuleRepository.class,
+        JavaSonarWayProfile.class,
+        SonarComponents.class,
+        DefaultJavaResourceLocator.class,
+        JavaSquidSensor.class,
+        SuppressWarningsFilter.class);
     return builder.build();
   }
 

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaPlugin.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaPlugin.java
@@ -29,6 +29,7 @@ import org.sonar.java.DefaultJavaResourceLocator;
 import org.sonar.java.JavaClasspath;
 import org.sonar.java.JavaClasspathProperties;
 import org.sonar.java.SonarComponents;
+import org.sonar.java.filters.SuppressWarningsFilter;
 import org.sonar.plugins.jacoco.JaCoCoExtensions;
 import org.sonar.plugins.surefire.SurefireExtensions;
 
@@ -49,42 +50,44 @@ public class JavaPlugin extends SonarPlugin {
     builder.addAll(JaCoCoExtensions.getExtensions());
     builder.addAll(JavaClasspathProperties.getProperties());
     builder.add(
-        JavaClasspath.class,
-        JavaCommonRulesEngine.class,
-        JavaCommonRulesDecorator.class,
-        Java.class,
-        CommonRulesSonarWayProfile.class,
-        PropertyDefinition.builder(Java.FILE_SUFFIXES_KEY)
-            .defaultValue(Java.DEFAULT_FILE_SUFFIXES)
-            .name("File suffixes")
-            .description("Comma-separated list of suffixes for files to analyze. To not filter, leave the list empty.")
-            .subCategory("General")
-            .onQualifiers(Qualifiers.PROJECT)
-            .build(),
-        PropertyDefinition.builder(JavaPlugin.SQUID_ANALYSE_ACCESSORS_PROPERTY)
-            .defaultValue(JavaPlugin.SQUID_ANALYSE_ACCESSORS_DEFAULT_VALUE + "")
-            .category(JAVA_CATEGORY)
-            .subCategory(GENERAL_SUBCATEGORY)
-            .name("Separate Accessors")
-            .description("Flag whether SonarQube should separate accessors (getters/setters) from methods. " +
-                "In that case, accessors are not counted in metrics such as complexity or API documentation.")
-            .type(PropertyType.BOOLEAN)
-            .onQualifiers(Qualifiers.PROJECT)
-            .build(),
-        PropertyDefinition.builder(CoreProperties.DESIGN_SKIP_DESIGN_PROPERTY)
-            .defaultValue(CoreProperties.DESIGN_SKIP_DESIGN_DEFAULT_VALUE + "")
-            .category(JAVA_CATEGORY)
-            .subCategory(GENERAL_SUBCATEGORY)
-            .name("Skip design analysis")
-            .type(PropertyType.BOOLEAN)
-            .hidden()
-            .build(),
+      JavaClasspath.class,
+      JavaCommonRulesEngine.class,
+      JavaCommonRulesDecorator.class,
+      Java.class,
+      CommonRulesSonarWayProfile.class,
+      PropertyDefinition.builder(Java.FILE_SUFFIXES_KEY)
+        .defaultValue(Java.DEFAULT_FILE_SUFFIXES)
+        .name("File suffixes")
+        .description("Comma-separated list of suffixes for files to analyze. To not filter, leave the list empty.")
+        .subCategory("General")
+        .onQualifiers(Qualifiers.PROJECT)
+        .build(),
+      PropertyDefinition.builder(JavaPlugin.SQUID_ANALYSE_ACCESSORS_PROPERTY)
+        .defaultValue(JavaPlugin.SQUID_ANALYSE_ACCESSORS_DEFAULT_VALUE + "")
+        .category(JAVA_CATEGORY)
+        .subCategory(GENERAL_SUBCATEGORY)
+        .name("Separate Accessors")
+        .description("Flag whether SonarQube should separate accessors (getters/setters) from methods. " +
+          "In that case, accessors are not counted in metrics such as complexity or API documentation.")
+        .type(PropertyType.BOOLEAN)
+        .onQualifiers(Qualifiers.PROJECT)
+        .build(),
+      PropertyDefinition.builder(CoreProperties.DESIGN_SKIP_DESIGN_PROPERTY)
+        .defaultValue(CoreProperties.DESIGN_SKIP_DESIGN_DEFAULT_VALUE + "")
+        .category(JAVA_CATEGORY)
+        .subCategory(GENERAL_SUBCATEGORY)
+        .name("Skip design analysis")
+        .type(PropertyType.BOOLEAN)
+        .hidden()
+        .build(),
 
-        JavaRuleRepository.class,
-        JavaSonarWayProfile.class,
-        SonarComponents.class,
-        DefaultJavaResourceLocator.class,
-        JavaSquidSensor.class);
+      JavaRuleRepository.class,
+      JavaSonarWayProfile.class,
+      SonarComponents.class,
+      DefaultJavaResourceLocator.class,
+      JavaSquidSensor.class,
+      SuppressWarningsFilter.class
+      );
     return builder.build();
   }
 

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSquidSensor.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSquidSensor.java
@@ -65,7 +65,7 @@ public class JavaSquidSensor implements Sensor {
   private final NoSonarFilter noSonarFilter;
 
   public JavaSquidSensor(RulesProfile profile, JavaClasspath javaClasspath, SonarComponents sonarComponents, FileSystem fs,
-                         DefaultJavaResourceLocator javaResourceLocator, Settings settings, NoSonarFilter noSonarFilter, CheckFactory checkFactory) {
+    DefaultJavaResourceLocator javaResourceLocator, Settings settings, NoSonarFilter noSonarFilter, CheckFactory checkFactory) {
     this.profile = profile;
     this.noSonarFilter = noSonarFilter;
     this.javaClasspath = javaClasspath;
@@ -83,6 +83,7 @@ public class JavaSquidSensor implements Sensor {
 
   @Override
   public void analyse(Project project, SensorContext context) {
+    javaResourceLocator.setSensorContext(context);
     Checks<CodeVisitor> checks = checkFactory.<CodeVisitor>create(CheckList.REPOSITORY_KEY).addAnnotatedChecks(CheckList.getChecks());
     Collection<CodeVisitor> checkList = checks.all();
     JavaConfiguration configuration = createConfiguration();
@@ -90,7 +91,7 @@ public class JavaSquidSensor implements Sensor {
     JavaSquid squid = new JavaSquid(configuration, sonarComponents, measurer, javaResourceLocator, checkList.toArray(new CodeVisitor[checkList.size()]));
     squid.scan(getSourceFiles(), getTestFiles(), getBytecodeFiles());
     new Bridges(squid, settings).save(context, project, checks, javaResourceLocator.getResourceMapping(),
-        sonarComponents.getResourcePerspectives(), noSonarFilter, profile, javaResourceLocator.getIgnoredLinesForRules());
+      sonarComponents.getResourcePerspectives(), noSonarFilter, profile);
   }
 
   private Iterable<File> getSourceFiles() {

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/bridges/ChecksBridge.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/bridges/ChecksBridge.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.plugins.java.bridges;
 
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.sonar.api.batch.rule.Checks;
 import org.sonar.api.component.ResourcePerspectives;
@@ -38,7 +37,6 @@ import org.sonar.squidbridge.api.CodeVisitor;
 import org.sonar.squidbridge.api.SourceFile;
 
 import java.io.File;
-import java.util.Map;
 import java.util.Set;
 
 public class ChecksBridge {
@@ -46,15 +44,12 @@ public class ChecksBridge {
   private final Checks<CodeVisitor> checks;
   private final ResourcePerspectives resourcePerspectives;
   private final RulesProfile rulesProfile;
-  private final Map<String, Multimap<String, Integer>> ignoredLinesForRulesByFile;
   private Set<Directory> dirsWithoutPackageInfo;
 
-  public ChecksBridge(Checks<CodeVisitor> checks, ResourcePerspectives resourcePerspectives,
-                      RulesProfile rulesProfile, Map<String, Multimap<String, Integer>> ignoredLinesForRulesByFile) {
+  public ChecksBridge(Checks<CodeVisitor> checks, ResourcePerspectives resourcePerspectives, RulesProfile rulesProfile) {
     this.checks = checks;
     this.resourcePerspectives = resourcePerspectives;
     this.rulesProfile = rulesProfile;
-    this.ignoredLinesForRulesByFile = ignoredLinesForRulesByFile;
   }
 
   public void reportIssues(SourceFile squidFile, Resource sonarFile) {
@@ -70,8 +65,7 @@ public class ChecksBridge {
         } else {
           ruleKey = checks.ruleKey((CodeVisitor) checkMessage.getCheck());
         }
-        Multimap<String, Integer> ignoreLinesForRules = ignoredLinesForRulesByFile.get(squidFile.getKey());
-        if (ruleKey != null && ignoreLinesForRules != null && !ignoreLinesForRules.get(ruleKey.toString()).contains(checkMessage.getLine())) {
+        if (ruleKey != null) {
           Issue issue = issuable.newIssueBuilder()
               .ruleKey(ruleKey)
               .line(checkMessage.getLine())

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaPluginTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaPluginTest.java
@@ -27,7 +27,7 @@ public class JavaPluginTest {
 
   @Test
   public void test() {
-    assertThat(new JavaPlugin().getExtensions().size()).isEqualTo(25);
+    assertThat(new JavaPlugin().getExtensions().size()).isEqualTo(26);
   }
 
 }


### PR DESCRIPTION
Added new IssueFilter `SuppressWarningFilter`, which will be used to hide issue if required.
Issues can be hidden by using the `@SuppressWarnings` annotation as folow:
- `@SuppressWarnings("[rule]")` : will hide all the issue related to the given rule in the following block
- `@SuppressWarnings("all")` : will hide all the issue in the block