### PR TITLE
SONARJAVA-991 Migrates EmptyMethodsCheck

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyMethodsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyMethodsCheck.java
@@ -19,14 +19,10 @@
  */
 package org.sonar.java.checks;
 
-import com.sonar.sslr.api.AstNode;
+import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.model.JavaTree;
-import org.sonar.plugins.java.api.JavaFileScanner;
-import org.sonar.plugins.java.api.JavaFileScannerContext;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
@@ -37,6 +33,8 @@ import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 
+import java.util.List;
+
 @Rule(
   key = "S1186",
   name = "Methods should not be empty",
@@ -45,49 +43,34 @@ import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 @ActivatedByDefault
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.ARCHITECTURE_RELIABILITY)
 @SqaleConstantRemediation("5min")
-public class EmptyMethodsCheck extends BaseTreeVisitor implements JavaFileScanner {
-
-  private JavaFileScannerContext context;
+public class EmptyMethodsCheck extends SubscriptionBaseVisitor {
 
   @Override
-  public void scanFile(JavaFileScannerContext context) {
-    this.context = context;
-
-    scan(context.getTree());
+  public List<Kind> nodesToVisit() {
+    return ImmutableList.of(Tree.Kind.CLASS, Tree.Kind.ENUM);
   }
 
   @Override
-  public void visitClass(ClassTree tree) {
-    if (!tree.modifiers().modifiers().contains(Modifier.ABSTRACT)) {
-      super.visitClass(tree);
-    } else {
-      scan(tree.modifiers());
-      scan(tree.typeParameters());
-      scan(tree.superClass());
-      scan(tree.superInterfaces());
-      for (Tree memberTree : tree.members()) {
-        if (memberTree.is(Kind.METHOD)) {
-          super.visitMethod((MethodTree) memberTree);
-        } else {
-          scan(memberTree);
+  public void visitNode(Tree tree) {
+    ClassTree classTree = (ClassTree) tree;
+    if (!classTree.modifiers().modifiers().contains(Modifier.ABSTRACT)) {
+      for (Tree member : classTree.members()) {
+        if (member.is(Kind.METHOD)) {
+          checkMethod((MethodTree) member);
         }
       }
     }
   }
 
-  @Override
-  public void visitMethod(MethodTree tree) {
-    super.visitMethod(tree);
-
-    BlockTree block = tree.block();
-    if (block != null && block.body().isEmpty() && !tree.is(Kind.CONSTRUCTOR) && !containsComment(block)) {
-      context.addIssue(tree, this, "Add a nested comment explaining why this method is empty, throw an UnsupportedOperationException or complete the implementation.");
+  private void checkMethod(MethodTree methodTree) {
+    BlockTree block = methodTree.block();
+    if (block != null && block.body().isEmpty() && !containsComment(block)) {
+      context.addIssue(methodTree, this, "Add a nested comment explaining why this method is empty, throw an UnsupportedOperationException or complete the implementation.");
     }
   }
 
-  private static boolean containsComment(BlockTree tree) {
-    AstNode blockAstNode = ((JavaTree) tree).getAstNode();
-    return blockAstNode.getLastToken().hasTrivia();
+  private static boolean containsComment(BlockTree block) {
+    return !block.closeBraceToken().trivias().isEmpty();
   }
 
 }

--- a/java-checks/src/test/files/checks/EmptyMethodsCheck.java
+++ b/java-checks/src/test/files/checks/EmptyMethodsCheck.java
@@ -11,7 +11,7 @@ class A {
   private <T> A() {
   }
 
-  // Non-Compliant
+  // Noncompliant@+1
   private void f() {
   }
 
@@ -25,11 +25,11 @@ class A {
     throw new UnsupportedOperationException();
   }
 
-  // Non-Compliant
+  // Noncompliant@+1
   private <T> void f() {
   }
 
-  // Non-Compliant
+  // Noncompliant@+1
   private int f() {
   }
 
@@ -53,14 +53,14 @@ abstract class AAbstract {
     }
 
     static class C {
-      // Non-Compliant
+      // Noncompliant@+1
       private void g() {
       }
     }
   }
 
   Foo bar = new IFoo() {
-    // Noncompliant
+    // Noncompliant@+1
     public void f() {
     }
   };
@@ -69,7 +69,7 @@ abstract class AAbstract {
 enum AEnum {
   ;
 
-  // Non-Compliant
+  // Noncompliant@+1
   public void f() {
   }
 
@@ -82,7 +82,7 @@ class ANestedEnum {
   enum B {
     ;
 
-    // Non-Compliant
+    // Noncompliant@+1
     public void f() {
     }
   }
@@ -91,7 +91,7 @@ class ANestedEnum {
 public interface IFoo {
 
   static IFoo FOO = new IFoo() {
-    // Noncompliant
+    // Noncompliant@+1
     public void foo() {
     }
 
@@ -106,7 +106,7 @@ public interface IFoo {
 enum Foo {
 
   FOO {
-    // Noncompliant
+    // Noncompliant@+1
     public void foo() {
     }
 
@@ -116,7 +116,7 @@ enum Foo {
     }
   };
 
-  // Noncompliant
+  // Noncompliant@+1
   public void foo() {
   }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/EmptyMethodsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/EmptyMethodsCheckTest.java
@@ -19,35 +19,13 @@
  */
 package org.sonar.java.checks;
 
-import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.sonar.java.JavaAstScanner;
-import org.sonar.java.model.VisitorsBridge;
-import org.sonar.squidbridge.api.SourceFile;
-
-import java.io.File;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
 public class EmptyMethodsCheckTest {
 
-  @Rule
-  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
-
   @Test
   public void detected() {
-    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/EmptyMethodsCheck.java"), new VisitorsBridge(new EmptyMethodsCheck()));
-    checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(15)
-      .withMessage("Add a nested comment explaining why this method is empty, throw an UnsupportedOperationException or complete the implementation.")
-      .next().atLine(29)
-      .next().atLine(33)
-      .next().atLine(57)
-      .next().atLine(64)
-      .next().atLine(73)
-      .next().atLine(86)
-      .next().atLine(95)
-      .next().atLine(110)
-      .next().atLine(120);
+    JavaCheckVerifier.verify("src/test/files/checks/EmptyMethodsCheck.java", new EmptyMethodsCheck());
   }
-
 }


### PR DESCRIPTION
- Removes use of AstNode.
- Migrate to SubscriptionBaseVisitor
- Migrate tests to JavaCheckVerifier
