### PR TITLE
SONARJAVA-892 RSPEC-2447 Boolean method return value check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/BooleanMethodReturnCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/BooleanMethodReturnCheck.java
@@ -1,0 +1,81 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.model.AbstractTypedTree;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.ReturnStatementTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.squidbridge.annotations.ActivatedByDefault;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import java.util.List;
+
+@Rule(
+  key = "S2447",
+  name = "Null should not be returned from a \"Boolean\" method",
+  priority = Priority.CRITICAL,
+  tags = {"pitfall"})
+@ActivatedByDefault
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.INSTRUCTION_RELIABILITY)
+@SqaleConstantRemediation("20min")
+public class BooleanMethodReturnCheck extends SubscriptionBaseVisitor {
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    MethodTree methodTree = (MethodTree) tree;
+    if (returnsBoolean(methodTree)) {
+      methodTree.accept(new ReturnStatementVisitor());
+    }
+  }
+
+  private boolean returnsBoolean(MethodTree methodTree) {
+    return ((AbstractTypedTree) methodTree.returnType()).getSymbolType().is("java.lang.Boolean");
+  }
+
+  private class ReturnStatementVisitor extends BaseTreeVisitor {
+
+    @Override
+    public void visitReturnStatement(ReturnStatementTree tree) {
+      if (tree.expression().is(Kind.NULL_LITERAL)) {
+        addIssue(tree, "Null is returned but a \"Boolean\" is expected.");
+      }
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // Do not visit inner classes as methods of inner classes will be visited by main visitor
+    }
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -282,7 +282,8 @@ public final class CheckList {
       NotifyCheck.class,
       ScheduledThreadPoolExecutorZeroCheck.class,
       ThreadOverridesRunCheck.class,
-      CollectionInappropriateCallsCheck.class
+      CollectionInappropriateCallsCheck.class,
+      BooleanMethodReturnCheck.class
       );
   }
 }

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2447.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2447.html
@@ -1,0 +1,9 @@
+<p>While <code>null</code> is technically a valid <code>Boolean</code> value, that fact, and the distinction between <code>Boolean</code> and <code>boolean</code> is easy to forget. So returning <code>null</code> from a <code>Boolean</code> method is likely to cause problems with callers' code.</p>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+public Boolean isUsable() {
+  // ...
+  return null;  // Noncompliant
+}
+</pre>

--- a/java-checks/src/test/files/checks/BooleanMethodReturnCheck.java
+++ b/java-checks/src/test/files/checks/BooleanMethodReturnCheck.java
@@ -1,0 +1,32 @@
+import org.apache.commons.lang.BooleanUtils;
+
+class A {
+  public Boolean myMethod() {
+    return null; // Noncompliant
+  }
+
+  public Boolean myOtherMethod() {
+    return Boolean.TRUE; // Compliant
+  }
+}
+
+class B {
+  private class Boolean {
+  }
+
+  public Boolean myMethod() {
+    return null; // Compliant
+  }
+  
+  public java.lang.Boolean myOtherMethod() {
+    private class C {
+      private java.lang.Boolean myInnerMethod() {
+        return null; // Noncompliant
+      }
+      private C foo() {
+        return null; // Compliant
+      }
+    }
+    return null; // Noncompliant
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/BooleanMethodReturnCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/BooleanMethodReturnCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class BooleanMethodReturnCheckTest {
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/BooleanMethodReturnCheck.java"),
+      new VisitorsBridge(new BooleanMethodReturnCheck()));
+    new CheckMessagesVerifierRule().verify(file.getCheckMessages())
+      .next().atLine(5).withMessage("Null is returned but a \"Boolean\" is expected.")
+      .next().atLine(24)
+      .next().atLine(30)
+      .noMore();
+  }
+}

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -43,7 +43,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(176);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(177);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
Boolean methid return value check:

- New check verifying return statements of methods returning `Boolean`. 
- While `null` is technically a valid `Boolean` value, that fact, and the distinction between `Boolean` and `boolean` is easy to forget. So returning `null` from a `Boolean` method is likely to cause problems with callers' code.