### PR TITLE
don't mark lombok's Getter/Setter as unused private field

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/UnusedPrivateFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UnusedPrivateFieldCheck.java
@@ -126,8 +126,29 @@ public class UnusedPrivateFieldCheck extends SubscriptionBaseVisitor {
     }
   }
 
+  private boolean isLombok(IdentifierTree tree) {
+    String name = tree.name();
+    return ("Getter".equals(name) || "Setter".equals(name));
+  }
+
+  private boolean isLombok(VariableTree tree) {
+    for (AnnotationTree annotationTree : tree.modifiers().annotations()) {
+      if (annotationTree.annotationType().is(Tree.Kind.MEMBER_SELECT)) {
+        MemberSelectExpressionTree annotationType = (MemberSelectExpressionTree) annotationTree.annotationType();
+        if ("lombok".equals(annotationType.expression().toString()) && isLombok(annotationType.identifier())) {
+          return true;
+        }
+      } else if (annotationTree.annotationType().is(Tree.Kind.IDENTIFIER)) {
+        if (isLombok((IdentifierTree) annotationTree.annotationType())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   public void checkIfUnused(VariableTree tree) {
-    if (tree.modifiers().modifiers().contains(Modifier.PRIVATE) && !"serialVersionUID".equals(tree.simpleName().name())) {
+    if (!isLombok(tree) && tree.modifiers().modifiers().contains(Modifier.PRIVATE) && !"serialVersionUID".equals(tree.simpleName().name())) {
       SemanticModel semanticModel = getSemanticModel();
       Symbol symbol = semanticModel.getSymbol(tree);
       if (symbol != null && semanticModel.getUsages(symbol).size() == assignments.get(symbol).size() && !hasExcludedAnnotation(tree)) {

--- a/java-checks/src/test/files/checks/UnusedPrivateMethodCheckLombok.java
+++ b/java-checks/src/test/files/checks/UnusedPrivateMethodCheckLombok.java
@@ -1,0 +1,27 @@
+import lombok.Getter;
+import lombok.Setter;
+
+public class UnusedPrivateMethodCheckLombok {
+
+    private int unused;
+
+    @Getter
+    private int getter;
+
+    @Setter
+    private int setter;
+
+    @Getter
+    @Setter
+    private int geterSetter;
+
+    @lombok.Getter
+    private int getter2;
+
+    @lombok.Setter
+    private int setter2;
+
+    @lombok.Getter
+    @lombok.Setter
+    private int getterSetter2;
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateFieldCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UnusedPrivateFieldCheckTest.java
@@ -29,6 +29,8 @@ import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 
 import java.io.File;
 
+import junit.framework.Assert;
+
 public class UnusedPrivateFieldCheckTest {
 
   @Rule
@@ -54,6 +56,14 @@ public class UnusedPrivateFieldCheckTest {
     return JavaAstScanner.scanSingleFile(
       new File("src/test/files/checks/" + fileName),
       new VisitorsBridge(new UnusedPrivateFieldCheck(), ImmutableList.of(new File("target/test-classes"))));
+  }
+
+  @Test
+  public void lombokTest() {
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UnusedPrivateMethodCheckLombok.java"), new VisitorsBridge(new UnusedPrivateFieldCheck()));
+    Assert.assertEquals(1, file.getCheckMessages().size());
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(6).withMessage("Remove this unused \"unused\" private field.");
   }
 
 }


### PR DESCRIPTION
See https://jira.codehaus.org/browse/SONARJAVA-73

http://projectlombok.org/ introduce `Getter/Setter`, which simplify `getter/setter` use annotation. This patch won't mark these annotation as unsed private field.