### PR TITLE
Removed typo in the S2134 example: Threads -> Thread

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2134.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2134.html
@@ -8,7 +8,7 @@ The other way to create a thread is to declare a class that implements the Runna
 
 <h2>Noncompliant Code Example</h2>
 <pre>
-public class MyRunner extends Threads { // Noncompliant; run method not overridden
+public class MyRunner extends Thread { // Noncompliant; run method not overridden
 
   public void doSometing() {...}
 }


### PR DESCRIPTION
Hi,
I found a typo in the description of the rule S2134, so I corrected it

Regards
   Adam Gabryś