### PR TITLE
Do not cache local Maven repository in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
   - master
 
 cache:
-  - C:\Users\appveyor\.m2 -> **\pom.xml
+  # Note that we don't use cache for local Maven repository - see https://github.com/SonarSource/sonar-java/pull/525
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - C:\bin\apache-maven-3.2.5 -> appveyor.yml


### PR DESCRIPTION
Appveyor almost never restores this cache, for reasons unclear to me, but spends significant amount of time to build it.