### PR TITLE
SONARJAVA-861 sonar.squid.analyse.property now taken into account in Public API metric

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
@@ -37,7 +37,7 @@ public class AbstractDeprecatedChecker extends SubscriptionBaseVisitor {
   private static final Kind[] METHOD_KINDS = PublicApiChecker.methodKinds();
   private static final Kind[] API_KINDS = PublicApiChecker.apiKinds();
 
-  private final PublicApiChecker publicApiChecker = new PublicApiChecker();
+  private final PublicApiChecker publicApiChecker = new PublicApiChecker(false);
 
   @Override
   public List<Kind> nodesToVisit() {

--- a/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
@@ -37,7 +37,7 @@ public class AbstractDeprecatedChecker extends SubscriptionBaseVisitor {
   private static final Kind[] METHOD_KINDS = PublicApiChecker.methodKinds();
   private static final Kind[] API_KINDS = PublicApiChecker.apiKinds();
 
-  private final PublicApiChecker publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
+  private final PublicApiChecker publicApiChecker = PublicApiChecker.newInstanceWithAccessorsHandledAsMethods();
 
   @Override
   public List<Kind> nodesToVisit() {

--- a/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
@@ -37,7 +37,7 @@ public class AbstractDeprecatedChecker extends SubscriptionBaseVisitor {
   private static final Kind[] METHOD_KINDS = PublicApiChecker.methodKinds();
   private static final Kind[] API_KINDS = PublicApiChecker.apiKinds();
 
-  private final PublicApiChecker publicApiChecker = new PublicApiChecker(false);
+  private final PublicApiChecker publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
 
   @Override
   public List<Kind> nodesToVisit() {

--- a/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbstractDeprecatedChecker.java
@@ -37,7 +37,7 @@ public class AbstractDeprecatedChecker extends SubscriptionBaseVisitor {
   private static final Kind[] METHOD_KINDS = PublicApiChecker.methodKinds();
   private static final Kind[] API_KINDS = PublicApiChecker.apiKinds();
 
-  private final PublicApiChecker publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
+  private final PublicApiChecker publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
 
   @Override
   public List<Kind> nodesToVisit() {

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -80,7 +80,7 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
     this.context = context;
     classTrees.clear();
     currentParents.clear();
-    publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
+    publicApiChecker = PublicApiChecker.newInstanceWithAccessorsHandledAsMethods();
     packageName = "";
     this.context = context;
     scan(context.getTree());

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -80,7 +80,7 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
     this.context = context;
     classTrees.clear();
     currentParents.clear();
-    publicApiChecker = new PublicApiChecker(false);
+    publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
     packageName = "";
     this.context = context;
     scan(context.getTree());

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -80,7 +80,7 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
     this.context = context;
     classTrees.clear();
     currentParents.clear();
-    publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
+    publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
     packageName = "";
     this.context = context;
     scan(context.getTree());

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -80,7 +80,7 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
     this.context = context;
     classTrees.clear();
     currentParents.clear();
-    publicApiChecker = new PublicApiChecker();
+    publicApiChecker = new PublicApiChecker(false);
     packageName = "";
     this.context = context;
     scan(context.getTree());

--- a/java-squid/src/main/java/org/sonar/java/JavaConfiguration.java
+++ b/java-squid/src/main/java/org/sonar/java/JavaConfiguration.java
@@ -24,7 +24,7 @@ import java.nio.charset.Charset;
 public class JavaConfiguration {
 
   private final Charset charset;
-  private boolean analyzePropertyAccessors = true;
+  private boolean separateAccessorsFromMethods = true;
 
   public JavaConfiguration(Charset charset) {
     this.charset = charset;
@@ -34,12 +34,12 @@ public class JavaConfiguration {
     return charset;
   }
 
-  public boolean isAnalysePropertyAccessors() {
-    return analyzePropertyAccessors;
+  public boolean separatesAccessorsFromMethods() {
+    return separateAccessorsFromMethods;
   }
 
-  public void setAnalyzePropertyAccessors(boolean analyzePropertyAccessors) {
-    this.analyzePropertyAccessors = analyzePropertyAccessors;
+  public void setSeparateAccessorsFromMethods(boolean separateAccessorsFromMethods) {
+    this.separateAccessorsFromMethods = separateAccessorsFromMethods;
   }
 
 }

--- a/java-squid/src/main/java/org/sonar/java/JavaSquid.java
+++ b/java-squid/src/main/java/org/sonar/java/JavaSquid.java
@@ -84,7 +84,7 @@ public class JavaSquid implements SourceCodeSearchEngine {
     }
     VisitorsBridge visitorsBridge = new VisitorsBridge(visitorsToBridge, sonarComponents);
     visitorsBridge.setCharset(conf.getCharset());
-    visitorsBridge.setAnalyseAccessors(conf.isAnalysePropertyAccessors());
+    visitorsBridge.setAnalyseAccessors(conf.separatesAccessorsFromMethods());
     astScanner.accept(visitorsBridge);
 
     if (sonarComponents != null) {

--- a/java-squid/src/main/java/org/sonar/java/Measurer.java
+++ b/java-squid/src/main/java/org/sonar/java/Measurer.java
@@ -90,9 +90,9 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     complexityInMethods = 0;
     accessors = 0;
     classes = 0;
-    PublicApiChecker publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
+    PublicApiChecker publicApiChecker = PublicApiChecker.newInstanceWithAccessorsHandledAsMethods();
     if (separateAccessorsFromMethods) {
-      publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsSeparatedFromMethods();
+      publicApiChecker = PublicApiChecker.newInstanceWithAccessorsSeparatedFromMethods();
     }
     publicApiChecker.scan(context.getTree());
     methodComplexityDistribution = new RangeDistributionBuilder(CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION, LIMITS_COMPLEXITY_METHODS);

--- a/java-squid/src/main/java/org/sonar/java/Measurer.java
+++ b/java-squid/src/main/java/org/sonar/java/Measurer.java
@@ -90,7 +90,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     complexityInMethods = 0;
     accessors = 0;
     classes = 0;
-    PublicApiChecker publicApiChecker = new PublicApiChecker();
+    PublicApiChecker publicApiChecker = new PublicApiChecker(analyseAccessors);
     publicApiChecker.scan(context.getTree());
     methodComplexityDistribution = new RangeDistributionBuilder(CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION, LIMITS_COMPLEXITY_METHODS);
     super.scanFile(context);

--- a/java-squid/src/main/java/org/sonar/java/Measurer.java
+++ b/java-squid/src/main/java/org/sonar/java/Measurer.java
@@ -55,7 +55,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
 
   private final SensorContext sensorContext;
   private final Project project;
-  private final boolean analyseAccessors;
+  private final boolean ignoreAccessors;
   private File sonarFile;
   private int methods;
   private int accessors;
@@ -67,10 +67,10 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
   private Charset charset;
   private double classes;
 
-  public Measurer(Project project, SensorContext context, boolean analyseAccessors) {
+  public Measurer(Project project, SensorContext context, boolean ignoreAccessors) {
     this.project = project;
     this.sensorContext = context;
-    this.analyseAccessors = analyseAccessors;
+    this.ignoreAccessors = ignoreAccessors;
     accessorVisitor = new AccessorVisitor();
   }
 
@@ -90,7 +90,10 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     complexityInMethods = 0;
     accessors = 0;
     classes = 0;
-    PublicApiChecker publicApiChecker = new PublicApiChecker(analyseAccessors);
+    PublicApiChecker publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
+    if (ignoreAccessors) {
+      publicApiChecker = PublicApiChecker.newPublicApiCheckerWithoutAccessorAnalysis();
+    }
     publicApiChecker.scan(context.getTree());
     methodComplexityDistribution = new RangeDistributionBuilder(CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION, LIMITS_COMPLEXITY_METHODS);
     super.scanFile(context);
@@ -137,7 +140,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     if (tree.is(Tree.Kind.METHOD, Tree.Kind.CONSTRUCTOR) && classTrees.peek().simpleName() != null) {
       //don't count methods in anonymous classes.
       MethodTree methodTree = (MethodTree) tree;
-      if (analyseAccessors && accessorVisitor.isAccessor(classTrees.peek(), methodTree)) {
+      if (ignoreAccessors && accessorVisitor.isAccessor(classTrees.peek(), methodTree)) {
         accessors++;
       } else {
         methods++;

--- a/java-squid/src/main/java/org/sonar/java/Measurer.java
+++ b/java-squid/src/main/java/org/sonar/java/Measurer.java
@@ -55,7 +55,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
 
   private final SensorContext sensorContext;
   private final Project project;
-  private final boolean ignoreAccessors;
+  private final boolean separateAccessorsFromMethods;
   private File sonarFile;
   private int methods;
   private int accessors;
@@ -67,10 +67,10 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
   private Charset charset;
   private double classes;
 
-  public Measurer(Project project, SensorContext context, boolean ignoreAccessors) {
+  public Measurer(Project project, SensorContext context, boolean separateAccessorsFromMethods) {
     this.project = project;
     this.sensorContext = context;
-    this.ignoreAccessors = ignoreAccessors;
+    this.separateAccessorsFromMethods = separateAccessorsFromMethods;
     accessorVisitor = new AccessorVisitor();
   }
 
@@ -90,9 +90,9 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     complexityInMethods = 0;
     accessors = 0;
     classes = 0;
-    PublicApiChecker publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
-    if (ignoreAccessors) {
-      publicApiChecker = PublicApiChecker.newPublicApiCheckerWithoutAccessorAnalysis();
+    PublicApiChecker publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
+    if (separateAccessorsFromMethods) {
+      publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsSeparatedFromMethods();
     }
     publicApiChecker.scan(context.getTree());
     methodComplexityDistribution = new RangeDistributionBuilder(CoreMetrics.FUNCTION_COMPLEXITY_DISTRIBUTION, LIMITS_COMPLEXITY_METHODS);
@@ -140,7 +140,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     if (tree.is(Tree.Kind.METHOD, Tree.Kind.CONSTRUCTOR) && classTrees.peek().simpleName() != null) {
       //don't count methods in anonymous classes.
       MethodTree methodTree = (MethodTree) tree;
-      if (ignoreAccessors && accessorVisitor.isAccessor(classTrees.peek(), methodTree)) {
+      if (separateAccessorsFromMethods && accessorVisitor.isAccessor(classTrees.peek(), methodTree)) {
         accessors++;
       } else {
         methods++;

--- a/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
@@ -76,7 +76,7 @@ public class PublicApiChecker extends BaseTreeVisitor {
   private final Deque<Tree> currentParents = new LinkedList<Tree>();
   private double publicApi;
   private double documentedPublicApi;
-  private boolean separateAccessorsFromMethods;
+  private final boolean separateAccessorsFromMethods;
   private final AccessorVisitor accessorVisitor;
 
   public static PublicApiChecker newInstanceWithAccessorsHandledAsMethods() {

--- a/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
@@ -79,11 +79,11 @@ public class PublicApiChecker extends BaseTreeVisitor {
   private boolean separateAccessorsFromMethods;
   private final AccessorVisitor accessorVisitor;
 
-  public static PublicApiChecker newPublicApiCheckerAccessorsHandledAsMethods() {
+  public static PublicApiChecker newInstanceWithAccessorsHandledAsMethods() {
     return new PublicApiChecker(false);
   }
 
-  public static PublicApiChecker newPublicApiCheckerAccessorsSeparatedFromMethods() {
+  public static PublicApiChecker newInstanceWithAccessorsSeparatedFromMethods() {
     return new PublicApiChecker(true);
   }
 
@@ -298,9 +298,4 @@ public class PublicApiChecker extends BaseTreeVisitor {
     }
     return ParsingUtils.scaleValue(documentedPublicApi / publicApi * 100, 2);
   }
-
-  public boolean separatesAccessorsFromMethods() {
-    return separateAccessorsFromMethods;
-  }
-
 }

--- a/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
@@ -44,6 +44,7 @@ import org.sonar.plugins.java.api.tree.Tree.Kind;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 import javax.annotation.Nullable;
+
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -75,11 +76,19 @@ public class PublicApiChecker extends BaseTreeVisitor {
   private final Deque<Tree> currentParents = new LinkedList<Tree>();
   private double publicApi;
   private double documentedPublicApi;
-  private boolean analyseAccessors;
+  private boolean ignoreAccessors;
   private final AccessorVisitor accessorVisitor;
 
-  public PublicApiChecker(boolean analyseAccessors) {
-    this.analyseAccessors = analyseAccessors;
+  public static PublicApiChecker newDefaultPublicApiChecker() {
+    return new PublicApiChecker(false);
+  }
+
+  public static PublicApiChecker newPublicApiCheckerWithoutAccessorAnalysis() {
+    return new PublicApiChecker(true);
+  }
+
+  private PublicApiChecker(boolean ignoreAccessors) {
+    this.ignoreAccessors = ignoreAccessors;
     this.accessorVisitor = new AccessorVisitor();
   }
 
@@ -152,7 +161,7 @@ public class PublicApiChecker extends BaseTreeVisitor {
 
   public boolean isPublicApi(ClassTree classTree, MethodTree methodTree) {
     Preconditions.checkNotNull(classTree);
-    if (analyseAccessors && accessorVisitor.isAccessor(classTree, methodTree)) {
+    if (ignoreAccessors && accessorVisitor.isAccessor(classTree, methodTree)) {
       return false;
     } else if (isPublicInterface(classTree)) {
       return !hasOverrideAnnotation(methodTree);
@@ -289,4 +298,9 @@ public class PublicApiChecker extends BaseTreeVisitor {
     }
     return ParsingUtils.scaleValue(documentedPublicApi / publicApi * 100, 2);
   }
+
+  public boolean ignoresAccessors() {
+    return ignoreAccessors;
+  }
+
 }

--- a/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
@@ -76,19 +76,19 @@ public class PublicApiChecker extends BaseTreeVisitor {
   private final Deque<Tree> currentParents = new LinkedList<Tree>();
   private double publicApi;
   private double documentedPublicApi;
-  private boolean ignoreAccessors;
+  private boolean separateAccessorsFromMethods;
   private final AccessorVisitor accessorVisitor;
 
-  public static PublicApiChecker newDefaultPublicApiChecker() {
+  public static PublicApiChecker newPublicApiCheckerAccessorsHandledAsMethods() {
     return new PublicApiChecker(false);
   }
 
-  public static PublicApiChecker newPublicApiCheckerWithoutAccessorAnalysis() {
+  public static PublicApiChecker newPublicApiCheckerAccessorsSeparatedFromMethods() {
     return new PublicApiChecker(true);
   }
 
-  private PublicApiChecker(boolean ignoreAccessors) {
-    this.ignoreAccessors = ignoreAccessors;
+  private PublicApiChecker(boolean separateAccessorsFromMethods) {
+    this.separateAccessorsFromMethods = separateAccessorsFromMethods;
     this.accessorVisitor = new AccessorVisitor();
   }
 
@@ -161,7 +161,7 @@ public class PublicApiChecker extends BaseTreeVisitor {
 
   public boolean isPublicApi(ClassTree classTree, MethodTree methodTree) {
     Preconditions.checkNotNull(classTree);
-    if (ignoreAccessors && accessorVisitor.isAccessor(classTree, methodTree)) {
+    if (separateAccessorsFromMethods && accessorVisitor.isAccessor(classTree, methodTree)) {
       return false;
     } else if (isPublicInterface(classTree)) {
       return !hasOverrideAnnotation(methodTree);
@@ -299,8 +299,8 @@ public class PublicApiChecker extends BaseTreeVisitor {
     return ParsingUtils.scaleValue(documentedPublicApi / publicApi * 100, 2);
   }
 
-  public boolean ignoresAccessors() {
-    return ignoreAccessors;
+  public boolean separatesAccessorsFromMethods() {
+    return separateAccessorsFromMethods;
   }
 
 }

--- a/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
@@ -75,6 +75,13 @@ public class PublicApiChecker extends BaseTreeVisitor {
   private final Deque<Tree> currentParents = new LinkedList<Tree>();
   private double publicApi;
   private double documentedPublicApi;
+  private boolean analyseAccessors;
+  private final AccessorVisitor accessorVisitor;
+
+  public PublicApiChecker(boolean analyseAccessors) {
+    this.analyseAccessors = analyseAccessors;
+    this.accessorVisitor = new AccessorVisitor();
+  }
 
   public static Kind[] classKinds() {
     return CLASS_KINDS.clone();
@@ -145,7 +152,9 @@ public class PublicApiChecker extends BaseTreeVisitor {
 
   public boolean isPublicApi(ClassTree classTree, MethodTree methodTree) {
     Preconditions.checkNotNull(classTree);
-    if (isPublicInterface(classTree)) {
+    if (analyseAccessors && accessorVisitor.isAccessor(classTree, methodTree)) {
+      return false;
+    } else if (isPublicInterface(classTree)) {
       return !hasOverrideAnnotation(methodTree);
     } else if (isEmptyDefaultConstructor(methodTree) || hasOverrideAnnotation(methodTree) || classTree.is(Tree.Kind.INTERFACE, Tree.Kind.ANNOTATION_TYPE)) {
       return false;

--- a/java-squid/src/test/files/ast/PublicApi.java
+++ b/java-squid/src/test/files/ast/PublicApi.java
@@ -139,3 +139,18 @@ class F {
     }
   };
 }
+
+class ClassWithGettersAndSetters {
+  private int myVarGetSet;
+
+  public void myMethodPublic() {
+  }
+
+  public int getMyVarGetSet() {
+    return myVarGetSet;
+  }
+
+  public void setMyVarGetSet(int myVarGetSet) {
+    this.myVarGetSet = myVarGetSet;
+  }
+}

--- a/java-squid/src/test/java/org/sonar/java/MeasurerTest.java
+++ b/java-squid/src/test/java/org/sonar/java/MeasurerTest.java
@@ -134,10 +134,10 @@ public class MeasurerTest {
   /**
    * Utility method to quickly get metric out of a file.
    */
-  private void checkMetric(boolean analyseAccessors, File baseDir, String filename, String metric, double expectedValue) {
-    Measurer measurer = new Measurer(sonarProject, context, analyseAccessors);
+  private void checkMetric(boolean ignoreAccessors, File baseDir, String filename, String metric, double expectedValue) {
+    Measurer measurer = new Measurer(sonarProject, context, ignoreAccessors);
     JavaConfiguration conf = new JavaConfiguration(Charsets.UTF_8);
-    conf.setAnalyzePropertyAccessors(analyseAccessors);
+    conf.setAnalyzePropertyAccessors(ignoreAccessors);
     squid = new JavaSquid(conf, null, measurer, null, new CodeVisitor[0]);
     squid.scan(Lists.newArrayList(new File(baseDir, filename)), Collections.<File>emptyList(), Collections.<File>emptyList());
     ArgumentCaptor<Measure> captor = ArgumentCaptor.forClass(Measure.class);

--- a/java-squid/src/test/java/org/sonar/java/MeasurerTest.java
+++ b/java-squid/src/test/java/org/sonar/java/MeasurerTest.java
@@ -134,10 +134,10 @@ public class MeasurerTest {
   /**
    * Utility method to quickly get metric out of a file.
    */
-  private void checkMetric(boolean ignoreAccessors, File baseDir, String filename, String metric, double expectedValue) {
-    Measurer measurer = new Measurer(sonarProject, context, ignoreAccessors);
+  private void checkMetric(boolean separateAccessorsFromMethods, File baseDir, String filename, String metric, double expectedValue) {
+    Measurer measurer = new Measurer(sonarProject, context, separateAccessorsFromMethods);
     JavaConfiguration conf = new JavaConfiguration(Charsets.UTF_8);
-    conf.setAnalyzePropertyAccessors(ignoreAccessors);
+    conf.setSeparateAccessorsFromMethods(separateAccessorsFromMethods);
     squid = new JavaSquid(conf, null, measurer, null, new CodeVisitor[0]);
     squid.scan(Lists.newArrayList(new File(baseDir, filename)), Collections.<File>emptyList(), Collections.<File>emptyList());
     ArgumentCaptor<Measure> captor = ArgumentCaptor.forClass(Measure.class);

--- a/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
+++ b/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
@@ -136,7 +136,7 @@ public class SquidUserGuideTest {
     return metrics;
   }
 
-  private void verifyCommonMetrics(Map<String, Double> metrics) {
+  private void verifySameResults(Map<String, Double> metrics) {
     assertThat(metrics.get("classes").intValue()).isEqualTo(412);
     assertThat(metrics.get("lines").intValue()).isEqualTo(64125);
     assertThat(metrics.get("ncloc").intValue()).isEqualTo(26323);
@@ -154,12 +154,12 @@ public class SquidUserGuideTest {
     initAndScan(true);
     Map<String, Double> metrics = getMetrics();
 
-    verifyCommonMetrics(metrics);
+    verifySameResults(metrics);
 
-    assertThat(metrics.get("functions").intValue()).isEqualTo(3693);
-    assertThat(metrics.get("complexity").intValue()).isEqualTo(8475 - 80 /* SONAR-3793 */- 2 /* SONAR-3794 */);
-    // 69: SONARJAVA-861 analyseAccessors property of the measurer is set to true. Getters and setters ignored.
+    // 69: SONARJAVA-861 separatedAccessorsFromMethods property of the measurer is set to true. Getters and setters ignored.
+    assertThat(metrics.get("functions").intValue()).isEqualTo(3762 - 69);
     assertThat(metrics.get("public_api").intValue()).isEqualTo(3221 - 69);
+    assertThat(metrics.get("complexity").intValue()).isEqualTo(8462 - 80 /* SONAR-3793 */- 2 /* SONAR-3794 */+ 13 /* SONARJAVA-861 */);
   }
 
   @Test
@@ -167,11 +167,11 @@ public class SquidUserGuideTest {
     initAndScan(false);
     Map<String, Double> metrics = getMetrics();
 
-    verifyCommonMetrics(metrics);
+    verifySameResults(metrics);
 
     assertThat(metrics.get("functions").intValue()).isEqualTo(3762);
-    assertThat(metrics.get("complexity").intValue()).isEqualTo(8462);
     assertThat(metrics.get("public_api").intValue()).isEqualTo(3221);
+    assertThat(metrics.get("complexity").intValue()).isEqualTo(8462);
   }
 
   @Test
@@ -180,9 +180,9 @@ public class SquidUserGuideTest {
     SourceCode collectionsPackage = squid.search("org/apache/commons/collections");
     SourceCode bufferPackage = squid.search("org/apache/commons/collections/buffer");
     SourceCode bidimapPackage = squid.search("org/apache/commons/collections/bidimap");
-//    assertThat(squid.getDependency(bidimapPackage, collectionsPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
-//    assertThat(squid.getDependency(collectionsPackage, bufferPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
-//    assertThat(squid.getDependency(collectionsPackage, bufferPackage).getRootEdges().size()).isEqualTo(7);
+    // assertThat(squid.getDependency(bidimapPackage, collectionsPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
+    // assertThat(squid.getDependency(collectionsPackage, bufferPackage).getUsage()).isEqualTo(SourceCodeEdgeUsage.USES);
+    // assertThat(squid.getDependency(collectionsPackage, bufferPackage).getRootEdges().size()).isEqualTo(7);
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
+++ b/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
@@ -23,7 +23,6 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
 import org.fest.assertions.Delta;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.sonar.api.batch.SensorContext;
@@ -54,20 +53,19 @@ public class SquidUserGuideTest {
   private static JavaSquid squid;
   private static SensorContext context;
 
-  @BeforeClass
-  public static void init() {
+  private void initAndScan(boolean ignoreAccessors) {
     File prjDir = new File("target/test-projects/commons-collections-3.2.1");
     File srcDir = new File(prjDir, "src");
     File binDir = new File(prjDir, "bin");
 
     JavaConfiguration conf = new JavaConfiguration(Charsets.UTF_8);
-    conf.setAnalyzePropertyAccessors(true);
+    conf.setAnalyzePropertyAccessors(ignoreAccessors);
     context = mock(SensorContext.class);
     Project sonarProject = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
     when(pfs.getBasedir()).thenReturn(prjDir);
     when(sonarProject.getFileSystem()).thenReturn(pfs);
-    Measurer measurer = new Measurer(sonarProject, context, true);
+    Measurer measurer = new Measurer(sonarProject, context, ignoreAccessors);
     JavaResourceLocator javaResourceLocator = new JavaResourceLocator() {
       public Map<String, String> sourceFileCache = Maps.newHashMap();
 
@@ -122,7 +120,8 @@ public class SquidUserGuideTest {
   }
 
   @Test
-  public void measures_on_project() throws Exception {
+  public void measures_on_project_ignored_accessors() throws Exception {
+    initAndScan(true);
     ArgumentCaptor<Measure> captor = ArgumentCaptor.forClass(Measure.class);
     ArgumentCaptor<org.sonar.api.resources.File> files = ArgumentCaptor.forClass(org.sonar.api.resources.File.class);
     verify(context, atLeastOnce()).saveMeasure(files.capture(), captor.capture());
@@ -154,7 +153,40 @@ public class SquidUserGuideTest {
   }
 
   @Test
+  public void measures_on_project_accessors_counted() throws Exception {
+    initAndScan(false);
+    ArgumentCaptor<Measure> captor = ArgumentCaptor.forClass(Measure.class);
+    ArgumentCaptor<org.sonar.api.resources.File> files = ArgumentCaptor.forClass(org.sonar.api.resources.File.class);
+    verify(context, atLeastOnce()).saveMeasure(files.capture(), captor.capture());
+    Map<String, Double> metrics = new HashMap<String, Double>();
+    for (Measure measure : captor.getAllValues()) {
+      if (measure.getValue() != null) {
+        if (metrics.get(measure.getMetricKey()) == null) {
+          metrics.put(measure.getMetricKey(), measure.getValue());
+        } else {
+          metrics.put(measure.getMetricKey(), metrics.get(measure.getMetricKey()) + measure.getValue());
+        }
+      }
+    }
+
+    assertThat(metrics.get("classes").intValue()).isEqualTo(412);
+    assertThat(metrics.get("functions").intValue()).isEqualTo(3762);
+    assertThat(metrics.get("lines").intValue()).isEqualTo(64125);
+    assertThat(metrics.get("ncloc").intValue()).isEqualTo(26323);
+    assertThat(metrics.get("statements").intValue()).isEqualTo(12047);
+    assertThat(metrics.get("complexity").intValue()).isEqualTo(8462);
+    assertThat(metrics.get("comment_lines").intValue()).isEqualTo(17908);
+    assertThat(metrics.get("public_api").intValue()).isEqualTo(3221);
+    double density = 1.0;
+    if (metrics.get("public_api").intValue() != 0) {
+      density = (metrics.get("public_api") - metrics.get("public_undocumented_api")) / metrics.get("public_api");
+    }
+    assertThat(density).isEqualTo(0.64, Delta.delta(0.01));
+  }
+
+  @Test
   public void getDependenciesBetweenPackages() {
+    initAndScan(true);
     SourceCode collectionsPackage = squid.search("org/apache/commons/collections");
     SourceCode bufferPackage = squid.search("org/apache/commons/collections/buffer");
     SourceCode bidimapPackage = squid.search("org/apache/commons/collections/bidimap");

--- a/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
+++ b/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
@@ -144,7 +144,8 @@ public class SquidUserGuideTest {
     assertThat(metrics.get("statements").intValue()).isEqualTo(12047);
     assertThat(metrics.get("complexity").intValue()).isEqualTo(8475 - 80 /* SONAR-3793 */- 2 /* SONAR-3794 */);
     assertThat(metrics.get("comment_lines").intValue()).isEqualTo(17908);
-    assertThat(metrics.get("public_api").intValue()).isEqualTo(3221);
+    // 69: SONARJAVA-861 analyseAccessors property of the measurer is set to true. Getters and setters ignored.
+    assertThat(metrics.get("public_api").intValue()).isEqualTo(3221 - 69);
     double density = 1.0;
     if (metrics.get("public_api").intValue() != 0) {
       density = (metrics.get("public_api") - metrics.get("public_undocumented_api")) / metrics.get("public_api");

--- a/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
+++ b/java-squid/src/test/java/org/sonar/java/SquidUserGuideTest.java
@@ -53,19 +53,19 @@ public class SquidUserGuideTest {
   private static JavaSquid squid;
   private static SensorContext context;
 
-  private void initAndScan(boolean ignoreAccessors) {
+  private void initAndScan(boolean separateAccessorsFromMethods) {
     File prjDir = new File("target/test-projects/commons-collections-3.2.1");
     File srcDir = new File(prjDir, "src");
     File binDir = new File(prjDir, "bin");
 
     JavaConfiguration conf = new JavaConfiguration(Charsets.UTF_8);
-    conf.setAnalyzePropertyAccessors(ignoreAccessors);
+    conf.setSeparateAccessorsFromMethods(separateAccessorsFromMethods);
     context = mock(SensorContext.class);
     Project sonarProject = mock(Project.class);
     ProjectFileSystem pfs = mock(ProjectFileSystem.class);
     when(pfs.getBasedir()).thenReturn(prjDir);
     when(sonarProject.getFileSystem()).thenReturn(pfs);
-    Measurer measurer = new Measurer(sonarProject, context, ignoreAccessors);
+    Measurer measurer = new Measurer(sonarProject, context, separateAccessorsFromMethods);
     JavaResourceLocator javaResourceLocator = new JavaResourceLocator() {
       public Map<String, String> sourceFileCache = Maps.newHashMap();
 
@@ -120,7 +120,7 @@ public class SquidUserGuideTest {
   }
 
   @Test
-  public void measures_on_project_ignored_accessors() throws Exception {
+  public void measures_on_project_accessors_separated_from_methods() throws Exception {
     initAndScan(true);
     ArgumentCaptor<Measure> captor = ArgumentCaptor.forClass(Measure.class);
     ArgumentCaptor<org.sonar.api.resources.File> files = ArgumentCaptor.forClass(org.sonar.api.resources.File.class);
@@ -153,7 +153,7 @@ public class SquidUserGuideTest {
   }
 
   @Test
-  public void measures_on_project_accessors_counted() throws Exception {
+  public void measures_on_project_accessors_handled_as_methods() throws Exception {
     initAndScan(false);
     ArgumentCaptor<Measure> captor = ArgumentCaptor.forClass(Measure.class);
     ArgumentCaptor<org.sonar.api.resources.File> files = ArgumentCaptor.forClass(org.sonar.api.resources.File.class);

--- a/java-squid/src/test/java/org/sonar/java/StrutsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/StrutsTest.java
@@ -81,7 +81,7 @@ public class StrutsTest {
     return metrics;
   }
 
-  private void verifyCommonMetrics(Map<String, Double> metrics) {
+  private void verifySameResults(Map<String, Double> metrics) {
     assertThat(metrics.get("classes").intValue()).isEqualTo(146);
     assertThat(metrics.get("lines").intValue()).isEqualTo(32878);
     assertThat(metrics.get("ncloc").intValue()).isEqualTo(14007);
@@ -94,13 +94,13 @@ public class StrutsTest {
     initAndScan(true);
     Map<String, Double> metrics = getMetrics();
 
-    verifyCommonMetrics(metrics);
+    verifySameResults(metrics);
 
-    //56 methods in anonymous classes: not part of metric but part of number of methods in project.
-    assertThat(metrics.get("functions").intValue()).isEqualTo(1437 - 56);
-    assertThat(metrics.get("complexity").intValue()).isEqualTo(3957 - 145 /* SONAR-3793 */- 1 /* SONAR-3794 */);
-    // 48: SONARJAVA-861 analyseAccessors property of the measurer is set to true. Getters and setters not counted as public api.
+    // 48: SONARJAVA-861 separatedAccessorsFromMethods property of the measurer is set to true. Getters and setters ignored.
     assertThat(metrics.get("public_api").intValue()).isEqualTo(1340 - 48);
+    // 56 methods in anonymous classes: not part of metric but part of number of methods in project.
+    assertThat(metrics.get("functions").intValue()).isEqualTo(1429 - 56 + 8);
+    assertThat(metrics.get("complexity").intValue()).isEqualTo(3859 - 145 /* SONAR-3793 */- 1 /* SONAR-3794 */+ 98 /* SONARJAVA-861 */);
   }
 
   @Test
@@ -108,11 +108,11 @@ public class StrutsTest {
     initAndScan(false);
     Map<String, Double> metrics = getMetrics();
 
-    verifyCommonMetrics(metrics);
+    verifySameResults(metrics);
 
+    assertThat(metrics.get("public_api").intValue()).isEqualTo(1340);
     assertThat(metrics.get("functions").intValue()).isEqualTo(1429);
     assertThat(metrics.get("complexity").intValue()).isEqualTo(3859);
-    assertThat(metrics.get("public_api").intValue()).isEqualTo(1340);
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/StrutsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/StrutsTest.java
@@ -89,7 +89,8 @@ public class StrutsTest {
     assertThat(metrics.get("statements").intValue()).isEqualTo(6403);
     assertThat(metrics.get("complexity").intValue()).isEqualTo(3957 - 145 /* SONAR-3793 */ - 1 /* SONAR-3794 */);
     assertThat(metrics.get("comment_lines").intValue()).isEqualTo(7605);
-    assertThat(metrics.get("public_api").intValue()).isEqualTo(1340);
+    // 48: SONARJAVA-861 analyseAccessors property of the measurer is set to true. Getters and setters ignored.
+    assertThat(metrics.get("public_api").intValue()).isEqualTo(1340 - 48);
   }
 
 

--- a/java-squid/src/test/java/org/sonar/java/ast/visitors/PublicApiCheckerTest.java
+++ b/java-squid/src/test/java/org/sonar/java/ast/visitors/PublicApiCheckerTest.java
@@ -47,19 +47,19 @@ public class PublicApiCheckerTest {
   @Before
   public void setUp() {
     Parser p = JavaParser.createParser(Charsets.UTF_8);
-    publicApiChecker = PublicApiChecker.newDefaultPublicApiChecker();
+    publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
     cut = (CompilationUnitTree) p.parse(new File("src/test/files/ast/PublicApi.java"));
   }
 
   @Test
-  public void isPublicApiDefaultBehavior() {
+  public void isPublicApiAccessorsHandledAsMethods() {
     SubscriptionVisitor visitor = getPublicApiVisitor(publicApiChecker);
     visitor.scanTree(cut);
   }
 
   @Test
-  public void isPublicApiSeparatedAccessors() {
-    publicApiChecker = PublicApiChecker.newPublicApiCheckerWithoutAccessorAnalysis();
+  public void isPublicApiAccessorsSeparatedFromMethods() {
+    publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsSeparatedFromMethods();
     SubscriptionVisitor visitor = getPublicApiVisitor(publicApiChecker);
     visitor.scanTree(cut);
   }
@@ -89,7 +89,7 @@ public class PublicApiCheckerTest {
           MethodTree methodTree = (MethodTree) tree;
           methodTrees.push(methodTree);
           String name = methodTree.simpleName().name();
-          if (publicApiChecker.ignoresAccessors()) {
+          if (publicApiChecker.separatesAccessorsFromMethods()) {
             assertThat(publicApiChecker.isPublicApi(classTrees.peek(), tree)).as(name).isEqualTo(name.endsWith("Public"));
           } else {
             // getters and setters are included in the public API only if checker does not ignore accessors

--- a/java-squid/src/test/java/org/sonar/java/ast/visitors/PublicApiCheckerTest.java
+++ b/java-squid/src/test/java/org/sonar/java/ast/visitors/PublicApiCheckerTest.java
@@ -47,24 +47,24 @@ public class PublicApiCheckerTest {
   @Before
   public void setUp() {
     Parser p = JavaParser.createParser(Charsets.UTF_8);
-    publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsHandledAsMethods();
+    publicApiChecker = PublicApiChecker.newInstanceWithAccessorsHandledAsMethods();
     cut = (CompilationUnitTree) p.parse(new File("src/test/files/ast/PublicApi.java"));
   }
 
   @Test
   public void isPublicApiAccessorsHandledAsMethods() {
-    SubscriptionVisitor visitor = getPublicApiVisitor(publicApiChecker);
+    SubscriptionVisitor visitor = getPublicApiVisitor(publicApiChecker, false);
     visitor.scanTree(cut);
   }
 
   @Test
   public void isPublicApiAccessorsSeparatedFromMethods() {
-    publicApiChecker = PublicApiChecker.newPublicApiCheckerAccessorsSeparatedFromMethods();
-    SubscriptionVisitor visitor = getPublicApiVisitor(publicApiChecker);
+    publicApiChecker = PublicApiChecker.newInstanceWithAccessorsSeparatedFromMethods();
+    SubscriptionVisitor visitor = getPublicApiVisitor(publicApiChecker, true);
     visitor.scanTree(cut);
   }
 
-  private SubscriptionVisitor getPublicApiVisitor(final PublicApiChecker publicApiChecker) {
+  private SubscriptionVisitor getPublicApiVisitor(final PublicApiChecker publicApiChecker, final boolean separateAccessorsFromMethods) {
     return new SubscriptionVisitor() {
 
       private final Deque<ClassTree> classTrees = Lists.newLinkedList();
@@ -89,7 +89,7 @@ public class PublicApiCheckerTest {
           MethodTree methodTree = (MethodTree) tree;
           methodTrees.push(methodTree);
           String name = methodTree.simpleName().name();
-          if (publicApiChecker.separatesAccessorsFromMethods()) {
+          if (separateAccessorsFromMethods) {
             assertThat(publicApiChecker.isPublicApi(classTrees.peek(), tree)).as(name).isEqualTo(name.endsWith("Public"));
           } else {
             // getters and setters are included in the public API only if checker does not ignore accessors

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSquidSensor.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSquidSensor.java
@@ -87,7 +87,7 @@ public class JavaSquidSensor implements Sensor {
     Checks<CodeVisitor> checks = checkFactory.<CodeVisitor>create(CheckList.REPOSITORY_KEY).addAnnotatedChecks(CheckList.getChecks());
     Collection<CodeVisitor> checkList = checks.all();
     JavaConfiguration configuration = createConfiguration();
-    Measurer measurer = new Measurer(project, context, configuration.isAnalysePropertyAccessors());
+    Measurer measurer = new Measurer(project, context, configuration.separatesAccessorsFromMethods());
     JavaSquid squid = new JavaSquid(configuration, sonarComponents, measurer, javaResourceLocator, checkList.toArray(new CodeVisitor[checkList.size()]));
     squid.scan(getSourceFiles(), getTestFiles(), getBytecodeFiles());
     new Bridges(squid, settings).save(context, project, checks, javaResourceLocator.getResourceMapping(),
@@ -121,7 +121,7 @@ public class JavaSquidSensor implements Sensor {
     boolean analyzePropertyAccessors = settings.getBoolean(JavaPlugin.SQUID_ANALYSE_ACCESSORS_PROPERTY);
     Charset charset = fs.encoding();
     JavaConfiguration conf = new JavaConfiguration(charset);
-    conf.setAnalyzePropertyAccessors(analyzePropertyAccessors);
+    conf.setSeparateAccessorsFromMethods(analyzePropertyAccessors);
     return conf;
   }
 


### PR DESCRIPTION
Added management of the property `sonar.squid.analyse.property` in the computation of the Public API metric. If the property is set to `true`, then `getters` and `setters` are now ignored.