### PR TITLE
SONARJAVA-868_RSPEC-2175 Inappropriate collection calls check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -280,7 +280,8 @@ public final class CheckList {
       CompareToReturnValueCheck.class,
       FinalizeFieldsSetCheck.class,
       NotifyCheck.class,
-      ScheduledThreadPoolExecutorZeroCheck.class
+      ScheduledThreadPoolExecutorZeroCheck.class,
+      CollectionInappropriateCallsCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/CollectionInappropriateCallsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CollectionInappropriateCallsCheck.java
@@ -1,0 +1,113 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.checks.methods.AbstractMethodDetection;
+import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.TypeCriteria;
+import org.sonar.java.model.AbstractTypedTree;
+import org.sonar.java.model.expression.MethodInvocationTreeImpl;
+import org.sonar.java.resolve.Type;
+import org.sonar.java.resolve.Type.ParametrizedTypeType;
+import org.sonar.java.resolve.Type.TypeVariableType;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.squidbridge.annotations.ActivatedByDefault;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import javax.annotation.Nullable;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+@Rule(
+  key = "S2175",
+  name = "Inappropriate \"Collection\" calls should not be made",
+  tags = {"bug"},
+  priority = Priority.CRITICAL)
+@ActivatedByDefault
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.DATA_RELIABILITY)
+@SqaleConstantRemediation("15min")
+public class CollectionInappropriateCallsCheck extends AbstractMethodDetection {
+
+  @Override
+  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(
+      collectionMethodInvocation("remove"),
+      collectionMethodInvocation("contains")
+      );
+  }
+
+  private MethodInvocationMatcher collectionMethodInvocation(String methodName) {
+    return MethodInvocationMatcher.create()
+      .typeDefinition(TypeCriteria.subtypeOf("java.util.Collection"))
+      .name(methodName)
+      .addParameter("java.lang.Object");
+  }
+
+  @Override
+  protected void onMethodFound(MethodInvocationTree tree) {
+    Type argumentType = getType(tree.arguments().get(0));
+    Type collectionType = getMethodOwner(tree);
+    Type collectionParameterType = getTypeParameter(collectionType);
+
+    if (collectionParameterType != null && !isArgumentCompatible(argumentType, collectionParameterType)) {
+      addIssue(tree, MessageFormat.format("A \"{0}<{1}>\" cannot contain a \"{2}\"", collectionType, collectionParameterType, argumentType));
+    }
+  }
+
+  private Type getType(ExpressionTree tree) {
+    return ((AbstractTypedTree) tree).getSymbolType();
+  }
+
+  private Type getMethodOwner(MethodInvocationTree mit) {
+    if (mit.methodSelect().is(Kind.MEMBER_SELECT)) {
+      return getType(((MemberSelectExpressionTree) mit.methodSelect()).expression());
+    }
+    return ((MethodInvocationTreeImpl) mit).getSymbol().owner().getType();
+  }
+
+  @Nullable
+  private Type getTypeParameter(Type collectionType) {
+    if (collectionType instanceof ParametrizedTypeType) {
+      return getFirstTypeParameter((ParametrizedTypeType) collectionType);
+    }
+    return null;
+  }
+
+  @Nullable
+  private Type getFirstTypeParameter(ParametrizedTypeType parametrizedTypeType) {
+    for (TypeVariableType variableType : parametrizedTypeType.typeParameters()) {
+      return parametrizedTypeType.substitution(variableType);
+    }
+    return null;
+  }
+
+  private boolean isArgumentCompatible(Type argumentType, Type collectionParameterType) {
+    return argumentType.isSubtypeOf(collectionParameterType.getSymbol().getFullyQualifiedName());
+  }
+}

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2175.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2175.html
@@ -1,0 +1,12 @@
+<p>A couple <code>Collection</code> methods can be called with arguments of an incorrect type, but doing so is pointless and likely the result of using the wrong argument.</p>
+
+<h2>Noncompliant Code Example</h2>
+
+<pre>
+List<String> list = new ArrayList<String>();
+Integer integer = Integer.valueOf(1);
+
+if (list.contains(integer)) {  // Noncompliant. Always false.
+  list.remove(integer); // Noncompliant. list.add(iger) doesn't compile, so this will always return false
+}
+</pre>

