### PR TITLE
SONARJAVA-956 Refactor check to use AbstractMethodDetection

### DIFF
--- a/java-checks/src/test/files/checks/ThreadRunCheck.java
+++ b/java-checks/src/test/files/checks/ThreadRunCheck.java
@@ -1,24 +1,3 @@
-/*
- * SonarQube Java
- * Copyright (C) 2012 SonarSource
- * dev@sonar.codehaus.org
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
- */
-package org.sonar.java.checks.targets;
-
 import java.io.Serializable;
 
 class A {
@@ -71,8 +50,8 @@ class A {
     @Override
     public void run() {
       C c = new C();
-      c.run(); // Noncompliant but false negative
-      super.run();
+      c.run(); // Noncompliant
+      super.run(); // Noncompliant
     }
   }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/ThreadRunCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ThreadRunCheckTest.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.java.checks;
 
-import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
 import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 
-import static org.fest.assertions.Assertions.assertThat;
+import java.io.File;
 
 public class ThreadRunCheckTest {
 
@@ -35,19 +37,16 @@ public class ThreadRunCheckTest {
 
   @Test
   public void detected() {
-    SourceFile file = BytecodeFixture.scan("ThreadRunCheck", check);
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/ThreadRunCheck.java"), new VisitorsBridge(check));
     checkMessagesVerifier
       .verify(file.getCheckMessages())
-      .next().atLine(29).withMessage("Call the method Thread.start() to execute the content of the run() method in a dedicated thread.")
-      .next().atLine(39)
-      .next().atLine(42)
-      .next().atLine(45)
-      .next().atLine(53);
+      .next().atLine(8).withMessage("Call the method Thread.start() to execute the content of the run() method in a dedicated thread.")
+      .next().atLine(18)
+      .next().atLine(21)
+      .next().atLine(24)
+      .next().atLine(32)
+      .next().atLine(53)
+      .next().atLine(54)
+      .noMore();
   }
-
-  @Test
-  public void test_toString() {
-    assertThat(check.toString()).isEqualTo("S1217 rule");
-  }
-
 }


### PR DESCRIPTION
Refactor from `BytecodeVisitor` to `AbstractMethodDetection`. 
Note that check only looks at method invocations from classes having `java.lang.Runnable` as super-type, as `java.lang.Thread` implements `java.lang.Runnable`.