### PR TITLE
SONARJAVA-1485 Preserving ordering in successors fix the issue.

### DIFF
--- a/java-squid/src/main/java/org/sonar/java/cfg/CFG.java
+++ b/java-squid/src/main/java/org/sonar/java/cfg/CFG.java
@@ -64,10 +64,9 @@ import org.sonar.plugins.java.api.tree.WhileStatementTree;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -126,8 +125,8 @@ public class CFG {
   public static class Block {
     private int id;
     private final List<Tree> elements = new ArrayList<>();
-    private final Set<Block> successors = new HashSet<>();
-    private final Set<Block> predecessors = new HashSet<>();
+    private final Set<Block> successors = new LinkedHashSet<>();
+    private final Set<Block> predecessors = new LinkedHashSet<>();
     private Block trueBlock;
     private Block falseBlock;
     private Block exitBlock;

--- a/java-squid/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-squid/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
@@ -1437,4 +1437,17 @@ class SuperClass {
       log("Error");
     }
   }
+
+  void SONARJAVA_1485(boolean condition) {
+    boolean still = false;
+    for (Foo foo : foos) {
+      for (Foo foo2 : foos) {
+        if (condition) {
+          still = true;
+        }
+      }
+    }
+    if (still) {
+    }
+  }
 }


### PR DESCRIPTION
By guaranteeing the fact that we will explore first body of a for loop it is very hard
(but not impossible) to have a case where the max execution of loops will lead to false positive.
Those cases seems to be out of real world example.