### PR TITLE
exclude method names from check by regular expressions

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateMethodCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateMethodCheckTest.java
@@ -60,10 +60,23 @@ public class UnusedPrivateMethodCheckTest {
     SourceFile file = BytecodeFixture.scan("UnusedPrivateMethod", check);
     CheckMessagesVerifier.verify(file.getCheckMessages())
         .next().withMessage("Private constructor 'org.sonar.java.checks.targets.UnusedPrivateMethod$A(UnusedPrivateMethod)' is never used.")
-        .next().atLine(54).withMessage("Private method 'unusedPrivateMethod' is never used.")
-        .next().atLine(57).withMessage("Private method 'unusedPrivateMethod' is never used.")
-        .next().atLine(67).withMessage("Private constructor 'org.sonar.java.checks.targets.UnusedPrivateMethod$Attribute(String,String[],int)' is never used.")
+        .next().atLine(53).withMessage("Private method 'unusedPrivateMethodExcludedByPattern' is never used.")
+        .next().atLine(58).withMessage("Private method 'unusedPrivateMethod' is never used.")
+        .next().atLine(61).withMessage("Private method 'unusedPrivateMethod' is never used.")
+        .next().atLine(71).withMessage("Private constructor 'org.sonar.java.checks.targets.UnusedPrivateMethod$Attribute(String,String[],int)' is never used.")
         .noMore();
+  }
+
+  @Test
+  public void test_exclusionByPattern() {
+	  check.setExcludeMethodNamePattern("^\\w+ExcludedByPattern$");
+	  SourceFile file = BytecodeFixture.scan("UnusedPrivateMethod", check);
+	  CheckMessagesVerifier.verify(file.getCheckMessages())
+	  .next().withMessage("Private constructor 'org.sonar.java.checks.targets.UnusedPrivateMethod$A(UnusedPrivateMethod)' is never used.")
+	  .next().atLine(58).withMessage("Private method 'unusedPrivateMethod' is never used.")
+	  .next().atLine(61).withMessage("Private method 'unusedPrivateMethod' is never used.")
+	  .next().atLine(71).withMessage("Private constructor 'org.sonar.java.checks.targets.UnusedPrivateMethod$Attribute(String,String[],int)' is never used.")
+	  .noMore();
   }
 
   @Test

--- a/java-checks/src/test/java/org/sonar/java/checks/targets/UnusedPrivateMethod.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/targets/UnusedPrivateMethod.java
@@ -50,6 +50,10 @@ public class UnusedPrivateMethod {
     // this method should not be considered as dead code, see Serializable contract
   }
 
+  private void unusedPrivateMethodExcludedByPattern() {
+    // this method should not be considered as dead code, see exclusion pattern
+  }
+
   @SuppressWarnings("unused")
   private int unusedPrivateMethod() {
     return 1;


### PR DESCRIPTION
We use a very old bytecode-enhancing technology (Kodo JDO) which produces getter and setter in our bytecode for intercepting access to persistent objects.
Some of the generated methods are not called (an they're private), so we get false positives with UnusedPrivateMethodCheck rule.
I added a string parameter to that rule which can hold a regular expression for method names to include (all our false positive methods match to '^jdo[GS]et\w+').
Test is included.