### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -103,15 +103,15 @@
                 <artifactItem>
                   <groupId>commons-collections</groupId>
                   <artifactId>commons-collections</artifactId>
-                  <version>3.2.1</version>
+                  <version>3.2.2</version>
                   <classifier>sources</classifier>
-                  <outputDirectory>${project.build.directory}/test-projects/commons-collections-3.2.1/src</outputDirectory>
+                  <outputDirectory>${project.build.directory}/test-projects/commons-collections-3.2.2/src</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>commons-collections</groupId>
                   <artifactId>commons-collections</artifactId>
-                  <version>3.2.1</version>
-                  <outputDirectory>${project.build.directory}/test-projects/commons-collections-3.2.1/bin</outputDirectory>
+                  <version>3.2.2</version>
+                  <outputDirectory>${project.build.directory}/test-projects/commons-collections-3.2.2/bin</outputDirectory>
                 </artifactItem>
                 <!-- struts-core -->
                 <artifactItem>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/

Also, do consider using Guava in the future.