### PR TITLE
Fix ClassCastException in TreeFactory

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
+++ b/java-squid/src/main/java/org/sonar/java/ast/parser/TreeFactory.java
@@ -1896,7 +1896,7 @@ public class TreeFactory {
       ((MemberSelectExpressionTreeImpl) type).complete(typeAnnotations);
     } else if (type.is(Tree.Kind.PARAMETERIZED_TYPE)) {
       ((ParameterizedTypeTreeImpl) type).complete(typeAnnotations);
-    } else {
+    } else if (type.is(Tree.Kind.PRIMITIVE_TYPE)) {
       ((PrimitiveTypeTreeImpl) type).complete(typeAnnotations);
     }
   }


### PR DESCRIPTION
An instance of ArrayTypeTreeImpl could be wrongly cast to
PrimitiveTypeTreeImpl.

See also https://groups.google.com/forum/#!topic/sonarqube/VTsAYxhGRiA