### PR TITLE
CompareObjectWithEqualsCheck: allow exclusion of class types

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CompareObjectWithEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CompareObjectWithEqualsCheck.java
@@ -61,26 +61,17 @@ public class CompareObjectWithEqualsCheck extends BaseTreeVisitor implements Jav
   @RuleProperty(
       key = "exclusions",
       defaultValue = "" + DEFAULT_EXCLUSIONS)
-  private String exclusions;
+  private String exclusions = DEFAULT_EXCLUSIONS;
   
   private Set<String> exclusionSet;
   
-  public CompareObjectWithEqualsCheck() {
-	  exclusionSet = new HashSet<String>();
-	  setExclusions(DEFAULT_EXCLUSIONS);
-  }
-
-  public void setExclusions(String exclusions) {
-	  this.exclusions = exclusions;
-	  exclusionSet.clear();
-	  
-	  if (exclusions != null) {
+  private synchronized Set<String> getExclusionSet() {
+	  if (exclusionSet == null) {
+		  exclusionSet = new HashSet<String>();
 		  exclusionSet.addAll(Arrays.asList(exclusions.split(SEPARATOR)));
 	  }
-  }
-  
-  public String getExclusions() {
-	  return exclusions;
+	  
+	  return exclusionSet;
   }
   
   @Override
@@ -151,6 +142,6 @@ public class CompareObjectWithEqualsCheck extends BaseTreeVisitor implements Jav
   }
 
   private boolean isExcludedComparison(Type leftOpType, Type rightOpType) {
-    return exclusionSet.contains(leftOpType.toString()) || exclusionSet.contains(rightOpType.toString());
+    return getExclusionSet().contains(leftOpType.toString()) || getExclusionSet().contains(rightOpType.toString());
   }
 }


### PR DESCRIPTION
The possibility to exclude certain class types from the comparison would be highly appreciated.

We have certain classes in our project for which a comparison with == and a comparison with the equals method gives the same result (e.g. key classes which are implemented as singletons per value). We prefer to compare instances of these classes with == (reasons are avoidance of NPEs and better readability) and have a custom SonarQube rule to ensure the adherence to this convention. However, our custom rule is understandably in conflict with the CompareObjectWithEqualsCheck for the these classes. As we would like to keep the "compare with equals"-check, a way to exclude certain class types would be desirable.

This pull request introduces a new rule parameter named "exclusions". The string parameter holds the fully qualified names of classes separated by ";". It is used to check if comparisons shall be skipped depending on the type. Currently, only comparisons with java.lang.Class are skipped.