### PR TITLE
SONARJAVA-888 RSPEC-2160 Equals not overriden in subclass check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -284,7 +284,8 @@ public final class CheckList {
       ThreadOverridesRunCheck.class,
       CollectionInappropriateCallsCheck.class,
       BooleanMethodReturnCheck.class,
-      PrimitiveTypeBoxingWithToStringCheck.class
+      PrimitiveTypeBoxingWithToStringCheck.class,
+      EqualsNotOverriddenInSubclassCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -1,0 +1,123 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.model.AbstractTypedTree;
+import org.sonar.java.model.declaration.ClassTreeImpl;
+import org.sonar.java.resolve.Symbol;
+import org.sonar.java.resolve.Symbol.MethodSymbol;
+import org.sonar.java.resolve.Symbol.TypeSymbol;
+import org.sonar.java.resolve.Type;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Modifier;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.plugins.java.api.tree.VariableTree;
+import org.sonar.squidbridge.annotations.ActivatedByDefault;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import java.util.List;
+
+@Rule(
+  key = "S2160",
+  name = "Subclasses that add fields should override \"equals\"",
+  tags = {"bug"},
+  priority = Priority.MAJOR)
+@ActivatedByDefault
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.LOGIC_RELIABILITY)
+@SqaleConstantRemediation("30min")
+public class EqualsNotOverriddenInSubclassCheck extends SubscriptionBaseVisitor {
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ClassTree classTree = (ClassTree) tree;
+    if (hasSemantic()
+      && hasAtLeastOneField(classTree)
+      && !implementsEquals(classTree)
+      && parentClassImplementsEquals(classTree)) {
+      addIssue(classTree, "Override this superclass' \"equals\" method.");
+    }
+  }
+
+  private boolean hasAtLeastOneField(ClassTree classTree) {
+    for (Tree member : classTree.members()) {
+      if (isField(member)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isField(Tree tree) {
+    return tree.is(Kind.VARIABLE) && !((VariableTree) tree).modifiers().modifiers().containsAll(Lists.newArrayList(Modifier.FINAL, Modifier.STATIC));
+  }
+
+  private boolean implementsEquals(ClassTree classTree) {
+    return hasEqualsMethod(((ClassTreeImpl) classTree).getSymbol());
+  }
+
+  private boolean parentClassImplementsEquals(ClassTree tree) {
+    Tree superClass = tree.superClass();
+    if (superClass != null) {
+      TypeSymbol superClassSymbol = ((AbstractTypedTree) superClass).getSymbolType().getSymbol();
+      while (!superClassSymbol.getType().is("java.lang.Object")) {
+        if (hasEqualsMethod(superClassSymbol)) {
+          return true;
+        }
+        Type superClassType = superClassSymbol.getSuperclass();
+        if (superClassType == null) {
+          break;
+        }
+        superClassSymbol = superClassType.getSymbol();
+      }
+    }
+    return false;
+  }
+
+  private boolean hasEqualsMethod(TypeSymbol superClassSymbol) {
+    List<Symbol> equalsMembers = superClassSymbol.members().lookup("equals");
+    for (Symbol symbol : equalsMembers) {
+      if (isEqualsMethod(symbol)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isEqualsMethod(Symbol symbol) {
+    if (symbol.isKind(Symbol.MTH)) {
+      MethodSymbol methodSymbol = (MethodSymbol) symbol;
+      return !methodSymbol.getParametersTypes().isEmpty()
+        && methodSymbol.getParametersTypes().get(0).is("java.lang.Object");
+    }
+    return false;
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -84,7 +84,7 @@ public class EqualsNotOverriddenInSubclassCheck extends SubscriptionBaseVisitor 
     Tree superClass = tree.superClass();
     if (superClass != null) {
       Type superClassType = ((AbstractTypedTree) superClass).getSymbolType();
-      while (!superClassType.erasure().isTagged(Type.UNKNOWN) && !superClassType.is("java.lang.Object")) {
+      while (!superClassType.getSymbol().getType().isTagged(Type.UNKNOWN) && !superClassType.is("java.lang.Object")) {
         TypeSymbol superClassSymbol = superClassType.getSymbol();
         if (hasEqualsMethod(superClassSymbol)) {
           return true;

--- a/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -84,6 +84,7 @@ public class EqualsNotOverriddenInSubclassCheck extends SubscriptionBaseVisitor 
     Tree superClass = tree.superClass();
     if (superClass != null) {
       Type superClassType = ((AbstractTypedTree) superClass).getSymbolType();
+      // Workaround for SONARJAVA-901 : ParametrizedTypeType with unknown rawType is tagged as CLASS instead of UNKNOWN.
       while (!superClassType.getSymbol().getType().isTagged(Type.UNKNOWN) && !superClassType.is("java.lang.Object")) {
         TypeSymbol superClassSymbol = superClassType.getSymbol();
         if (hasEqualsMethod(superClassSymbol)) {

--- a/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -84,7 +84,7 @@ public class EqualsNotOverriddenInSubclassCheck extends SubscriptionBaseVisitor 
     Tree superClass = tree.superClass();
     if (superClass != null) {
       Type superClassType = ((AbstractTypedTree) superClass).getSymbolType();
-      // Workaround for SONARJAVA-901 : ParametrizedTypeType with unknown rawType is tagged as CLASS instead of UNKNOWN.
+      // FIXME Workaround until SONARJAVA-901 is resolved
       while (!superClassType.getSymbol().getType().isTagged(Type.UNKNOWN) && !superClassType.is("java.lang.Object")) {
         TypeSymbol superClassSymbol = superClassType.getSymbol();
         if (hasEqualsMethod(superClassSymbol)) {

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2160.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2160.html
@@ -1,0 +1,69 @@
+<p>Extend a class that overrides <code>equals</code> and add fields without overriding <code>equals</code> in the subclass, and you run the risk of non-equivalent instances of your subclass being seen as equal, because only the superclass fields will be considered in the equality test.</p>
+
+<p>This rule looks for classes that do all of the following:</p>
+<ul>
+    <li>extend classes that override <code>equals</code>.</li>
+    <li>do not themselves override <code>equals</code>.</li>
+    <li>add fields.</li>
+</ul>
+
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class Fruit {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (this.class != obj.class) {
+      return false;
+    }
+    Fruit fobj = (Fruit) obj;
+    if (ripe.equals(fobj.getRipe()) {
+      return true;
+    }
+    return false;
+  }
+}
+
+public class Raspberry extends Fruit {  // Noncompliant; instances will use Fruit's equals method
+  private Color ripeColor;
+}
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+public class Fruit {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (this.class != obj.class) {
+      return false;
+    }
+    Fruit fobj = (Fruit) obj;
+    if (ripe.equals(fobj.getRipe()) {
+      return true;
+    }
+    return false;
+  }
+}
+
+public class Raspberry extends Fruit {
+  private Color ripeColor;
+
+  public boolean equals(Object obj) {
+    if (! super.equals(obj)) {
+      return false;
+    }
+    Raspberry fobj = (Raspberry) obj;
+    if (ripeColor.equals(fobj.getRipeColor()) {  // added fields are tested
+      return true;
+    }
+    return false;
+  }
+}
+</pre>

--- a/java-checks/src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -1,0 +1,60 @@
+class A {
+  static final String CONST = "constant";
+  String s1;
+
+  public boolean equals(Object obj) {
+    return true;
+  }
+}
+
+class B extends A { // Noncompliant; instances will use A's equals method
+  String s2;
+}
+
+abstract class C {
+  boolean equals;
+  
+  public abstract boolean equals(Object obj); 
+}
+
+class D extends C { // Compliant
+  int i;
+
+  @Override
+  public boolean equals(Object obj) {
+    return false;
+  }
+}
+
+class E {
+  public boolean equals() { 
+    return true;
+  }
+}
+
+class F extends E { // Compliant
+  String s;
+  
+  public boolean equals(int i) {
+    return true;
+  }
+}
+
+class G {
+  public boolean equals(Object obj) {
+    return true;
+  }
+}
+
+class H extends G { // Compliant
+  String s;
+  
+  @Override
+  public boolean equals(Object obj) {
+    return false;
+  }
+}
+
+class J extends tst.MyUnknownClass {
+  
+}

--- a/java-checks/src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -63,3 +63,7 @@ class J {
 class K extends com.tst.UnknownClass {
   String s;
 }
+
+class L<T> extends com.tst.MyList<T> {
+  int s;
+}

--- a/java-checks/src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java
+++ b/java-checks/src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java
@@ -1,5 +1,6 @@
 class A {
   static final String CONST = "constant";
+  static String staticMember = "static member";
   String s1;
 
   public boolean equals(Object obj) {
@@ -55,6 +56,10 @@ class H extends G { // Compliant
   }
 }
 
-class J extends tst.MyUnknownClass {
-  
+class J {
+  String s;
+}
+
+class K extends com.tst.UnknownClass {
+  String s;
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheckTest.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class EqualsNotOverriddenInSubclassCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void test() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java"),
+      new VisitorsBridge(new EqualsNotOverriddenInSubclassCheck()));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(10).withMessage("Override this superclass' \"equals\" method.")
+      .noMore();
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/EqualsNotOverriddenInSubclassCheckTest.java
@@ -38,8 +38,7 @@ public class EqualsNotOverriddenInSubclassCheckTest {
     SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/EqualsNotOverriddenInSubclassCheck.java"),
       new VisitorsBridge(new EqualsNotOverriddenInSubclassCheck()));
     checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(10).withMessage("Override this superclass' \"equals\" method.")
+      .next().atLine(11).withMessage("Override this superclass' \"equals\" method.")
       .noMore();
   }
-
 }

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -43,7 +43,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(178);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(179);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
New check on equals methods not overridden in subclass:

- Extend a class that overrides `equals` and add fields without overriding `equals` in the subclass, and you run the risk of non-equivalent instances of your subclass being seen as equal, because only the superclass fields will be considered in the equality test.
- The check verifies that any class extending a class implementing `equals` (which is not `java.lang.Object`) implements the `equals` method if it has new fields.