### PR TITLE
add 'aar' to file suffix filter

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/AbstractJavaClasspath.java
+++ b/java-squid/src/main/java/org/sonar/java/AbstractJavaClasspath.java
@@ -127,7 +127,10 @@ public abstract class AbstractJavaClasspath implements BatchExtension {
     if (libraryProperty) {
       if (pattern.endsWith("*")) {
         fileFilter = new AndFileFilter((IOFileFilter) fileFilter,
-            new OrFileFilter(Lists.newArrayList(suffixFileFilter(".jar", IOCase.INSENSITIVE), suffixFileFilter(".zip", IOCase.INSENSITIVE))));
+            new OrFileFilter(Lists.newArrayList(
+                suffixFileFilter(".jar", IOCase.INSENSITIVE),
+                suffixFileFilter(".zip", IOCase.INSENSITIVE),
+                suffixFileFilter(".aar", IOCase.INSENSITIVE))));
       }
       //find jar and zip files
       files.addAll(Lists.newArrayList(FileUtils.listFiles(dir, (IOFileFilter) fileFilter, TrueFileFilter.TRUE)));


### PR DESCRIPTION
Android library archive is now widely used. aar suffix is very common. The filter should include this suffix.

And I am wondering if we should filter the file if user passed a absolute file which is not a directory?

Maybe before filtering the file list, we should check like this:

``` java
      for (String pathPattern : fileNames) {
        File file = new File(pathPattern);
        if (file.exists() && !file.isDirectory()) {
          result.add(file);
          continue;
        }
        List<File> libraryFilesForPattern = getFilesForPattern(baseDir, pathPattern, isLibraryProperty);
      ......
      }
```

If this is proper I will add it to this PR or create a new one.