### PR TITLE
IT Ruling: Remove unused dependency on diffutils

### DIFF
--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -40,12 +40,6 @@
       <artifactId>fest-assert</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.googlecode.java-diff-utils</groupId>
-      <artifactId>diffutils</artifactId>
-      <version>1.3.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
This `diffutils` dependency doesn't seem to be used to me - but let's leave the ITs verify this!