### PR TITLE
SONARJAVA-1018 Fix S2325 Serializable false positive

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AbsOnNegativeCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbsOnNegativeCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -55,26 +55,26 @@ import java.util.List;
 public class AbsOnNegativeCheck extends SubscriptionBaseVisitor implements JavaFileScanner {
 
   private static final MethodInvocationMatcherCollection MATH_ABS_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition("java.lang.Math")
       .name("abs")
       .addParameter("int"),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition("java.lang.Math")
       .name("abs")
       .addParameter("long")
     );
 
   private static final MethodInvocationMatcherCollection NEGATIVE_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .name("hashCode"),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.util.Random"))
       .name("nextInt"),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.util.Random"))
       .name("nextLong"),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.lang.Comparable"))
       .name("compareTo")
       .addParameter(TypeCriteria.anyType())

--- a/java-checks/src/main/java/org/sonar/java/checks/ArrayHashCodeAndToStringCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ArrayHashCodeAndToStringCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -47,20 +47,20 @@ public class ArrayHashCodeAndToStringCheck extends AbstractMethodDetection {
   private static final TypeCriteria IS_ARRAY = new IsArrayCriteria();
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
       arrayMethodInvocation("toString"),
       arrayMethodInvocation("hashCode"));
   }
 
-  private static MethodInvocationMatcher arrayMethodInvocation(String methodName) {
-    return MethodInvocationMatcher.create()
+  private static MethodMatcher arrayMethodInvocation(String methodName) {
+    return MethodMatcher.create()
       .callSite(IS_ARRAY)
       .name(methodName);
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     String methodName = mit.symbol().name();
     addIssue(mit, "Use \"Arrays." + methodName + "(array)\" instead.");
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
@@ -23,7 +23,7 @@ import com.google.common.base.Objects;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -46,19 +46,19 @@ import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 @SqaleConstantRemediation("5min")
 public class AssertionsCompletenessCheck extends BaseTreeVisitor implements JavaFileScanner {
 
-  private static final MethodInvocationMatcher MOCKITO_VERIFY = MethodInvocationMatcher.create()
+  private static final MethodMatcher MOCKITO_VERIFY = MethodMatcher.create()
     .typeDefinition("org.mockito.Mockito").name("verify").withNoParameterConstraint();
   private static final MethodInvocationMatcherCollection FEST_ASSERT_THAT = MethodInvocationMatcherCollection.create(
     // Fest 1.X
-    MethodInvocationMatcher.create().typeDefinition("org.fest.assertions.Assertions").name("assertThat").addParameter(TypeCriteria.anyType()),
+    MethodMatcher.create().typeDefinition("org.fest.assertions.Assertions").name("assertThat").addParameter(TypeCriteria.anyType()),
     // Fest 2.X
-    MethodInvocationMatcher.create().typeDefinition("org.fest.assertions.api.Assertions").name("assertThat").addParameter(TypeCriteria.anyType())
+    MethodMatcher.create().typeDefinition("org.fest.assertions.api.Assertions").name("assertThat").addParameter(TypeCriteria.anyType())
   );
 
   private static final MethodInvocationMatcherCollection FEST_EXCLUSIONS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition(TypeCriteria.anyType()).name("as").withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition(TypeCriteria.anyType()).name("describedAs").withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition(TypeCriteria.anyType()).name("overridingErrorMessage").withNoParameterConstraint()
+    MethodMatcher.create().typeDefinition(TypeCriteria.anyType()).name("as").withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition(TypeCriteria.anyType()).name("describedAs").withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition(TypeCriteria.anyType()).name("overridingErrorMessage").withNoParameterConstraint()
   );
 
   private Boolean chainedToAnyMethodButFestExclusions = null;

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
@@ -22,7 +22,7 @@ package org.sonar.java.checks;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.NameCriteria;
 import org.sonar.java.checks.methods.TypeCriteria;
@@ -47,30 +47,30 @@ import java.util.Deque;
 @SqaleConstantRemediation("10min")
 public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileScanner {
 
-  private static final MethodInvocationMatcher MOCKITO_VERIFY = MethodInvocationMatcher.create()
+  private static final MethodMatcher MOCKITO_VERIFY = MethodMatcher.create()
     .typeDefinition("org.mockito.Mockito").name("verify").withNoParameterConstraint();
-  private static final MethodInvocationMatcher ASSERT_THAT = MethodInvocationMatcher.create()
+  private static final MethodMatcher ASSERT_THAT = MethodMatcher.create()
     .typeDefinition(TypeCriteria.anyType()).name("assertThat").addParameter(TypeCriteria.anyType());
-  private static final MethodInvocationMatcher FEST_AS_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher FEST_AS_METHOD = MethodMatcher.create()
     .typeDefinition(TypeCriteria.anyType()).name("as").withNoParameterConstraint();
-  private static final MethodInvocationMatcher FEST_DESCRIBED_AS_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher FEST_DESCRIBED_AS_METHOD = MethodMatcher.create()
     .typeDefinition(TypeCriteria.anyType()).name("describedAs").withNoParameterConstraint();
-  private static final MethodInvocationMatcher FEST_OVERRIDE_ERROR_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher FEST_OVERRIDE_ERROR_METHOD = MethodMatcher.create()
     .typeDefinition(TypeCriteria.anyType()).name("overridingErrorMessage").withNoParameterConstraint();
   private static final MethodInvocationMatcherCollection ASSERTION_INVOCATION_MATCHERS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition("org.junit.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition("org.junit.Assert").name("fail").withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition("org.junit.rules.ExpectedException").name(NameCriteria.startsWith("expect")).withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("org.junit.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("org.junit.Assert").name("fail").withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("org.junit.rules.ExpectedException").name(NameCriteria.startsWith("expect")).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
     // fest 1.x
-    MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf("org.fest.assertions.GenericAssert")).name(NameCriteria.any()).withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition("org.fest.assertions.Fail").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("org.fest.assertions.GenericAssert")).name(NameCriteria.any()).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("org.fest.assertions.Fail").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
     // fest 2.x
-    MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf("org.fest.assertions.api.AbstractAssert")).name(NameCriteria.any()).withNoParameterConstraint(),
-    MethodInvocationMatcher.create().typeDefinition("org.fest.assertions.api.Fail").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("org.fest.assertions.api.AbstractAssert")).name(NameCriteria.any()).withNoParameterConstraint(),
+    MethodMatcher.create().typeDefinition("org.fest.assertions.api.Fail").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
     // Mockito
