### PR TITLE
Change project property name to be valid sonar.java.source in inline docs

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1602.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1602.html
@@ -1,7 +1,7 @@
 <p>There are two ways to write lambdas that contain single statement, but one is definitely more compact and readable than the other.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1604.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1604.html
@@ -3,7 +3,7 @@
 <p>With Java 8, most uses of anonymous inner classes should be replaced by lambdas to highly increase the readability of the source code.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1609.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1609.html
@@ -2,7 +2,7 @@
 <p>Using <code>@FunctionalInterface</code> forces a compile break when an additional, non-overriding abstract method is added to a SAM, which would break the use of Lambda implementations.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1610.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1610.html
@@ -1,7 +1,7 @@
 <p>With Java 8's "default method" feature, any abstract class without direct or inherited field should be converted into an interface.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1611.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1611.html
@@ -1,7 +1,7 @@
 <p>There are two possible syntaxes for a lambda having only one input parameter with an inferred type: with and without parentheses around that single parameter. The simpler syntax, without parentheses, is more compact and readable than the one with parentheses, and is therefore preferred.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1612.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1612.html
@@ -1,7 +1,7 @@
 <p>Method/constructor references are more compact and readable than using lambdas, and are therefore preferred.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1710.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1710.html
@@ -1,7 +1,7 @@
 <p>Before Java 8 if you needed to use multiple instances of the same annotation, they had to be wrapped in a container annotation. With Java 8, that's no longer necessary, allowing for cleaner, more readable code.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2293.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2293.html
@@ -1,7 +1,7 @@
 <p>Java 7 introduced the diamond operator (<code>&lt;&gt;</code>) to reduce the verbosity of generics code. For instance, instead of having to declare a <code>List</code>'s type in both its declaration and its constructor, you can now simplify the constructor declaration with <code>&lt;&gt;</code>, and the compiler will infer the type.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>7</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>7</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2718.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2718.html
@@ -1,7 +1,7 @@
 <p>The use of the <code>Instant</code> class introduced in Java 8 to truncate a date can be significantly faster than the <code>DateUtils</code> class from Commons Lang.</p>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>8</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2976.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2976.html
@@ -11,7 +11,7 @@
 </ul>
 
 <p>
-  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>7</code>.
+  <em>Note</em> that this rule is automatically disabled when the project's <code>sonar.java.source</code> is lower than <code>7</code>.
 </p>
 
 <h2>Noncompliant Code Example</h2>


### PR DESCRIPTION
The property was listed as `java.source.version` only in inline docs. They are actually read by end users. In source files there were only `sonar.java.source`. I've change that to correct this issue.

Here are listings:

```bash
$ grep -r 'java.source.version'
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1602.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1604.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1609.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1610.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1611.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1612.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1710.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2293.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>7</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2718.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>8</code>.
java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2976.html:  <em>Note</em> that this rule is automatically disabled when the project's <code>java.source.version</code> is lower than <code>7</code>.
```
in code:
```bash
 $ grep -r 'sonar.java.source'
its/plugin/projects/java-version-aware-visitor/src/main/java/CreateTempFile.java:    tempDir.mkdir(); // squid:S2976 when sonar.java.source is set to java7+
its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java:    String sonarJavaSource = "sonar.java.source";
its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java:      "Invalid Java version set for property \"sonar.java.source\"");
java-checks/src/main/java/org/sonar/java/checks/helpers/JavaVersionHelper.java:    return provided == null ? (" (sonar.java.source not set. Assuming " + expeced + " or greater.)") : "";
java-checks/src/test/files/checks/AbstractClassNoFieldShouldBeInterfaceCheck_no_version.java:abstract class B { // Noncompliant {{Convert the abstract class "B" into an interface. (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/AnonymousClassShouldBeLambdaCheck_no_version.java:    new Handler(){ // Noncompliant {{Make this anonymous inner class a lambda (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/AnonymousClassShouldBeLambdaCheck_no_version.java:    new Handler(){ // Noncompliant {{Make this anonymous inner class a lambda (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/AnonymousClassShouldBeLambdaCheck_no_version.java:    new Handler(){ // Noncompliant {{Make this anonymous inner class a lambda (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/AnonymousClassShouldBeLambdaCheck_no_version.java:    Handler // Noncompliant {{Make this anonymous inner class a lambda (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/DateUtilsTruncateCheck_no_version.java:    DateUtils.truncate(date, field);      // Noncompliant {{Use "Instant.truncatedTo" instead. (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/DiamondOperatorCheck_no_version.java:  List<Object> myList2 = new ArrayList<Object>(); // Noncompliant [[sc=39;ec=47]] {{Replace the type specification in this constructor call with the diamond operator ("<>"). (sonar.java.source not set. Assuming 7 or greater.)}}
java-checks/src/test/files/checks/FileCreateTempFileCheck_no_version.java:    tempDir.mkdir();  // Noncompliant {{Use "Files.createTempDirectory" or a library function to create this directory instead. (sonar.java.source not set. Assuming 7 or greater.)}}
java-checks/src/test/files/checks/LambdaOptionalParenthesisCheck_no_version.java:                        .map((a)->a+1) // Noncompliant {{Remove the parentheses around the "a" parameter (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/LambdaSingleExpressionCheck_no_version.java:    IntStream.range(1, 5).map(x -> {return x * x - 1;}) // Noncompliant {{Remove useless curly braces around statement and then remove useless return keyword (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/LambdaSingleExpressionCheck_no_version.java:        .forEach(x -> { // Noncompliant {{Remove useless curly braces around statement (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/LambdaSingleExpressionCheck_no_version.java:    IntStream.range(1, 5).map(x -> { // Noncompliant {{Remove useless curly braces around statement (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/RepeatAnnotationCheck_no_version.java:  @SomeAnnotations({ // Noncompliant {{Remove the 'SomeAnnotations' wrapper from this annotation group (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/ReplaceLambdaByMethodRefCheck_no_version.java:        .map(x -> square(x)) // Noncompliant {{Replace this lambda with a method reference. (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/SAMAnnotatedCheck_no_version.java:interface notAnnotated { // Noncompliant {{Annotate the "notAnnotated" interface with the @FunctionalInterface annotation (sonar.java.source not set. Assuming 8 or greater.)}}
java-checks/src/test/files/checks/SAMAnnotatedCheck_no_version.java:interface MyFunc { // Noncompliant {{Annotate the "MyFunc" interface with the @FunctionalInterface annotation (sonar.java.source not set. Assuming 8 or greater.)}}
java-squid/src/main/java/org/sonar/java/JavaVersionAwareVisitor.java: * In order to be taken into account during analysis, the property <code>sonar.java.source</code> must be set.
java-squid/src/main/java/org/sonar/java/JavaVersionAwareVisitor.java:   * property <code>sonar.java.source</code>. Note that if the property is not set, The method will be called with <code>null</code> as parameter.
sonar-java-plugin/src/main/java/org/sonar/plugins/java/Java.java:  public static final String SOURCE_VERSION = "sonar.java.source";
sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSquidSensor.java:        LOG.warn("Invalid Java version set for property \"sonar.java.source\" (got \"" + javaVersion + "\"). "
```

BTW. Finding this mine took me about 2h of my work time, here: https://github.com/wavesoftware/java-eid-exceptions/commit/a32cfbf857060877796d678d2e1b25bb25e28e25