### PR TITLE
Added support for String constants as parameter to @SuppressWarnings

### DIFF
--- a/java-squid/src/test/java/org/sonar/java/JavaFilesCacheTest.java
+++ b/java-squid/src/test/java/org/sonar/java/JavaFilesCacheTest.java
@@ -86,8 +86,8 @@ public class JavaFilesCacheTest {
   public void suppressWarning_external() {
     JavaFilesCache javaFilesCache = new JavaFilesCache();
     JavaAstScanner.scanSingleFileForTests(new File("src/test/resources/JavaSuppressWarning.java"), new VisitorsBridge(javaFilesCache));
-    assertThat(javaFilesCache.suppressWarningLines.keySet()).hasSize(3);
-    for (Integer line : Lists.newArrayList(10, 11)) {
+    assertThat(javaFilesCache.suppressWarningLines.keySet()).hasSize(6);
+    for (Integer line : Lists.newArrayList(10, 11, 16, 17)) {
       assertThat(javaFilesCache.suppressWarningLines.get(line)).as("on line " + line).contains("foo");
     }
   }

--- a/java-squid/src/test/resources/JavaSuppressWarning.java
+++ b/java-squid/src/test/resources/JavaSuppressWarning.java
@@ -9,4 +9,10 @@ class JavaFilesCacheTestWithSuppressWarnings {
   @java.lang.SuppressWarnings("foo")
   static class C {
   }
+
+  private static final String FOO = "foo";
+
+  @java.lang.SuppressWarnings(FOO)
+  static class D {
+  }
 }


### PR DESCRIPTION
Since I'm new to the code there might be a smarter/cleaner way to solve the problem and I would happily do any changes that you suggest.

I also modified the existing test file JavaSuppressWarning.java but if you would rather want a separate file (with a separate test) I can fix that.