--- a/java-checks/src/test/files/checks/CollectionInappropriateCallsCheck.java
+++ b/java-checks/src/test/files/checks/CollectionInappropriateCallsCheck.java
@@ -1,0 +1,87 @@
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class A {
+  private void myMethod() {
+    List<String> myList = new ArrayList<String>();
+    Set<A> myASet = new HashSet<A>();
+    ArrayList<B> myBList = new ArrayList<B>();
+    List<Set<Integer>> mySetList = new ArrayList<Set<Integer>>();
+
+    Integer myInteger = Integer.valueOf(1);
+    String myString = "";
+    String[] myArrayString = new String[] {"myString"};
+    Integer[] myArrayInteger = new Integer[] {Integer.valueOf(1)};
+
+    if (myList.contains(myInteger)) { // Noncompliant. Always false.
+      myList.remove(myInteger); // Noncompliant. list.add(iger) doesn't compile, so this will always return false
+    }
+
+    if (myList.contains(myString)) { // Compliant
+      myList.remove(myString); // Compliant
+    }
+
+    if (myBList.contains(myInteger)) { // Noncompliant
+      myBList.remove(myInteger); // Noncompliant
+    }
+
+    if (mySetList.contains(myString)) { // Noncompliant
+      mySetList.remove(myString); // Noncompliant
+    }
+
+    if (mySetList.contains(returnOne())) { // Noncompliant
+      mySetList.remove(B.returnOne()); // Noncompliant
+    }
+
+    if (myBList.contains(new B())) { // Compliant
+      myBList.remove(new A()); // Noncompliant
+    }
+
+    if (myList.contains(myArrayInteger)) { // Noncompliant - THIS CASE IS CURRENTLY NOT DETECTED
+      myList.remove(myArrayInteger[0]); // Noncompliant
+      myList.remove(myArrayString[0]); // Compliant
+    }
+
+    if (myASet.contains(new C())) { // Compliant
+      myASet.remove(new B()); // Compliant
+    }
+  }
+
+  private static Integer returnOne() {
+    return Integer.valueOf(1);
+  }
+}
+
+class B extends A {
+  public String value;
+
+  public static Integer returnOne() {
+    return Integer.valueOf(1);
+  }
+}
+
+class C extends B {
+
+  private void myOtherMethod() {
+    Set mySet = new HashSet<B>();
+    A myA = new A();
+
+    if (mySet.contains(myA)) { // Compliant
+      mySet.remove(new B()); // Compliant
+    }
+  }
+}
+
+class MyCollection<E> extends ArrayList<E> {
+  
+  @Override
+  public boolean add(E e) {
+    if (contains(e)) { // Compliant
+      return false;
+    }
+    return super.add(e);
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/CollectionInappropriateCallsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CollectionInappropriateCallsCheckTest.java
@@ -1,0 +1,50 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifier;
+
+import java.io.File;
+
+public class CollectionInappropriateCallsCheckTest {
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/CollectionInappropriateCallsCheck.java"), new VisitorsBridge(
+      new CollectionInappropriateCallsCheck()));
+    CheckMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(18).withMessage("A \"List<String>\" cannot contain a \"Integer\"")
+      .next().atLine(19).withMessage("A \"List<String>\" cannot contain a \"Integer\"")
+      .next().atLine(26).withMessage("A \"ArrayList<B>\" cannot contain a \"Integer\"")
+      .next().atLine(27).withMessage("A \"ArrayList<B>\" cannot contain a \"Integer\"")
+      .next().atLine(30).withMessage("A \"List<Set>\" cannot contain a \"String\"")
+      .next().atLine(31).withMessage("A \"List<Set>\" cannot contain a \"String\"")
+      .next().atLine(34).withMessage("A \"List<Set>\" cannot contain a \"Integer\"")
+      .next().atLine(35).withMessage("A \"List<Set>\" cannot contain a \"Integer\"")
+      .next().atLine(39).withMessage("A \"ArrayList<B>\" cannot contain a \"A\"")
+      // .next().atLine(42).withMessage("A \"List<String>\" cannot contain a \"String[]\"") // CURRENTLY NOT DETECTED
+      .next().atLine(43).withMessage("A \"List<String>\" cannot contain a \"Integer\"")
+      .noMore();
+  }
+}

