### PR TITLE
SONARJAVA-1272 Restore complexity api breaking change and deprecate some methods

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/ClassComplexityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ClassComplexityCheck.java
@@ -58,7 +58,7 @@ public class ClassComplexityCheck extends SubscriptionBaseVisitor {
 
   @Override
   public void visitNode(Tree tree) {
-    List<Tree> complexity = context.getComplexity(tree);
+    List<Tree> complexity = context.getComplexityNodes(tree);
     int size = complexity.size();
     if (size > max) {
       List<JavaFileScannerContext.Location> flow = new ArrayList<>();

--- a/java-checks/src/main/java/org/sonar/java/checks/MethodComplexityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/MethodComplexityCheck.java
@@ -60,7 +60,7 @@ public class MethodComplexityCheck extends SubscriptionBaseVisitor {
   @Override
   public void visitNode(Tree tree) {
     MethodTree methodTree = (MethodTree) tree;
-    List<Tree> complexity = context.getComplexity(methodTree);
+    List<Tree> complexity = context.getComplexityNodes(methodTree);
     int size = complexity.size();
     if (size > max) {
       List<JavaFileScannerContext.Location> flow = new ArrayList<>();

--- a/java-squid/src/main/java/org/sonar/java/Measurer.java
+++ b/java-squid/src/main/java/org/sonar/java/Measurer.java
@@ -99,7 +99,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
     context.addNoSonarLines(commentLinesVisitor.noSonarLines());
     super.scanFile(context);
     //leave file.
-    int fileComplexity = context.getComplexity(context.getTree()).size();
+    int fileComplexity = context.getComplexityNodes(context.getTree()).size();
     saveMetricOnFile(CoreMetrics.CLASSES, classes);
     saveMetricOnFile(CoreMetrics.FUNCTIONS, methods);
     saveMetricOnFile(CoreMetrics.ACCESSORS, accessors);
@@ -145,7 +145,7 @@ public class Measurer extends SubscriptionVisitor implements CharsetAwareVisitor
         accessors++;
       } else {
         methods++;
-        int methodComplexity = context.getMethodComplexity(classTrees.peek(), methodTree).size();
+        int methodComplexity = context.getMethodComplexityNodes(classTrees.peek(), methodTree).size();
         methodComplexityDistribution.add(methodComplexity);
         complexityInMethods += methodComplexity;
       }

--- a/java-squid/src/main/java/org/sonar/java/model/VisitorsBridge.java
+++ b/java-squid/src/main/java/org/sonar/java/model/VisitorsBridge.java
@@ -329,12 +329,22 @@ public class VisitorsBridge {
     }
 
     @Override
-    public List<Tree> getComplexity(Tree tree) {
+    public int getComplexity(Tree tree) {
+      return getComplexityNodes(tree).size();
+    }
+
+    @Override
+    public int getMethodComplexity(ClassTree enclosingClass, MethodTree methodTree) {
+      return getMethodComplexityNodes(enclosingClass, methodTree).size();
+    }
+
+    @Override
+    public List<Tree> getComplexityNodes(Tree tree) {
       return complexityVisitor.scan(tree);
     }
 
     @Override
-    public List<Tree> getMethodComplexity(ClassTree enclosingClass, MethodTree methodTree) {
+    public List<Tree> getMethodComplexityNodes(ClassTree enclosingClass, MethodTree methodTree) {
       return complexityVisitor.scan(enclosingClass, methodTree);
     }
 

--- a/java-squid/src/main/java/org/sonar/plugins/java/api/JavaFileScannerContext.java
+++ b/java-squid/src/main/java/org/sonar/plugins/java/api/JavaFileScannerContext.java
@@ -54,10 +54,26 @@ public interface JavaFileScannerContext {
 
   File getFile();
 
-  List<Tree> getComplexity(Tree tree);
+  /**
+   * @deprecated As of release 3.6, replaced by {@link #getComplexityNodes(Tree)}
+   */
+  @Deprecated
+  int getComplexity(Tree tree);
 
-  List<Tree> getMethodComplexity(ClassTree enclosingClass, MethodTree methodTree);
+  /**
+   * @deprecated As of release 3.6, replaced by {@link #getMethodComplexityNodes(ClassTree, MethodTree)}
+   */
+  @Deprecated
+  int getMethodComplexity(ClassTree enclosingClass, MethodTree methodTree);
 
+  List<Tree> getComplexityNodes(Tree tree);
+
+  List<Tree> getMethodComplexityNodes(ClassTree enclosingClass, MethodTree methodTree);
+
+  /**
+   * @deprecated As of release 3.6, this method was not intended on a public interface
+   */
+  @Deprecated
   void addNoSonarLines(Set<Integer> lines);
 
   void reportIssue(JavaCheck javaCheck, Tree tree, String message);


### PR DESCRIPTION
From JavaFileScannerContext deprecate:
* int getComplexity(Tree tree)
* int getMethodComplexity(ClassTree enclosingClass, MethodTree methodTree)
* void addNoSonarLines(Set<Integer> lines)