### PR TITLE
Remove ASTNode from Tree factory

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/ast/parser/JavaGrammar.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/JavaGrammar.java
@@ -25,6 +25,7 @@ import org.sonar.java.ast.api.JavaPunctuator;
 import org.sonar.java.ast.api.JavaTokenType;
 import org.sonar.java.ast.parser.TreeFactory.Tuple;
 import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.JavaTree;
 import org.sonar.java.model.JavaTree.CompilationUnitTreeImpl;
 import org.sonar.java.model.JavaTree.PrimitiveTypeTreeImpl;
 import org.sonar.java.model.TypeParameterTreeImpl;
@@ -273,8 +274,8 @@ public class JavaGrammar {
       .is(f.newClassBody(b.invokeRule(JavaPunctuator.LWING), b.zeroOrMore(CLASS_MEMBER()), b.invokeRule(JavaPunctuator.RWING)));
   }
 
-  public AstNode CLASS_MEMBER() {
-    return b.<AstNode>nonterminal(JavaLexer.MEMBER_DECL)
+  public JavaTree CLASS_MEMBER() {
+    return b.<JavaTree>nonterminal(JavaLexer.MEMBER_DECL)
       .is(
         b.firstOf(
           f.completeMember(
@@ -527,7 +528,7 @@ public class JavaGrammar {
     return b.<FormalParametersListTreeImpl>nonterminal(JavaLexer.FORMAL_PARAMETERS_DECLS_REST)
       .is(
         b.firstOf(
-          f.prependNewFormalParameter(VARIABLE_DECLARATOR_ID(), b.optional(f.newWrapperAstNode10(b.invokeRule(JavaPunctuator.COMMA), FORMAL_PARAMETERS_DECLS()))),
+          f.prependNewFormalParameter(VARIABLE_DECLARATOR_ID(), b.optional(f.newTuple18(b.invokeRule(JavaPunctuator.COMMA), FORMAL_PARAMETERS_DECLS()))),
           f.newVariableArgumentFormalParameter(b.zeroOrMore(ANNOTATION()), b.invokeRule(JavaPunctuator.ELLIPSIS), VARIABLE_DECLARATOR_ID())));
   }
 

--- a/java-squid/src/main/java/org/sonar/java/ast/parser/JavaGrammar.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/JavaGrammar.java
@@ -1265,8 +1265,8 @@ public class JavaGrammar {
       .is(f.newClassCreatorRest(ARGUMENTS(), b.optional(CLASS_BODY())));
   }
 
-  public Tuple<AstNode, AstNode> DIMENSION() {
-    return b.<Tuple<AstNode, AstNode>>nonterminal(JavaLexer.DIM)
+  public Tuple<InternalSyntaxToken, InternalSyntaxToken> DIMENSION() {
+    return b.<Tuple<InternalSyntaxToken, InternalSyntaxToken>>nonterminal(JavaLexer.DIM)
       .is(f.newTuple6(b.invokeRule(JavaPunctuator.LBRK), b.invokeRule(JavaPunctuator.RBRK)));
   }
 

--- a/java-squid/src/main/java/org/sonar/java/ast/parser/ListTreeImpl.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/ListTreeImpl.java
@@ -60,14 +60,17 @@ public abstract class ListTreeImpl<T> extends JavaTree implements ListTree<T> {
 
   @Override
   public void accept(TreeVisitor visitor) {
+    for (T t : list) {
+      ((Tree) t).accept(visitor);
+    }
     // TODO
-    throw new UnsupportedOperationException("On class: " + getClass().getSimpleName());
+//    throw new UnsupportedOperationException("On class: " + getClass().getSimpleName());
   }
 
   @Override
   public Kind getKind() {
     // TODO
-    throw new UnsupportedOperationException();
+    return Kind.OTHER;
   }
 
   @Override

--- a/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
@@ -783,9 +783,7 @@ public class TreeFactory {
     return new Tuple<>(defaultToken, elementValue);
   }
 
-  public AnnotationTreeImpl newAnnotation(AstNode atTokenAstNode, TypeTree qualifiedIdentifier, Optional<ArgumentListTreeImpl> arguments) {
-    InternalSyntaxToken atToken = InternalSyntaxToken.create(atTokenAstNode);
-
+  public AnnotationTreeImpl newAnnotation(InternalSyntaxToken atToken, TypeTree qualifiedIdentifier, Optional<ArgumentListTreeImpl> arguments) {
     return new AnnotationTreeImpl(
       atToken,
       qualifiedIdentifier,
@@ -794,10 +792,7 @@ public class TreeFactory {
         null);
   }
 
-  public ArgumentListTreeImpl completeNormalAnnotation(AstNode openParenTokenAstNode, Optional<ArgumentListTreeImpl> partial, AstNode closeParenTokenAstNode) {
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParenTokenAstNode);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParenTokenAstNode);
-
+  public ArgumentListTreeImpl completeNormalAnnotation(InternalSyntaxToken openParenToken, Optional<ArgumentListTreeImpl> partial, InternalSyntaxToken closeParenToken) {
     if (!partial.isPresent()) {
       return new ArgumentListTreeImpl(openParenToken, closeParenToken);
     }
@@ -831,22 +826,18 @@ public class TreeFactory {
     return new ArgumentListTreeImpl(expressions.build(), children);
   }
 
-  public AssignmentExpressionTreeImpl newElementValuePair(AstNode identifierAstNode, AstNode equalTokenAstNode, ExpressionTree elementValue) {
-    InternalSyntaxToken operator = InternalSyntaxToken.create(equalTokenAstNode);
-
+  public AssignmentExpressionTreeImpl newElementValuePair(JavaTree identifierAstNode, InternalSyntaxToken operator, ExpressionTree elementValue) {
     return new AssignmentExpressionTreeImpl(
       kindMaps.getAssignmentOperator((JavaPunctuator) operator.getType()),
-      new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode)),
+      new IdentifierTreeImpl((InternalSyntaxToken) identifierAstNode),
       operator,
       elementValue);
   }
 
   public NewArrayTreeImpl completeElementValueArrayInitializer(
-    AstNode openBraceTokenAstNode, Optional<NewArrayTreeImpl> partial, Optional<InternalSyntaxToken> commaTokenAstNode, AstNode closeBraceTokenAstNode) {
+      InternalSyntaxToken openBraceToken, Optional<NewArrayTreeImpl> partial, Optional<InternalSyntaxToken> commaTokenAstNode, InternalSyntaxToken closeBraceToken) {
 
-    InternalSyntaxToken openBraceToken = InternalSyntaxToken.create(openBraceTokenAstNode);
     InternalSyntaxToken commaToken = commaTokenAstNode.orNull();
-    InternalSyntaxToken closeBraceToken = InternalSyntaxToken.create(closeBraceTokenAstNode);
 
     NewArrayTreeImpl elementValues = partial.isPresent() ?
       partial.get() :
@@ -882,10 +873,7 @@ public class TreeFactory {
     return new NewArrayTreeImpl(ImmutableList.<ExpressionTree>of(), expressions.build(), children);
   }
 
-  public ArgumentListTreeImpl newSingleElementAnnotation(AstNode openParenTokenAstNode, ExpressionTree elementValue, AstNode closeParenTokenAstNode) {
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParenTokenAstNode);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParenTokenAstNode);
-
+  public ArgumentListTreeImpl newSingleElementAnnotation(InternalSyntaxToken openParenToken, ExpressionTree elementValue, InternalSyntaxToken closeParenToken) {
     return new ArgumentListTreeImpl(openParenToken, elementValue, closeParenToken);
   }
 
@@ -958,9 +946,7 @@ public class TreeFactory {
     ModifiersTreeImpl modifiers,
     TypeTree type,
     VariableDeclaratorListTreeImpl variables,
-    AstNode semicolonTokenAstNode) {
-    InternalSyntaxToken semicolonSyntaxToken = InternalSyntaxToken.create(semicolonTokenAstNode);
-
+    InternalSyntaxToken semicolonSyntaxToken) {
     variables.prependChildren(modifiers, (AstNode) type);
 
     for (VariableTreeImpl variable : variables) {
@@ -998,9 +984,9 @@ public class TreeFactory {
     return new VariableDeclaratorListTreeImpl(variables.build(), children);
   }
 
-  public VariableTreeImpl completeVariableDeclarator(AstNode identifierAstNode, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dimensions,
+  public VariableTreeImpl completeVariableDeclarator(JavaTree identifierToken, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dimensions,
     Optional<VariableTreeImpl> partial) {
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
 
     ArrayTypeTreeImpl nestedDimensions = newArrayTypeTreeWithAnnotations(dimensions);
 
@@ -1342,10 +1328,9 @@ public class TreeFactory {
     return new ThrowStatementTreeImpl((InternalSyntaxToken) throwToken, expression, semicolonToken);
   }
 
-  public LabeledStatementTreeImpl labeledStatement(AstNode identifierAstNode, AstNode colon, StatementTree statement) {
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
-    InternalSyntaxToken colonSyntaxToken = InternalSyntaxToken.create(colon);
-    return new LabeledStatementTreeImpl(identifier, colonSyntaxToken, statement);
+  public LabeledStatementTreeImpl labeledStatement(JavaTree identifierToken, InternalSyntaxToken colon, StatementTree statement) {
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
+    return new LabeledStatementTreeImpl(identifier, colon, statement);
   }
 
   public ExpressionStatementTreeImpl expressionStatement(ExpressionTree expression, AstNode semicolonTokenAstNode) {
@@ -1443,9 +1428,8 @@ public class TreeFactory {
       expression;
   }
 
-  public InstanceOfTreeImpl newInstanceofExpression(AstNode instanceofTokenAstNode, TypeTree type) {
-    InternalSyntaxToken instanceofToken = InternalSyntaxToken.create(instanceofTokenAstNode);
-    return new InstanceOfTreeImpl(instanceofToken, type);
+  public InstanceOfTreeImpl newInstanceofExpression(JavaTree instanceofToken, TypeTree type) {
+    return new InstanceOfTreeImpl((InternalSyntaxToken) instanceofToken, type);
   }
 
   private static class OperatorAndOperand {
@@ -1484,13 +1468,13 @@ public class TreeFactory {
     return result;
   }
 
-  private OperatorAndOperand newOperatorAndOperand(AstNode operator, ExpressionTree operand) {
-    return new OperatorAndOperand(InternalSyntaxToken.create(operator), operand);
+  private OperatorAndOperand newOperatorAndOperand(InternalSyntaxToken operator, ExpressionTree operand) {
+    return new OperatorAndOperand(operator, operand);
   }
 
   // TODO Allow to use the same method several times
 
-  public OperatorAndOperand newOperatorAndOperand11(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand11(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1498,7 +1482,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand10(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand10(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1506,7 +1490,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand9(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand9(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1514,7 +1498,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand8(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand8(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1522,7 +1506,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand7(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand7(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1530,7 +1514,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand6(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand6(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1538,7 +1522,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand5(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand5(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1546,7 +1530,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand4(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand4(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1554,7 +1538,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand3(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand3(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1562,7 +1546,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand2(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand2(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1570,7 +1554,7 @@ public class TreeFactory {
     return binaryExpression(expression, operatorAndOperands);
   }
 
-  public OperatorAndOperand newOperatorAndOperand1(AstNode operator, ExpressionTree operand) {
+  public OperatorAndOperand newOperatorAndOperand1(InternalSyntaxToken operator, ExpressionTree operand) {
     return newOperatorAndOperand(operator, operand);
   }
 
@@ -1876,8 +1860,8 @@ public class TreeFactory {
     return new ArgumentListTreeImpl(expressions.build(), children);
   }
 
-  public TypeTree annotationIdentifier(AstNode firstIdentifier, Optional<List<Tuple<InternalSyntaxToken, JavaTree>>> rests) {
-    List<AstNode> children = Lists.newArrayList();
+  public TypeTree annotationIdentifier(JavaTree firstIdentifier, Optional<List<Tuple<InternalSyntaxToken, JavaTree>>> rests) {
+    List<JavaTree> children = Lists.newArrayList();
     children.add(firstIdentifier);
     if (rests.isPresent()) {
       for (Tuple<InternalSyntaxToken, JavaTree> rest : rests.get()) {
@@ -1890,12 +1874,12 @@ public class TreeFactory {
 
     List<AstNode> pendingChildren = Lists.newArrayList();
     InternalSyntaxToken dotToken = null;
-    for (AstNode child : children) {
+    for (JavaTree child : children) {
       if (!child.is(JavaTokenType.IDENTIFIER)) {
-        dotToken = InternalSyntaxToken.create(child);
+        dotToken = (InternalSyntaxToken) child;
         pendingChildren.add(child);
       } else {
-        InternalSyntaxToken identifierToken = InternalSyntaxToken.create(child);
+        InternalSyntaxToken identifierToken = (InternalSyntaxToken) child;
 
         if (result == null) {
           result = new IdentifierTreeImpl(identifierToken);
@@ -2033,8 +2017,8 @@ public class TreeFactory {
     return result;
   }
 
-  public Tuple<Optional<InternalSyntaxToken>, ExpressionTree> completeMemberSelectOrMethodSelector(AstNode dotTokenAstNode, ExpressionTree partial) {
-    return newTuple(Optional.of(InternalSyntaxToken.create(dotTokenAstNode)), partial);
+  public Tuple<Optional<InternalSyntaxToken>, ExpressionTree> completeMemberSelectOrMethodSelector(InternalSyntaxToken dotToken, ExpressionTree partial) {
+    return newTuple(Optional.of(dotToken), partial);
   }
 
   public Tuple<Optional<InternalSyntaxToken>, ExpressionTree> completeCreatorSelector(AstNode dotTokenAstNode, ExpressionTree partial) {

--- a/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
@@ -156,12 +156,7 @@ public class TreeFactory {
     if (importDeclarations.isPresent()) {
       for (ImportClauseTree child : importDeclarations.get()) {
         children.add((AstNode) child);
-
-        if (!child.is(Kind.EMPTY_STATEMENT)) {
-          imports.add((ImportTreeImpl) child);
-        } else {
-          imports.add((EmptyStatementTreeImpl) child);
-        }
+        imports.add(child);
       }
     }
 
@@ -203,14 +198,14 @@ public class TreeFactory {
     return new EmptyStatementTreeImpl(InternalSyntaxToken.create(semicolonTokenAstNode));
   }
 
-  public ImportTreeImpl newImportDeclaration(AstNode importTokenAstNode, Optional<AstNode> staticTokenAstNode, ExpressionTree qualifiedIdentifier,
-    Optional<Tuple<AstNode, AstNode>> dotStar,
+  public ImportTreeImpl newImportDeclaration(AstNode importTokenAstNode, Optional<JavaTree> staticTokenAstNode, ExpressionTree qualifiedIdentifier,
+    Optional<Tuple<InternalSyntaxToken, InternalSyntaxToken>> dotStar,
     AstNode semicolonTokenAstNode) {
 
     ExpressionTree target = qualifiedIdentifier;
     if (dotStar.isPresent()) {
-      IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(dotStar.get().second()));
-      InternalSyntaxToken dotToken = InternalSyntaxToken.create(dotStar.get().first());
+      IdentifierTreeImpl identifier = new IdentifierTreeImpl(dotStar.get().second());
+      InternalSyntaxToken dotToken = dotStar.get().first();
       target = new MemberSelectExpressionTreeImpl(qualifiedIdentifier, dotToken, identifier,
         (AstNode) qualifiedIdentifier, dotStar.get().first(), identifier);
     }
@@ -218,7 +213,7 @@ public class TreeFactory {
     InternalSyntaxToken importToken = InternalSyntaxToken.create(importTokenAstNode);
     InternalSyntaxToken staticToken = null;
     if (staticTokenAstNode.isPresent()) {
-      staticToken = InternalSyntaxToken.create(staticTokenAstNode.get());
+      staticToken = (InternalSyntaxToken) staticTokenAstNode.get();
     }
     InternalSyntaxToken semiColonToken = InternalSyntaxToken.create(semicolonTokenAstNode);
     return new ImportTreeImpl(importToken, staticToken, target, semiColonToken);
@@ -238,13 +233,13 @@ public class TreeFactory {
   // Types
 
   public TypeTree newType(TypeTree basicOrClassType,
-    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> dims) {
+    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dims) {
     if (!dims.isPresent()) {
       return basicOrClassType;
     } else {
       TypeTree result = basicOrClassType;
 
-      for (Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>> dim : dims.get()) {
+      for (Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>> dim : dims.get()) {
         result = newArrayTypeTreeWithAnnotations(result, dim);
       }
 
@@ -383,8 +378,8 @@ public class TreeFactory {
   public ClassTreeImpl completeClassDeclaration(
     AstNode classTokenAstNode,
     AstNode identifierAstNode, Optional<TypeParameterListTreeImpl> typeParameters,
-    Optional<Tuple<AstNode, TypeTree>> extendsClause,
-    Optional<Tuple<AstNode, QualifiedIdentifierListTreeImpl>> implementsClause,
+    Optional<Tuple<JavaTree, TypeTree>> extendsClause,
+    Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> implementsClause,
     ClassTreeImpl partial) {
 
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
@@ -447,10 +442,10 @@ public class TreeFactory {
   public ClassTreeImpl newEnumDeclaration(
     AstNode enumTokenAstNode,
     AstNode identifierAstNode,
-    Optional<Tuple<AstNode, QualifiedIdentifierListTreeImpl>> implementsClause,
+    Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> implementsClause,
     AstNode openBraceTokenAstNode,
     Optional<List<EnumConstantTreeImpl>> enumConstants,
-    Optional<AstNode> semicolonTokenAstNode,
+    Optional<InternalSyntaxToken> semicolonTokenAstNode,
     Optional<List<AstNode>> enumDeclarations,
     AstNode closeBraceTokenAstNode) {
 
@@ -496,7 +491,7 @@ public class TreeFactory {
     Optional<List<AnnotationTreeImpl>> annotations, AstNode identifierAstNode,
     Optional<ArgumentListTreeImpl> arguments,
     Optional<ClassTreeImpl> classBody,
-    Optional<AstNode> semicolonTokenAstNode) {
+    Optional<InternalSyntaxToken> semicolonTokenAstNode) {
 
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
     if (annotations.isPresent()) {
@@ -542,7 +537,7 @@ public class TreeFactory {
   public ClassTreeImpl completeInterfaceDeclaration(
     AstNode interfaceTokenAstNode,
     AstNode identifierAstNode, Optional<TypeParameterListTreeImpl> typeParameters,
-    Optional<Tuple<AstNode, QualifiedIdentifierListTreeImpl>> extendsClause,
+    Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> extendsClause,
     ClassTreeImpl partial) {
 
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
@@ -593,7 +588,7 @@ public class TreeFactory {
     return partial;
   }
 
-  public BlockTreeImpl newInitializerMember(Optional<AstNode> staticTokenAstNode, BlockTreeImpl block) {
+  public BlockTreeImpl newInitializerMember(Optional<JavaTree> staticTokenAstNode, BlockTreeImpl block) {
     BlockTreeImpl blockTree;
     List<AstNode> children = Lists.newArrayList();
 
@@ -625,8 +620,8 @@ public class TreeFactory {
 
   private MethodTreeImpl newMethodOrConstructor(
     Optional<TypeTree> type, AstNode identifierAstNode, FormalParametersListTreeImpl parameters,
-    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> annotatedDimensions,
-    Optional<Tuple<AstNode, QualifiedIdentifierListTreeImpl>> throwsClause,
+    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> annotatedDimensions,
+    Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> throwsClause,
     AstNode blockOrSemicolon) {
 
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
@@ -680,8 +675,8 @@ public class TreeFactory {
 
   public MethodTreeImpl newMethod(
     TypeTree type, AstNode identifierAstNode, FormalParametersListTreeImpl parameters,
-    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> annotatedDimensions,
-    Optional<Tuple<AstNode, QualifiedIdentifierListTreeImpl>> throwsClause,
+    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> annotatedDimensions,
+    Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> throwsClause,
     AstNode blockOrSemicolon) {
 
     return newMethodOrConstructor(Optional.of(type), identifierAstNode, parameters, annotatedDimensions, throwsClause, blockOrSemicolon);
@@ -689,8 +684,8 @@ public class TreeFactory {
 
   public MethodTreeImpl newConstructor(
     AstNode identifierAstNode, FormalParametersListTreeImpl parameters,
-    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> annotatedDimensions,
-    Optional<Tuple<AstNode, QualifiedIdentifierListTreeImpl>> throwsClause,
+    Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> annotatedDimensions,
+    Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> throwsClause,
     AstNode blockOrSemicolon) {
 
     return newMethodOrConstructor(Optional.<TypeTree>absent(), identifierAstNode, parameters, annotatedDimensions, throwsClause, blockOrSemicolon);
@@ -854,10 +849,10 @@ public class TreeFactory {
   }
 
   public NewArrayTreeImpl completeElementValueArrayInitializer(
-    AstNode openBraceTokenAstNode, Optional<NewArrayTreeImpl> partial, Optional<AstNode> commaTokenAstNode, AstNode closeBraceTokenAstNode) {
+    AstNode openBraceTokenAstNode, Optional<NewArrayTreeImpl> partial, Optional<InternalSyntaxToken> commaTokenAstNode, AstNode closeBraceTokenAstNode) {
 
     InternalSyntaxToken openBraceToken = InternalSyntaxToken.create(openBraceTokenAstNode);
-    InternalSyntaxToken commaToken = commaTokenAstNode.isPresent() ? InternalSyntaxToken.create(commaTokenAstNode.get()) : null;
+    InternalSyntaxToken commaToken = commaTokenAstNode.orNull();
     InternalSyntaxToken closeBraceToken = InternalSyntaxToken.create(closeBraceTokenAstNode);
 
     NewArrayTreeImpl elementValues = partial.isPresent() ?
@@ -905,9 +900,7 @@ public class TreeFactory {
 
   // Formal parameters
 
-  public FormalParametersListTreeImpl completeParenFormalParameters(AstNode openParenTokenAstNode, Optional<FormalParametersListTreeImpl> partial, AstNode closeParenTokenAstNode) {
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParenTokenAstNode);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParenTokenAstNode);
+  public FormalParametersListTreeImpl completeParenFormalParameters(InternalSyntaxToken openParenToken, Optional<FormalParametersListTreeImpl> partial, InternalSyntaxToken closeParenToken) {
 
     return partial.isPresent() ?
       partial.get().complete(openParenToken, closeParenToken) :
@@ -951,7 +944,7 @@ public class TreeFactory {
       variable);
   }
 
-  public VariableTreeImpl newVariableDeclaratorId(AstNode identifierAstNode, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> dims) {
+  public VariableTreeImpl newVariableDeclaratorId(AstNode identifierAstNode, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dims) {
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
     ArrayTypeTreeImpl nestedDimensions = newArrayTypeTreeWithAnnotations(dims);
     List<AstNode> children = Lists.newArrayList();
@@ -987,7 +980,7 @@ public class TreeFactory {
     return variables;
   }
 
-  public VariableDeclaratorListTreeImpl newVariableDeclarators(VariableTreeImpl variable, Optional<List<Tuple<AstNode, VariableTreeImpl>>> rests) {
+  public VariableDeclaratorListTreeImpl newVariableDeclarators(VariableTreeImpl variable, Optional<List<Tuple<InternalSyntaxToken, VariableTreeImpl>>> rests) {
     ImmutableList.Builder<VariableTreeImpl> variables = ImmutableList.builder();
 
     variables.add(variable);
@@ -996,9 +989,9 @@ public class TreeFactory {
 
     if (rests.isPresent()) {
       VariableTreeImpl previousVariable = variable;
-      for (Tuple<AstNode, VariableTreeImpl> rest : rests.get()) {
+      for (Tuple<InternalSyntaxToken, VariableTreeImpl> rest : rests.get()) {
         VariableTreeImpl newVariable = rest.second();
-        InternalSyntaxToken separator = InternalSyntaxToken.create(rest.first());
+        InternalSyntaxToken separator = rest.first();
 
         variables.add(newVariable);
         children.add(newVariable);
@@ -1012,7 +1005,7 @@ public class TreeFactory {
     return new VariableDeclaratorListTreeImpl(variables.build(), children);
   }
 
-  public VariableTreeImpl completeVariableDeclarator(AstNode identifierAstNode, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> dimensions,
+  public VariableTreeImpl completeVariableDeclarator(AstNode identifierAstNode, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dimensions,
     Optional<VariableTreeImpl> partial) {
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
 
@@ -1334,7 +1327,7 @@ public class TreeFactory {
     return new SynchronizedStatementTreeImpl(synchronizedKeyword, openParenToken, expression, closeParenToken, block);
   }
 
-  public BreakStatementTreeImpl breakStatement(AstNode breakToken, Optional<AstNode> identifierAstNode, AstNode semicolonToken) {
+  public BreakStatementTreeImpl breakStatement(AstNode breakToken, Optional<JavaTree> identifierAstNode, AstNode semicolonToken) {
     InternalSyntaxToken breakSyntaxToken = InternalSyntaxToken.create(breakToken);
     InternalSyntaxToken semicolonSyntaxToken = InternalSyntaxToken.create(semicolonToken);
     IdentifierTreeImpl identifier = null;
@@ -1344,7 +1337,7 @@ public class TreeFactory {
     return new BreakStatementTreeImpl(breakSyntaxToken, identifier, semicolonSyntaxToken);
   }
 
-  public ContinueStatementTreeImpl continueStatement(AstNode continueToken, Optional<AstNode> identifierAstNode, AstNode semicolonToken) {
+  public ContinueStatementTreeImpl continueStatement(AstNode continueToken, Optional<JavaTree> identifierAstNode, AstNode semicolonToken) {
     InternalSyntaxToken continueKeywordSyntaxToken = InternalSyntaxToken.create(continueToken);
     InternalSyntaxToken semicolonSyntaxToken = InternalSyntaxToken.create(semicolonToken);
     IdentifierTreeImpl identifier = null;
@@ -1604,11 +1597,11 @@ public class TreeFactory {
     return new InternalPrefixUnaryExpression(kindMaps.getPrefixOperator((JavaPunctuator) operatorTokenAstNode.getType()), operatorToken, expression);
   }
 
-  public ExpressionTree newPostfixExpression(ExpressionTree expression, Optional<AstNode> postfixOperatorAstNode) {
+  public ExpressionTree newPostfixExpression(ExpressionTree expression, Optional<InternalSyntaxToken> postfixOperatorAstNode) {
     ExpressionTree result = expression;
 
     if (postfixOperatorAstNode.isPresent()) {
-      InternalSyntaxToken postfixOperatorToken = InternalSyntaxToken.create(postfixOperatorAstNode.get());
+      InternalSyntaxToken postfixOperatorToken = postfixOperatorAstNode.get();
       result = new InternalPostfixUnaryExpression(kindMaps.getPostfixOperator((JavaPunctuator) postfixOperatorAstNode.get().getType()), result, postfixOperatorToken);
     }
 
@@ -1690,7 +1683,7 @@ public class TreeFactory {
 
   public LambdaParameterListTreeImpl newInferedParameters(
     AstNode openParenTokenAstNode,
-    Optional<Tuple<VariableTreeImpl, Optional<List<Tuple<AstNode, VariableTreeImpl>>>>> identifiersOpt,
+    Optional<Tuple<VariableTreeImpl, Optional<List<Tuple<InternalSyntaxToken, VariableTreeImpl>>>>> identifiersOpt,
     AstNode closeParenTokenAstNode) {
 
     InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParenTokenAstNode);
@@ -1702,7 +1695,7 @@ public class TreeFactory {
     children.add(openParenToken);
 
     if (identifiersOpt.isPresent()) {
-      Tuple<VariableTreeImpl, Optional<List<Tuple<AstNode, VariableTreeImpl>>>> identifiers = identifiersOpt.get();
+      Tuple<VariableTreeImpl, Optional<List<Tuple<InternalSyntaxToken, VariableTreeImpl>>>> identifiers = identifiersOpt.get();
 
       VariableTreeImpl variable = identifiers.first();
       params.add(variable);
@@ -1710,12 +1703,12 @@ public class TreeFactory {
 
       VariableTreeImpl previousVariable = variable;
       if (identifiers.second().isPresent()) {
-        for (Tuple<AstNode, VariableTreeImpl> identifier : identifiers.second().get()) {
+        for (Tuple<InternalSyntaxToken, VariableTreeImpl> identifier : identifiers.second().get()) {
           variable = identifier.second();
           params.add(variable);
           children.add(variable);
 
-          InternalSyntaxToken comma = InternalSyntaxToken.create(identifier.first());
+          InternalSyntaxToken comma = identifier.first();
           previousVariable.setEndToken(comma);
           previousVariable = variable;
         }
@@ -1787,14 +1780,14 @@ public class TreeFactory {
 
   public NewArrayTreeImpl newArrayCreatorWithInitializer(
     AstNode openBracketToken, AstNode closeBracketToken,
-    Optional<List<Tuple<AstNode, AstNode>>> dimensions,
+    Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions,
     NewArrayTreeImpl partial) {
 
     List<AstNode> children = Lists.newArrayList();
     children.add(openBracketToken);
     children.add(closeBracketToken);
     if (dimensions.isPresent()) {
-      for (Tuple<AstNode, AstNode> dimension : dimensions.get()) {
+      for (Tuple<InternalSyntaxToken, InternalSyntaxToken> dimension : dimensions.get()) {
         children.add(dimension.first());
         children.add(dimension.second());
       }
@@ -1832,7 +1825,7 @@ public class TreeFactory {
       children);
   }
 
-  public ExpressionTree basicClassExpression(PrimitiveTypeTreeImpl basicType, Optional<List<Tuple<AstNode, AstNode>>> dimensions, AstNode dotToken, AstNode classTokenAstNode) {
+  public ExpressionTree basicClassExpression(PrimitiveTypeTreeImpl basicType, Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions, AstNode dotToken, AstNode classTokenAstNode) {
     // 15.8.2. Class Literals
     // int.class
     // int[].class
@@ -1866,16 +1859,15 @@ public class TreeFactory {
       voidType, dotToken, classToken);
   }
 
-  public PrimitiveTypeTreeImpl newBasicType(Optional<List<AnnotationTreeImpl>> annotations, AstNode basicType) {
-    InternalSyntaxToken token = InternalSyntaxToken.create(basicType);
+  public PrimitiveTypeTreeImpl newBasicType(Optional<List<AnnotationTreeImpl>> annotations, JavaTree basicType) {
 
     List<AstNode> children = Lists.newArrayList();
     if (annotations.isPresent()) {
       children.addAll(annotations.get());
     }
-    children.add(token);
+    children.add(basicType);
 
-    return new JavaTree.PrimitiveTypeTreeImpl(token, children);
+    return new JavaTree.PrimitiveTypeTreeImpl((InternalSyntaxToken) basicType, children);
   }
 
   public ArgumentListTreeImpl completeArguments(AstNode openParenthesisTokenAstNode, Optional<ArgumentListTreeImpl> expressions, AstNode closeParenthesisTokenAstNode) {
@@ -1904,11 +1896,11 @@ public class TreeFactory {
     return new ArgumentListTreeImpl(expressions.build(), children);
   }
 
-  public TypeTree annotationIdentifier(AstNode firstIdentifier, Optional<List<Tuple<AstNode, AstNode>>> rests) {
+  public TypeTree annotationIdentifier(AstNode firstIdentifier, Optional<List<Tuple<InternalSyntaxToken, JavaTree>>> rests) {
     List<AstNode> children = Lists.newArrayList();
     children.add(firstIdentifier);
     if (rests.isPresent()) {
-      for (Tuple<AstNode, AstNode> rest : rests.get()) {
+      for (Tuple<InternalSyntaxToken, JavaTree> rest : rests.get()) {
         children.add(rest.first());
         children.add(rest.second());
       }
@@ -1944,12 +1936,12 @@ public class TreeFactory {
     return (TypeTree) result;
   }
 
-  public <T extends Tree> T newQualifiedIdentifier(ExpressionTree firstIdentifier, Optional<List<Tuple<AstNode, ExpressionTree>>> rests) {
+  public <T extends Tree> T newQualifiedIdentifier(ExpressionTree firstIdentifier, Optional<List<Tuple<InternalSyntaxToken, ExpressionTree>>> rests) {
     ExpressionTree result = firstIdentifier;
 
     if (rests.isPresent()) {
-      for (Tuple<AstNode, ExpressionTree> rest : rests.get()) {
-        InternalSyntaxToken dotToken = InternalSyntaxToken.create(rest.first());
+      for (Tuple<InternalSyntaxToken, ExpressionTree> rest : rests.get()) {
+        InternalSyntaxToken dotToken = rest.first();
         if (rest.second().is(Kind.IDENTIFIER)) {
           result = new MemberSelectExpressionTreeImpl(result, dotToken, (IdentifierTreeImpl) rest.second(),
             (AstNode) result, rest.first(), (AstNode) rest.second());
@@ -2006,7 +1998,7 @@ public class TreeFactory {
     return new NewArrayTreeImpl(ImmutableList.<ExpressionTree>of(), initializers.build(), children);
   }
 
-  public QualifiedIdentifierListTreeImpl newQualifiedIdentifierList(TypeTree qualifiedIdentifier, Optional<List<Tuple<AstNode, TypeTree>>> rests) {
+  public QualifiedIdentifierListTreeImpl newQualifiedIdentifierList(TypeTree qualifiedIdentifier, Optional<List<Tuple<InternalSyntaxToken, TypeTree>>> rests) {
     ImmutableList.Builder<TypeTree> qualifiedIdentifiers = ImmutableList.builder();
     List<AstNode> children = Lists.newArrayList();
 
@@ -2014,7 +2006,7 @@ public class TreeFactory {
     children.add((AstNode) qualifiedIdentifier);
 
     if (rests.isPresent()) {
-      for (Tuple<AstNode, TypeTree> rest : rests.get()) {
+      for (Tuple<InternalSyntaxToken, TypeTree> rest : rests.get()) {
         qualifiedIdentifiers.add(rest.second());
         children.add(rest.first());
         children.add((AstNode) rest.second());
@@ -2075,7 +2067,7 @@ public class TreeFactory {
     return newTuple(Optional.<InternalSyntaxToken>absent(), partial);
   }
 
-  public ExpressionTree newDotClassSelector(Optional<List<Tuple<AstNode, AstNode>>> dimensions, AstNode dotTokenAstNode, AstNode classTokenAstNode) {
+  public ExpressionTree newDotClassSelector(Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions, AstNode dotTokenAstNode, AstNode classTokenAstNode) {
     IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(classTokenAstNode));
     InternalSyntaxToken dotToken = InternalSyntaxToken.create(dotTokenAstNode);
 
@@ -2172,7 +2164,7 @@ public class TreeFactory {
     return astNode;
   }
 
-  public AstNode newWrapperAstNode(AstNode e1, Optional<AstNode> e2) {
+  public AstNode newWrapperAstNode(AstNode e1, Optional<? extends JavaTree> e2) {
     AstNode astNode = new AstNode(WRAPPER_AST_NODE, WRAPPER_AST_NODE.toString(), null);
     astNode.addChild(e1);
     if (e2.isPresent()) {
@@ -2219,11 +2211,11 @@ public class TreeFactory {
     return newWrapperAstNode(e1, e2);
   }
 
-  public AstNode newWrapperAstNode14(AstNode e1, Optional<AstNode> e2) {
+  public AstNode newWrapperAstNode14(AstNode e1, Optional<InternalSyntaxToken> e2) {
     return newWrapperAstNode(e1, e2);
   }
 
-  public AstNode newWrapperAstNode15(AstNode e1, Optional<AstNode> e2) {
+  public AstNode newWrapperAstNode15(AstNode e1, Optional<InternalSyntaxToken> e2) {
     return newWrapperAstNode(e1, e2);
   }
 
@@ -2375,17 +2367,17 @@ public class TreeFactory {
   }
 
   @CheckForNull
-  private static ArrayTypeTreeImpl newArrayTypeTreeWithAnnotations(Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>>>> dims) {
+  private static ArrayTypeTreeImpl newArrayTypeTreeWithAnnotations(Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dims) {
     ArrayTypeTreeImpl result = null;
     if (dims.isPresent()) {
-      for (Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>> dim : dims.get()) {
+      for (Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>> dim : dims.get()) {
         result = newArrayTypeTreeWithAnnotations(result, dim);
       }
     }
     return result;
   }
 
-  private static ArrayTypeTreeImpl newArrayTypeTreeWithAnnotations(TypeTree type, Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<AstNode, AstNode>> dim) {
+  private static ArrayTypeTreeImpl newArrayTypeTreeWithAnnotations(TypeTree type, Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>> dim) {
     List<AnnotationTreeImpl> annotations = dim.first().isPresent() ? dim.first().get() : ImmutableList.<AnnotationTreeImpl>of();
     InternalSyntaxToken openBracketToken = InternalSyntaxToken.create(dim.second().first());
     InternalSyntaxToken closeBracketToken = InternalSyntaxToken.create(dim.second().second());
@@ -2393,12 +2385,12 @@ public class TreeFactory {
   }
 
   @CheckForNull
-  private static ArrayTypeTreeImpl newArrayTypeTree(Optional<List<Tuple<AstNode, AstNode>>> dims) {
+  private static ArrayTypeTreeImpl newArrayTypeTree(Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dims) {
     ArrayTypeTreeImpl result = null;
     if (dims.isPresent()) {
-      for (Tuple<AstNode, AstNode> dim : dims.get()) {
-        InternalSyntaxToken openBracketToken = InternalSyntaxToken.create(dim.first());
-        InternalSyntaxToken closeBracketToken = InternalSyntaxToken.create(dim.second());
+      for (Tuple<InternalSyntaxToken, InternalSyntaxToken> dim : dims.get()) {
+        InternalSyntaxToken openBracketToken = dim.first();
+        InternalSyntaxToken closeBracketToken = dim.second();
         result = new ArrayTypeTreeImpl(result, ImmutableList.<AnnotationTreeImpl>of(), openBracketToken, closeBracketToken);
       }
     }

--- a/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
@@ -304,11 +304,8 @@ public class TreeFactory {
       type);
   }
 
-  public TypeParameterListTreeImpl newTypeParameterList(AstNode openBracketTokenAstNode, TypeParameterTreeImpl typeParameter, Optional<List<AstNode>> rests,
-    AstNode closeBracketTokenAstNode) {
-    InternalSyntaxToken openBracketToken = InternalSyntaxToken.create(openBracketTokenAstNode);
-    InternalSyntaxToken closeBracketToken = InternalSyntaxToken.create(closeBracketTokenAstNode);
-
+  public TypeParameterListTreeImpl newTypeParameterList(InternalSyntaxToken openBracketToken, TypeParameterTreeImpl typeParameter, Optional<List<AstNode>> rests,
+                                                        InternalSyntaxToken closeBracketToken) {
     ImmutableList.Builder<TypeParameterTree> typeParameters = ImmutableList.builder();
     List<AstNode> children = Lists.newArrayList();
 
@@ -330,8 +327,8 @@ public class TreeFactory {
     return new TypeParameterListTreeImpl(openBracketToken, typeParameters.build(), children, closeBracketToken);
   }
 
-  public TypeParameterTreeImpl completeTypeParameter(Optional<List<AnnotationTreeImpl>> annotations, AstNode identifierAstNode, Optional<TypeParameterTreeImpl> partial) {
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
+  public TypeParameterTreeImpl completeTypeParameter(Optional<List<AnnotationTreeImpl>> annotations, JavaTree identifierToken, Optional<TypeParameterTreeImpl> partial) {
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
     if (annotations.isPresent()) {
       identifier.prependChildren(annotations.get());
     }
@@ -481,12 +478,12 @@ public class TreeFactory {
   }
 
   public EnumConstantTreeImpl newEnumConstant(
-    Optional<List<AnnotationTreeImpl>> annotations, AstNode identifierAstNode,
+    Optional<List<AnnotationTreeImpl>> annotations, JavaTree identifierToken,
     Optional<ArgumentListTreeImpl> arguments,
     Optional<ClassTreeImpl> classBody,
     Optional<InternalSyntaxToken> semicolonTokenAstNode) {
 
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
     if (annotations.isPresent()) {
       identifier.prependChildren(annotations.get());
     }
@@ -528,15 +525,15 @@ public class TreeFactory {
   }
 
   public ClassTreeImpl completeInterfaceDeclaration(
-    AstNode interfaceTokenAstNode,
-    AstNode identifierAstNode, Optional<TypeParameterListTreeImpl> typeParameters,
+    JavaTree interfaceToken,
+    JavaTree identifierToken, Optional<TypeParameterListTreeImpl> typeParameters,
     Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> extendsClause,
     ClassTreeImpl partial) {
 
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
 
-    List<AstNode> children = Lists.newArrayList();
-    InternalSyntaxToken interfaceSyntaxToken = InternalSyntaxToken.create(interfaceTokenAstNode);
+    List<JavaTree> children = Lists.newArrayList();
+    InternalSyntaxToken interfaceSyntaxToken = (InternalSyntaxToken) interfaceToken;
     children.add(interfaceSyntaxToken);
     partial.completeDeclarationKeyword(interfaceSyntaxToken);
 
@@ -581,12 +578,12 @@ public class TreeFactory {
     return partial;
   }
 
-  public BlockTreeImpl newInitializerMember(Optional<JavaTree> staticTokenAstNode, BlockTreeImpl block) {
+  public BlockTreeImpl newInitializerMember(Optional<JavaTree> staticToken, BlockTreeImpl block) {
     BlockTreeImpl blockTree;
     List<AstNode> children = Lists.newArrayList();
 
-    if (staticTokenAstNode.isPresent()) {
-      InternalSyntaxToken staticKeyword = InternalSyntaxToken.create(staticTokenAstNode.get());
+    if (staticToken.isPresent()) {
+      InternalSyntaxToken staticKeyword = (InternalSyntaxToken) staticToken.get();
       children.add(staticKeyword);
       children.addAll(block.getChildren());
       blockTree = new StaticInitializerTreeImpl(staticKeyword, (InternalSyntaxToken) block.openBraceToken(), block.body(), (InternalSyntaxToken) block.closeBraceToken(),
@@ -631,7 +628,7 @@ public class TreeFactory {
     if (blockOrSemicolon.is(Tree.Kind.BLOCK)) {
       block = (BlockTreeImpl) blockOrSemicolon;
     } else {
-      semicolonToken = InternalSyntaxToken.create(blockOrSemicolon);
+      semicolonToken = (InternalSyntaxToken) blockOrSemicolon;
     }
 
     MethodTreeImpl result = new MethodTreeImpl(
@@ -667,12 +664,12 @@ public class TreeFactory {
   }
 
   public MethodTreeImpl newMethod(
-    TypeTree type, JavaTree identifierAstNode, FormalParametersListTreeImpl parameters,
+    TypeTree type, JavaTree identifierToken, FormalParametersListTreeImpl parameters,
     Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> annotatedDimensions,
     Optional<Tuple<JavaTree, QualifiedIdentifierListTreeImpl>> throwsClause,
-    AstNode blockOrSemicolon) {
+    JavaTree blockOrSemicolon) {
 
-    return newMethodOrConstructor(Optional.of(type), identifierAstNode, parameters, annotatedDimensions, throwsClause, blockOrSemicolon);
+    return newMethodOrConstructor(Optional.of(type), identifierToken, parameters, annotatedDimensions, throwsClause, blockOrSemicolon);
   }
 
   public MethodTreeImpl newConstructor(
@@ -684,14 +681,13 @@ public class TreeFactory {
     return newMethodOrConstructor(Optional.<TypeTree>absent(), identifierAstNode, parameters, annotatedDimensions, throwsClause, blockOrSemicolon);
   }
 
-  public VariableDeclaratorListTreeImpl completeFieldDeclaration(TypeTree type, VariableDeclaratorListTreeImpl partial, AstNode semicolonTokenAstNode) {
+  public VariableDeclaratorListTreeImpl completeFieldDeclaration(TypeTree type, VariableDeclaratorListTreeImpl partial, InternalSyntaxToken semicolonToken) {
     partial.prependChildren((AstNode) type);
     for (VariableTreeImpl variable : partial) {
       variable.completeType(type);
     }
 
     // store the semicolon as endToken for the last variable
-    InternalSyntaxToken semicolonToken = InternalSyntaxToken.create(semicolonTokenAstNode);
     partial.get(partial.size() - 1).setEndToken(semicolonToken);
 
     partial.addChild(semicolonToken);
@@ -702,17 +698,14 @@ public class TreeFactory {
 
   // Annotations
 
-  public ClassTreeImpl completeAnnotationType(AstNode atTokenAstNode, AstNode interfaceTokenAstNode, AstNode identifier, ClassTreeImpl partial) {
+  public ClassTreeImpl completeAnnotationType(InternalSyntaxToken atToken, JavaTree interfaceToken, JavaTree identifier, ClassTreeImpl partial) {
     return partial.complete(
-      InternalSyntaxToken.create(atTokenAstNode),
-      InternalSyntaxToken.create(interfaceTokenAstNode),
-      new IdentifierTreeImpl(InternalSyntaxToken.create(identifier)));
+      atToken,
+      (InternalSyntaxToken) interfaceToken,
+      new IdentifierTreeImpl((InternalSyntaxToken) identifier));
   }
 
-  public ClassTreeImpl newAnnotationType(AstNode openBraceTokenAstNode, Optional<List<AstNode>> annotationTypeElementDeclarations, AstNode closeBraceTokenAstNode) {
-    InternalSyntaxToken openBraceToken = InternalSyntaxToken.create(openBraceTokenAstNode);
-    InternalSyntaxToken closeBraceToken = InternalSyntaxToken.create(closeBraceTokenAstNode);
-
+  public ClassTreeImpl newAnnotationType(InternalSyntaxToken openBraceToken, Optional<List<AstNode>> annotationTypeElementDeclarations, InternalSyntaxToken closeBraceToken) {
     // TODO
     ModifiersTreeImpl emptyModifiers = ModifiersTreeImpl.emptyModifiers();
 
@@ -758,16 +751,12 @@ public class TreeFactory {
     return partial;
   }
 
-  public AstNode completeAnnotationMethod(TypeTree type, AstNode identifierAstNode, MethodTreeImpl partial, AstNode semiTokenAstNode) {
-    partial.complete(type, new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode)), InternalSyntaxToken.create(semiTokenAstNode));
-
+  public AstNode completeAnnotationMethod(TypeTree type, JavaTree identifierAstNode, MethodTreeImpl partial, InternalSyntaxToken semiToken) {
+    partial.complete(type, new IdentifierTreeImpl(((InternalSyntaxToken) identifierAstNode)), semiToken);
     return partial;
   }
 
-  public MethodTreeImpl newAnnotationTypeMethod(AstNode openParenTokenAstNode, AstNode closeParenTokenAstNode, Optional<Tuple<InternalSyntaxToken, ExpressionTree>> defaultValue) {
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParenTokenAstNode);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParenTokenAstNode);
-
+  public MethodTreeImpl newAnnotationTypeMethod(InternalSyntaxToken openParenToken, InternalSyntaxToken closeParenToken, Optional<Tuple<InternalSyntaxToken, ExpressionTree>> defaultValue) {
     FormalParametersListTreeImpl parameters = new FormalParametersListTreeImpl(openParenToken, closeParenToken);
     InternalSyntaxToken defaultToken = null;
     ExpressionTree defaultExpression = null;
@@ -778,9 +767,8 @@ public class TreeFactory {
     return new MethodTreeImpl(parameters, defaultToken, defaultExpression);
   }
 
-  public Tuple<InternalSyntaxToken, ExpressionTree> newDefaultValue(AstNode defaultTokenAstNode, ExpressionTree elementValue) {
-    InternalSyntaxToken defaultToken = InternalSyntaxToken.create(defaultTokenAstNode);
-    return new Tuple<>(defaultToken, elementValue);
+  public Tuple<InternalSyntaxToken, ExpressionTree> newDefaultValue(JavaTree defaultToken, ExpressionTree elementValue) {
+    return new Tuple<>((InternalSyntaxToken)defaultToken, elementValue);
   }
 
   public AnnotationTreeImpl newAnnotation(InternalSyntaxToken atToken, TypeTree qualifiedIdentifier, Optional<ArgumentListTreeImpl> arguments) {
@@ -914,9 +902,7 @@ public class TreeFactory {
     }
   }
 
-  public FormalParametersListTreeImpl newVariableArgumentFormalParameter(Optional<List<AnnotationTreeImpl>> annotations, AstNode ellipsisTokenAstNode, VariableTreeImpl variable) {
-    InternalSyntaxToken ellipsisToken = InternalSyntaxToken.create(ellipsisTokenAstNode);
-
+  public FormalParametersListTreeImpl newVariableArgumentFormalParameter(Optional<List<AnnotationTreeImpl>> annotations, InternalSyntaxToken ellipsisToken, VariableTreeImpl variable) {
     variable.addEllipsisDimension(new ArrayTypeTreeImpl(null, annotations.isPresent() ? annotations.get() : ImmutableList.<AnnotationTreeImpl>of(), ellipsisToken));
 
     return new FormalParametersListTreeImpl(
@@ -925,8 +911,8 @@ public class TreeFactory {
       variable);
   }
 
-  public VariableTreeImpl newVariableDeclaratorId(AstNode identifierAstNode, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dims) {
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode));
+  public VariableTreeImpl newVariableDeclaratorId(JavaTree identifierToken, Optional<List<Tuple<Optional<List<AnnotationTreeImpl>>, Tuple<InternalSyntaxToken, InternalSyntaxToken>>>> dims) {
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
     ArrayTypeTreeImpl nestedDimensions = newArrayTypeTreeWithAnnotations(dims);
     List<AstNode> children = Lists.newArrayList();
     children.add(nestedDimensions);
@@ -1004,9 +990,7 @@ public class TreeFactory {
     }
   }
 
-  public VariableTreeImpl newVariableDeclarator(AstNode equalTokenAstNode, ExpressionTree initializer) {
-    InternalSyntaxToken equalToken = InternalSyntaxToken.create(equalTokenAstNode);
-
+  public VariableTreeImpl newVariableDeclarator(InternalSyntaxToken equalToken, ExpressionTree initializer) {
     return new VariableTreeImpl(equalToken, initializer,
       equalToken, (AstNode) initializer);
   }
@@ -1016,17 +1000,16 @@ public class TreeFactory {
   }
 
   public AssertStatementTreeImpl completeAssertStatement(
-    AstNode assertToken, ExpressionTree expression, Optional<AssertStatementTreeImpl> detailExpression, AstNode semicolonToken) {
+    JavaTree assertToken, ExpressionTree expression, Optional<AssertStatementTreeImpl> detailExpression, InternalSyntaxToken semicolonSyntaxToken) {
 
-    InternalSyntaxToken assertSyntaxToken = InternalSyntaxToken.create(assertToken);
-    InternalSyntaxToken semicolonSyntaxToken = InternalSyntaxToken.create(semicolonToken);
+    InternalSyntaxToken assertSyntaxToken = (InternalSyntaxToken) assertToken;
     return detailExpression.isPresent() ?
       detailExpression.get().complete(assertSyntaxToken, expression, semicolonSyntaxToken) :
       new AssertStatementTreeImpl(assertSyntaxToken, expression, semicolonSyntaxToken);
   }
 
-  public AssertStatementTreeImpl newAssertStatement(AstNode colonToken, ExpressionTree expression) {
-    return new AssertStatementTreeImpl(InternalSyntaxToken.create(colonToken), expression);
+  public AssertStatementTreeImpl newAssertStatement(InternalSyntaxToken colonToken, ExpressionTree expression) {
+    return new AssertStatementTreeImpl(colonToken, expression);
   }
 
   public IfStatementTreeImpl completeIf(JavaTree ifToken, InternalSyntaxToken openParenToken, ExpressionTree condition, InternalSyntaxToken closeParenToken, StatementTree statement,
@@ -1125,35 +1108,24 @@ public class TreeFactory {
   }
 
   public ForEachStatementImpl newForeachStatement(
-    AstNode forTokenAstNode,
-    AstNode openParenTokenAstNode,
-    VariableTreeImpl variable, AstNode colonTokenAstNode, ExpressionTree expression,
-    AstNode closeParenTokenAstNode,
+    JavaTree forTokenAstNode,
+    InternalSyntaxToken openParenToken,
+    VariableTreeImpl variable, InternalSyntaxToken colonToken, ExpressionTree expression,
+    InternalSyntaxToken closeParenToken,
     StatementTree statement) {
-
-    InternalSyntaxToken forKeyword = InternalSyntaxToken.create(forTokenAstNode);
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParenTokenAstNode);
-    InternalSyntaxToken colonToken = InternalSyntaxToken.create(colonTokenAstNode);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParenTokenAstNode);
-
-    return new ForEachStatementImpl(forKeyword, openParenToken, variable, colonToken, expression, closeParenToken, statement);
+    return new ForEachStatementImpl((InternalSyntaxToken) forTokenAstNode, openParenToken, variable, colonToken, expression, closeParenToken, statement);
   }
 
-  public WhileStatementTreeImpl whileStatement(AstNode whileToken, AstNode openParen, ExpressionTree expression, AstNode closeParen, StatementTree statement) {
-    InternalSyntaxToken whileKeyword = InternalSyntaxToken.create(whileToken);
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParen);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParen);
-    return new WhileStatementTreeImpl(whileKeyword, openParenToken, expression, closeParenToken, statement);
+  public WhileStatementTreeImpl whileStatement(JavaTree whileToken, InternalSyntaxToken openParen, ExpressionTree expression, InternalSyntaxToken closeParen, StatementTree statement) {
+    InternalSyntaxToken whileKeyword = (InternalSyntaxToken) whileToken;
+    return new WhileStatementTreeImpl(whileKeyword, openParen, expression, closeParen, statement);
   }
 
-  public DoWhileStatementTreeImpl doWhileStatement(AstNode doToken, StatementTree statement, AstNode whileToken, AstNode openParen, ExpressionTree expression, AstNode closeParen,
-    AstNode semicolon) {
-    InternalSyntaxToken doKeyword = InternalSyntaxToken.create(doToken);
-    InternalSyntaxToken whileKeyword = InternalSyntaxToken.create(whileToken);
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParen);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParen);
-    InternalSyntaxToken semiColonToken = InternalSyntaxToken.create(semicolon);
-    return new DoWhileStatementTreeImpl(doKeyword, statement, whileKeyword, openParenToken, expression, closeParenToken, semiColonToken);
+  public DoWhileStatementTreeImpl doWhileStatement(JavaTree doToken, StatementTree statement, JavaTree whileToken, InternalSyntaxToken openParen, ExpressionTree expression,
+                                                   InternalSyntaxToken closeParen, InternalSyntaxToken semicolon) {
+    InternalSyntaxToken doKeyword = (InternalSyntaxToken) doToken;
+    InternalSyntaxToken whileKeyword = (InternalSyntaxToken) whileToken;
+    return new DoWhileStatementTreeImpl(doKeyword, statement, whileKeyword, openParen, expression, closeParen, semicolon);
   }
 
   public TryStatementTreeImpl completeStandardTryStatement(AstNode tryTokenAstNode, BlockTreeImpl block, TryStatementTreeImpl partial) {
@@ -1308,14 +1280,13 @@ public class TreeFactory {
     return new BreakStatementTreeImpl(breakSyntaxToken, identifier, semicolonSyntaxToken);
   }
 
-  public ContinueStatementTreeImpl continueStatement(AstNode continueToken, Optional<JavaTree> identifierAstNode, AstNode semicolonToken) {
-    InternalSyntaxToken continueKeywordSyntaxToken = InternalSyntaxToken.create(continueToken);
-    InternalSyntaxToken semicolonSyntaxToken = InternalSyntaxToken.create(semicolonToken);
+  public ContinueStatementTreeImpl continueStatement(JavaTree continueToken, Optional<JavaTree> identifierAstNode, InternalSyntaxToken semicolonToken) {
+    InternalSyntaxToken continueKeywordSyntaxToken = (InternalSyntaxToken) continueToken;
     IdentifierTreeImpl identifier = null;
     if (identifierAstNode.isPresent()) {
-      identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(identifierAstNode.get()));
+      identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierAstNode.get());
     }
-    return new ContinueStatementTreeImpl(continueKeywordSyntaxToken, identifier, semicolonSyntaxToken);
+    return new ContinueStatementTreeImpl(continueKeywordSyntaxToken, identifier, semicolonToken);
   }
 
   public ReturnStatementTreeImpl returnStatement(JavaTree returnToken, Optional<ExpressionTree> expression, InternalSyntaxToken semicolonSyntaxToken) {
@@ -1333,9 +1304,7 @@ public class TreeFactory {
     return new LabeledStatementTreeImpl(identifier, colon, statement);
   }
 
-  public ExpressionStatementTreeImpl expressionStatement(ExpressionTree expression, AstNode semicolonTokenAstNode) {
-    InternalSyntaxToken semicolonToken = InternalSyntaxToken.create(semicolonTokenAstNode);
-
+  public ExpressionStatementTreeImpl expressionStatement(ExpressionTree expression, InternalSyntaxToken semicolonToken) {
     return new ExpressionStatementTreeImpl(expression, semicolonToken);
   }
 
@@ -1415,10 +1384,7 @@ public class TreeFactory {
       expression;
   }
 
-  public ConditionalExpressionTreeImpl newTernaryExpression(AstNode queryTokenAstNode, ExpressionTree trueExpression, AstNode colonTokenAstNode, ExpressionTree falseExpression) {
-    InternalSyntaxToken queryToken = InternalSyntaxToken.create(queryTokenAstNode);
-    InternalSyntaxToken colonToken = InternalSyntaxToken.create(colonTokenAstNode);
-
+  public ConditionalExpressionTreeImpl newTernaryExpression(InternalSyntaxToken queryToken, ExpressionTree trueExpression, InternalSyntaxToken colonToken, ExpressionTree falseExpression) {
     return new ConditionalExpressionTreeImpl(queryToken, trueExpression, colonToken, falseExpression);
   }
 
@@ -1703,11 +1669,11 @@ public class TreeFactory {
     return new ParenthesizedTreeImpl(leftParenSyntaxToken, expression, rightParenSyntaxToken);
   }
 
-  public ExpressionTree newExpression(AstNode newToken, Optional<List<AnnotationTreeImpl>> annotations, ExpressionTree partial) {
+  public ExpressionTree newExpression(JavaTree newToken, Optional<List<AnnotationTreeImpl>> annotations, ExpressionTree partial) {
     if (annotations.isPresent()) {
       ((JavaTree) partial).prependChildren(annotations.get());
     }
-    InternalSyntaxToken newSyntaxToken = InternalSyntaxToken.create(newToken);
+    InternalSyntaxToken newSyntaxToken = (InternalSyntaxToken) newToken;
     ((JavaTree) partial).prependChildren(newSyntaxToken);
     if (partial.is(Tree.Kind.NEW_CLASS)) {
       ((NewClassTreeImpl) partial).completeWithNewKeyword(newSyntaxToken);
@@ -1789,25 +1755,25 @@ public class TreeFactory {
       children);
   }
 
-  public ExpressionTree basicClassExpression(PrimitiveTypeTreeImpl basicType, Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions, AstNode dotToken, AstNode classTokenAstNode) {
+  public ExpressionTree basicClassExpression(PrimitiveTypeTreeImpl basicType, Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions,
+                                             InternalSyntaxToken dotToken, JavaTree classTokenAstNode) {
     // 15.8.2. Class Literals
     // int.class
     // int[].class
 
-    IdentifierTreeImpl classToken = new IdentifierTreeImpl(InternalSyntaxToken.create(classTokenAstNode));
+    IdentifierTreeImpl classToken = new IdentifierTreeImpl((InternalSyntaxToken) classTokenAstNode);
     ArrayTypeTreeImpl nestedDimensions = newArrayTypeTree(dimensions);
-    InternalSyntaxToken dotSyntaxToken = InternalSyntaxToken.create(dotToken);
 
     List<AstNode> children = Lists.newArrayList();
     children.add(basicType);
     if (nestedDimensions != null) {
       children.add(nestedDimensions);
     }
-    children.add(dotSyntaxToken);
+    children.add(dotToken);
     children.add(classToken);
 
     TypeTree typeTree = applyDim(basicType, nestedDimensions);
-    return new MemberSelectExpressionTreeImpl((ExpressionTree) typeTree, dotSyntaxToken, classToken, children.toArray(new AstNode[children.size()]));
+    return new MemberSelectExpressionTreeImpl((ExpressionTree) typeTree, dotToken, classToken, children.toArray(new AstNode[children.size()]));
   }
 
   public ExpressionTree voidClassExpression(AstNode voidTokenAstNode, AstNode dotToken, AstNode classTokenAstNode) {
@@ -1834,10 +1800,7 @@ public class TreeFactory {
     return new JavaTree.PrimitiveTypeTreeImpl((InternalSyntaxToken) basicType, children);
   }
 
-  public ArgumentListTreeImpl completeArguments(AstNode openParenthesisTokenAstNode, Optional<ArgumentListTreeImpl> expressions, AstNode closeParenthesisTokenAstNode) {
-    InternalSyntaxToken openParenthesisToken = InternalSyntaxToken.create(openParenthesisTokenAstNode);
-    InternalSyntaxToken closeParenthesisToken = InternalSyntaxToken.create(closeParenthesisTokenAstNode);
-
+  public ArgumentListTreeImpl completeArguments(InternalSyntaxToken openParenthesisToken, Optional<ArgumentListTreeImpl> expressions, InternalSyntaxToken closeParenthesisToken) {
     return expressions.isPresent() ?
       expressions.get().complete(openParenthesisToken, closeParenthesisToken) :
       new ArgumentListTreeImpl(openParenthesisToken, closeParenthesisToken);
@@ -1980,11 +1943,8 @@ public class TreeFactory {
     return new QualifiedIdentifierListTreeImpl(qualifiedIdentifiers.build(), children);
   }
 
-  public ArrayAccessExpressionTreeImpl newArrayAccessExpression(Optional<List<AnnotationTreeImpl>> annotations, AstNode openBracketTokenAstNode, ExpressionTree index,
-    AstNode closeBracketTokenAstNode) {
-    InternalSyntaxToken openBracketToken = InternalSyntaxToken.create(openBracketTokenAstNode);
-    InternalSyntaxToken closeBracketToken = InternalSyntaxToken.create(closeBracketTokenAstNode);
-
+  public ArrayAccessExpressionTreeImpl newArrayAccessExpression(Optional<List<AnnotationTreeImpl>> annotations, InternalSyntaxToken openBracketToken, ExpressionTree index,
+                                                                InternalSyntaxToken closeBracketToken) {
     ArrayAccessExpressionTreeImpl result = new ArrayAccessExpressionTreeImpl(openBracketToken, index, closeBracketToken);
     if (annotations.isPresent()) {
       result.prependChildren(annotations.get());
@@ -2021,21 +1981,20 @@ public class TreeFactory {
     return newTuple(Optional.of(dotToken), partial);
   }
 
-  public Tuple<Optional<InternalSyntaxToken>, ExpressionTree> completeCreatorSelector(AstNode dotTokenAstNode, ExpressionTree partial) {
-    ((NewClassTreeImpl) partial).completeWithDotToken(InternalSyntaxToken.create(dotTokenAstNode));
+  public Tuple<Optional<InternalSyntaxToken>, ExpressionTree> completeCreatorSelector(InternalSyntaxToken dotToken, ExpressionTree partial) {
+    ((NewClassTreeImpl) partial).completeWithDotToken(dotToken);
     return newTuple(Optional.<InternalSyntaxToken>absent(), partial);
   }
 
-  public ExpressionTree newDotClassSelector(Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions, AstNode dotTokenAstNode, AstNode classTokenAstNode) {
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(InternalSyntaxToken.create(classTokenAstNode));
-    InternalSyntaxToken dotToken = InternalSyntaxToken.create(dotTokenAstNode);
+  public ExpressionTree newDotClassSelector(Optional<List<Tuple<InternalSyntaxToken, InternalSyntaxToken>>> dimensions, InternalSyntaxToken dotToken, JavaTree classToken) {
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) classToken);
 
     ArrayTypeTreeImpl nestedDimensions = newArrayTypeTree(dimensions);
     List<AstNode> children = Lists.newArrayList();
     if (nestedDimensions != null) {
       children.add(nestedDimensions);
     }
-    children.add(dotTokenAstNode);
+    children.add(dotToken);
     children.add(identifier);
 
     return new MemberSelectExpressionTreeImpl(nestedDimensions, dotToken, identifier, children);

--- a/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
@@ -246,10 +246,7 @@ public class TreeFactory {
     }
   }
 
-  public TypeArgumentListTreeImpl newTypeArgumentList(AstNode openBracketTokenAstNode, Tree typeArgument, Optional<List<AstNode>> rests, AstNode closeBracketTokenAstNode) {
-    InternalSyntaxToken openBracketToken = InternalSyntaxToken.create(openBracketTokenAstNode);
-    InternalSyntaxToken closeBracketToken = InternalSyntaxToken.create(closeBracketTokenAstNode);
-
+  public TypeArgumentListTreeImpl newTypeArgumentList(InternalSyntaxToken openBracketToken, Tree typeArgument, Optional<List<AstNode>> rests, InternalSyntaxToken closeBracketToken) {
     ImmutableList.Builder<Tree> typeArguments = ImmutableList.builder();
     List<AstNode> children = Lists.newArrayList();
 
@@ -1046,11 +1043,9 @@ public class TreeFactory {
     return new AssertStatementTreeImpl(InternalSyntaxToken.create(colonToken), expression);
   }
 
-  public IfStatementTreeImpl completeIf(AstNode ifToken, AstNode openParen, ExpressionTree condition, AstNode closeParen, StatementTree statement,
+  public IfStatementTreeImpl completeIf(JavaTree ifToken, InternalSyntaxToken openParenToken, ExpressionTree condition, InternalSyntaxToken closeParenToken, StatementTree statement,
     Optional<IfStatementTreeImpl> elseClause) {
-    InternalSyntaxToken ifKeyword = InternalSyntaxToken.create(ifToken);
-    InternalSyntaxToken openParenToken = InternalSyntaxToken.create(openParen);
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParen);
+    InternalSyntaxToken ifKeyword = (InternalSyntaxToken) ifToken;
     if (elseClause.isPresent()) {
       return elseClause.get().complete(ifKeyword, openParenToken, condition, closeParenToken, statement);
     } else {
@@ -1058,9 +1053,8 @@ public class TreeFactory {
     }
   }
 
-  public IfStatementTreeImpl newIfWithElse(AstNode elseToken, StatementTree elseStatement) {
-    InternalSyntaxToken elseKeyword = InternalSyntaxToken.create(elseToken);
-    return new IfStatementTreeImpl(elseKeyword, elseStatement);
+  public IfStatementTreeImpl newIfWithElse(JavaTree elseToken, StatementTree elseStatement) {
+    return new IfStatementTreeImpl((InternalSyntaxToken) elseToken, elseStatement);
   }
 
   public ForStatementTreeImpl newStandardForStatement(
@@ -1344,10 +1338,8 @@ public class TreeFactory {
     return new ReturnStatementTreeImpl(returnKeywordSyntaxToken, expressionTree, semicolonSyntaxToken);
   }
 
-  public ThrowStatementTreeImpl throwStatement(AstNode throwToken, ExpressionTree expression, AstNode semicolonToken) {
-    InternalSyntaxToken throwSyntaxToken = InternalSyntaxToken.create(throwToken);
-    InternalSyntaxToken semicolonSyntaxToken = InternalSyntaxToken.create(semicolonToken);
-    return new ThrowStatementTreeImpl(throwSyntaxToken, expression, semicolonSyntaxToken);
+  public ThrowStatementTreeImpl throwStatement(JavaTree throwToken, ExpressionTree expression, InternalSyntaxToken semicolonToken) {
+    return new ThrowStatementTreeImpl((InternalSyntaxToken) throwToken, expression, semicolonToken);
   }
 
   public LabeledStatementTreeImpl labeledStatement(AstNode identifierAstNode, AstNode colon, StatementTree statement) {
@@ -1362,8 +1354,8 @@ public class TreeFactory {
     return new ExpressionStatementTreeImpl(expression, semicolonToken);
   }
 
-  public EmptyStatementTreeImpl emptyStatement(AstNode semicolon) {
-    return new EmptyStatementTreeImpl(InternalSyntaxToken.create(semicolon));
+  public EmptyStatementTreeImpl emptyStatement(InternalSyntaxToken semicolon) {
+    return new EmptyStatementTreeImpl(semicolon);
   }
 
   public BlockStatementListTreeImpl blockStatements(Optional<List<BlockStatementListTreeImpl>> blockStatements) {
@@ -1608,8 +1600,8 @@ public class TreeFactory {
     return new InternalPrefixUnaryExpression(Kind.LOGICAL_COMPLEMENT, operatorToken, expression);
   }
 
-  public ExpressionTree completeCastExpression(AstNode openParenTokenAstNode, TypeCastExpressionTreeImpl partial) {
-    return partial.complete(InternalSyntaxToken.create(openParenTokenAstNode));
+  public ExpressionTree completeCastExpression(InternalSyntaxToken openParenTokenAstNode, TypeCastExpressionTreeImpl partial) {
+    return partial.complete(openParenTokenAstNode);
   }
 
   public TypeCastExpressionTreeImpl newBasicTypeCastExpression(PrimitiveTypeTreeImpl basicType, AstNode closeParenTokenAstNode, ExpressionTree expression) {
@@ -1617,9 +1609,7 @@ public class TreeFactory {
     return new TypeCastExpressionTreeImpl(basicType, closeParenToken, expression);
   }
 
-  public TypeCastExpressionTreeImpl newClassCastExpression(TypeTree type, Optional<List<AstNode>> classTypes, AstNode closeParenTokenAstNode, ExpressionTree expression) {
-    InternalSyntaxToken closeParenToken = InternalSyntaxToken.create(closeParenTokenAstNode);
-
+  public TypeCastExpressionTreeImpl newClassCastExpression(TypeTree type, Optional<List<AstNode>> classTypes, InternalSyntaxToken closeParenToken, ExpressionTree expression) {
     List<AstNode> children = Lists.newArrayList();
     children.add((AstNode) type);
     // TODO SONARJAVA-1139 bound should be present in castTree
@@ -2031,20 +2021,15 @@ public class TreeFactory {
       children.toArray(new AstNode[0]));
   }
 
-  public ExpressionTree newIdentifierOrMethodInvocation(Optional<TypeArgumentListTreeImpl> typeArguments, AstNode identifierAstNode, Optional<ArgumentListTreeImpl> arguments) {
-    InternalSyntaxToken identifierToken = InternalSyntaxToken.create(identifierAstNode);
-    IdentifierTreeImpl identifier = new IdentifierTreeImpl(identifierToken);
-
+  public ExpressionTree newIdentifierOrMethodInvocation(Optional<TypeArgumentListTreeImpl> typeArguments, JavaTree identifierToken, Optional<ArgumentListTreeImpl> arguments) {
+    IdentifierTreeImpl identifier = new IdentifierTreeImpl((InternalSyntaxToken) identifierToken);
     if (typeArguments.isPresent()) {
       identifier.prependChildren(typeArguments.get());
     }
-
     ExpressionTree result = identifier;
-
     if (arguments.isPresent()) {
       result = new MethodInvocationTreeImpl(identifier, typeArguments.orNull(), arguments.get());
     }
-
     return result;
   }
 

--- a/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/visitors/PublicApiChecker.java
@@ -20,12 +20,11 @@
 package org.sonar.java.ast.visitors;
 
 import com.google.common.base.Preconditions;
-import com.sonar.sslr.api.Token;
 import org.sonar.api.utils.ParsingUtils;
 import org.sonar.java.ast.parser.TypeParameterListTreeImpl;
-import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.java.model.ModifiersUtils;
+import org.sonar.java.syntaxtoken.FirstSyntaxTokenFinder;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.ArrayTypeTree;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
@@ -45,7 +44,6 @@ import org.sonar.plugins.java.api.tree.Tree.Kind;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 import javax.annotation.Nullable;
-
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -249,8 +247,7 @@ public class PublicApiChecker extends BaseTreeVisitor {
   }
 
   private static String getCommentFromTree(Tree tokenTree) {
-    Token token = ((JavaTree) tokenTree).getToken();
-    return getCommentFromToken(token);
+    return getCommentFromSyntaxToken(FirstSyntaxTokenFinder.firstSyntaxToken(tokenTree));
   }
 
   private static ModifiersTree getModifierTrees(Tree tree) {
@@ -263,11 +260,6 @@ public class PublicApiChecker extends BaseTreeVisitor {
       modifiersTree = ((VariableTree) tree).modifiers();
     }
     return modifiersTree;
-  }
-
-  public static String getCommentFromToken(Token token) {
-    SyntaxToken syntaxToken = new InternalSyntaxToken(token);
-    return getCommentFromSyntaxToken(syntaxToken);
   }
 
   private static String getCommentFromSyntaxToken(SyntaxToken syntaxToken) {

--- a/java-squid/src/main/java/org/sonar/java/model/InternalSyntaxToken.java
+++ b/java-squid/src/main/java/org/sonar/java/model/InternalSyntaxToken.java
@@ -119,7 +119,7 @@ public class InternalSyntaxToken extends JavaTree implements SyntaxToken {
   }
 
   public static InternalSyntaxToken create(AstNode astNode) {
-    Preconditions.checkArgument(astNode.hasToken(), "has no token");
+//    Preconditions.checkArgument(astNode.hasToken(), "has no token");
     Preconditions.checkArgument(astNode.getToken() == astNode.getLastToken(), "has several tokens");
     return new InternalSyntaxToken(astNode.getType(), astNode.getToken(), astNode.getFromIndex(), astNode.getToIndex());
   }

--- a/java-squid/src/main/java/org/sonar/java/model/InternalSyntaxToken.java
+++ b/java-squid/src/main/java/org/sonar/java/model/InternalSyntaxToken.java
@@ -60,6 +60,10 @@ public class InternalSyntaxToken extends JavaTree implements SyntaxToken {
     this.trivias = createTrivias(token);
   }
 
+  public InternalSyntaxToken(InternalSyntaxToken internalSyntaxToken) {
+    this(internalSyntaxToken.token);
+  }
+
   @Override
   public String text() {
     return token.getValue();
@@ -128,4 +132,7 @@ public class InternalSyntaxToken extends JavaTree implements SyntaxToken {
     return new InternalSyntaxToken(astNode);
   }
 
+  public void setType(AstNodeType type) {
+    this.type = type;
+  }
 }

--- a/java-squid/src/main/java/org/sonar/java/model/declaration/ClassTreeImpl.java
+++ b/java-squid/src/main/java/org/sonar/java/model/declaration/ClassTreeImpl.java
@@ -62,7 +62,7 @@ public class ClassTreeImpl extends JavaTree implements ClassTree {
   private List<TypeTree> superInterfaces;
   private JavaSymbol.TypeJavaSymbol symbol = Symbols.unknownSymbol;
 
-  public ClassTreeImpl(Kind kind, SyntaxToken openBraceToken, List<Tree> members, SyntaxToken closeBraceToken, List<AstNode> children) {
+  public ClassTreeImpl(Kind kind, SyntaxToken openBraceToken, List<Tree> members, SyntaxToken closeBraceToken, List<? extends AstNode> children) {
     super(kind);
 
     this.kind = kind;

--- a/java-squid/src/main/java/org/sonar/java/model/declaration/ModifierKeywordTreeImpl.java
+++ b/java-squid/src/main/java/org/sonar/java/model/declaration/ModifierKeywordTreeImpl.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.model.declaration;
 
-import com.sonar.sslr.api.AstNode;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.Modifier;
 import org.sonar.plugins.java.api.tree.ModifierKeywordTree;
@@ -29,8 +28,8 @@ public class ModifierKeywordTreeImpl extends InternalSyntaxToken implements Modi
 
   private final Modifier modifier;
 
-  public ModifierKeywordTreeImpl(Modifier modifier, AstNode astNode) {
-    super(astNode.getType(), astNode.getToken(), astNode.getFromIndex(), astNode.getToIndex());
+  public ModifierKeywordTreeImpl(Modifier modifier, InternalSyntaxToken internalSyntaxToken) {
+    super(internalSyntaxToken);
     this.modifier = modifier;
   }
 

--- a/java-squid/src/main/java/org/sonar/java/parser/sslr/ActionParser2.java
+++ b/java-squid/src/main/java/org/sonar/java/parser/sslr/ActionParser2.java
@@ -34,7 +34,10 @@ import com.sonar.sslr.impl.matcher.RuleDefinition;
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
+import org.sonar.java.ast.api.JavaPunctuator;
 import org.sonar.java.ast.parser.AstNodeSanitizer;
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.JavaTree;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 import org.sonar.sslr.grammar.LexerlessGrammarBuilder;
 import org.sonar.sslr.internal.matchers.InputBuffer;
@@ -64,7 +67,7 @@ public class ActionParser2 extends Parser {
 
   private final AstNodeSanitizer astNodeSanitzer = new AstNodeSanitizer();
   private final GrammarBuilderInterceptor grammarBuilderInterceptor;
-  private final SyntaxTreeCreator<AstNode> syntaxTreeCreator;
+  private final SyntaxTreeCreator<JavaTree> syntaxTreeCreator;
   private final GrammarRuleKey rootRule;
   private final Grammar grammar;
   private final ParseRunner parseRunner;
@@ -102,7 +105,7 @@ public class ActionParser2 extends Parser {
       }
     }
 
-    this.syntaxTreeCreator = new SyntaxTreeCreator<AstNode>(treeFactory, grammarBuilderInterceptor);
+    this.syntaxTreeCreator = new SyntaxTreeCreator<>(treeFactory, grammarBuilderInterceptor);
 
     b.setRootRule(rootRule);
     this.rootRule = rootRule;
@@ -260,7 +263,13 @@ public class ActionParser2 extends Parser {
     }
 
     @Override
-    public AstNode invokeRule(GrammarRuleKey ruleKey) {
+    public JavaTree invokeRule(GrammarRuleKey ruleKey) {
+      push(new DelayedRuleInvocationExpression(b, ruleKey));
+      return null;
+    }
+
+    @Override
+    public InternalSyntaxToken invokeRule(JavaPunctuator ruleKey) {
       push(new DelayedRuleInvocationExpression(b, ruleKey));
       return null;
     }

--- a/java-squid/src/main/java/org/sonar/java/parser/sslr/GrammarBuilder.java
+++ b/java-squid/src/main/java/org/sonar/java/parser/sslr/GrammarBuilder.java
@@ -20,6 +20,9 @@
 package org.sonar.java.parser.sslr;
 
 import com.sonar.sslr.api.AstNode;
+import org.sonar.java.ast.api.JavaPunctuator;
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.JavaTree;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 
 import java.util.List;
@@ -38,7 +41,8 @@ public interface GrammarBuilder {
 
   <T> Optional<List<T>> zeroOrMore(T method);
 
-  AstNode invokeRule(GrammarRuleKey ruleKey);
+  JavaTree invokeRule(GrammarRuleKey ruleKey);
+  InternalSyntaxToken invokeRule(JavaPunctuator ruleKey);
 
   AstNode token(String value);
 

--- a/java-squid/src/main/java/org/sonar/java/parser/sslr/SyntaxTreeCreator.java
+++ b/java-squid/src/main/java/org/sonar/java/parser/sslr/SyntaxTreeCreator.java
@@ -28,6 +28,7 @@ import com.sonar.sslr.api.Token;
 import com.sonar.sslr.api.TokenType;
 import com.sonar.sslr.api.Trivia;
 import com.sonar.sslr.api.Trivia.TriviaKind;
+import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.parser.sslr.ActionParser2.GrammarBuilderInterceptor;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 import org.sonar.sslr.internal.grammar.MutableParsingRule;
@@ -134,6 +135,9 @@ public class SyntaxTreeCreator<T> {
       Token token = null;
 
       for (Object child : convertedChildren) {
+        if(child instanceof InternalSyntaxToken) {
+          return child;
+        }
         if (child instanceof AstNode && ((AstNode) child).hasToken()) {
           token = ((AstNode) child).getToken();
           break;
@@ -161,7 +165,7 @@ public class SyntaxTreeCreator<T> {
     }
   }
 
-  private AstNode visitTerminal(ParseNode node) {
+  private InternalSyntaxToken visitTerminal(ParseNode node) {
     if (node.getMatcher() instanceof TriviaExpression) {
       TriviaExpression ruleMatcher = (TriviaExpression) node.getMatcher();
       if (ruleMatcher.getTriviaKind() == TriviaKind.SKIPPED_TEXT) {
@@ -190,10 +194,7 @@ public class SyntaxTreeCreator<T> {
     }
     Token token = tokenBuilder.setTrivia(trivias).build();
     trivias.clear();
-    AstNode astNode = new AstNode(token);
-    astNode.setFromIndex(node.getStartIndex());
-    astNode.setToIndex(node.getEndIndex());
-    return astNode;
+    return new InternalSyntaxToken(token);
   }
 
   private void updateTokenPositionAndValue(ParseNode node) {

--- a/java-squid/src/main/java/org/sonar/java/parser/sslr/SyntaxTreeCreator.java
+++ b/java-squid/src/main/java/org/sonar/java/parser/sslr/SyntaxTreeCreator.java
@@ -136,6 +136,7 @@ public class SyntaxTreeCreator<T> {
 
       for (Object child : convertedChildren) {
         if(child instanceof InternalSyntaxToken) {
+          ((InternalSyntaxToken) child).setType(rule.getRealAstNodeType());
           return child;
         }
         if (child instanceof AstNode && ((AstNode) child).hasToken()) {

--- a/java-squid/src/test/java/org/sonar/java/resolve/Result.java
+++ b/java-squid/src/test/java/org/sonar/java/resolve/Result.java
@@ -22,14 +22,14 @@ package org.sonar.java.resolve;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
 import com.sonar.sslr.impl.Parser;
 import org.sonar.java.ast.parser.JavaParser;
 import org.sonar.java.model.JavaTree;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.semantic.Symbol;
 
 import java.io.File;
 
@@ -71,7 +71,7 @@ class Result {
   public JavaSymbol symbol(String name, int line) {
     Symbol result = null;
     for (Symbol symbol : semanticModel.getSymbolsTree().values()) {
-      if (name.equals(symbol.name()) && ((JavaTree) semanticModel.getTree(symbol)).getAstNode().getTokenLine() == line) {
+      if (name.equals(symbol.name()) && ((JavaTree) semanticModel.getTree(symbol)).getLine() == line) {
         if (result != null) {
           throw new IllegalArgumentException("Ambiguous coordinates of symbol");
         }
@@ -97,8 +97,8 @@ class Result {
     column -= 1;
     for (Symbol symbol : semanticModel.getSymbolUsed()) {
       for (IdentifierTree usage : symbol.usages()) {
-        Token token = ((JavaTree) usage.identifierToken()).getAstNode().getToken();
-        if (token.getLine() == line && token.getColumn() == column) {
+        SyntaxToken token = usage.identifierToken();
+        if (token.line() == line && token.column() == column) {
           if(searchSymbol) {
             return symbol;
           } else {

--- a/java-squid/src/test/java/org/sonar/sslr/tests/Assertions.java
+++ b/java-squid/src/test/java/org/sonar/sslr/tests/Assertions.java
@@ -29,6 +29,9 @@ import org.sonar.java.ast.parser.JavaGrammar;
 import org.sonar.java.ast.parser.JavaLexer;
 import org.sonar.java.ast.parser.TreeFactory;
 import org.sonar.java.parser.sslr.ActionParser2;
+import org.sonar.java.syntaxtoken.LastSyntaxTokenFinder;
+import org.sonar.plugins.java.api.tree.SyntaxToken;
+import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 import org.sonar.sslr.grammar.LexerlessGrammarBuilder;
 
@@ -59,10 +62,13 @@ public class Assertions {
 
     private void parseTillEof(String input) {
       AstNode astNode = actual.parse(input);
-
-      if (astNode.getToIndex() != input.length()) {
+      SyntaxToken syntaxToken = LastSyntaxTokenFinder.lastSyntaxToken((Tree) astNode);
+      if (syntaxToken == null || (syntaxToken.column()+syntaxToken.text().length() != input.length())) {
+        if (syntaxToken == null)  {
+          throw new RecognitionException(0, "Did not match till EOF : Last syntax token cannot be found");
+        }
         throw new RecognitionException(
-          0, "Did not match till EOF, but till line " + astNode.getLastToken().getLine() + ": token \"" + astNode.getLastToken().getValue() + "\"");
+          0, "Did not match till EOF, but till line " + syntaxToken.line() + ": token \"" + syntaxToken.text() + "\"");
       }
     }
 


### PR DESCRIPTION
This is not fully functional as this breaks the parsing tests as tokens are no longer relying on AstNodes