### PR TITLE
Regular expression rule template for checking for architectural constraints

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -344,6 +344,7 @@ public final class CheckList {
       .add(MembersDifferOnlyByCapitalizationCheck.class)
       .add(LoopsOnSameSetCheck.class)
       .add(PublicStaticMutableMembersCheck.class)
+      .add(RegularExpressionSimpleCheck.class)
       .build();
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/RegularExpressionSimpleCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RegularExpressionSimpleCheck.java
@@ -1,0 +1,216 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+package org.sonar.java.checks;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+import org.sonar.java.CharsetAwareVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.squidbridge.annotations.RuleTemplate;
+import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
+import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
+ * @since 2015-08-21
+ */
+@Rule(
+        key = "RegularExpressionSimpleCheck",
+        tags = {"custom"},
+        name = "Regular expression check should be fulfilled",
+        priority = Priority.MAJOR)
+@RuleTemplate
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.ERRORS)
+@SqaleConstantRemediation("10min")
+public class RegularExpressionSimpleCheck extends SubscriptionBaseVisitor implements CharsetAwareVisitor {
+
+    @RuleProperty(description = "Mandatory. The regular expession pattern to be search")
+    protected String pattern = "";
+    @RuleProperty(description = "Optional. If set rule will pass check if metch is not found. By default " +
+            "this is false and possitive search is performed. Default: false")
+    protected boolean invertMode = false;
+    @RuleProperty(description = "Optional. The message that will be registered as issue if positive check fails")
+    protected String issueMessage = "Text \"${" + MATCH_KEY + "}\" matches given regular expression \"${" + REGEX_KEY + "}\"";
+    @RuleProperty(description = "Optional. The message that will be registered as issue if invert mode check fails")
+    protected String invertModeIssueMessage = "File do not contain requested text, that should match given " +
+            "regular expression \"${" + REGEX_KEY + "}\"";
+    private Charset charset;
+
+    private static final String REGEX_KEY = "REGEX";
+    private static final String MATCH_KEY = "MATCH";
+
+    @Override
+    public List<Tree.Kind> nodesToVisit() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void scanFile(JavaFileScannerContext context) {
+        try {
+            super.context = context;
+            super.scanFile(context);
+            if (context.getSemanticModel() != null) {
+                visitContext(context);
+            }
+        } catch (IOException | PatternSyntaxException e) {
+            throw new IllegalArgumentException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    @Override
+    public void setCharset(Charset charset) {
+        this.charset = checkNotNull(charset);
+    }
+
+    private void visitContext(JavaFileScannerContext context) throws IOException, PatternSyntaxException {
+        validatePattern();
+        String content = readFile(context.getFile());
+        Pattern patternObj = Pattern.compile(pattern);
+        Matcher matcher = patternObj.matcher(content);
+        Iterable<MatchResult> resultIterable = matches(matcher);
+        List<MatchResult> results = Lists.newArrayList(resultIterable);
+        boolean atLeastOne = results.iterator().hasNext();
+        if (atLeastOne) {
+            addIssuesOnFoundMatches(content, results);
+        } else if (invertMode) {
+            addIssueOnFile(Formatter.createFrom(invertModeIssueMessage).setValue(REGEX_KEY, pattern).format());
+        }
+    }
+
+    private static Iterable<MatchResult> matches(final Matcher matcher) {
+        return new Iterable<MatchResult>() {
+            public Iterator<MatchResult> iterator() {
+                return new MatchResultIterator(matcher);
+            }
+        };
+    }
+
+    private void validatePattern() {
+        if (pattern == null || pattern.isEmpty()) {
+            throw new PatternSyntaxException("Regular expression given must not be empty!", pattern, 0);
+        }
+    }
+
+    private void addIssuesOnFoundMatches(String content, Iterable<MatchResult> resultIterable) {
+        for (MatchResult matchResult : resultIterable) {
+            int start = matchResult.start();
+            String match = matchResult.group();
+            int lineNo = getLineNumer(start, content);
+            String message = Formatter.createFrom(issueMessage)
+                    .setValue(MATCH_KEY, match)
+                    .setValue(REGEX_KEY, pattern)
+                    .format();
+            addIssue(lineNo, message);
+        }
+    }
+
+    private int getLineNumer(int start, String content) {
+        String sub = content.substring(0, start);
+        return sub.split("\n").length;
+    }
+
+    private String readFile(File file) throws IOException {
+        byte[] bytes = Files.readAllBytes(file.toPath());
+        return new String(bytes, charset);
+    }
+
+    private static class Formatter {
+        private final String format;
+        private final Map<String, Object> map = Maps.newHashMap();
+
+        public static Formatter createFrom(String format) {
+            return new Formatter(format);
+        }
+
+        private Formatter(String format) {
+            this.format = checkNotNull(format);
+        }
+
+        public Formatter setValue(String key, Object value) {
+            this.map.put(checkNotNull(key).toUpperCase(), checkNotNull(value));
+            return this;
+        }
+
+        public String format() {
+            String message = format;
+            Matcher matcher = Pattern.compile("\\$\\{([^\\}]+)\\}").matcher(format);
+            Iterable<MatchResult> matches = matches(matcher);
+            for (MatchResult match : matches) {
+                String key = match.group(1).toUpperCase();
+                String all = match.group(0);
+                String value = map.containsKey(key) ? map.get(key).toString() : "";
+                message = message.replace(all, value);
+            }
+            return message;
+        }
+    }
+
+    protected static class MatchResultIterator implements Iterator<MatchResult> {
+        // Keep a match around that supports any interleaving of hasNext/next calls.
+        MatchResult pending;
+
+        private final Matcher matcher;
+
+        public MatchResultIterator(final Matcher matcher) {
+            this.matcher = matcher;
+        }
+
+        public boolean hasNext() {
+            // Lazily fill pending, and avoid calling find() multiple times if the
+            // clients call hasNext() repeatedly before sampling via next().
+            if (pending == null && matcher.find()) {
+                pending = matcher.toMatchResult();
+            }
+            return pending != null;
+        }
+
+        public MatchResult next() {
+            // Fill pending if necessary (as when clients call next() without
+            // checking hasNext()), throw if not possible.
+            if (!hasNext()) { throw new NoSuchElementException(); }
+            // Consume pending so next call to hasNext() does a find().
+            MatchResult next = pending;
+            pending = null;
+            return next;
+        }
+
+        /** Required to satisfy the interface, but unsupported. */
+        public void remove() { throw new UnsupportedOperationException(); }
+    }
+
+}

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/RegularExpressionSimpleCheck.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/RegularExpressionSimpleCheck.html
@@ -1,0 +1,8 @@
+<p>A source code comply to an architectural model when it fully adheres to a set of
+    architectural constraints. A constraint set with regular expression allows to
+    deny various code conventions, or to force them.</p>
+<p>You can for instance use this rule to :</p>
+<ul>
+    <li>Force using given format of error codes ex.: <code>new ErrCode\((?!"[A-Z]{2}-[0-9]{6}").*\);</code></li>
+    <li>Deny using given code ex.: <code>@ManagedBean</code></li>
+</ul>

--- a/java-checks/src/test/files/checks/RegularExpressionCheckTestFile.java
+++ b/java-checks/src/test/files/checks/RegularExpressionCheckTestFile.java
@@ -1,0 +1,25 @@
+package org.sonar.java.checks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
+ */
+class RegularExpressionCheckTestFile {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RegularExpressionCheckTestFile.class);
+
+    private void sampleMethod() {
+        // a comment
+        LOG.debug(new Eid("20150822:222000", "A test mess"));
+        LOG.warn("A message");
+
+        // a split line
+        LoggerFactory.getLogger(RegularExpressionCheckTestFile.class).error("ddd");
+        LoggerFactory.getLogger(RegularExpressionCheckTestFile.class).error(ex);
+
+        LoggerFactory.getLogger(RegularExpressionCheckTestFile.class).error(new Eid("20150822:222140"));
+        LOG.error(new Cin("20150822:222140"));
+    }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/RegularExpressionSimpleCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/RegularExpressionSimpleCheckTest.java
@@ -1,0 +1,151 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+package org.sonar.java.checks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.sonar.java.ast.JavaAstScanner;
+import org.sonar.java.checks.helpers.ExceptionMatcher;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.AnalysisException;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifier;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * @author Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
+ * @since 2015-08-22
+ */
+public class RegularExpressionSimpleCheckTest {
+
+    private final RegularExpressionSimpleCheck check = new RegularExpressionSimpleCheck();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testNodesToVisit() {
+        assertThat(check.nodesToVisit()).isNotNull();
+        assertThat(check.nodesToVisit()).isEmpty();
+    }
+
+    @Test
+    public void testSetCharset_NPE() {
+        expectedException.expect(NullPointerException.class);
+        Charset charset = null;
+        check.setCharset(charset);
+    }
+
+    @Test
+    public void testSetCharset() {
+        check.setCharset(Charset.defaultCharset());
+        assertThat(check).isNotNull();
+    }
+
+    @Test
+    public void testInvalidPattern() {
+        check.pattern = null;
+        ExceptionMatcher matcher = ExceptionMatcher.createFor(AnalysisException.class);
+        ExceptionMatcher cause = ExceptionMatcher.createFor(IllegalArgumentException.class)
+                .expectMessage(containsString("Regular expression given must not be empty!"));
+        matcher.expectCause(cause);
+        expectedException.expect(matcher);
+        run();
+    }
+
+    @Test
+    public void testInvalidPattern2() {
+        check.pattern = "Alice has a cat (qwerty";
+        ExceptionMatcher matcher = ExceptionMatcher.createFor(AnalysisException.class);
+        ExceptionMatcher cause = ExceptionMatcher.createFor(IllegalArgumentException.class)
+                .expectMessage(containsString(check.pattern));
+        matcher.expectCause(cause);
+        expectedException.expect(matcher);
+        run();
+    }
+
+    @Test
+    public void testPositive() {
+        check.pattern = "(\\.(?:log|trace|debug|info|warn|error)\\((?!.*(?:Eid|Cin)).*\\))";
+        SourceFile file = run();
+        CheckMessagesVerifier.verify(file.getCheckMessages())
+                .next()
+                .atLine(16)
+                .withMessage("Text \".warn(\"A message\")\" matches given regular expression " +
+                        "\"(\\.(?:log|trace|debug|info|warn|error)\\((?!.*(?:Eid|Cin)).*\\))\"")
+                .next()
+                .atLine(19)
+                .withMessage("Text \".error(\"ddd\")\" matches given regular expression " +
+                        "\"(\\.(?:log|trace|debug|info|warn|error)\\((?!.*(?:Eid|Cin)).*\\))\"")
+                .next()
+                .atLine(20)
+                .withMessage("Text \".error(ex)\" matches given regular expression " +
+                        "\"(\\.(?:log|trace|debug|info|warn|error)\\((?!.*(?:Eid|Cin)).*\\))\"")
+                .noMore();
+    }
+
+    @Test
+    public void testNegative() {
+        check.pattern = "not found regex";
+        check.invertMode = true;
+        SourceFile file = run();
+        CheckMessagesVerifier.verify(file.getCheckMessages())
+                .next()
+                .atLine(null)
+                .withMessage("File do not contain requested text, that should match given regular expression " +
+                        "\"not found regex\"")
+                .noMore();
+    }
+
+    @Test
+    public void testNegative2() {
+        check.pattern = "@author\\s+[a-zA-Z]+\\s+[a-zA-Z]+\\s+\\<[a-z@.]+\\>";
+        check.invertMode = true;
+        SourceFile file = run();
+        CheckMessagesVerifier.verify(file.getCheckMessages())
+                .next()
+                .noMore();
+    }
+
+    @Test
+    public void testIterator() {
+        expectedException.expect(UnsupportedOperationException.class);
+        Matcher matcher = Pattern.compile(".*").matcher("");
+        RegularExpressionSimpleCheck.MatchResultIterator iter = new RegularExpressionSimpleCheck.MatchResultIterator(matcher);
+        iter.remove();
+    }
+
+    private SourceFile run() {
+        return JavaAstScanner.scanSingleFile(
+                new File("src/test/files/checks/RegularExpressionCheckTestFile.java"),
+                new VisitorsBridge(check)
+        );
+    }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/ExceptionMatcher.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/ExceptionMatcher.java
@@ -1,0 +1,99 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+package org.sonar.java.checks.helpers;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.internal.matchers.TypeSafeMatcher;
+
+import javax.annotation.Nonnull;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
+ * @since 2015-08-23
+ */
+public class ExceptionMatcher extends TypeSafeMatcher<Exception> {
+
+    private Class<? extends Exception> instanceOf;
+    private ExceptionMatcher casueMatcher;
+    private Matcher<String> messageMatcher;
+
+    public static ExceptionMatcher createFor(Class<? extends Exception> cls) {
+        return new ExceptionMatcher(cls);
+    }
+
+    private ExceptionMatcher(Class<? extends Exception> cls) {
+        expectInstanceOf(cls);
+    }
+
+    @Nonnull
+    public ExceptionMatcher expectInstanceOf(@Nonnull Class<? extends Exception> cls) {
+        this.instanceOf = checkNotNull(cls);
+        return this;
+    }
+
+    @Nonnull
+    public ExceptionMatcher expectCause(@Nonnull ExceptionMatcher causeExceptionMatcher) {
+        this.casueMatcher = checkNotNull(causeExceptionMatcher);
+        return this;
+    }
+
+    @Override
+    public boolean matchesSafely(@Nonnull Exception ex) {
+        boolean matches;
+        if (instanceOf.isAssignableFrom(ex.getClass())) {
+            matches = messageMatcher == null || messageMatcher.matches(ex.getMessage());
+            if (casueMatcher != null) {
+                matches = matches && casueMatcher.matches(ex.getCause());
+            }
+        } else {
+            matches = false;
+        }
+        return matches;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(this.instanceOf.getName());
+        if (messageMatcher != null) {
+            description.appendText(" with message ");
+            messageMatcher.describeTo(description);
+        }
+        if (casueMatcher != null) {
+            description.appendText(" with cause ");
+            casueMatcher.describeTo(description);
+        }
+    }
+
+
+
+    public ExceptionMatcher expectMessage(String message) {
+        return expectMessage(CoreMatchers.equalTo(message));
+    }
+
+    public ExceptionMatcher expectMessage(Matcher<String> messageMatcher) {
+        this.messageMatcher = messageMatcher;
+        return this;
+    }
+}


### PR DESCRIPTION
A source code comply to an architectural model when it fully adheres to a set of architectural constraints. A constraint set with regular expression allows to deny various code conventions, or to force them.

You can for instance use this rule to :

 * Force using given format of error codes ex.: `new ErrCode\((?!"[A-Z]{2}-[0-9]{6}").*\);`
 * Deny using given code ex.: `@ManagedBean`