### PR TITLE
SONARJAVA-1067 Symbol not found now has unknown owner instead of null

### DIFF
--- a/java-checks/src/test/files/checks/AssertionInThreadRunCheck.java
+++ b/java-checks/src/test/files/checks/AssertionInThreadRunCheck.java
@@ -29,3 +29,12 @@ class C extends junit.framework.TestCase {
     }
   }
 }
+
+class D extends Thread {
+  
+  @Override
+  public void run() { // Compliant
+    foo();
+  }
+  
+}

--- a/java-squid/src/main/java/org/sonar/java/resolve/Resolve.java
+++ b/java-squid/src/main/java/org/sonar/java/resolve/Resolve.java
@@ -770,13 +770,13 @@ public class Resolve {
 
   public static class JavaSymbolNotFound extends JavaSymbol {
     public JavaSymbolNotFound() {
-      super(JavaSymbol.ABSENT, 0, null, null);
+      super(JavaSymbol.ABSENT, 0, null, Symbols.unknownSymbol);
     }
   }
 
   public static class AmbiguityErrorJavaSymbol extends JavaSymbol {
     public AmbiguityErrorJavaSymbol() {
-      super(JavaSymbol.AMBIGUOUS, 0, null, null);
+      super(JavaSymbol.AMBIGUOUS, 0, null, Symbols.unknownSymbol);
     }
   }
 

--- a/java-squid/src/main/java/org/sonar/java/resolve/Resolve.java
+++ b/java-squid/src/main/java/org/sonar/java/resolve/Resolve.java
@@ -776,7 +776,7 @@ public class Resolve {
 
   public static class AmbiguityErrorJavaSymbol extends JavaSymbol {
     public AmbiguityErrorJavaSymbol() {
-      super(JavaSymbol.AMBIGUOUS, 0, null, Symbols.unknownSymbol);
+      super(JavaSymbol.AMBIGUOUS, 0, null, null);
     }
   }
 

--- a/java-squid/src/test/files/sym/SymbolsNotFound.java
+++ b/java-squid/src/test/files/sym/SymbolsNotFound.java
@@ -1,0 +1,5 @@
+class A {
+  void method() {
+    bar();
+  }
+}

--- a/java-squid/src/test/java/org/sonar/java/resolve/SymbolTableTest.java
+++ b/java-squid/src/test/java/org/sonar/java/resolve/SymbolTableTest.java
@@ -23,8 +23,11 @@ import com.google.common.collect.Iterables;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
@@ -604,6 +607,20 @@ public class SymbolTableTest {
     assertThat(result.reference(12, 25).owner).isSameAs(result.symbol("A"));
     assertThat(result.reference(13, 21)).isSameAs(result.symbol("A"));
 
+  }
+
+  @Test
+  public void symbolNotFound() throws Exception {
+    Result result = Result.createFor("SymbolsNotFound");
+
+    MethodTree methodDeclaration = (MethodTree) result.symbol("method").declaration();
+    ExpressionStatementTree expression = (ExpressionStatementTree) methodDeclaration.block().body().get(0);
+    MethodInvocationTree methodInvocation = (MethodInvocationTree) expression.expression();
+
+    Symbol symbolNotFound = methodInvocation.symbol();
+    assertThat(symbolNotFound).isNotNull();
+    assertThat(symbolNotFound.name()).isNull();
+    assertThat(symbolNotFound.owner()).isSameAs(Symbols.unknownSymbol);
   }
 
   public void assertThatReferenceNotFound(Result result, int line, int column){


### PR DESCRIPTION
`JavaSymbol.owner()` is not marked with `@CheckForNull`, nor `JavaSymbol.owner`. I prefered to force the unknown symbol as owner in case of ambiguity and not found symbol.