### PR TITLE
SONARJAVA-73 don't mark Lombok's @Getter/@Setter as unused private field

### DIFF
--- a/java-checks/src/test/files/checks/UnusedPrivateMethodCheckLombok.java
+++ b/java-checks/src/test/files/checks/UnusedPrivateMethodCheckLombok.java
@@ -1,0 +1,27 @@
+import lombok.Getter;
+import lombok.Setter;
+
+public class UnusedPrivateMethodCheckLombok {
+
+    private int unused;
+
+    @Getter
+    private int getter;
+
+    @Setter
+    private int setter;
+
+    @Getter
+    @Setter
+    private int geterSetter;
+
+    @lombok.Getter
+    private int getter2;
+
+    @lombok.Setter
+    private int setter2;
+
+    @lombok.Getter
+    @lombok.Setter
+    private int getterSetter2;
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateFieldCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateFieldCheckTest.java
@@ -29,6 +29,8 @@ import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 
 import java.io.File;
 
+import junit.framework.Assert;
+
 public class UnusedPrivateFieldCheckTest {
 
   @Rule
@@ -54,6 +56,14 @@ public class UnusedPrivateFieldCheckTest {
     return JavaAstScanner.scanSingleFile(
       new File("src/test/files/checks/" + fileName),
       new VisitorsBridge(new UnusedPrivateFieldCheck(), ImmutableList.of(new File("target/test-classes"))));
+  }
+
+  @Test
+  public void lombokTest() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UnusedPrivateMethodCheckLombok.java"), new VisitorsBridge(new UnusedPrivateFieldCheck()));
+    Assert.assertEquals(1, file.getCheckMessages().size());
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(6).withMessage("Remove this unused \"unused\" private field.");
   }
 
 }


### PR DESCRIPTION
http://projectlombok.org/ introduces @Getter/@Setter to simplify method.

This patch won't mark Lombok's @Getter/@Setter as unused private field.

// maybe S1068.html should be updated too?