### PR TITLE
S00119: use ^[A-Z][1-9]?$ as default regex for type parameters.

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/BadTypeParameterName_S00119_Check.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/BadTypeParameterName_S00119_Check.java
@@ -45,7 +45,7 @@ import java.util.regex.Pattern;
 @SqaleConstantRemediation("10min")
 public class BadTypeParameterName_S00119_Check extends SubscriptionBaseVisitor {
 
-  private static final String DEFAULT_FORMAT = "^[A-Z]$";
+  private static final String DEFAULT_FORMAT = "^[A-Z][1-9]?$";
 
   @RuleProperty(
       key = "format",

--- a/java-checks/src/test/files/checks/BadGenericName.java
+++ b/java-checks/src/test/files/checks/BadGenericName.java
@@ -6,4 +6,6 @@ class MyClass<TYPE> {
 public class MyClass2<T> {
   <T> void addAll(Collection<T> c) {
   }
+  <T1 extends T, T2 extends T> void addAll(Collection<T1> c1, Collection<T2> c2) {
+  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/BadTypeParameterName_S00119_CheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/BadTypeParameterName_S00119_CheckTest.java
@@ -35,7 +35,7 @@ public class BadTypeParameterName_S00119_CheckTest {
   public void test() {
     SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/checks/BadGenericName.java"), new VisitorsBridge(check));
     CheckMessagesVerifier.verify(file.getCheckMessages())
-        .next().atLine(1).withMessage("Rename this generic name to match the regular expression '^[A-Z]$'.")
+        .next().atLine(1).withMessage("Rename this generic name to match the regular expression '^[A-Z][1-9]?$'.")
         .next().atLine(2)
         .noMore();
   }


### PR DESCRIPTION
using type parameter like V1, V2 is pretty common to indicate
types parameters that have a closely related role in an algorithm.
eg.
```java
static <K,V1,V2> Map<K,V2> transformValues(Map<K,V1> fromMap,
                                  Function<? super V1,V2> function)
```
from guava ```com.google.common.collect.Maps```.