### PR TITLE
SONARJAVA-890 RSPEC-2437 Silly bit operation check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -284,7 +284,8 @@ public final class CheckList {
       ThreadOverridesRunCheck.class,
       CollectionInappropriateCallsCheck.class,
       BooleanMethodReturnCheck.class,
-      PrimitiveTypeBoxingWithToStringCheck.class
+      PrimitiveTypeBoxingWithToStringCheck.class,
+      SillyBitOperationCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ShiftOnIntOrLongCheck.java
@@ -24,6 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.model.AbstractTypedTree;
+import org.sonar.java.model.LiteralUtils;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
@@ -80,7 +81,7 @@ public class ShiftOnIntOrLongCheck extends SubscriptionBaseVisitor {
 
     if (shift.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
       int base = getBase(tree);
-      long numberBits = sign * Long.decode(trimLongSuffix(((LiteralTree) shift).value()));
+      long numberBits = sign * Long.decode(LiteralUtils.trimLongSuffix(((LiteralTree) shift).value()));
       long reducedNumberBits = numberBits % base;
       String message = getMessage(numberBits, reducedNumberBits, base, identifier);
       if (message != null) {
@@ -95,19 +96,9 @@ public class ShiftOnIntOrLongCheck extends SubscriptionBaseVisitor {
 
   private boolean isLiteralValue(ExpressionTree tree, long value) {
     if (tree.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
-      return Long.decode(trimLongSuffix(((LiteralTree) tree).value())) == value;
+      return Long.decode(LiteralUtils.trimLongSuffix(((LiteralTree) tree).value())) == value;
     }
     return false;
-  }
-
-  private String trimLongSuffix(String longString) {
-    int lastCharPosition = longString.length() - 1;
-    char lastChar = longString.charAt(lastCharPosition);
-    String value = longString;
-    if (lastChar == 'L' || lastChar == 'l') {
-      value = longString.substring(0, lastCharPosition);
-    }
-    return value;
   }
 
   private String getMessage(long numberBits, long reducedNumberBits, int base, String identifier) {

--- a/java-checks/src/main/java/org/sonar/java/checks/SillyBitOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SillyBitOperationCheck.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
+import org.sonar.java.model.LiteralUtils;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -64,7 +65,7 @@ public class SillyBitOperationCheck extends SubscriptionBaseVisitor {
     Long identityElement = getBitwiseOperationIdentityElement(tree);
     Long evaluatedExpression = evaluateExpression(getExpression(tree));
 
-    if (evaluatedExpression != null && evaluatedExpression == identityElement) {
+    if (evaluatedExpression != null && identityElement.equals(evaluatedExpression)) {
       addIssue(tree, "Remove this silly bit operation.");
     }
   }
@@ -97,19 +98,8 @@ public class SillyBitOperationCheck extends SubscriptionBaseVisitor {
     }
 
     if (expression.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
-      return sign * Long.decode(trimLongSuffix(((LiteralTree) expression).value()));
+      return sign * Long.decode(LiteralUtils.trimLongSuffix(((LiteralTree) expression).value()));
     }
     return null;
   }
-
-  private String trimLongSuffix(String longString) {
-    int lastCharPosition = longString.length() - 1;
-    char lastChar = longString.charAt(lastCharPosition);
-    String value = longString;
-    if (lastChar == 'L' || lastChar == 'l') {
-      value = longString.substring(0, lastCharPosition);
-    }
-    return value;
-  }
-
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/SillyBitOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SillyBitOperationCheck.java
@@ -1,0 +1,115 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
+import org.sonar.squidbridge.annotations.ActivatedByDefault;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+@Rule(
+  key = "S2437",
+  name = "Silly bit operations should not be performed",
+  tags = {"bug"},
+  priority = Priority.MAJOR)
+@ActivatedByDefault
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.LOGIC_RELIABILITY)
+@SqaleConstantRemediation("5min")
+public class SillyBitOperationCheck extends SubscriptionBaseVisitor {
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(
+      Kind.XOR,
+      Kind.XOR_ASSIGNMENT,
+      Kind.AND,
+      Kind.AND_ASSIGNMENT,
+      Kind.OR,
+      Kind.OR_ASSIGNMENT);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    Long identityElement = getBitwiseOperationIdentityElement(tree);
+    Long evaluatedExpression = evaluateExpression(getExpression(tree));
+
+    if (evaluatedExpression != null && evaluatedExpression == identityElement) {
+      addIssue(tree, "Remove this silly bit operation.");
+    }
+  }
+
+  private Long getBitwiseOperationIdentityElement(Tree tree) {
+    Long identityElement = 0L;
+    if (tree.is(Kind.AND, Kind.AND_ASSIGNMENT)) {
+      identityElement = -1L;
+    }
+    return identityElement;
+  }
+
+  private ExpressionTree getExpression(Tree tree) {
+    ExpressionTree expression;
+    if (tree.is(Kind.OR, Kind.XOR, Kind.AND)) {
+      expression = ((BinaryExpressionTree) tree).rightOperand();
+    } else {
+      expression = ((AssignmentExpressionTree) tree).expression();
+    }
+    return expression;
+  }
+
+  @Nullable
+  private Long evaluateExpression(ExpressionTree tree) {
+    ExpressionTree expression = tree;
+
+    int sign = expression.is(Kind.UNARY_MINUS) ? -1 : 1;
+    if (expression.is(Kind.UNARY_MINUS, Kind.UNARY_PLUS)) {
+      expression = ((UnaryExpressionTree) expression).expression();
+    }
+
+    if (expression.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
+      return sign * Long.decode(trimLongSuffix(((LiteralTree) expression).value()));
+    }
+    return null;
+  }
+
+  private String trimLongSuffix(String longString) {
+    int lastCharPosition = longString.length() - 1;
+    char lastChar = longString.charAt(lastCharPosition);
+    String value = longString;
+    if (lastChar == 'L' || lastChar == 'l') {
+      value = longString.substring(0, lastCharPosition);
+    }
+    return value;
+  }
+
+}

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2437.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2437.html
@@ -1,0 +1,3 @@
+<p>Certain bit operations are just silly and should not be performed because their results are predictable.</p>
+
+<p>Specifically, using <code>&amp; -1</code> with any value will always result in the original value, as will <code>anyValue ^ 0</code> and <code>anyValue | 0</code>.</p>

--- a/java-checks/src/test/files/checks/SillyBitOperationCheck.java
+++ b/java-checks/src/test/files/checks/SillyBitOperationCheck.java
@@ -1,0 +1,31 @@
+class A {
+  private void foo() {
+    int result;
+    int bitMask = 0x000F;
+
+    result = bitMask & -1; // Noncompliant
+    result = bitMask | 0;  // Noncompliant
+    result = bitMask ^ 0;  // Noncompliant
+    result &= -1; // Noncompliant
+    result |= 0;  // NonCompliant
+    result ^= 0;  // Noncompliant
+
+    result = bitMask & 1; // Compliant
+    result = bitMask | 1; // compliant
+    result = bitMask ^ 1; // Compliant
+    result &= 1; // Compliant
+    result |= 1; // compliant
+    result ^= 1; // Compliant
+
+    long bitMaskLong = 0x000F;
+    long resultLong;
+    resultLong = bitMaskLong & -1l; // Noncompliant
+    resultLong = bitMaskLong & 0L; // Compliant
+    resultLong = bitMaskLong & returnLong(); // Compliant
+    resultLong = bitMaskLong & 0x0F; // Compliant
+  }
+  
+  private long returnLong() {
+    return Long.valueOf(1L);
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/SillyBitOperationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/SillyBitOperationCheckTest.java
@@ -1,0 +1,50 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class SillyBitOperationCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/SillyBitOperationCheck.java"),
+      new VisitorsBridge(new SillyBitOperationCheck()));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(6).withMessage("Remove this silly bit operation.")
+      .next().atLine(7)
+      .next().atLine(8)
+      .next().atLine(9)
+      .next().atLine(10)
+      .next().atLine(11)
+      .next().atLine(22)
+      .noMore();
+  }
+}

--- a/java-squid/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-squid/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.java.model;
 
+import org.apache.commons.lang.StringUtils;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -65,6 +66,9 @@ public class LiteralUtils {
   }
 
   public static String trimLongSuffix(String longString) {
+    if (StringUtils.isBlank(longString)) {
+      return longString;
+    }
     int lastCharPosition = longString.length() - 1;
     char lastChar = longString.charAt(lastCharPosition);
     String value = longString;
@@ -73,5 +77,4 @@ public class LiteralUtils {
     }
     return value;
   }
-
 }

--- a/java-squid/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-squid/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -65,6 +65,7 @@ public class LiteralUtils {
     return value.substring(1, value.length() - 1);
   }
 
+  @Nullable
   public static String trimLongSuffix(String longString) {
     if (StringUtils.isBlank(longString)) {
       return longString;

--- a/java-squid/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-squid/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -60,9 +60,18 @@ public class LiteralUtils {
     return nullableInteger == null ? null : -nullableInteger;
   }
 
-
   public static String trimQuotes(String value) {
     return value.substring(1, value.length() - 1);
+  }
+
+  public static String trimLongSuffix(String longString) {
+    int lastCharPosition = longString.length() - 1;
+    char lastChar = longString.charAt(lastCharPosition);
+    String value = longString;
+    if (lastChar == 'L' || lastChar == 'l') {
+      value = longString.substring(0, lastCharPosition);
+    }
+    return value;
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
@@ -61,6 +61,7 @@ public class LiteralUtilsTest {
     assertThat(LiteralUtils.trimLongSuffix(longValue)).isEqualTo(longValue);
     assertThat(LiteralUtils.trimLongSuffix(longValue + "l")).isEqualTo(longValue);
     assertThat(LiteralUtils.trimLongSuffix(longValue + "L")).isEqualTo(longValue);
+    assertThat(LiteralUtils.trimLongSuffix("")).isEqualTo("");
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
@@ -57,11 +57,12 @@ public class LiteralUtilsTest {
 
   @Test
   public void testTrimLongSuffix() throws Exception {
+    assertThat(LiteralUtils.trimLongSuffix(null)).isEqualTo(null);
+    assertThat(LiteralUtils.trimLongSuffix("")).isEqualTo("");
     String longValue = "12345";
     assertThat(LiteralUtils.trimLongSuffix(longValue)).isEqualTo(longValue);
     assertThat(LiteralUtils.trimLongSuffix(longValue + "l")).isEqualTo(longValue);
     assertThat(LiteralUtils.trimLongSuffix(longValue + "L")).isEqualTo(longValue);
-    assertThat(LiteralUtils.trimLongSuffix("")).isEqualTo("");
   }
 
 }

--- a/java-squid/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
+++ b/java-squid/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
@@ -55,4 +55,12 @@ public class LiteralUtilsTest {
     }
   }
 
+  @Test
+  public void testTrimLongSuffix() throws Exception {
+    String longValue = "12345";
+    assertThat(LiteralUtils.trimLongSuffix(longValue)).isEqualTo(longValue);
+    assertThat(LiteralUtils.trimLongSuffix(longValue + "l")).isEqualTo(longValue);
+    assertThat(LiteralUtils.trimLongSuffix(longValue + "L")).isEqualTo(longValue);
+  }
+
 }

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -43,7 +43,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(178);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(179);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
New check on silly bit operation.
- Certain bit operations are just silly and should not be performed because their results are predictable.
- Specifically, using `& -1` with any value will always result in the original value, as will `anyValue ^ 0` and `anyValue | 0`.