-    MethodInvocationMatcher.create().typeDefinition("org.mockito.Mockito").name("verifyNoMoreInteractions").withNoParameterConstraint()
+    MethodMatcher.create().typeDefinition("org.mockito.Mockito").name("verifyNoMoreInteractions").withNoParameterConstraint()
   );
 
   private final Deque<Boolean> methodContainsAssertion = new ArrayDeque<>();

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsWithoutMessageCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsWithoutMessageCheck.java
@@ -25,7 +25,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.NameCriteria;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
@@ -47,25 +47,25 @@ import java.util.Set;
 public class AssertionsWithoutMessageCheck extends AbstractMethodDetection {
 
   private static final String GENERIC_ASSERT = "org.fest.assertions.GenericAssert";
-  private static final MethodInvocationMatcher FEST_AS_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher FEST_AS_METHOD = MethodMatcher.create()
         .typeDefinition(GENERIC_ASSERT).name("as").addParameter("java.lang.String");
   private static final Set<String> ASSERT_METHODS_WITH_ONE_PARAM = Sets.newHashSet("assertNull", "assertNotNull");
   private static final Set<String> ASSERT_METHODS_WITH_TWO_PARAMS = Sets.newHashSet("assertEquals", "assertSame", "assertNotSame", "assertThat");
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return Lists.newArrayList(
-        MethodInvocationMatcher.create().typeDefinition("org.junit.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("org.junit.Assert").name("fail").withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("org.fest.assertions.Fail").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf(GENERIC_ASSERT)).name(NameCriteria.any()).withNoParameterConstraint()
+        MethodMatcher.create().typeDefinition("org.junit.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("org.junit.Assert").name("fail").withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("assert")).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("org.fest.assertions.Fail").name(NameCriteria.startsWith("fail")).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf(GENERIC_ASSERT)).name(NameCriteria.any()).withNoParameterConstraint()
     );
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if(mit.symbol().owner().type().isSubtypeOf(GENERIC_ASSERT) && !FEST_AS_METHOD.matches(mit)) {
       FestVisitor visitor = new FestVisitor();
       mit.methodSelect().accept(visitor);

--- a/java-checks/src/main/java/org/sonar/java/checks/AvoidDESCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AvoidDESCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -44,12 +44,12 @@ import java.util.List;
 public class AvoidDESCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create().typeDefinition("javax.crypto.Cipher").name("getInstance").withNoParameterConstraint());
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create().typeDefinition("javax.crypto.Cipher").name("getInstance").withNoParameterConstraint());
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree firstArg = mit.arguments().get(0);
     if (firstArg.is(Tree.Kind.STRING_LITERAL)) {
       String tranformation = trimQuotes(((LiteralTree) firstArg).value());

--- a/java-checks/src/main/java/org/sonar/java/checks/BooleanLiteralInAssertionsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/BooleanLiteralInAssertionsCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.NameCriteria;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -46,17 +46,17 @@ public class BooleanLiteralInAssertionsCheck extends AbstractMethodDetection {
   private static final String ASSERT = "assert";
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return Lists.newArrayList(
-      MethodInvocationMatcher.create().typeDefinition("org.junit.Assert").name(NameCriteria.startsWith(ASSERT)).withNoParameterConstraint(),
-      MethodInvocationMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith(ASSERT)).withNoParameterConstraint(),
-      MethodInvocationMatcher.create().typeDefinition("junit.framework.TestCase").name(NameCriteria.startsWith(ASSERT)).withNoParameterConstraint(),
-      MethodInvocationMatcher.create().typeDefinition("org.fest.assertions.Assertions").name("assertThat").addParameter("boolean")
+      MethodMatcher.create().typeDefinition("org.junit.Assert").name(NameCriteria.startsWith(ASSERT)).withNoParameterConstraint(),
+      MethodMatcher.create().typeDefinition("junit.framework.Assert").name(NameCriteria.startsWith(ASSERT)).withNoParameterConstraint(),
+      MethodMatcher.create().typeDefinition("junit.framework.TestCase").name(NameCriteria.startsWith(ASSERT)).withNoParameterConstraint(),
+      MethodMatcher.create().typeDefinition("org.fest.assertions.Assertions").name("assertThat").addParameter("boolean")
       );
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     int arity = mit.arguments().size();
     for (int i = 0; i < arity; i++) {
       ExpressionTree booleanArg = mit.arguments().get(i);

--- a/java-checks/src/main/java/org/sonar/java/checks/CatchOfThrowableOrErrorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CatchOfThrowableOrErrorCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -120,8 +120,8 @@ public class CatchOfThrowableOrErrorCheck extends SubscriptionBaseVisitor {
       return false;
     }
 
-    private static MethodInvocationMatcher rethrowMethod() {
-      return MethodInvocationMatcher.create().typeDefinition("com.google.common.io.Closer").name("rethrow").addParameter("java.lang.Throwable");
+    private static MethodMatcher rethrowMethod() {
+      return MethodMatcher.create().typeDefinition("com.google.common.io.Closer").name("rethrow").addParameter("java.lang.Throwable");
     }
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ClassComparedByNameCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ClassComparedByNameCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
@@ -49,12 +49,12 @@ public class ClassComparedByNameCheck extends AbstractMethodDetection {
   private ClassGetNameDetector classGetNameDetector = new ClassGetNameDetector();
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create().typeDefinition("java.lang.String").name("equals").withNoParameterConstraint());
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create().typeDefinition("java.lang.String").name("equals").withNoParameterConstraint());
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if (mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
       ((MemberSelectExpressionTree) mit.methodSelect()).expression().accept(classGetNameDetector);
     }
@@ -64,8 +64,8 @@ public class ClassComparedByNameCheck extends AbstractMethodDetection {
   private class ClassGetNameDetector extends BaseTreeVisitor {
 
     private final MethodInvocationMatcherCollection methodMatchers = MethodInvocationMatcherCollection.create(
-      MethodInvocationMatcher.create().typeDefinition("java.lang.Class").name("getName"),
-      MethodInvocationMatcher.create().typeDefinition("java.lang.Class").name("getSimpleName"));
+      MethodMatcher.create().typeDefinition("java.lang.Class").name("getName"),
+      MethodMatcher.create().typeDefinition("java.lang.Class").name("getSimpleName"));
 
     @Override
     public void visitMethodInvocation(MethodInvocationTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/CollectionInappropriateCallsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CollectionInappropriateCallsCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.java.resolve.JavaType;
 import org.sonar.java.resolve.JavaType.ParametrizedTypeJavaType;
@@ -54,22 +54,22 @@ import java.util.List;
 public class CollectionInappropriateCallsCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
       collectionMethodInvocation("remove"),
       collectionMethodInvocation("contains")
       );
   }
 
-  private MethodInvocationMatcher collectionMethodInvocation(String methodName) {
-    return MethodInvocationMatcher.create()
+  private MethodMatcher collectionMethodInvocation(String methodName) {
+    return MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.util.Collection"))
       .name(methodName)
       .addParameter("java.lang.Object");
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree tree) {
+  protected void onMethodInvocationFound(MethodInvocationTree tree) {
     Type argumentType = getType(tree.arguments().get(0));
     Type collectionType = getMethodOwner(tree);
     // can be null when using raw types

--- a/java-checks/src/main/java/org/sonar/java/checks/CollectionIsEmptyCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CollectionIsEmptyCheck.java
@@ -22,7 +22,7 @@ package org.sonar.java.checks;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
@@ -49,7 +49,7 @@ import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 public class CollectionIsEmptyCheck extends BaseTreeVisitor implements JavaFileScanner {
 
   private static final String JAVA_UTIL_COLLECTION = "java.util.Collection";
-  private static final MethodInvocationMatcher SIZE_METHOD = getSizeMethodInvocationMatcher();
+  private static final MethodMatcher SIZE_METHOD = getSizeMethodInvocationMatcher();
   private JavaFileScannerContext context;
 
   @Override
@@ -120,8 +120,8 @@ public class CollectionIsEmptyCheck extends BaseTreeVisitor implements JavaFileS
       "1".equals(((LiteralTree) tree).value());
   }
 
-  private static MethodInvocationMatcher getSizeMethodInvocationMatcher() {
-    return MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf(JAVA_UTIL_COLLECTION)).name("size").withNoParameterConstraint();
+  private static MethodMatcher getSizeMethodInvocationMatcher() {
+    return MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf(JAVA_UTIL_COLLECTION)).name("size").withNoParameterConstraint();
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ConcurrentLinkedQueueSizeCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ConcurrentLinkedQueueSizeCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
@@ -43,14 +43,14 @@ import java.util.List;
 public class ConcurrentLinkedQueueSizeCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create()
         .typeDefinition("java.util.concurrent.ConcurrentLinkedQueue")
         .name("size"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Remove this call to \"ConcurrentLinkedQueue.size()\"");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ConstantMathCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ConstantMathCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.model.LiteralUtils;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -62,45 +62,45 @@ public class ConstantMathCheck extends SubscriptionBaseVisitor implements JavaFi
   private static final String ROUND = "round";
 
   private static final MethodInvocationMatcherCollection CONSTANT_WITH_LITERAL_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter(FLOAT),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter("int"),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter("long")
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter(FLOAT),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter("int"),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ABS).addParameter("long")
     );
 
   private static final MethodInvocationMatcherCollection TRUNCATION_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(CEIL).addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(CEIL).addParameter(FLOAT),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(FLOOR).addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(FLOOR).addParameter(FLOAT),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("rint").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ROUND).addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ROUND).addParameter(FLOAT)
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(CEIL).addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(CEIL).addParameter(FLOAT),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(FLOOR).addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(FLOOR).addParameter(FLOAT),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("rint").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ROUND).addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name(ROUND).addParameter(FLOAT)
     );
 
   private static final MethodInvocationMatcherCollection CONSTANT_WITH_ZERO_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("atan2").addParameter(DOUBLE).addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("cos").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("cosh").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("expm1").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("sin").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("sinh").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("tan").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("tanh").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("toRadians").addParameter(DOUBLE)
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("atan2").addParameter(DOUBLE).addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("cos").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("cosh").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("expm1").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("sin").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("sinh").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("tan").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("tanh").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("toRadians").addParameter(DOUBLE)
     );
 
   private static final MethodInvocationMatcherCollection CONSTANT_WITH_ZERO_OR_ONE_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("acos").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("asin").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("atan").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("cbrt").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("exp").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("log").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("log10").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("sqrt").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("toDegrees").addParameter(DOUBLE),
-    MethodInvocationMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("exp").addParameter(DOUBLE)
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("acos").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("asin").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("atan").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("cbrt").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("exp").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("log").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("log10").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("sqrt").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("toDegrees").addParameter(DOUBLE),
+    MethodMatcher.create().typeDefinition(MATH_PACKAGE_NAME).name("exp").addParameter(DOUBLE)
     );
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/DateUtilsTruncateCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateUtilsTruncateCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
@@ -41,7 +41,7 @@ import java.util.List;
 public class DateUtilsTruncateCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
       truncateMethodMatcher("java.util.Date"),
       truncateMethodMatcher("java.util.Calendar"),
@@ -49,12 +49,12 @@ public class DateUtilsTruncateCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Use \"Instant.truncatedTo\" instead.");
   }
 
