### PR TITLE
Explained limitation of current calculation

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/SwitchCaseTooBigCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SwitchCaseTooBigCheck.java
@@ -71,7 +71,9 @@ public class SwitchCaseTooBigCheck extends SquidCheck<LexerlessGrammar> {
 
   private void check(int caseStartLine, int nextCaseStartLine) {
     int lines = Math.max(nextCaseStartLine - caseStartLine, 1);
-
+    // That number is not correct if the case statement contains empty lines.
+    // My students like to create empty lines in their code and their are caught
+    // by that too simple calculation.
     if (lines > max) {
       getContext().createLineViolation(
         this,


### PR DESCRIPTION
The current calculation does not take into account empty lines added within the case statements.

This is not a real pull request because I do not provide the code to fix this. I use the PR mechanism because I found no other way (JIRA, GitHub issues) to point out that issue.
