### PR TITLE
SONARJAVA-1254 Update rule S2187: NoTestInTestClassCheck should support TestNG Test annotation

### DIFF
--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -127,6 +127,12 @@
                   <version>4.0</version>
                   <type>jar</type>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.testng</groupId>
+                  <artifactId>testng</artifactId>
+                  <version>6.9.6</version>
+                  <type>jar</type>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
             </configuration>

--- a/java-checks/src/main/java/org/sonar/java/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NoTestInTestClassCheck.java
@@ -55,7 +55,7 @@ public class NoTestInTestClassCheck extends SubscriptionBaseVisitor {
     @Override
     public boolean apply(SymbolMetadata.AnnotationInstance input) {
       Type type = input.symbol().type();
-      return type.isUnknown() || type.is("org.junit.Test");
+      return type.isUnknown() || type.is("org.junit.Test") || type.is("org.testng.annotations.Test");
     }
   };
 
@@ -92,16 +92,12 @@ public class NoTestInTestClassCheck extends SubscriptionBaseVisitor {
   }
 
   private void checkMethods(ClassTree classTree, boolean forJunit4) {
-    boolean hasNoTest = true;
     for (Tree member : classTree.members()) {
       if (member.is(Kind.METHOD) && isTestMethod(forJunit4, (MethodTree) member)) {
-        hasNoTest = false;
-        break;
+        return;
       }
     }
-    if (hasNoTest) {
-      addIssue(classTree, "Add some tests to this class.");
-    }
+    addIssue(classTree, "Add some tests to this class.");
   }
 
   private static boolean isTestMethod(boolean forJunit4, MethodTree member) {

--- a/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
@@ -32,3 +32,9 @@ class AnonymousClass extends junit.framework.TestCase{
 public abstract class AbstractIntegrationTest { //designed for extension should not raise issue.
 
 }
+
+class TestNGTest {
+  @org.testng.annotations.Test
+  void foo() {
+  }
+}


### PR DESCRIPTION
https://jira.sonarsource.com/browse/SONARJAVA-1254