### PR TITLE
SONARJAVA-889 RSPEC-2162 Symmetric equals

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -295,7 +295,8 @@ public final class CheckList {
       UselessIncrementCheck.class,
       ObjectCreatedOnlyToCallGetClassCheck.class,
       PrimitiveWrappersInTernaryOperatorCheck.class,
-      SynchronizedLockCheck.class
+      SynchronizedLockCheck.class,
+      SymmetricEqualsCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
@@ -1,0 +1,117 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.ast.api.JavaKeyword;
+import org.sonar.java.model.AbstractTypedTree;
+import org.sonar.java.model.declaration.MethodTreeImpl;
+import org.sonar.java.resolve.Symbol;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.InstanceOfTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.squidbridge.annotations.ActivatedByDefault;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import java.util.List;
+
+@Rule(
+  key = "S2162",
+  name = "\"equals\" methods should be symmetric and work for subclasses",
+  tags = {"bug"},
+  priority = Priority.CRITICAL)
+@ActivatedByDefault
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.INSTRUCTION_RELIABILITY)
+@SqaleConstantRemediation("5min")
+public class SymmetricEqualsCheck extends SubscriptionBaseVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return ImmutableList.of(Tree.Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    MethodTreeImpl methodTree = (MethodTreeImpl) tree;
+    if (methodTree.isEqualsMethod()) {
+      methodTree.block().accept(new SymmetryBrokePatterns(methodTree.getSymbol().owner()));
+    }
+  }
+
+  private class SymmetryBrokePatterns extends BaseTreeVisitor {
+
+    private final Symbol owner;
+
+    public SymmetryBrokePatterns(Symbol owner) {
+      this.owner = owner;
+    }
+
+    @Override
+    public void visitInstanceOf(InstanceOfTree tree) {
+      if (((AbstractTypedTree) tree.type()).getSymbolType().equals(owner.getType())) {
+        addIssue(tree, "Compare to \"this.getClass()\" instead.");
+      } else {
+        addIssue(tree, "Remove this comparison to an unrelated class.");
+      }
+      super.visitInstanceOf(tree);
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      //inner classes will be visited by main visitor.
+    }
+
+    @Override
+    public void visitBinaryExpression(BinaryExpressionTree tree) {
+      if (tree.is(Tree.Kind.EQUAL_TO, Tree.Kind.NOT_EQUAL_TO)) {
+        checkOperand(tree.leftOperand());
+        checkOperand(tree.rightOperand());
+      }
+      super.visitBinaryExpression(tree);
+    }
+
+    private void checkOperand(ExpressionTree expressionTree) {
+      if (expressionTree.is(Tree.Kind.MEMBER_SELECT)) {
+        MemberSelectExpressionTree mset = (MemberSelectExpressionTree) expressionTree;
+        if (isClassExpression(mset) && isClassOfOwner(mset)) {
+          addIssue(expressionTree, "Compare to \"this.getClass()\" instead.");
+        }
+      }
+    }
+
+    private boolean isClassExpression(MemberSelectExpressionTree mset) {
+      return JavaKeyword.CLASS.getValue().equals(mset.identifier().name());
+    }
+
+    private boolean isClassOfOwner(MemberSelectExpressionTree mset) {
+      return ((AbstractTypedTree) mset.expression()).getSymbolType().equals(owner.getType());
+    }
+
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
@@ -58,7 +58,7 @@ public class SymmetricEqualsCheck extends SubscriptionBaseVisitor {
   @Override
   public void visitNode(Tree tree) {
     MethodTreeImpl methodTree = (MethodTreeImpl) tree;
-    if (methodTree.isEqualsMethod()) {
+    if (methodTree.isEqualsMethod() && methodTree.block() != null) {
       methodTree.block().accept(new SymmetryBrokePatterns(methodTree.getSymbol().owner()));
     }
   }
@@ -83,7 +83,7 @@ public class SymmetricEqualsCheck extends SubscriptionBaseVisitor {
 
     @Override
     public void visitClass(ClassTree tree) {
-      //inner classes will be visited by main visitor.
+      // inner classes will be visited by main visitor.
     }
 
     @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
@@ -57,9 +57,11 @@ public class SymmetricEqualsCheck extends SubscriptionBaseVisitor {
 
   @Override
   public void visitNode(Tree tree) {
-    MethodTreeImpl methodTree = (MethodTreeImpl) tree;
-    if (methodTree.isEqualsMethod() && methodTree.block() != null) {
-      methodTree.block().accept(new SymmetryBrokePatterns(methodTree.getSymbol().owner()));
+    if(hasSemantic()) {
+      MethodTreeImpl methodTree = (MethodTreeImpl) tree;
+      if (methodTree.isEqualsMethod() && methodTree.block() != null) {
+        methodTree.block().accept(new SymmetryBrokePatterns(methodTree.getSymbol().owner()));
+      }
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SymmetricEqualsCheck.java
@@ -73,10 +73,16 @@ public class SymmetricEqualsCheck extends SubscriptionBaseVisitor {
       this.owner = owner;
     }
 
+    private boolean isOwnerFinal() {
+      return owner.isFinal();
+    }
+
     @Override
     public void visitInstanceOf(InstanceOfTree tree) {
       if (((AbstractTypedTree) tree.type()).getSymbolType().equals(owner.getType())) {
-        addIssue(tree, "Compare to \"this.getClass()\" instead.");
+        if(!isOwnerFinal()) {
+          addIssue(tree, "Compare to \"this.getClass()\" instead.");
+        }
       } else {
         addIssue(tree, "Remove this comparison to an unrelated class.");
       }
@@ -100,7 +106,7 @@ public class SymmetricEqualsCheck extends SubscriptionBaseVisitor {
     private void checkOperand(ExpressionTree expressionTree) {
       if (expressionTree.is(Tree.Kind.MEMBER_SELECT)) {
         MemberSelectExpressionTree mset = (MemberSelectExpressionTree) expressionTree;
-        if (isClassExpression(mset) && isClassOfOwner(mset)) {
+        if (isClassExpression(mset) && isClassOfOwner(mset) && !isOwnerFinal()) {
           addIssue(expressionTree, "Compare to \"this.getClass()\" instead.");
         }
       }

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2162.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2162.html
@@ -1,5 +1,5 @@
 <p>A key facet of the <code>equals</code> contract is that if <code>a.equals(b)</code> then <code>b.equals(a)</code>, i.e. that the relationship is symmetric. </p>
-<p>Using <code>instanceof</code> breaks the contract when there are subclasses, because while the child is an <code>instanceof</code> the parent, the parent is not an <code>intanceof</code> the child. For instance, assume that <code>Raspberry extends Fruit</code>:</p>
+<p>Using <code>instanceof</code> breaks the contract when there are subclasses, because while the child is an <code>instanceof</code> the parent, the parent is not an <code>intanceof</code> the child. For instance, assume that <code>Raspberry extends Fruit</code> and add some fields on which the <code>equals</code> method is based on:</p>
 <pre>
 Fruit fruit = new Fruit();
 Raspberry raspberry = new Raspberry();
@@ -7,7 +7,11 @@ Raspberry raspberry = new Raspberry();
 if (raspberry instanceof Fruit) { ... } // true
 if (fruit instanceof Raspberry) { ... } // false
 </pre>
-<p>If similar <code>instanceof</code> checks were used in the classes' <code>equals</code> methods, the symmetry principle would be broken.</p>
+<p>If similar <code>instanceof</code> checks were used in the classes' <code>equals</code> methods, the symmetry principle would be broken:</p>
+<pre>
+raspberry.equals(fruit); // false
+fruit.equals(raspberry); //true
+</pre>
 <p>Additionally, non <code>final</code> classes shouldn't use a hardcoded class name in the <code>equals</code> method because doing so breaks the method for subclasses. Instead, make the comparison dynamic.</p>
 <p>Further, comparing to an unrelated class type breaks the contract for that unrelated type, because while <code>thisClass.equals(unrelatedClass)</code> can return true, <code>unrelatedClass.equals(thisClass)</code> will not.</p>
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2162.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2162.html
@@ -1,5 +1,14 @@
 <p>A key facet of the <code>equals</code> contract is that if <code>a.equals(b)</code> then <code>b.equals(a)</code>, i.e. that the relationship is symmetric. </p>
-<p>Using <code>instanceof</code> breaks the contract when there are subclasses, because while the child is an <code>instanceof</code> the parent, the parent is not an <code>intanceof</code> the child. Additionally, non <code>final</code> classes shouldn't use a hardcoded class name in the <code>equals</code> method because doing so breaks the method for subclasses. Instead, make the comparison dynamic.</p>
+<p>Using <code>instanceof</code> breaks the contract when there are subclasses, because while the child is an <code>instanceof</code> the parent, the parent is not an <code>intanceof</code> the child. For instance, assume that <code>Raspberry extends Fruit</code>:</p>
+<pre>
+Fruit fruit = new Fruit();
+Raspberry raspberry = new Raspberry();
+
+if (raspberry instanceof Fruit) { ... } // true
+if (fruit instanceof Raspberry) { ... } // false
+</pre>
+<p>If similar <code>instanceof</code> checks were used in the classes' <code>equals</code> methods, the symmetry principle would be broken.</p>
+<p>Additionally, non <code>final</code> classes shouldn't use a hardcoded class name in the <code>equals</code> method because doing so breaks the method for subclasses. Instead, make the comparison dynamic.</p>
 <p>Further, comparing to an unrelated class type breaks the contract for that unrelated type, because while <code>thisClass.equals(unrelatedClass)</code> can return true, <code>unrelatedClass.equals(thisClass)</code> will not.</p>
 <h2>Noncompliant Code Example</h2>
 

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2162.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2162.html
@@ -1,0 +1,41 @@
+<p>A key facet of the <code>equals</code> contract is that if <code>a.equals(b)</code> then <code>b.equals(a)</code>, i.e. that the relationship is symmetric. </p>
+<p>Using <code>instanceof</code> breaks the contract when there are subclasses, because while the child is an <code>instanceof</code> the parent, the parent is not an <code>intanceof</code> the child. Additionally, non <code>final</code> classes shouldn't use a hardcoded class name in the <code>equals</code> method because doing so breaks the method for subclasses. Instead, make the comparison dynamic.</p>
+<p>Further, comparing to an unrelated class type breaks the contract for that unrelated type, because while <code>thisClass.equals(unrelatedClass)</code> can return true, <code>unrelatedClass.equals(thisClass)</code> will not.</p>
+<h2>Noncompliant Code Example</h2>
+
+<pre>
+public class Fruit extends Food {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (Fruit.class == obj.getClass()) { // Noncompliant; broken for child classes
+      return ripe.equals(((Fruit)obj).getRipe());
+    }
+    if (obj instanceof Fruit ) {  // Noncompliant; broken for child classes
+      return ripe.equals(((Fruit)obj).getRipe());
+    }
+    else if (obj instanceof Season) { // Noncompliant; symmetry broken for Season class
+      // ...
+    }
+    //...
+</pre>
+<h2>Compliant Solution</h2>
+
+<pre>
+public class Fruit extends Food {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (this.getClass() == obj.getClass()) {
+      return ripe.equals(((Fruit)obj).getRipe());
+    }
+    return false;
+}
+</pre>
+

--- a/java-checks/src/test/files/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/test/files/checks/SymmetricEqualsCheck.java
@@ -54,3 +54,7 @@ public class Fruit3 extends Food {
     return false;
   }
 }
+
+public interface I {
+  public abstract boolean equals(Object anObject);
+}

--- a/java-checks/src/test/files/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/test/files/checks/SymmetricEqualsCheck.java
@@ -58,3 +58,20 @@ public class Fruit3 extends Food {
 public interface I {
   public abstract boolean equals(Object anObject);
 }
+public final class Fruit4 extends Food {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (Fruit4.class == obj.getClass()) { // Compliant; class is final
+      return ripe.equals(((Fruit4) obj).getRipe());
+    }
+    if (obj instanceof Fruit4) {  // Compliant; class is final
+      return ripe.equals(((Fruit4) obj).getRipe());
+    }
+    if (Fruit4.class != obj.getClass()) { // Compliant; class is final
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/SymmetricEqualsCheck.java
+++ b/java-checks/src/test/files/checks/SymmetricEqualsCheck.java
@@ -1,0 +1,56 @@
+public class Fruit extends Food {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (Fruit.class == obj.getClass()) { // Noncompliant; broken for child classes
+      return ripe.equals(((Fruit) obj).getRipe());
+    }
+    if (obj instanceof Fruit) {  // Noncompliant; broken for child classes
+      return ripe.equals(((Fruit) obj).getRipe());
+    } else if (obj instanceof Season) { // Noncompliant; symmetry broken for Season class
+      // ...
+    }
+    if (Fruit.class != obj.getClass()) { // Noncompliant; broken for child classes
+    }
+  }
+}
+public class Fruit2 extends Food {
+  private Season ripe;
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (this.getClass()==obj.getClass()){
+      return ripe.equals(((Fruit2) obj).getRipe());
+    }
+    return false;
+  }
+}
+
+public class Fruit3 extends Food {
+
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (this.getClass()==obj.getClass()){
+      return ripe.equals(((Fruit2) obj).getRipe());
+    }
+    class Foo {
+      public boolean equals(Object j) {
+        if (Foo.class==obj.getClass()){ //NonCompliant
+
+        }
+        if (obj instanceof Season) { // Noncompliant; symmetry broken for Season class
+          // ...
+        }
+        return false;
+      }
+    }
+    return false;
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/SymmetricEqualsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/SymmetricEqualsCheckTest.java
@@ -1,0 +1,49 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class SymmetricEqualsCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void detected() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/SymmetricEqualsCheck.java"), new VisitorsBridge(new SymmetricEqualsCheck()));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(8).withMessage("Compare to \"this.getClass()\" instead.")
+      .next().atLine(11).withMessage("Compare to \"this.getClass()\" instead.")
+      .next().atLine(13).withMessage("Remove this comparison to an unrelated class.")
+      .next().atLine(16).withMessage("Compare to \"this.getClass()\" instead.")
+      .next().atLine(45).withMessage("Compare to \"this.getClass()\" instead.")
+      .next().atLine(48).withMessage("Remove this comparison to an unrelated class.")
+    .noMore();
+  }
+
+}

--- a/java-squid/src/main/java/org/sonar/java/model/declaration/MethodTreeImpl.java
+++ b/java-squid/src/main/java/org/sonar/java/model/declaration/MethodTreeImpl.java
@@ -291,5 +291,18 @@ public class MethodTreeImpl extends JavaTree implements MethodTree {
     return name.equals(simpleName().name());
   }
 
+  public boolean isEqualsMethod() {
+    return isPublic() && !isStatic() && isNamed("equals") && returnsBoolean() && hasObjectParameter();
+  }
 
+  private boolean hasObjectParameter() {
+    return parameters.size()==1 && parameters.get(0).getSymbol().getType().is("java.lang.Object");
+  }
+
+  private boolean returnsBoolean() {
+    if (returnType != null) {
+      return returnType.is(Tree.Kind.PRIMITIVE_TYPE) && "boolean".equals(((PrimitiveTypeTree) returnType).keyword().text());
+    }
+    return false;
+  }
 }

--- a/java-squid/src/test/java/org/sonar/java/model/declaration/MethodTreeImplTest.java
+++ b/java-squid/src/test/java/org/sonar/java/model/declaration/MethodTreeImplTest.java
@@ -113,6 +113,16 @@ public class MethodTreeImplTest {
   }
 
   @Test
+  public void is_equals_method() throws Exception {
+    assertThat(getUniqueMethod("class A { public boolean equals(Object o){} }").isEqualsMethod()).isTrue();
+    assertThat(getUniqueMethod("class A { public static boolean equals(Object o){} }").isEqualsMethod()).isFalse();
+    assertThat(getUniqueMethod("class A { public boolean equal(Object o){} }").isEqualsMethod()).isFalse();
+    assertThat(getUniqueMethod("class A { public boolean equals(Object o, int a){} }").isEqualsMethod()).isFalse();
+    assertThat(getUniqueMethod("class A { public boolean equals(int a){} }").isEqualsMethod()).isFalse();
+    assertThat(getUniqueMethod("class equals { public equals(Object o){} }").isEqualsMethod()).isFalse();
+  }
+
+  @Test
   public void varargs_flag() {
     assertThat((getUniqueMethod("class A { public static void main(String[] args){} }").getSymbol().flags() & Flags.VARARGS) != 0).isFalse();
     assertThat((getUniqueMethod("class A { public static void main(String... args){} }").getSymbol().flags() & Flags.VARARGS) != 0).isTrue();

--- a/java-squid/src/test/java/org/sonar/java/model/declaration/MethodTreeImplTest.java
+++ b/java-squid/src/test/java/org/sonar/java/model/declaration/MethodTreeImplTest.java
@@ -120,6 +120,7 @@ public class MethodTreeImplTest {
     assertThat(getUniqueMethod("class A { public boolean equals(Object o, int a){} }").isEqualsMethod()).isFalse();
     assertThat(getUniqueMethod("class A { public boolean equals(int a){} }").isEqualsMethod()).isFalse();
     assertThat(getUniqueMethod("class equals { public equals(Object o){} }").isEqualsMethod()).isFalse();
+    assertThat(getUniqueMethod("interface I { public abstract boolean equals(Object o); }").isEqualsMethod()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
This includes an implementation of the `isEqualsMethod` in `MethodTreeImpl` in order to stop implementing this over and over again.