### PR TITLE
Change MethodTooBigCheck and TooManyLinesOfCodeInFile into template rule

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/MethodTooBigCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/MethodTooBigCheck.java
@@ -28,6 +28,7 @@ import org.sonar.java.tag.Tag;
 import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.squidbridge.annotations.RuleTemplate;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 
@@ -37,7 +38,9 @@ import java.util.List;
   key = "S138",
   name = "Methods should not have too many lines",
   priority = Priority.MAJOR,
-  tags = {Tag.BRAIN_OVERLOAD})
+  tags = {Tag.BRAIN_OVERLOAD}
+)
+@RuleTemplate
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.UNDERSTANDABILITY)
 @SqaleConstantRemediation("20min")
 public class MethodTooBigCheck extends SubscriptionBaseVisitor {

--- a/java-checks/src/main/java/org/sonar/java/checks/TooManyLinesOfCodeInFile_S00104_Check.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TooManyLinesOfCodeInFile_S00104_Check.java
@@ -28,6 +28,7 @@ import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.tag.Tag;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.squidbridge.annotations.RuleTemplate;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 
@@ -41,6 +42,7 @@ import java.util.List;
   tags = {Tag.BRAIN_OVERLOAD})
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.READABILITY)
 @SqaleConstantRemediation("1h")
+@RuleTemplate
 public class TooManyLinesOfCodeInFile_S00104_Check extends SubscriptionBaseVisitor {
 
   private static final int DEFAULT_MAXIMUM = 1000;

--- a/java-checks/src/test/java/org/sonar/java/checks/MethodTooBigCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/MethodTooBigCheckTest.java
@@ -45,4 +45,13 @@ public class MethodTooBigCheckTest {
     JavaCheckVerifier.verify("src/test/files/checks/MethodTooBigCheckCustom5.java", check);
   }
 
+  @Test
+  public void multipleInstances() {
+    MethodTooBigCheck checkLowerLimit = new MethodTooBigCheck();
+    checkLowerLimit.max = 4;
+    MethodTooBigCheck checkHigherLimit = new MethodTooBigCheck();
+    checkHigherLimit.max = 5;
+    JavaCheckVerifier.verify("src/test/files/checks/MethodTooBigCheckCustom4.java", checkLowerLimit);
+    JavaCheckVerifier.verify("src/test/files/checks/MethodTooBigCheckCustom5.java", checkHigherLimit);
+  }
 }


### PR DESCRIPTION
Changed the rules into template rules so that multiple instances can be created.
This is often needed in legacy code bases where one needs different thresholds in parallel.

E.g. threshold 1000 lines in file is a blocker, but 500 is major.