-  private MethodInvocationMatcher truncateMethodMatcher(String firstParameterType) {
-    return MethodInvocationMatcher.create()
+  private MethodMatcher truncateMethodMatcher(String firstParameterType) {
+    return MethodMatcher.create()
       .typeDefinition("org.apache.commons.lang.time.DateUtils").name("truncate").addParameter(firstParameterType).addParameter("int");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/DefaultEncodingUsageCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DefaultEncodingUsageCheck.java
@@ -26,7 +26,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.model.expression.NewClassTreeImpl;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -122,7 +122,7 @@ public class DefaultEncodingUsageCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
       method(JAVA_LANG_STRING, "getBytes"),
       method(JAVA_LANG_STRING, "getBytes", INT, INT, BYTE_ARRAY, INT),
@@ -149,20 +149,20 @@ public class DefaultEncodingUsageCheck extends AbstractMethodDetection {
       constructor(JAVA_UTIL_SCANNER, JAVA_IO_INPUTSTREAM));
   }
 
-  private static MethodInvocationMatcher method(String type, String methodName, String... argTypes) {
-    MethodInvocationMatcher matcher = MethodInvocationMatcher.create().typeDefinition(type).name(methodName);
+  private static MethodMatcher method(String type, String methodName, String... argTypes) {
+    MethodMatcher matcher = MethodMatcher.create().typeDefinition(type).name(methodName);
     for (String argType : argTypes) {
       matcher = matcher.addParameter(argType);
     }
     return matcher;
   }
 
-  private static MethodInvocationMatcher constructor(String type, String... argTypes) {
+  private static MethodMatcher constructor(String type, String... argTypes) {
     return method(type, "<init>", argTypes);
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Remove this use of \"" + mit.symbol().name() + "\"");
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/DeprecatedHashAlgorithmCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DeprecatedHashAlgorithmCheck.java
@@ -26,7 +26,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
@@ -64,24 +64,24 @@ public class DeprecatedHashAlgorithmCheck extends AbstractMethodDetection {
     .build();
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    Builder<MethodInvocationMatcher> builder = ImmutableList.<MethodInvocationMatcher>builder()
-      .add(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    Builder<MethodMatcher> builder = ImmutableList.<MethodMatcher>builder()
+      .add(MethodMatcher.create()
         .typeDefinition("java.security.MessageDigest")
         .name("getInstance")
         .addParameter("java.lang.String"))
-      .add(MethodInvocationMatcher.create()
+      .add(MethodMatcher.create()
         .typeDefinition("org.apache.commons.codec.digest.DigestUtils")
         .name("getDigest")
         .addParameter("java.lang.String"));
     for (String methodName : ALGORITHM_BY_METHOD_NAME.keySet()) {
-      builder.add(MethodInvocationMatcher.create()
+      builder.add(MethodMatcher.create()
         .typeDefinition("org.apache.commons.codec.digest.DigestUtils")
         .name(methodName)
         .withNoParameterConstraint());
     }
     for (String methodName : ImmutableList.of("md5", "sha1")) {
-      builder.add(MethodInvocationMatcher.create()
+      builder.add(MethodMatcher.create()
         .typeDefinition("com.google.common.hash.Hashing")
         .name(methodName));
     }
@@ -89,7 +89,7 @@ public class DeprecatedHashAlgorithmCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     String methodName = methodName(mit);
     String algorithm = ALGORITHM_BY_METHOD_NAME.get(methodName);
     if (algorithm == null) {

--- a/java-checks/src/main/java/org/sonar/java/checks/DisallowedMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DisallowedMethodCheck.java
@@ -25,7 +25,7 @@ import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.NoSqale;
 import org.sonar.squidbridge.annotations.RuleTemplate;
@@ -51,11 +51,11 @@ public class DisallowedMethodCheck extends AbstractMethodDetection {
   private String argumentTypes = "";
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     if(StringUtils.isEmpty(methodName)) {
       return ImmutableList.of();
     }
-    MethodInvocationMatcher invocationMatcher = MethodInvocationMatcher.create().name(methodName);
+    MethodMatcher invocationMatcher = MethodMatcher.create().name(methodName);
     if(StringUtils.isNotEmpty(className)) {
       invocationMatcher.typeDefinition(className);
     }
@@ -67,7 +67,7 @@ public class DisallowedMethodCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     context.addIssue(mit, new CheckMessage(this, "Remove this forbidden call"));
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/EqualsArgumentTypeCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EqualsArgumentTypeCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
@@ -55,11 +55,11 @@ import java.util.List;
 @SqaleConstantRemediation("5min")
 public class EqualsArgumentTypeCheck extends SubscriptionBaseVisitor {
 
-  private static final MethodInvocationMatcher EQUALS_MATCHER = MethodInvocationMatcher.create()
+  private static final MethodMatcher EQUALS_MATCHER = MethodMatcher.create()
     .name("equals")
     .addParameter(TypeCriteria.anyType());
 
-  private static final MethodInvocationMatcher GETCLASS_MATCHER = MethodInvocationMatcher.create()
+  private static final MethodMatcher GETCLASS_MATCHER = MethodMatcher.create()
     .name("getClass");
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/EqualsOnAtomicClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EqualsOnAtomicClassCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -44,24 +44,24 @@ import java.util.List;
 public class EqualsOnAtomicClassCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
       equalsInvocationMatcher("java.util.concurrent.atomic.AtomicBoolean"),
       equalsInvocationMatcher("java.util.concurrent.atomic.AtomicInteger"),
       equalsInvocationMatcher("java.util.concurrent.atomic.AtomicLong"));
   }
 
-  private static MethodInvocationMatcher equalsInvocationMatcher(String fullyQualifiedName) {
-    return MethodInvocationMatcher.create()
+  private static MethodMatcher equalsInvocationMatcher(String fullyQualifiedName) {
+    return MethodMatcher.create()
       .callSite(TypeCriteria.is(fullyQualifiedName))
       .name("equals")
       .addParameter("java.lang.Object");
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Use \".get()\" to retrieve the value and compare it instead.");
-    super.onMethodFound(mit);
+    super.onMethodInvocationFound(mit);
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/FileCreateTempFileCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FileCreateTempFileCheck.java
@@ -22,7 +22,7 @@ package org.sonar.java.checks;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -63,11 +63,11 @@ public class FileCreateTempFileCheck extends BaseTreeVisitor implements JavaFile
   }
 
   private static final String JAVA_IO_FILE = "java.io.File";
-  private static final MethodInvocationMatcher FILE_CREATE_TEMP_FILE = MethodInvocationMatcher.create()
+  private static final MethodMatcher FILE_CREATE_TEMP_FILE = MethodMatcher.create()
     .typeDefinition(JAVA_IO_FILE).name("createTempFile").withNoParameterConstraint();
-  private static final MethodInvocationMatcher FILE_DELETE = MethodInvocationMatcher.create()
+  private static final MethodMatcher FILE_DELETE = MethodMatcher.create()
     .typeDefinition(JAVA_IO_FILE).name("delete");
-  private static final MethodInvocationMatcher FILE_MKDIR = MethodInvocationMatcher.create()
+  private static final MethodMatcher FILE_MKDIR = MethodMatcher.create()
     .typeDefinition(JAVA_IO_FILE).name("mkdir");
 
   private final Deque<Map<Symbol, State>> symbolStack = new LinkedList<>();

--- a/java-checks/src/main/java/org/sonar/java/checks/GetRequestedSessionIdCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/GetRequestedSessionIdCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
@@ -43,14 +43,14 @@ import java.util.List;
 public class GetRequestedSessionIdCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create()
         .typeDefinition("javax.servlet.http.HttpServletRequest")
         .name("getRequestedSessionId"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Remove use of this unsecured \"getRequestedSessionId()\" method");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/HttpRefererCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/HttpRefererCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -44,15 +44,15 @@ import java.util.List;
 public class HttpRefererCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create()
         .typeDefinition("javax.servlet.http.HttpServletRequest")
         .name("getHeader")
         .addParameter("java.lang.String"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree arg = mit.arguments().get(0);
     if (arg.is(Tree.Kind.STRING_LITERAL)) {
       LiteralTree lt = (LiteralTree) arg;

--- a/java-checks/src/main/java/org/sonar/java/checks/IgnoredStreamReturnValueCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IgnoredStreamReturnValueCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
@@ -71,8 +71,8 @@ public class IgnoredStreamReturnValueCheck extends SubscriptionBaseVisitor {
     }
   }
 
-  private static MethodInvocationMatcher inputStreamInvocationMatcher(String methodName, String parameterType) {
-    return MethodInvocationMatcher.create()
+  private static MethodMatcher inputStreamInvocationMatcher(String methodName, String parameterType) {
+    return MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.io.InputStream"))
       .name(methodName)
       .addParameter(parameterType);

--- a/java-checks/src/main/java/org/sonar/java/checks/ImmediateReverseBoxingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ImmediateReverseBoxingCheck.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -203,7 +203,7 @@ public class ImmediateReverseBoxingCheck extends SubscriptionBaseVisitor {
     MethodInvocationMatcherCollection matchers = MethodInvocationMatcherCollection.create();
     for (String primitiveType : PRIMITIVE_TYPES_BY_WRAPPER.values()) {
       matchers.add(
-        MethodInvocationMatcher.create()
+        MethodMatcher.create()
           .callSite("boolean".equals(primitiveType) ? TypeCriteria.is("java.lang.Boolean") : TypeCriteria.subtypeOf("java.lang.Number"))
           .name(primitiveType + "Value"));
     }
@@ -214,7 +214,7 @@ public class ImmediateReverseBoxingCheck extends SubscriptionBaseVisitor {
     MethodInvocationMatcherCollection matchers = MethodInvocationMatcherCollection.create();
     for (Entry<String, String> primitiveMapping : PRIMITIVE_TYPES_BY_WRAPPER.entrySet()) {
       matchers.add(
-        MethodInvocationMatcher.create()
+        MethodMatcher.create()
           .typeDefinition(primitiveMapping.getKey())
           .name("valueOf")
           .addParameter(primitiveMapping.getValue()));

--- a/java-checks/src/main/java/org/sonar/java/checks/IndexOfStartPositionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IndexOfStartPositionCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.model.LiteralUtils;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -49,7 +49,7 @@ import java.util.List;
 public class IndexOfStartPositionCheck extends SubscriptionBaseVisitor {
 
   private static final String JAVA_LANG_STRING = "java.lang.String";
-  private static final MethodInvocationMatcher INDEX_OF_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher INDEX_OF_METHOD = MethodMatcher.create()
     .typeDefinition(JAVA_LANG_STRING).name("indexOf").addParameter(JAVA_LANG_STRING);
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/IndexOfWithPositiveNumberCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IndexOfWithPositiveNumberCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.java.model.LiteralUtils;
@@ -52,15 +52,15 @@ public class IndexOfWithPositiveNumberCheck extends SubscriptionBaseVisitor {
   private static final String INDEXOF = "indexOf";
 
   private static final MethodInvocationMatcherCollection CHECKED_METHODS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(String.class.getName())
       .name(INDEXOF)
       .addParameter("int"),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(String.class.getName())
       .name(INDEXOF)
       .addParameter(String.class.getName()),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.util.List"))
       .name(INDEXOF)
       .addParameter("java.lang.Object")

--- a/java-checks/src/main/java/org/sonar/java/checks/InvalidDateValuesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InvalidDateValuesCheck.java
@@ -25,7 +25,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -64,13 +64,13 @@ public class InvalidDateValuesCheck extends AbstractMethodDetection {
   private static final String[] DATE_GET_METHODS = {"getDate", "getMonth", "getHours", "getMinutes", "getSeconds"};
   private static final String[] DATE_SET_METHODS = {"setDate", "setMonth", "setHours", "setMinutes", "setSeconds"};
 
-  private static final List<MethodInvocationMatcher> DATE_METHODS_COMPARISON = ImmutableList.<MethodInvocationMatcher>builder()
-    .add(MethodInvocationMatcher.create().typeDefinition(JAVA_UTIL_CALENDAR).name("get").addParameter("int"))
+  private static final List<MethodMatcher> DATE_METHODS_COMPARISON = ImmutableList.<MethodMatcher>builder()
+    .add(MethodMatcher.create().typeDefinition(JAVA_UTIL_CALENDAR).name("get").addParameter("int"))
     .addAll(dateGetMatchers())
     .build();
 
-  private static List<MethodInvocationMatcher> dateGetMatchers() {
-    ImmutableList.Builder<MethodInvocationMatcher> builder = ImmutableList.builder();
+  private static List<MethodMatcher> dateGetMatchers() {
+    ImmutableList.Builder<MethodMatcher> builder = ImmutableList.builder();
     for (String dateGetMethod : DATE_GET_METHODS) {
       builder.add(dateMethodInvocationMatcherGetter(JAVA_UTIL_DATE, dateGetMethod));
       builder.add(dateMethodInvocationMatcherGetter(JAVA_SQL_DATE, dateGetMethod));
@@ -112,7 +112,7 @@ public class InvalidDateValuesCheck extends AbstractMethodDetection {
     if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
       MethodInvocationTree mit = (MethodInvocationTree) tree;
       String name = getMethodName(mit);
-      for (MethodInvocationMatcher methodInvocationMatcher : DATE_METHODS_COMPARISON) {
+      for (MethodMatcher methodInvocationMatcher : DATE_METHODS_COMPARISON) {
         if (methodInvocationMatcher.matches(mit)) {
           if ("get".equals(name)) {
             // Calendar
@@ -139,28 +139,28 @@ public class InvalidDateValuesCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    ImmutableList.Builder<MethodInvocationMatcher> builder = ImmutableList.builder();
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    ImmutableList.Builder<MethodMatcher> builder = ImmutableList.builder();
     for (String dateSetMethod : DATE_SET_METHODS) {
       builder.add(dateMethodInvocationMatcherSetter(JAVA_UTIL_DATE, dateSetMethod));
       builder.add(dateMethodInvocationMatcherSetter(JAVA_SQL_DATE, dateSetMethod));
     }
     return builder
-      .add(MethodInvocationMatcher.create().typeDefinition(JAVA_UTIL_CALENDAR).name("set").addParameter("int").addParameter("int"))
-      .add(MethodInvocationMatcher.create().typeDefinition("java.util.GregorianCalendar").name("<init>").withNoParameterConstraint())
+      .add(MethodMatcher.create().typeDefinition(JAVA_UTIL_CALENDAR).name("set").addParameter("int").addParameter("int"))
+      .add(MethodMatcher.create().typeDefinition("java.util.GregorianCalendar").name("<init>").withNoParameterConstraint())
       .build();
   }
 
-  private static MethodInvocationMatcher dateMethodInvocationMatcherGetter(String type, String methodName) {
-    return MethodInvocationMatcher.create().typeDefinition(type).name(methodName);
+  private static MethodMatcher dateMethodInvocationMatcherGetter(String type, String methodName) {
+    return MethodMatcher.create().typeDefinition(type).name(methodName);
   }
 
-  private static MethodInvocationMatcher dateMethodInvocationMatcherSetter(String type, String methodName) {
-    return MethodInvocationMatcher.create().typeDefinition(type).name(methodName).addParameter("int");
+  private static MethodMatcher dateMethodInvocationMatcherSetter(String type, String methodName) {
+    return MethodMatcher.create().typeDefinition(type).name(methodName).addParameter("int");
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     String name = getMethodName(mit);
     if ("set".equals(name)) {
       // Calendar method

--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -51,8 +51,8 @@ import java.util.List;
 @SqaleConstantRemediation("5min")
 public class IteratorNextExceptionCheck extends SubscriptionBaseVisitor {
 
-  private static final MethodInvocationMatcher NEXT_INVOCATION_MATCHER =
-    MethodInvocationMatcher.create()
+  private static final MethodMatcher NEXT_INVOCATION_MATCHER =
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.util.Iterator"))
       .name("next");
 

--- a/java-checks/src/main/java/org/sonar/java/checks/KeySetInsteadOfEntrySetCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/KeySetInsteadOfEntrySetCheck.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Iterables;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
@@ -53,12 +53,12 @@ import java.util.List;
 @SqaleConstantRemediation("5min")
 public class KeySetInsteadOfEntrySetCheck extends SubscriptionBaseVisitor {
 
-  private static final MethodInvocationMatcher MAP_GET_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher MAP_GET_METHOD = MethodMatcher.create()
     .typeDefinition(TypeCriteria.subtypeOf("java.util.Map"))
     .name("get")
     .addParameter("java.lang.Object");
 
-  private static final MethodInvocationMatcher MAP_KEYSET_METHOD = MethodInvocationMatcher.create()
+  private static final MethodMatcher MAP_KEYSET_METHOD = MethodMatcher.create()
     .typeDefinition(TypeCriteria.subtypeOf("java.util.Map"))
     .name("keySet");
 

--- a/java-checks/src/main/java/org/sonar/java/checks/LDAPInjectionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/LDAPInjectionCheck.java
@@ -22,7 +22,7 @@ package org.sonar.java.checks;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.NewArrayTree;
@@ -39,11 +39,11 @@ import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 @SqaleConstantRemediation("30min")
 public class LDAPInjectionCheck extends AbstractInjectionChecker {
 
-  private static final MethodInvocationMatcher LDAP_SEARCH_MATCHER = MethodInvocationMatcher.create()
+  private static final MethodMatcher LDAP_SEARCH_MATCHER = MethodMatcher.create()
     .typeDefinition("javax.naming.directory.DirContext")
     .name("search").withNoParameterConstraint();
 
-  private static final MethodInvocationMatcher SEARCH_CONTROLS_MATCHER = MethodInvocationMatcher.create()
+  private static final MethodMatcher SEARCH_CONTROLS_MATCHER = MethodMatcher.create()
     .typeDefinition("javax.naming.directory.SearchControls")
     .name("setReturningAttributes").addParameter("java.lang.String[]");
 

--- a/java-checks/src/main/java/org/sonar/java/checks/LongBitsToDoubleOnIntCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/LongBitsToDoubleOnIntCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -44,14 +44,14 @@ import java.util.List;
 public class LongBitsToDoubleOnIntCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.<MethodInvocationMatcher>builder()
-        .add(MethodInvocationMatcher.create().typeDefinition("java.lang.Double").name("longBitsToDouble").addParameter("long"))
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.<MethodMatcher>builder()
+        .add(MethodMatcher.create().typeDefinition("java.lang.Double").name("longBitsToDouble").addParameter("long"))
         .build();
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     Type symbolType = mit.arguments().get(0).symbolType();
     if (!(symbolType.is("long") || symbolType.is("java.lang.Long"))) {
       addIssue(mit, "Remove this \"Double.longBitsToDouble\" call.");

--- a/java-checks/src/main/java/org/sonar/java/checks/NonSerializableWriteCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NonSerializableWriteCheck.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Lists;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -49,7 +49,7 @@ import java.util.List;
 @SqaleConstantRemediation("15min")
 public class NonSerializableWriteCheck extends SubscriptionBaseVisitor {
 
-  private static final MethodInvocationMatcher WRITE_OBJECT_MATCHER = MethodInvocationMatcher.create()
+  private static final MethodMatcher WRITE_OBJECT_MATCHER = MethodMatcher.create()
     .typeDefinition("java.io.ObjectOutputStream")
     .name("writeObject")
     .addParameter("java.lang.Object");

--- a/java-checks/src/main/java/org/sonar/java/checks/NotifyCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NotifyCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
@@ -41,12 +41,12 @@ import java.util.List;
 public class NotifyCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create().typeDefinition("java.lang.Object").name("notify"));
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create().typeDefinition("java.lang.Object").name("notify"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "\"notify\" may not wake up the appropriate thread.");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/OSCommandInjectionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/OSCommandInjectionCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.NewArrayTree;
@@ -45,7 +45,7 @@ import java.util.List;
 @SqaleConstantRemediation("30min")
 public class OSCommandInjectionCheck extends AbstractInjectionChecker {
 
-  private static final MethodInvocationMatcher RUNTIME_EXEC_MATCHER = MethodInvocationMatcher.create()
+  private static final MethodMatcher RUNTIME_EXEC_MATCHER = MethodMatcher.create()
     .typeDefinition("java.lang.Runtime")
     .name("exec").withNoParameterConstraint();
 

--- a/java-checks/src/main/java/org/sonar/java/checks/ObjectCreatedOnlyToCallGetClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ObjectCreatedOnlyToCallGetClassCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -53,13 +53,13 @@ import java.util.List;
 public class ObjectCreatedOnlyToCallGetClassCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
-      MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.lang.Object")).name("getClass"));
+      MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.lang.Object")).name("getClass"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if (hasSemantic() && mit.methodSelect().is(Kind.MEMBER_SELECT)) {
       ExpressionTree expressionTree = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
       if (expressionTree.is(Kind.NEW_CLASS)) {

--- a/java-checks/src/main/java/org/sonar/java/checks/PreparedStatementAndResultSetCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PreparedStatementAndResultSetCheck.java
@@ -25,7 +25,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.NameCriteria;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.java.model.LiteralUtils;
@@ -61,15 +61,15 @@ public class PreparedStatementAndResultSetCheck extends AbstractMethodDetection 
   private static final String JAVA_SQL_RESULTSET = "java.sql.ResultSet";
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
-      MethodInvocationMatcher.create().typeDefinition("java.sql.PreparedStatement").name(NameCriteria.startsWith("set")).addParameter(INT).addParameter(TypeCriteria.anyType()),
-      MethodInvocationMatcher.create().typeDefinition(JAVA_SQL_RESULTSET).name(NameCriteria.startsWith("get")).addParameter(INT),
-      MethodInvocationMatcher.create().typeDefinition(JAVA_SQL_RESULTSET).name(NameCriteria.startsWith("get")).addParameter(INT).addParameter(TypeCriteria.anyType()));
+      MethodMatcher.create().typeDefinition("java.sql.PreparedStatement").name(NameCriteria.startsWith("set")).addParameter(INT).addParameter(TypeCriteria.anyType()),
+      MethodMatcher.create().typeDefinition(JAVA_SQL_RESULTSET).name(NameCriteria.startsWith("get")).addParameter(INT),
+      MethodMatcher.create().typeDefinition(JAVA_SQL_RESULTSET).name(NameCriteria.startsWith("get")).addParameter(INT).addParameter(TypeCriteria.anyType()));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     Integer methodFirstArgumentAsInteger = LiteralUtils.intLiteralValue(mit.arguments().get(0));
     if (methodFirstArgumentAsInteger == null) {
       // nothing to say if first argument can not be evaluated

--- a/java-checks/src/main/java/org/sonar/java/checks/PrimitiveTypeBoxingWithToStringCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PrimitiveTypeBoxingWithToStringCheck.java
@@ -25,7 +25,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.java.model.LiteralUtils;
 import org.sonar.java.resolve.JavaType;
@@ -61,7 +61,7 @@ public class PrimitiveTypeBoxingWithToStringCheck extends AbstractMethodDetectio
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return getToStringMatchers(
       "java.lang.Byte",
       "java.lang.Character",
@@ -73,10 +73,10 @@ public class PrimitiveTypeBoxingWithToStringCheck extends AbstractMethodDetectio
       "java.lang.Boolean");
   }
 
-  private static List<MethodInvocationMatcher> getToStringMatchers(String... typeFullyQualifiedNames) {
-    List<MethodInvocationMatcher> matchers = Lists.newArrayList();
+  private static List<MethodMatcher> getToStringMatchers(String... typeFullyQualifiedNames) {
+    List<MethodMatcher> matchers = Lists.newArrayList();
     for (String fullyQualifiedName : typeFullyQualifiedNames) {
-      matchers.add(MethodInvocationMatcher.create()
+      matchers.add(MethodMatcher.create()
         .typeDefinition(TypeCriteria.subtypeOf(fullyQualifiedName))
         .name("toString"));
     }
@@ -110,7 +110,7 @@ public class PrimitiveTypeBoxingWithToStringCheck extends AbstractMethodDetectio
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree abstractTypedTree = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
     if (abstractTypedTree.is(Kind.NEW_CLASS) || isValueOfInvocation(abstractTypedTree)) {
       String typeName = abstractTypedTree.symbolType().toString();
@@ -123,7 +123,7 @@ public class PrimitiveTypeBoxingWithToStringCheck extends AbstractMethodDetectio
       return false;
     }
     Type type = abstractTypedTree.symbolType();
-    MethodInvocationMatcher valueOfMatcher = MethodInvocationMatcher.create()
+    MethodMatcher valueOfMatcher = MethodMatcher.create()
       .typeDefinition(type.fullyQualifiedName())
       .name("valueOf")
       .addParameter(((JavaType) type).primitiveType().fullyQualifiedName());

--- a/java-checks/src/main/java/org/sonar/java/checks/PrintfCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PrintfCheck.java
@@ -26,7 +26,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
@@ -63,19 +63,19 @@ public class PrintfCheck extends AbstractMethodDetection {
   private static final String FORMAT_METHOD_NAME = "format";
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
-        MethodInvocationMatcher.create().typeDefinition("java.lang.String").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("java.util.Formatter").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("java.io.PrintStream").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("java.io.PrintStream").name("printf").withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("java.io.PrintWriter").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
-        MethodInvocationMatcher.create().typeDefinition("java.io.PrintWriter").name("printf").withNoParameterConstraint()
+        MethodMatcher.create().typeDefinition("java.lang.String").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("java.util.Formatter").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("java.io.PrintStream").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("java.io.PrintStream").name("printf").withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("java.io.PrintWriter").name(FORMAT_METHOD_NAME).withNoParameterConstraint(),
+        MethodMatcher.create().typeDefinition("java.io.PrintWriter").name("printf").withNoParameterConstraint()
     );
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree formatStringTree;
     List<ExpressionTree> args;
     //Check type of first argument:

--- a/java-checks/src/main/java/org/sonar/java/checks/PseudoRandomCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PseudoRandomCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -41,7 +41,7 @@ import java.util.List;
 @SqaleConstantRemediation("10min")
 public class PseudoRandomCheck extends SubscriptionBaseVisitor {
 
-  private MethodInvocationMatcher methodInvocationMatcher = MethodInvocationMatcher.create().typeDefinition("java.lang.Math").name("random");
+  private MethodMatcher methodInvocationMatcher = MethodMatcher.create().typeDefinition("java.lang.Math").name("random");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {

--- a/java-checks/src/main/java/org/sonar/java/checks/ReflectionOnNonRuntimeAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReflectionOnNonRuntimeAnnotationCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
@@ -53,14 +53,14 @@ import java.util.List;
 public class ReflectionOnNonRuntimeAnnotationCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.lang.reflect.AnnotatedElement"))
       .name("isAnnotationPresent").withNoParameterConstraint());
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree expressionTree = mit.arguments().get(0);
     // For now ignore everything that is not a .class expression
     if (expressionTree.is(Tree.Kind.MEMBER_SELECT)) {

--- a/java-checks/src/main/java/org/sonar/java/checks/ResultSetIsLastCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ResultSetIsLastCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
@@ -43,12 +43,12 @@ import java.util.List;
 public class ResultSetIsLastCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create().typeDefinition("java.sql.ResultSet").name("isLast"));
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create().typeDefinition("java.sql.ResultSet").name("isLast"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Remove this call to \"isLast()\".");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/RunFinalizersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RunFinalizersCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
@@ -43,15 +43,15 @@ import java.util.List;
 public class RunFinalizersCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.<MethodInvocationMatcher>builder()
-        .add(MethodInvocationMatcher.create().typeDefinition("java.lang.Runtime").name("runFinalizersOnExit").addParameter("boolean"))
-        .add(MethodInvocationMatcher.create().typeDefinition("java.lang.System").name("runFinalizersOnExit").addParameter("boolean"))
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.<MethodMatcher>builder()
+        .add(MethodMatcher.create().typeDefinition("java.lang.Runtime").name("runFinalizersOnExit").addParameter("boolean"))
+        .add(MethodMatcher.create().typeDefinition("java.lang.System").name("runFinalizersOnExit").addParameter("boolean"))
         .build();
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Remove this call to \"" + mit.symbol().owner().name() + ".runFinalizersOnExit()\".");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ScheduledThreadPoolExecutorZeroCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ScheduledThreadPoolExecutorZeroCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
@@ -48,15 +48,15 @@ import java.util.List;
 public class ScheduledThreadPoolExecutorZeroCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
-        MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.util.concurrent.ThreadPoolExecutor")).name("setCorePoolSize").addParameter("int"),
-        MethodInvocationMatcher.create().typeDefinition("java.util.concurrent.ScheduledThreadPoolExecutor").name("<init>").addParameter("int")
+        MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.util.concurrent.ThreadPoolExecutor")).name("setCorePoolSize").addParameter("int"),
+        MethodMatcher.create().typeDefinition("java.util.concurrent.ScheduledThreadPoolExecutor").name("<init>").addParameter("int")
     );
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if(isZeroIntLiteral(mit.arguments().get(0))) {
       reportIssue(mit);
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/SerializableObjectInSessionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SerializableObjectInSessionCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -46,13 +46,13 @@ public class SerializableObjectInSessionCheck extends AbstractMethodDetection {
 
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create().typeDefinition("javax.servlet.http.HttpSession")
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create().typeDefinition("javax.servlet.http.HttpSession")
         .name("setAttribute").addParameter("java.lang.String").addParameter("java.lang.Object"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree argument = mit.arguments().get(1);
     Type type = argument.symbolType();
     if(!type.isSubtypeOf("java.io.Serializable")) {

--- a/java-checks/src/main/java/org/sonar/java/checks/SillyEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SillyEqualsCheck.java
@@ -25,7 +25,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.resolve.JavaType;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -53,14 +53,14 @@ public class SillyEqualsCheck extends AbstractMethodDetection {
   private static final String MESSAGE = "Remove this call to \"equals\"; comparisons between unrelated types always return false.";
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create()
       .name("equals")
       .addParameter(JAVA_LANG_OBJECT));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree tree) {
+  protected void onMethodInvocationFound(MethodInvocationTree tree) {
     ExpressionTree firstArgument = Iterables.getOnlyElement(tree.arguments());
     Type argumentType = firstArgument.symbolType().erasure();
     if (argumentType.isPrimitive()) {

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticFieldInitializationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticFieldInitializationCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
@@ -97,7 +97,7 @@ public class StaticFieldInitializationCheck extends AbstractInSynchronizeChecker
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of();
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticFieldUpateCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticFieldUpateCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
@@ -149,7 +149,7 @@ public class StaticFieldUpateCheck extends AbstractInSynchronizeChecker {
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of();
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/StringToPrimitiveConversionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringToPrimitiveConversionCheck.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang.StringUtils;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.model.declaration.VariableTreeImpl;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -107,18 +107,18 @@ public class StringToPrimitiveConversionCheck extends SubscriptionBaseVisitor {
     private final String className;
     private final Type.Primitives tag;
     private final String message;
-    private final MethodInvocationMatcher unboxingInvocationMatcher;
-    private final MethodInvocationMatcher valueOfInvocationMatcher;
+    private final MethodMatcher unboxingInvocationMatcher;
+    private final MethodMatcher valueOfInvocationMatcher;
 
     private PrimitiveCheck(String primitiveName, String className, Type.Primitives tag) {
       this.primitiveName = primitiveName;
       this.className = className;
       this.tag = tag;
       this.message = "Use \"" + parseMethodName() + "\" for this string-to-" + primitiveName + " conversion.";
-      this.unboxingInvocationMatcher = MethodInvocationMatcher.create()
+      this.unboxingInvocationMatcher = MethodMatcher.create()
         .typeDefinition("java.lang." + className)
         .name(primitiveName + "Value");
-      this.valueOfInvocationMatcher = MethodInvocationMatcher.create()
+      this.valueOfInvocationMatcher = MethodMatcher.create()
         .typeDefinition("java.lang." + className)
         .name("valueOf")
         .addParameter("java.lang.String");

--- a/java-checks/src/main/java/org/sonar/java/checks/StringToStringCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringToStringCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
@@ -50,14 +50,14 @@ import java.util.List;
 public class StringToStringCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create()
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create()
       .typeDefinition("java.lang.String")
       .name("toString"));
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree tree) {
+  protected void onMethodInvocationFound(MethodInvocationTree tree) {
     ExpressionTree expressionTree = extractBaseExpression(((MemberSelectExpressionTree) tree.methodSelect()).expression());
     if (expressionTree.is(Tree.Kind.IDENTIFIER)) {
       addIssue(expressionTree, String.format("\"%s\" is already a string, there's no need to call \"toString()\" on it.",

--- a/java-checks/src/main/java/org/sonar/java/checks/ThreadRunCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ThreadRunCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -44,13 +44,13 @@ import java.util.List;
 public class ThreadRunCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
-      MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.lang.Runnable")).name("run").withNoParameterConstraint());
+      MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.lang.Runnable")).name("run").withNoParameterConstraint());
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Call the method Thread.start() to execute the content of the run() method in a dedicated thread.");
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/ThreadSleepCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ThreadSleepCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
@@ -42,14 +42,14 @@ import java.util.List;
 public class ThreadSleepCheck extends AbstractInSynchronizeChecker {
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if (isInSyncBlock()) {
       addIssue(mit, "Replace the call to \"Thread.sleep(...)\" with a call to \"wait(...)\".");
     }
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.of(MethodInvocationMatcher.create().typeDefinition("java.lang.Thread").name("sleep").withNoParameterConstraint());
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.of(MethodMatcher.create().typeDefinition("java.lang.Thread").name("sleep").withNoParameterConstraint());
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ThreadStartedInConstructorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ThreadStartedInConstructorCheck.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang.BooleanUtils;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -45,7 +45,7 @@ import java.util.List;
 @SqaleConstantRemediation("30min")
 public class ThreadStartedInConstructorCheck extends SubscriptionBaseVisitor {
 
-  private static final MethodInvocationMatcher THREAD_START = MethodInvocationMatcher.create()
+  private static final MethodMatcher THREAD_START = MethodMatcher.create()
     .typeDefinition("java.lang.Thread")
     .name("start");
 

--- a/java-checks/src/main/java/org/sonar/java/checks/ThreadWaitCallCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ThreadWaitCallCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -44,18 +44,18 @@ import java.util.List;
 public class ThreadWaitCallCheck extends AbstractMethodDetection {
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "Refactor the synchronisation mechanism to not use a Thread instance as a monitor");
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     TypeCriteria subtypeOfThread = TypeCriteria.subtypeOf("java.lang.Thread");
-    return ImmutableList.<MethodInvocationMatcher>builder()
-        .add(MethodInvocationMatcher.create().callSite(subtypeOfThread).name("wait"))
-        .add(MethodInvocationMatcher.create().callSite(subtypeOfThread).name("wait").addParameter("long"))
-        .add(MethodInvocationMatcher.create().callSite(subtypeOfThread).name("wait").addParameter("long").addParameter("int"))
-        .add(MethodInvocationMatcher.create().callSite(subtypeOfThread).name("notify"))
-        .add(MethodInvocationMatcher.create().callSite(subtypeOfThread).name("notifyAll")).build();
+    return ImmutableList.<MethodMatcher>builder()
+        .add(MethodMatcher.create().callSite(subtypeOfThread).name("wait"))
+        .add(MethodMatcher.create().callSite(subtypeOfThread).name("wait").addParameter("long"))
+        .add(MethodMatcher.create().callSite(subtypeOfThread).name("wait").addParameter("long").addParameter("int"))
+        .add(MethodMatcher.create().callSite(subtypeOfThread).name("notify"))
+        .add(MethodMatcher.create().callSite(subtypeOfThread).name("notifyAll")).build();
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/URLHashCodeAndEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/URLHashCodeAndEqualsCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.resolve.JavaType;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -51,8 +51,8 @@ public class URLHashCodeAndEqualsCheck extends SubscriptionBaseVisitor {
   private static final String JAVA_NET_URL = "java.net.URL";
 
   private static final MethodInvocationMatcherCollection URL_MATCHERS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create().typeDefinition(JAVA_NET_URL).name("equals").addParameter("java.lang.Object"),
-    MethodInvocationMatcher.create().typeDefinition(JAVA_NET_URL).name("hashCode"));
+    MethodMatcher.create().typeDefinition(JAVA_NET_URL).name("equals").addParameter("java.lang.Object"),
+    MethodMatcher.create().typeDefinition(JAVA_NET_URL).name("hashCode"));
 
   @Override
   public List<Tree.Kind> nodesToVisit() {

--- a/java-checks/src/main/java/org/sonar/java/checks/UnusedReturnedDataCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UnusedReturnedDataCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
@@ -50,11 +50,11 @@ import java.util.List;
 @SqaleConstantRemediation("5min")
 public class UnusedReturnedDataCheck extends SubscriptionBaseVisitor {
 
-  private static final List<MethodInvocationMatcher> CHECKED_METHODS = ImmutableList.of(
-    MethodInvocationMatcher.create()
+  private static final List<MethodMatcher> CHECKED_METHODS = ImmutableList.of(
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.io.BufferedReader"))
       .name("readLine"),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("java.io.Reader"))
       .name("read"));
 
@@ -66,7 +66,7 @@ public class UnusedReturnedDataCheck extends SubscriptionBaseVisitor {
   @Override
   public void visitNode(Tree tree) {
     if (tree.is(Tree.Kind.EXPRESSION_STATEMENT)) {
-      for (MethodInvocationMatcher matcher : CHECKED_METHODS) {
+      for (MethodMatcher matcher : CHECKED_METHODS) {
         Symbol symbol = isTreeMethodInvocation(((ExpressionStatementTree) tree).expression(), matcher);
         if (symbol != null) {
           raiseIssue(tree, symbol.name());
@@ -74,7 +74,7 @@ public class UnusedReturnedDataCheck extends SubscriptionBaseVisitor {
       }
     } else {
       BinaryExpressionTree expressionTree = (BinaryExpressionTree) tree;
-      for (MethodInvocationMatcher matcher : CHECKED_METHODS) {
+      for (MethodMatcher matcher : CHECKED_METHODS) {
         Symbol leftSymbol = isTreeMethodInvocation(expressionTree.leftOperand(), matcher);
         if (leftSymbol != null && isTreeLiteralNull(expressionTree.rightOperand())) {
           raiseIssue(tree, leftSymbol.name());
@@ -88,7 +88,7 @@ public class UnusedReturnedDataCheck extends SubscriptionBaseVisitor {
   }
 
   @CheckForNull
-  private Symbol isTreeMethodInvocation(ExpressionTree tree, MethodInvocationMatcher matcher) {
+  private Symbol isTreeMethodInvocation(ExpressionTree tree, MethodMatcher matcher) {
     Tree expression = removeParenthesis(tree);
     if (expression.is(Tree.Kind.METHOD_INVOCATION)) {
       MethodInvocationTree methodInvocation = (MethodInvocationTree) expression;

--- a/java-checks/src/main/java/org/sonar/java/checks/WaitInSynchronizeCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/WaitInSynchronizeCheck.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -45,7 +45,7 @@ import java.util.List;
 public class WaitInSynchronizeCheck extends AbstractInSynchronizeChecker {
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if (!isInSyncBlock()) {
       String methodName;
       String lockName;
@@ -62,12 +62,12 @@ public class WaitInSynchronizeCheck extends AbstractInSynchronizeChecker {
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
-    return ImmutableList.<MethodInvocationMatcher>builder()
-        .add(MethodInvocationMatcher.create().name("wait"))
-        .add(MethodInvocationMatcher.create().name("wait").addParameter("long"))
-        .add(MethodInvocationMatcher.create().name("wait").addParameter("long").addParameter("int"))
-        .add(MethodInvocationMatcher.create().name("notify"))
-        .add(MethodInvocationMatcher.create().name("notifyAll")).build();
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
+    return ImmutableList.<MethodMatcher>builder()
+        .add(MethodMatcher.create().name("wait"))
+        .add(MethodMatcher.create().name("wait").addParameter("long"))
+        .add(MethodMatcher.create().name("wait").addParameter("long").addParameter("int"))
+        .add(MethodMatcher.create().name("notify"))
+        .add(MethodMatcher.create().name("notifyAll")).build();
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/WaitInWhileLoopCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/WaitInWhileLoopCheck.java
@@ -25,7 +25,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.ForStatementTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
@@ -83,7 +83,7 @@ public class WaitInWhileLoopCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if (!inWhileLoop.peek()) {
       String methodName;
       if(mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
@@ -97,12 +97,12 @@ public class WaitInWhileLoopCheck extends AbstractMethodDetection {
   }
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     return ImmutableList.of(
-        MethodInvocationMatcher.create().name("wait"),
-        MethodInvocationMatcher.create().name("wait").addParameter("long"),
-        MethodInvocationMatcher.create().name("wait").addParameter("long").addParameter("int"),
-        MethodInvocationMatcher.create().typeDefinition("java.util.concurrent.locks.Condition").name("await").withNoParameterConstraint()
+        MethodMatcher.create().name("wait"),
+        MethodMatcher.create().name("wait").addParameter("long"),
+        MethodMatcher.create().name("wait").addParameter("long").addParameter("int"),
+        MethodMatcher.create().typeDefinition("java.util.concurrent.locks.Condition").name("await").withNoParameterConstraint()
     );
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/WaitOnConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/WaitOnConditionCheck.java
@@ -24,7 +24,7 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.squidbridge.annotations.ActivatedByDefault;
@@ -44,17 +44,17 @@ import java.util.List;
 public class WaitOnConditionCheck extends AbstractMethodDetection {
 
   @Override
-  protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+  protected List<MethodMatcher> getMethodInvocationMatchers() {
     TypeCriteria conditionSubType = TypeCriteria.subtypeOf("java.util.concurrent.locks.Condition");
-    return ImmutableList.<MethodInvocationMatcher>builder()
-        .add(MethodInvocationMatcher.create().callSite(conditionSubType).name("wait"))
-        .add(MethodInvocationMatcher.create().callSite(conditionSubType).name("wait").addParameter("long"))
-        .add(MethodInvocationMatcher.create().callSite(conditionSubType).name("wait").addParameter("long").addParameter("int"))
+    return ImmutableList.<MethodMatcher>builder()
+        .add(MethodMatcher.create().callSite(conditionSubType).name("wait"))
+        .add(MethodMatcher.create().callSite(conditionSubType).name("wait").addParameter("long"))
+        .add(MethodMatcher.create().callSite(conditionSubType).name("wait").addParameter("long").addParameter("int"))
         .build();
   }
 
   @Override
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     addIssue(mit, "The \"Condition.await(...)\" method should be used instead of \"Object.wait(...)\"");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/methods/AbstractMethodDetection.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/methods/AbstractMethodDetection.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 public abstract class AbstractMethodDetection extends SubscriptionBaseVisitor {
 
-  private List<MethodInvocationMatcher> matchers;
+  private List<MethodMatcher> matchers;
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -39,17 +39,17 @@ public abstract class AbstractMethodDetection extends SubscriptionBaseVisitor {
   @Override
   public void visitNode(Tree tree) {
     if (hasSemantic()) {
-      for (MethodInvocationMatcher invocationMatcher : matchers()) {
+      for (MethodMatcher invocationMatcher : matchers()) {
         checkInvocation(tree, invocationMatcher);
       }
     }
   }
 
-  private void checkInvocation(Tree tree, MethodInvocationMatcher invocationMatcher) {
+  private void checkInvocation(Tree tree, MethodMatcher invocationMatcher) {
     if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
       MethodInvocationTree mit = (MethodInvocationTree) tree;
       if (invocationMatcher.matches(mit)) {
-        onMethodFound(mit);
+        onMethodInvocationFound(mit);
       }
     } else if (tree.is(Tree.Kind.NEW_CLASS)) {
       NewClassTree newClassTree = (NewClassTree) tree;
@@ -59,9 +59,9 @@ public abstract class AbstractMethodDetection extends SubscriptionBaseVisitor {
     }
   }
 
-  protected abstract List<MethodInvocationMatcher> getMethodInvocationMatchers();
+  protected abstract List<MethodMatcher> getMethodInvocationMatchers();
 
-  protected void onMethodFound(MethodInvocationTree mit) {
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
     // Do nothing by default
   }
 
@@ -69,7 +69,7 @@ public abstract class AbstractMethodDetection extends SubscriptionBaseVisitor {
     // Do nothing by default
   }
 
-  private List<MethodInvocationMatcher> matchers() {
+  private List<MethodMatcher> matchers() {
     if (matchers == null) {
       matchers = getMethodInvocationMatchers();
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/methods/MethodInvocationMatcherCollection.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/methods/MethodInvocationMatcherCollection.java
@@ -21,7 +21,9 @@ package org.sonar.java.checks.methods;
 
 import com.google.common.collect.Lists;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
 
+import java.util.Collections;
 import java.util.List;
 
 public class MethodInvocationMatcherCollection {
@@ -37,9 +39,7 @@ public class MethodInvocationMatcherCollection {
 
   public static MethodInvocationMatcherCollection create(MethodInvocationMatcher... matchers) {
     MethodInvocationMatcherCollection collection = new MethodInvocationMatcherCollection();
-    for (MethodInvocationMatcher matcher : matchers) {
-      collection.matchers.add(matcher);
-    }
+    Collections.addAll(collection.matchers, matchers);
     return collection;
   }
 
@@ -51,6 +51,15 @@ public class MethodInvocationMatcherCollection {
   public boolean anyMatch(MethodInvocationTree mit) {
     for (MethodInvocationMatcher matcher : matchers) {
       if (matcher.matches(mit)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean anyMatch(final MethodTree method) {
+    for (MethodInvocationMatcher matcher : matchers) {
+      if (matcher.matches(method)) {
         return true;
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/methods/MethodInvocationMatcherCollection.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/methods/MethodInvocationMatcherCollection.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class MethodInvocationMatcherCollection {
 
-  private List<MethodInvocationMatcher> matchers = Lists.newLinkedList();
+  private List<MethodMatcher> matchers = Lists.newLinkedList();
 
   private MethodInvocationMatcherCollection() {
   }
@@ -37,19 +37,19 @@ public class MethodInvocationMatcherCollection {
     return new MethodInvocationMatcherCollection();
   }
 
-  public static MethodInvocationMatcherCollection create(MethodInvocationMatcher... matchers) {
+  public static MethodInvocationMatcherCollection create(MethodMatcher... matchers) {
     MethodInvocationMatcherCollection collection = new MethodInvocationMatcherCollection();
     Collections.addAll(collection.matchers, matchers);
     return collection;
   }
 
-  public MethodInvocationMatcherCollection add(MethodInvocationMatcher matcher) {
+  public MethodInvocationMatcherCollection add(MethodMatcher matcher) {
     this.matchers.add(matcher);
     return this;
   }
 
   public boolean anyMatch(MethodInvocationTree mit) {
-    for (MethodInvocationMatcher matcher : matchers) {
+    for (MethodMatcher matcher : matchers) {
       if (matcher.matches(mit)) {
         return true;
       }
@@ -58,7 +58,7 @@ public class MethodInvocationMatcherCollection {
   }
 
   public boolean anyMatch(final MethodTree method) {
-    for (MethodInvocationMatcher matcher : matchers) {
+    for (MethodMatcher matcher : matchers) {
       if (matcher.matches(method)) {
         return true;
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/methods/MethodMatcher.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/methods/MethodMatcher.java
@@ -35,62 +35,62 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 import java.util.List;
 
-public class MethodInvocationMatcher {
+public class MethodMatcher {
 
   private TypeCriteria typeDefinition;
   private TypeCriteria callSite;
   private NameCriteria methodName;
   private List<TypeCriteria> parameterTypes;
 
-  MethodInvocationMatcher() {
+  MethodMatcher() {
     parameterTypes = Lists.newArrayList();
   }
 
-  public static MethodInvocationMatcher create() {
-    return new MethodInvocationMatcher();
+  public static MethodMatcher create() {
+    return new MethodMatcher();
   }
 
-  public MethodInvocationMatcher name(String methodName) {
+  public MethodMatcher name(String methodName) {
     this.methodName = NameCriteria.is(methodName);
     return this;
   }
 
-  public MethodInvocationMatcher name(NameCriteria methodName) {
+  public MethodMatcher name(NameCriteria methodName) {
     Preconditions.checkState(this.methodName == null);
     this.methodName = methodName;
     return this;
   }
 
-  public MethodInvocationMatcher typeDefinition(TypeCriteria typeDefinition) {
+  public MethodMatcher typeDefinition(TypeCriteria typeDefinition) {
     Preconditions.checkState(this.typeDefinition == null);
     this.typeDefinition = typeDefinition;
     return this;
   }
 
-  public MethodInvocationMatcher typeDefinition(String fullyQualifiedTypeName) {
+  public MethodMatcher typeDefinition(String fullyQualifiedTypeName) {
     Preconditions.checkState(typeDefinition == null);
     this.typeDefinition = TypeCriteria.is(fullyQualifiedTypeName);
     return this;
   }
 
-  public MethodInvocationMatcher callSite(TypeCriteria callSite) {
+  public MethodMatcher callSite(TypeCriteria callSite) {
     this.callSite = callSite;
     return this;
   }
 
-  public MethodInvocationMatcher addParameter(String fullyQualifiedTypeParameterName) {
+  public MethodMatcher addParameter(String fullyQualifiedTypeParameterName) {
     Preconditions.checkState(parameterTypes != null);
     parameterTypes.add(TypeCriteria.is(fullyQualifiedTypeParameterName));
     return this;
   }
 
-  public MethodInvocationMatcher addParameter(TypeCriteria parameterTypeCriteria) {
+  public MethodMatcher addParameter(TypeCriteria parameterTypeCriteria) {
     Preconditions.checkState(parameterTypes != null);
     parameterTypes.add(parameterTypeCriteria);
     return this;
   }
 
-  public MethodInvocationMatcher withNoParameterConstraint() {
+  public MethodMatcher withNoParameterConstraint() {
     Preconditions.checkState(parameterTypes == null || parameterTypes.isEmpty());
     parameterTypes = null;
     return this;
@@ -108,11 +108,8 @@ public class MethodInvocationMatcher {
 
   public boolean matches(MethodTree methodTree) {
     MethodSymbol symbol = methodTree.symbol();
-    if (symbol != null) {
-      Symbol.TypeSymbol enclosingClass = symbol.enclosingClass();
-      return enclosingClass != null && matches(symbol, enclosingClass.type());
-    }
-    return false;
+    Symbol.TypeSymbol enclosingClass = symbol.enclosingClass();
+    return enclosingClass != null && matches(symbol, enclosingClass.type());
   }
 
   private boolean matches(Symbol symbol, Type callSiteType) {
@@ -125,7 +122,7 @@ public class MethodInvocationMatcher {
     return false;
   }
 
-  private Type getCallSiteType(MethodInvocationTree mit) {
+  private static Type getCallSiteType(MethodInvocationTree mit) {
     ExpressionTree methodSelect = mit.methodSelect();
     if (methodSelect.is(Tree.Kind.IDENTIFIER)) {
       Symbol.TypeSymbol enclosingClassSymbol = ((IdentifierTree) methodSelect).symbol().enclosingClass();
@@ -174,7 +171,7 @@ public class MethodInvocationMatcher {
     return true;
   }
 
-  private IdentifierTree getIdentifier(MethodInvocationTree mit) {
+  private static IdentifierTree getIdentifier(MethodInvocationTree mit) {
     IdentifierTree id = null;
     if (mit.methodSelect().is(Tree.Kind.IDENTIFIER)) {
       id = (IdentifierTree) mit.methodSelect();

--- a/java-checks/src/main/java/org/sonar/java/closeresource/CloseableVisitor.java
+++ b/java-checks/src/main/java/org/sonar/java/closeresource/CloseableVisitor.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.closeresource;
 
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.java.symexecengine.ExecutionState;
@@ -52,15 +52,15 @@ public class CloseableVisitor extends SymbolicExecutionCheck {
   private static final String JAVA_LANG_AUTOCLOSEABLE = "java.lang.AutoCloseable";
 
   private static final MethodInvocationMatcherCollection CLOSE_INVOCATIONS = MethodInvocationMatcherCollection.create(
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf(JAVA_IO_CLOSEABLE))
       .name(CLOSE_METHOD_NAME)
       .withNoParameterConstraint(),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf(JAVA_LANG_AUTOCLOSEABLE))
       .name(CLOSE_METHOD_NAME)
       .withNoParameterConstraint(),
-    MethodInvocationMatcher.create()
+    MethodMatcher.create()
       .typeDefinition(TypeCriteria.subtypeOf("org.springframework.context.support.AbstractApplicationContext"))
       .name("registerShutdownHook")
       .withNoParameterConstraint());

--- a/java-checks/src/main/java/org/sonar/java/locks/LockedVisitor.java
+++ b/java-checks/src/main/java/org/sonar/java/locks/LockedVisitor.java
@@ -20,7 +20,7 @@
 package org.sonar.java.locks;
 
 import com.google.common.collect.Lists;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.checks.methods.MethodInvocationMatcherCollection;
 import org.sonar.java.checks.methods.TypeCriteria;
 import org.sonar.java.symexecengine.ExecutionState;
@@ -44,17 +44,17 @@ public class LockedVisitor extends SymbolicExecutionCheck {
   private static final String JAVA_LOCK = "java.util.concurrent.locks.Lock";
 
   private static final MethodInvocationMatcherCollection LOCK_INVOCATIONS = lockMethodInvocationMatcher();
-  private static final MethodInvocationMatcher UNLOCK_INVOCATION = MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf(JAVA_LOCK)).name("unlock");
+  private static final MethodMatcher UNLOCK_INVOCATION = MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf(JAVA_LOCK)).name("unlock");
 
   private static MethodInvocationMatcherCollection lockMethodInvocationMatcher() {
     return MethodInvocationMatcherCollection.create(
-      MethodInvocationMatcher.create()
+      MethodMatcher.create()
         .typeDefinition(TypeCriteria.subtypeOf(JAVA_LOCK))
         .name("lock"),
-      MethodInvocationMatcher.create()
+      MethodMatcher.create()
         .typeDefinition(TypeCriteria.subtypeOf(JAVA_LOCK))
         .name("lockInterruptibly"),
-      MethodInvocationMatcher.create()
+      MethodMatcher.create()
         .typeDefinition(TypeCriteria.subtypeOf(JAVA_LOCK))
         .name("tryLock")
         .withNoParameterConstraint());

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2325.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2325.html
@@ -34,3 +34,13 @@ class Utilities {
 
 }
 </pre>
+
+<h2>Exceptions</h2>
+<p>
+  When <code>java.io.Serializable</code> is implemented the following three methods are excluded by the rule:
+</p>
+<ul>
+  <li><code>private void writeObject(java.io.ObjectOutputStream out) throws IOException;</code></li>
+  <li><code>private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException;</code></li>
+  <li><code>private void readObjectNoData() throws ObjectStreamException;</code></li>
+</ul>

--- a/java-checks/src/test/files/checks/StaticMethodCheck.java
+++ b/java-checks/src/test/files/checks/StaticMethodCheck.java
@@ -1,5 +1,9 @@
 package foo;
 
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
 class Utilities {
   private static String magicWord = "magic";
   private static String string = magicWord; // coverage
@@ -72,4 +76,14 @@ class UtilitiesExtension extends Utilities {
   private void method() { // Compliant
     publicMethod();
   }
+}
+
+class SerializableExclusions implements Serializable {
+  private void writeObject(java.io.ObjectOutputStream out) throws IOException {}
+
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {}
+
+  private void readObjectNoData() throws ObjectStreamException {}
+
+  private void other() {} // Noncompliant
 }

--- a/java-checks/src/test/files/checks/methodMatcher/Test.java
+++ b/java-checks/src/test/files/checks/methodMatcher/Test.java
@@ -1,0 +1,16 @@
+import java.lang.Boolean;
+import java.lang.Integer;
+
+class Test extends Object {
+
+  public String toString() {
+  }
+
+  public String toString(int bad) {
+
+  }
+
+  public String mit() {
+    return new Integer(5).toString();
+  }
+}

--- a/java-checks/src/test/files/symexecengine/DataFlowVisitor.java
+++ b/java-checks/src/test/files/symexecengine/DataFlowVisitor.java
@@ -1,33 +1,8 @@
-import com.google.common.base.Charsets;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.fest.assertions.Assertions;
 import org.junit.Test;
-import org.sonar.java.ast.parser.JavaParser;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
-import org.sonar.java.resolve.SemanticModel;
-import org.sonar.java.symexecengine.DataFlowVisitor;
-import org.sonar.java.symexecengine.ExecutionState;
-import org.sonar.java.symexecengine.State;
-import org.sonar.java.symexecengine.SymbolicExecutionCheck;
 import org.sonar.java.symexecengine.DataFlowVisitorTest.Check;
 import org.sonar.java.symexecengine.DataFlowVisitorTest.ExecutionContext;
 import org.sonar.java.symexecengine.DataFlowVisitorTest.TestState;
-import org.sonar.plugins.java.api.tree.ClassTree;
-import org.sonar.plugins.java.api.tree.CompilationUnitTree;
-import org.sonar.plugins.java.api.tree.ExpressionTree;
-import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.LiteralTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
-import org.sonar.plugins.java.api.tree.MethodInvocationTree;
-import org.sonar.plugins.java.api.tree.MethodTree;
-import org.sonar.plugins.java.api.tree.Tree;
-
-import java.io.File;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 public abstract class TestClass {
 

--- a/java-checks/src/test/java/org/sonar/java/checks/AbstractMethodDetectionTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AbstractMethodDetectionTest.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.java.JavaAstScanner;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.checks.methods.MethodInvocationMatcher;
+import org.sonar.java.checks.methods.MethodMatcher;
 import org.sonar.java.model.JavaTree;
 import org.sonar.java.model.VisitorsBridge;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -45,8 +45,8 @@ public class AbstractMethodDetectionTest {
   public void detected() {
 
     Visitor visitor = new Visitor(ImmutableList.of(
-      MethodInvocationMatcher.create().typeDefinition("A").name("method").addParameter("int"),
-      MethodInvocationMatcher.create().typeDefinition("A").name("method").addParameter("java.lang.String[]")
+      MethodMatcher.create().typeDefinition("A").name("method").addParameter("int"),
+      MethodMatcher.create().typeDefinition("A").name("method").addParameter("java.lang.String[]")
       ));
     JavaAstScanner.scanSingleFile(new File("src/test/files/checks/AbstractMethodDetection.java"), new VisitorsBridge(visitor));
 
@@ -57,7 +57,7 @@ public class AbstractMethodDetectionTest {
   @Test
   public void withNoParameterConstraint() throws Exception {
     Visitor visitor = new Visitor(ImmutableList.of(
-      MethodInvocationMatcher.create().typeDefinition("A").name("method").withNoParameterConstraint()
+      MethodMatcher.create().typeDefinition("A").name("method").withNoParameterConstraint()
       ));
     JavaAstScanner.scanSingleFile(new File("src/test/files/checks/AbstractMethodDetection.java"), new VisitorsBridge(visitor));
 
@@ -68,19 +68,19 @@ public class AbstractMethodDetectionTest {
   class Visitor extends AbstractMethodDetection {
 
     public List<Integer> lines = Lists.newArrayList();
-    private List<MethodInvocationMatcher> methodInvocationMatchers;
+    private List<MethodMatcher> methodInvocationMatchers;
 
-    public Visitor(List<MethodInvocationMatcher> methodInvocationMatchers) {
+    public Visitor(List<MethodMatcher> methodInvocationMatchers) {
       this.methodInvocationMatchers = methodInvocationMatchers;
     }
 
     @Override
-    protected List<MethodInvocationMatcher> getMethodInvocationMatchers() {
+    protected List<MethodMatcher> getMethodInvocationMatchers() {
       return methodInvocationMatchers;
     }
 
     @Override
-    protected void onMethodFound(MethodInvocationTree tree) {
+    protected void onMethodInvocationFound(MethodInvocationTree tree) {
       lines.add(((JavaTree) tree).getLine());
     }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/methods/MethodInvocationMatcherCollectionTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/methods/MethodInvocationMatcherCollectionTest.java
@@ -21,6 +21,7 @@ package org.sonar.java.checks.methods;
 
 import org.junit.Test;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -54,6 +55,7 @@ public class MethodInvocationMatcherCollectionTest {
     MethodInvocationMatcher matcher = mock(MethodInvocationMatcher.class);
     when(matcher.matches(any(MethodInvocationTree.class))).thenReturn(false);
     assertThat(MethodInvocationMatcherCollection.create(matcher).anyMatch(mock(MethodInvocationTree.class))).isFalse();
+    assertThat(MethodInvocationMatcherCollection.create(matcher).anyMatch(mock(MethodTree.class))).isFalse();
   }
 
   @Test
@@ -63,5 +65,11 @@ public class MethodInvocationMatcherCollectionTest {
     MethodInvocationMatcher matcher2 = mock(MethodInvocationMatcher.class);
     when(matcher2.matches(any(MethodInvocationTree.class))).thenReturn(true);
     assertThat(MethodInvocationMatcherCollection.create(matcher1, matcher2).anyMatch(mock(MethodInvocationTree.class))).isTrue();
+
+    matcher1 = mock(MethodInvocationMatcher.class);
+    when(matcher1.matches(any(MethodTree.class))).thenReturn(false);
+    matcher2 = mock(MethodInvocationMatcher.class);
+    when(matcher2.matches(any(MethodTree.class))).thenReturn(true);
+    assertThat(MethodInvocationMatcherCollection.create(matcher1, matcher2).anyMatch(mock(MethodTree.class))).isTrue();
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/methods/MethodMatcherCollectionTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/methods/MethodMatcherCollectionTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class MethodInvocationMatcherCollectionTest {
+public class MethodMatcherCollectionTest {
 
   @Test
   public void should_create_a_collection() {
@@ -37,12 +37,12 @@ public class MethodInvocationMatcherCollectionTest {
 
   @Test
   public void should_create_a_collection_with_MethodInvocationMatcher() {
-    assertThat(MethodInvocationMatcherCollection.create(MethodInvocationMatcher.create())).isNotNull();
+    assertThat(MethodInvocationMatcherCollection.create(MethodMatcher.create())).isNotNull();
   }
 
   @Test
   public void should_be_able_to_add_MethodInvocationMatcher() {
-    assertThat(MethodInvocationMatcherCollection.create().add(MethodInvocationMatcher.create())).isNotNull();
+    assertThat(MethodInvocationMatcherCollection.create().add(MethodMatcher.create())).isNotNull();
   }
 
   @Test
@@ -52,7 +52,7 @@ public class MethodInvocationMatcherCollectionTest {
 
   @Test
   public void should_not_match_when_method_invocation_tree_does_not_match() {
-    MethodInvocationMatcher matcher = mock(MethodInvocationMatcher.class);
+    MethodMatcher matcher = mock(MethodMatcher.class);
     when(matcher.matches(any(MethodInvocationTree.class))).thenReturn(false);
     assertThat(MethodInvocationMatcherCollection.create(matcher).anyMatch(mock(MethodInvocationTree.class))).isFalse();
     assertThat(MethodInvocationMatcherCollection.create(matcher).anyMatch(mock(MethodTree.class))).isFalse();
@@ -60,15 +60,15 @@ public class MethodInvocationMatcherCollectionTest {
 
   @Test
   public void should_match_if_any_of_the_matchers_match() {
-    MethodInvocationMatcher matcher1 = mock(MethodInvocationMatcher.class);
+    MethodMatcher matcher1 = mock(MethodMatcher.class);
     when(matcher1.matches(any(MethodInvocationTree.class))).thenReturn(false);
-    MethodInvocationMatcher matcher2 = mock(MethodInvocationMatcher.class);
+    MethodMatcher matcher2 = mock(MethodMatcher.class);
     when(matcher2.matches(any(MethodInvocationTree.class))).thenReturn(true);
     assertThat(MethodInvocationMatcherCollection.create(matcher1, matcher2).anyMatch(mock(MethodInvocationTree.class))).isTrue();
 
-    matcher1 = mock(MethodInvocationMatcher.class);
+    matcher1 = mock(MethodMatcher.class);
     when(matcher1.matches(any(MethodTree.class))).thenReturn(false);
-    matcher2 = mock(MethodInvocationMatcher.class);
+    matcher2 = mock(MethodMatcher.class);
     when(matcher2.matches(any(MethodTree.class))).thenReturn(true);
     assertThat(MethodInvocationMatcherCollection.create(matcher1, matcher2).anyMatch(mock(MethodTree.class))).isTrue();
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/methods/MethodMatcherTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/methods/MethodMatcherTest.java
@@ -39,14 +39,14 @@ import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-public class MethodInvocationMatcherTest {
+public class MethodMatcherTest {
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void should_fail_if_addParameter_is_called_after_withNoParameterConstraint() throws Exception {
-    MethodInvocationMatcher matcher = MethodInvocationMatcher.create().name("name")
+    MethodMatcher matcher = MethodMatcher.create().name("name")
       .withNoParameterConstraint()
       .withNoParameterConstraint();
     exception.expect(IllegalStateException.class);
@@ -55,17 +55,17 @@ public class MethodInvocationMatcherTest {
 
   @Test
   public void should_fail_if_withNoParameterConstraint_is_called_after_addParameter() throws Exception {
-    MethodInvocationMatcher matcher = MethodInvocationMatcher.create().name("name").addParameter("int");
+    MethodMatcher matcher = MethodMatcher.create().name("name").addParameter("int");
     exception.expect(IllegalStateException.class);
     matcher.withNoParameterConstraint();
   }
 
   @Test
   public void detected() {
-    MethodInvocationMatcher objectToString = MethodInvocationMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.lang.Object")).name("toString");
-    MethodInvocationMatcher integerToString = MethodInvocationMatcher.create().typeDefinition("java.lang.Integer").name("toString");
+    MethodMatcher objectToString = MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("java.lang.Object")).name("toString");
+    MethodMatcher integerToString = MethodMatcher.create().typeDefinition("java.lang.Integer").name("toString");
 
-    Map<MethodInvocationMatcher, List<Integer>> matches = new HashMap<>();
+    Map<MethodMatcher, List<Integer>> matches = new HashMap<>();
     matches.put(objectToString, new ArrayList<Integer>());
     matches.put(integerToString, new ArrayList<Integer>());
 
@@ -77,9 +77,9 @@ public class MethodInvocationMatcherTest {
 
   class Visitor extends SubscriptionBaseVisitor {
 
-    public Map<MethodInvocationMatcher, List<Integer>> matches;
+    public Map<MethodMatcher, List<Integer>> matches;
 
-    public Visitor(Map<MethodInvocationMatcher, List<Integer>> matches) {
+    public Visitor(Map<MethodMatcher, List<Integer>> matches) {
       this.matches = matches;
     }
 
@@ -91,9 +91,9 @@ public class MethodInvocationMatcherTest {
     @Override
     public void visitNode(Tree tree) {
       super.visitNode(tree);
-      for (Map.Entry<MethodInvocationMatcher, List<Integer>> entry : matches.entrySet()) {
+      for (Map.Entry<MethodMatcher, List<Integer>> entry : matches.entrySet()) {
         boolean match  = false;
-        MethodInvocationMatcher matcher = entry.getKey();
+        MethodMatcher matcher = entry.getKey();
         if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
           match = matcher.matches((MethodInvocationTree) tree);
         } else if (tree.is(Tree.Kind.METHOD)) {


### PR DESCRIPTION
This fixes `Serializable` FPs, rename `MethodInvocationMatcher` to `MethodMatcher`, add support for `MethodTree` to `MethodMatcher`.