### PR TITLE
Implemented exclude filter for try-with-resource variables

### DIFF
--- a/java-checks/src/test/files/checks/UnusedLocalVariableCheck.java
+++ b/java-checks/src/test/files/checks/UnusedLocalVariableCheck.java
@@ -1,3 +1,5 @@
+import java.nio.channels.FileLock;
+
 class Foo {
 
   int unusedField;
@@ -40,6 +42,12 @@ class Foo {
     this.unknown++;
     java.util.Stream<Object> s;
     s.map(v -> "");
+    
+    java.io.FileOutputStream fileOutputStream = new java.io.FileOutputStream();
+    try (FileLock fileLock = fileOutputStream.getChannel().lock()) {
+      // write content to fileOutputStream
+      fileOutputStream.flush();
+    }
   }
 
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/UnusedLocalVariableCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UnusedLocalVariableCheckTest.java
@@ -34,14 +34,28 @@ public class UnusedLocalVariableCheckTest {
   public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @Test
-  public void test() {
+  public void testDefault() {
     SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UnusedLocalVariableCheck.java"), new VisitorsBridge(new UnusedLocalVariableCheck()));
     checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(6).withMessage("Remove this unused \"unusedLocalVariable\" local variable.")
-      .next().atLine(15).withMessage("Remove this unused \"foo\" local variable.")
-      .next().atLine(18)
-      .next().atLine(21)
-      .next().atLine(31);
+      .next().atLine(8).withMessage("Remove this unused \"unusedLocalVariable\" local variable.")
+      .next().atLine(17).withMessage("Remove this unused \"foo\" local variable.")
+      .next().atLine(20)
+      .next().atLine(23)
+      .next().atLine(33);
   }
 
+  @Test
+  public void testDifferentExcludeFilter() {
+    UnusedLocalVariableCheck check = new UnusedLocalVariableCheck();
+    check.excludeTryWithResourceVariableTypes = "";
+
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/UnusedLocalVariableCheck.java"), new VisitorsBridge(check));
+    checkMessagesVerifier.verify(file.getCheckMessages())
+      .next().atLine(8).withMessage("Remove this unused \"unusedLocalVariable\" local variable.")
+      .next().atLine(17).withMessage("Remove this unused \"foo\" local variable.")
+      .next().atLine(20)
+      .next().atLine(23)
+      .next().atLine(33)
+      .next().atLine(47);
+  }
 }


### PR DESCRIPTION
Rule S1481 gives a false positive on the following snippet
```java
java.io.FileOutputStream fileOutputStream = new java.io.FileOutputStream();
try (java.nio.channels.FileLock fileLock = fileOutputStream.getChannel().lock()) {
  // write content to fileOutputStream
  fileOutputStream.flush();
}
```

The `fileLock` variable is required in a try-with-resource statement but there may be no need to do anything with the `FileLock` variable.

This features adds logic to skip the variable-usage check for try-with-resource variables based on a configurable list of classes. The exclude filter can also be used to skip the check for custom AutoCloseable locking implementations.