### PR TITLE
SONARJAVA-1556 Handle NPEs on anonymous classes

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AbstractSerializableInnerClassRule.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbstractSerializableInnerClassRule.java
@@ -20,6 +20,8 @@
 package org.sonar.java.checks;
 
 import com.google.common.collect.ImmutableList;
+
+import org.sonar.java.checks.helpers.ExpressionsHelper;
 import org.sonar.java.resolve.JavaSymbol;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -46,17 +48,18 @@ public abstract class AbstractSerializableInnerClassRule extends SubscriptionBas
   private void visitClassTree(ClassTree classTree) {
     Symbol.TypeSymbol symbol = classTree.symbol();
     if (isInnerClass(symbol) && directlyImplementsSerializable(symbol)) {
+      Tree reportTree = ExpressionsHelper.reportOnClassTree(classTree);
       Symbol owner = symbol.owner();
       if (owner.isTypeSymbol()) {
         Symbol.TypeSymbol ownerType = (Symbol.TypeSymbol) owner;
         if (isMatchingOuterClass(ownerType.type()) && !symbol.isStatic()) {
-          reportIssue(classTree.simpleName(), "Make this inner class static");
+          reportIssue(reportTree, "Make this inner class static");
         }
       } else if (owner.isMethodSymbol()) {
         Symbol.TypeSymbol methodOwner = (Symbol.TypeSymbol) owner.owner();
         if (isMatchingOuterClass(methodOwner.type()) && !owner.isStatic()) {
           String methodName = owner.name();
-          reportIssue(classTree.simpleName(), "Make \"" + methodName + "\" static");
+          reportIssue(reportTree, "Make \"" + methodName + "\" static");
         }
       }
     }

--- a/java-checks/src/test/files/checks/InnerClassOfNonSerializableCheck.java
+++ b/java-checks/src/test/files/checks/InnerClassOfNonSerializableCheck.java
@@ -11,6 +11,8 @@ class A implements Serializable {
 
 class B {
   
+  Serializable Anon = new Serializable() {}; // Noncompliant [[sc=27;ec=39]] {{Make this inner class static}}
+
   class B1 {}
   class B2 implements Cloneable {}
   class B3 implements Serializable {} // Noncompliant [[sc=9;ec=11]]{{Make this inner class static}}


### PR DESCRIPTION
Note that this regression was introduced by 37c91855fcbd03b1ef3fb3540675e1a09fc2502d, which didn't take into account anonymous classes.