### PR TITLE
Fix parsing of Scala classes containing symbols

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/resolve/Convert.java
+++ b/java-squid/src/main/java/org/sonar/java/resolve/Convert.java
@@ -20,10 +20,33 @@
 package org.sonar.java.resolve;
 
 import com.google.common.base.Preconditions;
+import java.util.HashSet;
 import org.apache.commons.lang.StringUtils;
 
 public class Convert {
+  private static final HashSet<String> scalaSymbols;
 
+  static {
+    scalaSymbols = new HashSet<String>();
+    scalaSymbols.add("$tilde");
+    scalaSymbols.add("$eq");
+    scalaSymbols.add("$less");
+    scalaSymbols.add("$greater");
+    scalaSymbols.add("$bang");
+    scalaSymbols.add("$hash");
+    scalaSymbols.add("$percent");
+    scalaSymbols.add("$up");
+    scalaSymbols.add("$amp");
+    scalaSymbols.add("$bar");
+    scalaSymbols.add("$times");
+    scalaSymbols.add("$div");
+    scalaSymbols.add("$plus");
+    scalaSymbols.add("$minus");
+    scalaSymbols.add("$colon");
+    scalaSymbols.add("$bslash");
+    scalaSymbols.add("$qmark");
+    scalaSymbols.add("$at");
+  }
   private Convert() {
   }
 
@@ -46,8 +69,18 @@ public class Convert {
 
   public static String enclosingClassName(String shortName) {
     String normalizedShortName = normalizeShortName(shortName);
-    int lastDollar = normalizedShortName.lastIndexOf('$');
-    return lastDollar < 0 ? "" : normalizedShortName.substring(0, lastDollar);
+    int endOfCurrentTerm = normalizedShortName.length();
+    int currentLastDollar = normalizedShortName.lastIndexOf('$');
+    String currentSubString = "";
+    if(currentLastDollar >= 0)
+      currentSubString = normalizedShortName.substring(currentLastDollar, endOfCurrentTerm);
+    while(currentLastDollar >= 0 &&
+      scalaSymbols.contains(currentSubString)) {
+      endOfCurrentTerm = currentLastDollar;
+      currentLastDollar = normalizedShortName.lastIndexOf('$', endOfCurrentTerm - 1);
+      currentSubString = normalizedShortName.substring(currentLastDollar, endOfCurrentTerm);
+    }
+    return currentLastDollar < 0 ? "" : normalizedShortName.substring(0, currentLastDollar);
   }
 
   public static String innerClassName(String enclosingClassName, String shortName) {

--- a/java-squid/src/test/java/org/sonar/java/resolve/ConvertTest.java
+++ b/java-squid/src/test/java/org/sonar/java/resolve/ConvertTest.java
@@ -66,6 +66,9 @@ public class ConvertTest {
     assertThat(Convert.enclosingClassName("MyClass$InnerClass")).isEqualTo("MyClass");
     assertThat(Convert.enclosingClassName("MyClass$$InnerClass$class")).isEqualTo("MyClass$");
     assertThat(Convert.enclosingClassName("MyClass$$InnerClass$")).isEqualTo("MyClass$");
+    assertThat(Convert.enclosingClassName(
+      "MyClass$$tilde$eq$less$greater$bang$hash$percent$up$amp$bar$times$div$plus$minus$colon$bslash$qmark$at"))
+      .isEqualTo("MyClass");
   }
 
   @Test
@@ -76,7 +79,9 @@ public class ConvertTest {
     assertThat(Convert.innerClassName(enclosingClassName, "MyClass$InnerClass$class")).isEqualTo("InnerClass$class");
     assertThat(Convert.innerClassName(enclosingClassName, "MyClass$$InnerClass$")).isEqualTo("$InnerClass$");
     assertThat(Convert.innerClassName("Rules$ListResponse$Rule", "Rules$ListResponse$Rule$Builder")).isEqualTo("Builder");
-
+    assertThat(Convert.innerClassName(enclosingClassName,
+      "MyClass$$tilde$eq$less$greater$bang$hash$percent$up$amp$bar$times$div$plus$minus$colon$bslash$qmark$at"))
+      .isEqualTo("$tilde$eq$less$greater$bang$hash$percent$up$amp$bar$times$div$plus$minus$colon$bslash$qmark$at");
   }
 
   @Test


### PR DESCRIPTION
Scala classes are allowed to have symbols like +-~/: in them.
When compiled, these become Java class names by replacing the symbol
with a $ and a word. + becomes $plus. The code for parsing class names
for inner classes didn't handle these cases and would throw errors
saying that classes didn't exist when sonar was run. This fixes the
parsing.