--- a/java-squid/src/main/java/org/sonar/java/resolve/Type.java
+++ b/java-squid/src/main/java/org/sonar/java/resolve/Type.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.java.resolve;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class Type {
 
@@ -267,6 +269,22 @@ public class Type {
     @Override
     public Type erasure() {
       return rawType.erasure();
+    }
+
+    @Nullable
+    public Type substitution(TypeVariableType typeVariableType) {
+      Type result = null;
+      if (typeSubstitution != null) {
+        result = typeSubstitution.get(typeVariableType);
+      }
+      return result;
+    }
+
+    public Set<TypeVariableType> typeParameters() {
+      if (typeSubstitution != null) {
+        return typeSubstitution.keySet();
+      }
+      return Sets.newHashSet();
     }
   }
 }

--- a/java-squid/src/test/java/org/sonar/java/resolve/TypeTest.java
+++ b/java-squid/src/test/java/org/sonar/java/resolve/TypeTest.java
@@ -21,9 +21,11 @@ package org.sonar.java.resolve;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -132,5 +134,26 @@ public class TypeTest {
     }
     assertThat(symbols.objectType.isPrimitiveWrapper()).isFalse();
     assertThat(symbols.intType.isPrimitiveWrapper()).isFalse();
+  }
+
+  @Test
+  public void parametrizedTypeType_methods_tests() {
+    Symbol.PackageSymbol packageSymbol = new Symbol.PackageSymbol("org.foo.bar", null);
+    Symbol.TypeSymbol typeSymbol = new Symbol.TypeSymbol(Flags.PUBLIC, "MyType", packageSymbol);
+    Symbol.TypeVariableSymbol typeVariableSymbol = new Symbol.TypeVariableSymbol("E", typeSymbol);
+    Type.ClassType classType = (Type.ClassType) typeSymbol.type;
+    Type.TypeVariableType typeVariableType = (Type.TypeVariableType) typeVariableSymbol.type;
+    Map<Type.TypeVariableType, Type> typeSubstitution = Maps.newHashMap();
+    typeSubstitution.put(typeVariableType, classType);
+
+    Type.ParametrizedTypeType ptt = new Type.ParametrizedTypeType(typeSymbol, typeSubstitution);
+    assertThat(ptt.substitution(typeVariableType)).isEqualTo(classType);
+    assertThat(ptt.substitution(new Type.TypeVariableType(new Symbol.TypeVariableSymbol("F", typeSymbol)))).isNull();
+    assertThat(ptt.typeParameters()).hasSize(1);
+    assertThat(ptt.typeParameters()).contains(typeVariableType);
+
+    ptt = new Type.ParametrizedTypeType(typeSymbol, null);
+    assertThat(ptt.substitution(typeVariableType)).isNull();
+    assertThat(ptt.typeParameters()).isEmpty();
   }
 }

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -43,7 +43,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(174);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(175);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
Check on inappropriate "Collection" calls:

- Calls of methods `contains` and `remove` of any sub-type of `java.util.Collection` are now checked to control compatibility of provided argument.
- Added new methods in the `ParametrizedTypeType` class to access more easily type parameters.