### PR TITLE
Fix false negative in 'useless parentheses' check on assignment of instance variables

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/UselessParenthesesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UselessParenthesesCheck.java
@@ -52,6 +52,7 @@ public class UselessParenthesesCheck extends SubscriptionBaseVisitor {
       Kind.ANNOTATION,
       Kind.ARRAY_ACCESS_EXPRESSION,
       Kind.ASSERT_STATEMENT,
+      Kind.ASSIGNMENT,
       Kind.CASE_LABEL,
       Kind.CONDITIONAL_EXPRESSION,
       Kind.DO_STATEMENT,

--- a/java-checks/src/test/files/checks/UselessParenthesesCheck.java
+++ b/java-checks/src/test/files/checks/UselessParenthesesCheck.java
@@ -24,6 +24,13 @@ class Foo {
     A a = new A((1/3)); // Noncompliant
     return (((x & 0x0000FFFF)) | y); // Noncompliant 2
     getContentSpec(((int[])contentSpec.value)[0], contentSpec);
+
+    this.a = b; // Compliant
+    this.a = (b); // Noncompliant
+    this.a = (true ?  1 : 2); // Noncompliant
+    this.a = false ? (true ? 1 : 2) : 2; // Compliant
+    this.a = (1+2)/2; // Compliant
+    this.a = ((int[])contentSpec.value)[0]; // Compliant
   }
     public static final short value = (short)(0);
 }


### PR DESCRIPTION
The UselessParenthesesCheck raises an issue on the return statement in the ```getValue``` (getter) method but not on the assignment of the instance variable in the ```setValue``` (setter) method. The UselessParenthesesCheck did not check for parent expressions of the type ```ASSIGNMENT```.

```java
public Date getValue() {
  return (this.value != null ? (Date) this.value.clone() : null);
}

public void setValue(Date newValue) {
  this.value = (newValue != null ? (Date) newValue.clone() : null);
}
```