### PR TITLE
SONARJAVA-957 RSPEC-2695 PreparedStatement and ResultSet check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -304,7 +304,8 @@ public final class CheckList {
       NullPointerCheck.class,
       StaticFieldUpateCheck.class,
       IgnoredStreamReturnValueCheck.class,
-      DateUtilsTruncateCheck.class
+      DateUtilsTruncateCheck.class,
+      PreparedStatementAndResultSetCheck.class
       );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/PreparedStatementAndResultSetCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PreparedStatementAndResultSetCheck.java
@@ -1,0 +1,119 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.java.checks.methods.AbstractMethodDetection;
+import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.NameCriteria;
+import org.sonar.java.checks.methods.TypeCriteria;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.plugins.java.api.tree.VariableTree;
+import org.sonar.squidbridge.annotations.ActivatedByDefault;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import javax.annotation.CheckForNull;
+
+import java.util.List;
+
+@Rule(
+  key = "S2695",
+  name = "\"PreparedStatement\" and \"ResultSet\" methods should be called with valid indices",
+  tags = {"bug", "sql"},
+  priority = Priority.BLOCKER)
+@ActivatedByDefault
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.INSTRUCTION_RELIABILITY)
+@SqaleConstantRemediation("2min")
+public class PreparedStatementAndResultSetCheck extends AbstractMethodDetection {
+
+  @Override
+  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(
+      MethodInvocationMatcher.create().typeDefinition("java.sql.PreparedStatement").name(NameCriteria.startsWith("set")).addParameter("int").addParameter(TypeCriteria.anyType()),
+      MethodInvocationMatcher.create().typeDefinition("java.sql.ResultSet").name(NameCriteria.startsWith("get")).addParameter("int"),
+      MethodInvocationMatcher.create().typeDefinition("java.sql.ResultSet").name(NameCriteria.startsWith("get")).addParameter("int").addParameter(TypeCriteria.anyType()));
+  }
+
+  @Override
+  protected void onMethodFound(MethodInvocationTree mit) {
+    Integer methodFirstArgumentAsInteger = LiteralUtils.intLiteralValue(mit.arguments().get(0));
+    if (methodFirstArgumentAsInteger == null) {
+      // nothing to say if first argument can not be evaluated
+      return;
+    }
+
+    boolean isMethodFromJavaSqlResultSet = mit.symbol().owner().type().is("java.sql.ResultSet");
+    int methodFirstArgumentValue = methodFirstArgumentAsInteger.intValue();
+
+    if (isMethodFromJavaSqlResultSet && methodFirstArgumentValue == 0) {
+      addIssue(mit, "ResultSet indices start at 1.");
+    } else if (!isMethodFromJavaSqlResultSet) {
+      if (methodFirstArgumentValue == 0) {
+        addIssue(mit, "PreparedStatement indices start at 1.");
+      } else {
+        Tree preparedStatementReference = getPreparedStatementReference(mit);
+        Integer numberParameters = getNumberParametersFromPreparedStatement(preparedStatementReference);
+        if (numberParameters != null && methodFirstArgumentValue > numberParameters.intValue()) {
+          addIssue(mit, "This \"PreparedStatement\" " + (numberParameters == 0 ? "has no" : "only has " + numberParameters) + " parameters.");
+        }
+      }
+    }
+  }
+
+  @CheckForNull
+  private Tree getPreparedStatementReference(MethodInvocationTree mit) {
+    ExpressionTree methodSelect = mit.methodSelect();
+    if (methodSelect.is(Kind.MEMBER_SELECT)) {
+      ExpressionTree expression = ((MemberSelectExpressionTree) methodSelect).expression();
+      if (expression.is(Kind.IDENTIFIER)) {
+        Symbol referenceSymbol = getSemanticModel().getReference((IdentifierTree) expression);
+        return getSemanticModel().getTree(referenceSymbol);
+      }
+    }
+    return null;
+  }
+
+  @CheckForNull
+  private Integer getNumberParametersFromPreparedStatement(Tree tree) {
+    if (tree != null && tree.is(Kind.VARIABLE)) {
+      ExpressionTree initializer = ((VariableTree) tree).initializer();
+      if (initializer != null && initializer.is(Kind.METHOD_INVOCATION)) {
+        List<ExpressionTree> arguments = ((MethodInvocationTree) initializer).arguments();
+        if (!arguments.isEmpty() && arguments.get(0).is(Tree.Kind.STRING_LITERAL)) {
+          return StringUtils.countMatches(((LiteralTree) arguments.get(0)).value(), "?");
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/methods/NameCriteria.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/methods/NameCriteria.java
@@ -1,0 +1,60 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks.methods;
+
+public abstract class NameCriteria {
+
+  public abstract boolean matches(String name);
+
+  public static NameCriteria is(String exactName) {
+    return new ExactNameCriteria(exactName);
+  }
+
+  public static NameCriteria startsWith(String prefix) {
+    return new PrefixNameCriteria(prefix);
+  }
+
+  private static class ExactNameCriteria extends NameCriteria {
+    private String exactName;
+
+    public ExactNameCriteria(String exactName) {
+      this.exactName = exactName;
+    }
+
+    @Override
+    public boolean matches(String name) {
+      return exactName.equals(name);
+    }
+  }
+
+  private static class PrefixNameCriteria extends NameCriteria {
+    private String prefix;
+
+    public PrefixNameCriteria(String prefix) {
+      this.prefix = prefix;
+    }
+
+    @Override
+    public boolean matches(String name) {
+      return name.startsWith(prefix);
+    }
+
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/methods/TypeCriteria.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/methods/TypeCriteria.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.checks.methods;
 
-
 import org.sonar.plugins.java.api.semantic.Type;
 
 public abstract class TypeCriteria {
@@ -29,6 +28,10 @@ public abstract class TypeCriteria {
 
   public static TypeCriteria is(String fullyQualifiedName) {
     return new FullyQualifiedNameTypeCriteria(fullyQualifiedName);
+  }
+
+  public static TypeCriteria anyType() {
+    return new AnyTypeCriteria();
   }
 
   public abstract boolean matches(Type type);
@@ -56,6 +59,14 @@ public abstract class TypeCriteria {
     @Override
     public boolean matches(Type type) {
       return type.isSubtypeOf(superTypeName);
+    }
+  }
+
+  private static class AnyTypeCriteria extends TypeCriteria {
+
+    @Override
+    public boolean matches(Type type) {
+      return true;
     }
   }
 }

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2695.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2695.html
@@ -1,0 +1,29 @@
+<p>The parameters in a <code>PreparedStatement</code> are numbered from 1, not 0, so using any set method of a <code>PreparedStatement</code> with a number less than 1 is a bug, as is using an index higher than the number of parameters. Similarly, <code>ResultSet</code> indices also start at 1, rather than 0.</p>
+
+<h2>Noncompliant Code Example</h2>
+
+<pre>
+PreparedStatement ps = con.prepareStatement("SELECT fname, lname FROM employees where hireDate > ? and salary < ?");
+ps.setDate(0, date);  // Noncompliant
+ps.setDouble(3, salary);  // Noncompliant
+
+ResultSet rs = ps.executeQuery();
+while (rs.next()) {
+  String fname = rs.getString(0);  // Noncompliant
+  // ...
+}
+</pre>
+
+<h2>Compliant Solution</h2>
+
+<pre>
+PreparedStatement ps = con.prepareStatement("SELECT fname, lname FROM employees where hireDate > ? and salary < ?");
+ps.setDate(1, date);
+ps.setDouble(2, salary);
+
+ResultSet rs = ps.executeQuery();
+while (rs.next()) {
+  String fname = rs.getString(1);
+  // ...
+}
+</pre>

--- a/java-checks/src/test/files/checks/PreparedStatementAndResultSetCheck.java
+++ b/java-checks/src/test/files/checks/PreparedStatementAndResultSetCheck.java
@@ -1,0 +1,66 @@
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.GregorianCalendar;
+
+class A {
+  void foo(Connection connection) throws SQLException {
+    PreparedStatement ps = connection.prepareStatement("SELECT fname, lname FROM employees where hireDate > ? and salary < ?");
+
+    ps.setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    ps.setDouble(3, 0.0); // Noncompliant - Statement has only 2 parameters
+    ps.setString(getIntValue(), ""); // Compliant - first argument can not be evaluated
+    ps.setInt(1, 0); // Compliant
+
+    ResultSet rs = ps.executeQuery();
+    rs.getString(0); // Noncompliant - First column index is 1
+    rs.getDate(0, new GregorianCalendar()); // Noncompliant - First column index is 1
+    rs.getString(1); // Compliant
+  }
+  
+  void bar(Connection connection) throws SQLException {
+    PreparedStatement ps = connection.prepareStatement("SELECT fname, lname FROM employees where hireDate > 1986");
+
+    ps.setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    ps.setDouble(3, 0.0); // Noncompliant - Statement has no parameter
+  }
+  
+  void dam(Connection connection, String query) throws SQLException {
+    PreparedStatement ps = connection.prepareStatement(query);
+
+    ps.setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    ps.setDouble(3, 0.0); // Compliant - Query of the preparedStatement is unknown
+  }
+  
+  void cro(PreparedStatement ps) throws SQLException {
+    ps.setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    ps.setDouble(3, 0.0); // Compliant - Query of the preparedStatement is unknown
+  }
+  
+  void elk() throws SQLException {
+    getPreparedStatement().setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    getPreparedStatement().setDouble(3, 0.0); // Compliant - Query of the preparedStatement is unknown
+  }
+  
+  void gra() throws SQLException {
+    PreparedStatement ps = getPreparedStatement();
+    
+    ps.setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    ps.setDouble(3, 0.0); // Compliant - Query of the preparedStatement is unknown
+    
+    PreparedStatement ps2 = ps;
+    ps2.setDate(0, new Date(0)); // Noncompliant - First parameter index is 1
+    ps2.setDouble(3, 0.0); // Compliant - Query of the preparedStatement is unknown
+  }
+
+  int getIntValue() {
+    return 0;
+  }
+  
+  PreparedStatement getPreparedStatement() {
+    return null;
+  }
+  
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/PreparedStatementAndResultSetCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/PreparedStatementAndResultSetCheckTest.java
@@ -1,0 +1,56 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+
+public class PreparedStatementAndResultSetCheckTest {
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void detected() {
+    SourceFile file = JavaAstScanner.scanSingleFile(
+      new File("src/test/files/checks/PreparedStatementAndResultSetCheck.java"),
+      new VisitorsBridge(new PreparedStatementAndResultSetCheck()));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(12).withMessage("PreparedStatement indices start at 1.")
+      .next().atLine(13).withMessage("This \"PreparedStatement\" only has 2 parameters.")
+      .next().atLine(18).withMessage("ResultSet indices start at 1.")
+      .next().atLine(19).withMessage("ResultSet indices start at 1.")
+      .next().atLine(26).withMessage("PreparedStatement indices start at 1.")
+      .next().atLine(27).withMessage("This \"PreparedStatement\" has no parameters.")
+      .next().atLine(33).withMessage("PreparedStatement indices start at 1.")
+      .next().atLine(38).withMessage("PreparedStatement indices start at 1.")
+      .next().atLine(43).withMessage("PreparedStatement indices start at 1.")
+      .next().atLine(50).withMessage("PreparedStatement indices start at 1.")
+      .next().atLine(54).withMessage("PreparedStatement indices start at 1.")
+      .noMore();
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/methods/NameCriteriaTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/methods/NameCriteriaTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.java.checks.methods;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class NameCriteriaTest {
+
+  @Test
+  public void should_match_exact_name() {
+    NameCriteria nc = NameCriteria.is("equal");
+    assertThat(nc.matches("foo")).isFalse();
+    assertThat(nc.matches("equal")).isTrue();
+  }
+
+  @Test
+  public void should_match_prefix() {
+    NameCriteria nc = NameCriteria.startsWith("get");
+    assertThat(nc.matches("equal")).isFalse();
+    assertThat(nc.matches("get")).isTrue();
+    assertThat(nc.matches("getObject")).isTrue();
+  }
+}

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -43,7 +43,7 @@ public class JavaSonarWayProfileTest {
     RulesProfile profile = definition.createProfile(validation);
 
     assertThat(profile.getLanguage()).isEqualTo(Java.KEY);
-    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(193);
+    assertThat(profile.getActiveRulesByRepository(CheckList.REPOSITORY_KEY)).hasSize(194);
     assertThat(profile.getName()).isEqualTo("Sonar way");
     assertThat(validation.hasErrors()).isFalse();
   }


### PR DESCRIPTION
The PR is in two parts:
- First part improves `MethodInvocationMatcher` by adding new features:
  - It is now possible to set a (new) `NameCriteria` to match method name, instead of only using exact name. Currently provided `NameCriteria` handle the following situations: 
    - exact name
    - prefix  (which can be used to target getter or setter for instance) 
  - Parameters can now be handled using `TypeCriteria`, allowing for instance to target methods having a parameter being a sub-type of a given fully qualified name.
  - A new `TypeCriteria` have been introduced, which corresponds to "*any Type*". It can be used as a wildcard for a method parameter.
- Second part adds new check verifying usages of `PreparedStatement` and `ResultSet` methods. It implements [RSPEC-2695] (http://jira.sonarsource.com/browse/RSPEC-2695)