### PR TITLE
SONARJAVA-1387 Fix leaking of stack in program state.

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/se/CheckerDispatcher.java
+++ b/java-squid/src/main/java/org/sonar/java/se/CheckerDispatcher.java
@@ -65,6 +65,9 @@ public class CheckerDispatcher implements CheckerContext {
     if (currentCheckerIndex < checks.size()) {
       checks.get(currentCheckerIndex).checkPostStatement(this, syntaxNode);
     } else {
+      if (explodedGraphWalker.programPosition.i< explodedGraphWalker.programPosition.block.elements().size()) {
+        explodedGraphWalker.clearStack(explodedGraphWalker.programPosition.block.elements().get(explodedGraphWalker.programPosition.i));
+      }
       explodedGraphWalker.enqueue(
         new ExplodedGraph.ProgramPoint(explodedGraphWalker.programPosition.block, explodedGraphWalker.programPosition.i + 1),
         explodedGraphWalker.programState);

--- a/java-squid/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-squid/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -423,6 +423,10 @@ public class ExplodedGraphWalker extends BaseTreeVisitor {
     }
 
     checkerDispatcher.executeCheckPostStatement(tree);
+    clearStack(tree);
+  }
+
+  public void clearStack(Tree tree) {
     if (tree.parent().is(Tree.Kind.EXPRESSION_STATEMENT)) {
       programState = ProgramState.unstack(programState, programState.stack.size()).a;
     }

--- a/java-squid/src/test/files/se/Reproducer.java
+++ b/java-squid/src/test/files/se/Reproducer.java
@@ -10,7 +10,15 @@ import java.lang.Object;
 
 class A {
   public void testCheckNotNull2(@CheckForNull Object parameter) {
-    String x = a == b ? foo(a) : foo(b);
+    long remainingNanos = 0;
+    final long endNanos = remainingNanos > 0 ? System.nanoTime() + remainingNanos : 0;
+    label :
+    do{
+      if(remainingNanos <0 ){
+        break label;
+      }
+    } while ( remainingNanos >0);
+//    String x = a == b ? foo(a) : foo(b);
   }
   public void testCheckNotNull(@CheckForNull Object parameter) {
     int i;

--- a/java-squid/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-squid/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -804,7 +804,7 @@ public class CFGTest {
         element(Tree.Kind.INT_LITERAL, 5),
         element(Tree.Kind.EQUAL_TO)
         ).terminator(Tree.Kind.IF_STATEMENT).successors(1, 2),
-      terminator(Tree.Kind.BREAK_STATEMENT, 5),
+      terminator(Tree.Kind.BREAK_STATEMENT, 0),
       block(
         element(Tree.Kind.IDENTIFIER, "i"),
         element(Tree.Kind.POSTFIX_INCREMENT)
@@ -814,27 +814,33 @@ public class CFGTest {
 
   @Test
   public void continue_on_label() {
-    final CFG cfg = buildCFG("void fun() { foo: for(int i = 0; i<10;i++) { if(i==5) continue foo; } }");
+    final CFG cfg = buildCFG("void fun() { foo: for(int i = 0; i<10;i++) { plop(); if(i==5) continue foo; plop();} }");
     final CFGChecker cfgChecker = checker(
       block(
         element(Tree.Kind.INT_LITERAL, 0),
         element(Tree.Kind.VARIABLE, "i")
-        ).successors(4),
+        ).successors(5),
       block(
         element(Tree.Kind.IDENTIFIER, "i"),
         element(Tree.Kind.INT_LITERAL, 10),
         element(Tree.Kind.LESS_THAN)
-        ).terminator(Tree.Kind.FOR_STATEMENT).successors(0, 3),
+        ).terminator(Tree.Kind.FOR_STATEMENT).successors(0, 4),
       block(
+        element(Tree.Kind.IDENTIFIER, "plop"),
+        element(Kind.METHOD_INVOCATION),
         element(Tree.Kind.IDENTIFIER, "i"),
         element(Tree.Kind.INT_LITERAL, 5),
         element(Tree.Kind.EQUAL_TO)
-        ).terminator(Tree.Kind.IF_STATEMENT).successors(1, 2),
-      terminator(Tree.Kind.CONTINUE_STATEMENT, 5),
+        ).terminator(Tree.Kind.IF_STATEMENT).successors(2,3),
+      terminator(Tree.Kind.CONTINUE_STATEMENT, 1),
+        block(
+            element(Tree.Kind.IDENTIFIER, "plop"),
+            element(Kind.METHOD_INVOCATION)
+        ).successors(1),
       block(
         element(Tree.Kind.IDENTIFIER, "i"),
         element(Tree.Kind.POSTFIX_INCREMENT)
-        ).successors(4));
+        ).successors(5));
     cfgChecker.check(cfg);
   }
 


### PR DESCRIPTION
Expression statements should clear the stack of program state. This was not done properly in some cases.
This lead to resolution of SONARJAVA-1386 about labeled break and continue. 