### PR TITLE
Added rule for slf4j log messages checks

### DIFF
--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -163,6 +163,12 @@
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>1.6.2</version>
+                  <type>jar</type>
+                </artifactItem>
+                <artifactItem>
                   <groupId>org.hibernate</groupId>
                   <artifactId>hibernate-core</artifactId>
                   <version>5.0.2.Final</version>

--- a/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CheckList.java
@@ -441,6 +441,7 @@ public final class CheckList {
       .add(PrivateReadResolveCheck.class)
       .add(RandomFloatToIntCheck.class)
       .add(SyncGetterAndSetterCheck.class)
+      .add(Slf4jLogMessageCheck.class)
       .build();
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/Slf4jLogMessageCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/Slf4jLogMessageCheck.java
@@ -1,0 +1,178 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.checks;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.sonar.check.Rule;
+import org.sonar.java.matcher.MethodMatcher;
+import org.sonar.java.matcher.MethodMatcherCollection;
+import org.sonar.java.matcher.NameCriteria;
+import org.sonar.java.matcher.TypeCriteria;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+/**
+ * This {@link Rule} checks if a slf4j log message is used without the use of {}-placeholders.
+ * 
+ * <pre>
+ * logger.debug("This is how slf4j logging should be done with {}", parameters);
+ * </pre>
+ */
+@Rule(key = "Methods4logmsg")
+public class Slf4jLogMessageCheck extends IssuableSubscriptionVisitor {
+
+	private static final String STRING_CLASSNAME = "java.lang.String";
+	private static final String SLF4J_LOGGER_CLASSNAME = "org.slf4j.Logger";
+	private static final String SLF4J_MARKER_CLASSNAME = "org.slf4j.Marker";
+
+	/**
+	 * Only looking for Method Invocation.
+	 */
+	@Override
+	public List<Kind> nodesToVisit() {
+		return Arrays.asList(Kind.METHOD_INVOCATION);
+	}
+
+	/**
+	 * Matchers that match for a call on the {@link Logger}.
+	 * 
+	 * @return
+	 */
+	private static boolean isLoggingInvocation(MethodInvocationTree tree) {
+		return MethodMatcherCollection.create(
+				MethodMatcher.create().typeDefinition(SLF4J_LOGGER_CLASSNAME).name(NameCriteria.any()).addParameter(TypeCriteria.anyType()),
+				MethodMatcher.create().typeDefinition(SLF4J_LOGGER_CLASSNAME).name(NameCriteria.any()).addParameter(STRING_CLASSNAME) .addParameter(TypeCriteria.anyType()),
+				MethodMatcher.create().typeDefinition(SLF4J_LOGGER_CLASSNAME).name(NameCriteria.any()).addParameter(SLF4J_MARKER_CLASSNAME).addParameter(TypeCriteria.anyType()),
+				MethodMatcher.create().typeDefinition(SLF4J_LOGGER_CLASSNAME).name(NameCriteria.any()).addParameter(SLF4J_MARKER_CLASSNAME).addParameter(STRING_CLASSNAME).addParameter(TypeCriteria.anyType())
+			).anyMatch(tree);
+	}
+
+	/**
+	 * Log invocation that start with the {@link Marker} class. This means the
+	 * log message is the 2nd argument, instead of the 1st.
+	 * 
+	 * @return
+	 */
+	private static boolean logInvocationStartsWithMarker(MethodInvocationTree tree) {
+		return MethodMatcherCollection.create(
+				MethodMatcher.create().name(NameCriteria.any()).addParameter(SLF4J_MARKER_CLASSNAME).addParameter(TypeCriteria.anyType()),
+				MethodMatcher.create().name(NameCriteria.any()).addParameter(SLF4J_MARKER_CLASSNAME).addParameter(STRING_CLASSNAME).addParameter(TypeCriteria.anyType())
+			).anyMatch(tree);
+	}
+
+	/**
+	 * Matchers that match for a call to {@link String#format(String, Object...)}.
+	 * 
+	 * @return
+	 */
+	private static boolean isStringFormatInvocation(MethodInvocationTree tree) {
+		return MethodMatcherCollection.create(
+				MethodMatcher.create().typeDefinition(STRING_CLASSNAME).name(NameCriteria.is("format")).addParameter(STRING_CLASSNAME).addParameter(TypeCriteria.anyType()),
+				MethodMatcher.create().typeDefinition(STRING_CLASSNAME).name(NameCriteria.is("format")).addParameter(TypeCriteria.anyType())
+			).anyMatch(tree);
+	}
+
+
+	@Override
+	public void visitNode(Tree tree) {
+		if (isLoggingInvocation((MethodInvocationTree) tree)) {
+			final ExpressionTree logMessageArgument = getLogMessageArgument((MethodInvocationTree) tree);
+
+			switch (logMessageArgument.kind()) {
+			case PLUS:
+				checkPlus(logMessageArgument);
+				break;
+			case METHOD_INVOCATION:
+			case METHOD_REFERENCE:
+				checkMethod(logMessageArgument);
+				break;
+			case STRING_LITERAL:
+			case IDENTIFIER:
+			default:
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Retrieve the argument containing the Log message.
+	 * If a {@link Marker} is also provided, this is the 2nd argument and not the 1st.
+	 * @param methodInvocationTree The method invocation tree
+	 * @return The argument expression tree
+	 */
+	private static final ExpressionTree getLogMessageArgument(MethodInvocationTree methodInvocationTree) {
+		if (logInvocationStartsWithMarker(methodInvocationTree)) {
+			return methodInvocationTree.arguments().get(1);
+		}
+		return methodInvocationTree.arguments().get(0);
+	}
+
+	/**
+	 * Warn about the concatenating in the log message.
+	 * @param tree
+	 */
+	private void checkPlus(ExpressionTree tree) {
+		BinaryExpressionTree plusArgument = (BinaryExpressionTree) tree;
+		if (!isOnlyStringConcatenate(plusArgument)) {
+			reportIssue(tree, "Avoid Object concatenating in log messages.");
+		}
+	}
+
+	/**
+	 * Check if the {@link BinaryExpressionTree} exists of only String literals.
+	 * @param tree
+	 * @return <code>true</code> if only String literals are concatenated. Otherwise <code>false</code>
+	 */
+	private static boolean isOnlyStringConcatenate(BinaryExpressionTree tree) {
+		boolean left = tree.leftOperand().is(Kind.STRING_LITERAL)
+				|| (tree.leftOperand().is(Kind.PLUS) && isOnlyStringConcatenate((BinaryExpressionTree) tree.leftOperand()));
+
+		if (left) {
+			return tree.rightOperand().is(Kind.STRING_LITERAL)
+					|| (tree.rightOperand().is(Kind.PLUS) && isOnlyStringConcatenate((BinaryExpressionTree) tree.rightOperand()));
+		}
+		return false;
+	}
+
+	/**
+	 * Warn about the method invocation for the log message
+	 * @param tree
+	 */
+	private void checkMethod(ExpressionTree tree) {
+		MethodInvocationTree methodArgument = (MethodInvocationTree) tree;
+
+		if (isStringFormatInvocation(methodArgument)) {
+			// error
+			reportIssue(tree, "String.format() should not be used as a log message.");
+			return;
+		}
+
+		reportIssue(tree, "A method call should not be used as a log messages.");
+	}
+
+}

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/Methods4logmsg_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/Methods4logmsg_java.html
@@ -2,7 +2,6 @@
 <p>Change the log message into a String with {}-placeholders.</p>
 
 <h2>Noncompliant Code Example</h2>
-<p></p>
 <pre>
 logger.warn("Do not concatenate with " + someString);
 logger.error(String.format("Do not format with %s", someVar));
@@ -17,5 +16,5 @@ logger.debug("This is how you should use logging with {}", someVar);
 
 <h2>See</h2>
 <ul>
-<li><a href="http://www.slf4j.org/faq.html#logging_performance">http://www.slf4j.org/faq.html#logging_performance</a></li>
+	<li><a href="http://www.slf4j.org/faq.html#logging_performance">http://www.slf4j.org/faq.html#logging_performance</a></li>
 </ul>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/Methods4logmsg_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/Methods4logmsg_java.html
@@ -1,0 +1,21 @@
+<p>Using <code>String.format()</code>, a method call or concatenation as a log message has a negative impact on the performance.</p>
+<p>Change the log message into a String with {}-placeholders.</p>
+
+<h2>Noncompliant Code Example</h2>
+<p></p>
+<pre>
+logger.warn("Do not concatenate with " + someString);
+logger.error(String.format("Do not format with %s", someVar));
+logger.error(doNotGetLogMessageByMethodcall());
+logger.error("Do not concatenate with " + someObject);
+</pre>
+
+<h2>Compliant Solution</h2>
+<pre>
+logger.debug("This is how you should use logging with {}", someVar);
+</pre>
+
+<h2>See</h2>
+<ul>
+<li><a href="http://www.slf4j.org/faq.html#logging_performance">http://www.slf4j.org/faq.html#logging_performance</a></li>
+</ul>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/Methods4logmsg_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/Methods4logmsg_java.json
@@ -1,0 +1,13 @@
+{
+  "title": "Log messages should not use \"String.format()\" or method calls",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "sqaleSubCharac": "EFFICIENCY_COMPLIANCE",
+  "tags": [
+    "bad-practice", "convention", "suspicious", "performance"
+  ],
+  "defaultSeverity": "Major"
+}

--- a/java-checks/src/test/files/checks/Slf4jLogMessageCheck.java
+++ b/java-checks/src/test/files/checks/Slf4jLogMessageCheck.java
@@ -3,23 +3,25 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MarkerFactory;
 
 class A {
-	final static String MSG1 = "ok";
-	final static Logger logger = LoggerFactory.getLogger("A");
+  final static String MSG1 = "ok";
+  final static Logger logger = LoggerFactory.getLogger("A");
 
-	private void method() {
-		String notok = "not ok";
-		logger.debug("check OK");
-		logger.debug(MSG1);
-		logger.warn("check" + "NOT OK");
-		logger.warn("check" + notok);  // Noncompliant {{Avoid Object concatenating in log messages.}}
-		logger.error(String.format("This is %s OK", "NOT"));  // Noncompliant {{String.format() should not be used as a log message.}}
-		logger.error(logmsg());  // Noncompliant {{A method call should not be used as a log messages.}}
-		logger.error("This is " + "NOT" + " OK");
-		logger.error("Is this OK" + false);  // Noncompliant {{Avoid Object concatenating in log messages.}}
-		logger.info("this is ok {}", true);
-		logger.info(MarkerFactory.getIMarkerFactory().getMarker("test"), "msg");
-		logger.info(MarkerFactory.getIMarkerFactory().getMarker("test"), "msg " + false);  // Noncompliant {{Avoid Object concatenating in log messages.}}
-	}
-	
-	private String logmsg(){ return "dummy"; }
+  private void method() {
+    String notok = "not ok";
+    logger.debug("check OK");
+    logger.debug(MSG1);
+    logger.warn("check" + "NOT OK");
+    logger.warn("check" + notok); // Noncompliant {{Avoid Object concatenating in log messages.}}
+    logger.error(String.format("This is %s OK", "NOT")); // Noncompliant {{String.format() should not be used as a log message.}}
+    logger.error(logmsg()); // Noncompliant {{A method call should not be used as a log messages.}}
+    logger.error("This is " + "NOT" + " OK");
+    logger.error("Is this OK" + false); // Noncompliant {{Avoid Object concatenating in log messages.}}
+    logger.info("this is ok {}", true);
+    logger.info(MarkerFactory.getIMarkerFactory().getMarker("test"), "msg");
+    logger.info(MarkerFactory.getIMarkerFactory().getMarker("test"), "msg " + false); // Noncompliant {{Avoid Object concatenating in log messages.}}
+  }
+
+  private String logmsg() {
+    return "dummy";
+  }
 }

--- a/java-checks/src/test/files/checks/Slf4jLogMessageCheck.java
+++ b/java-checks/src/test/files/checks/Slf4jLogMessageCheck.java
@@ -1,0 +1,25 @@
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
+
+class A {
+	final static String MSG1 = "ok";
+	final static Logger logger = LoggerFactory.getLogger("A");
+
+	private void method() {
+		String notok = "not ok";
+		logger.debug("check OK");
+		logger.debug(MSG1);
+		logger.warn("check" + "NOT OK");
+		logger.warn("check" + notok);  // Noncompliant {{Avoid Object concatenating in log messages.}}
+		logger.error(String.format("This is %s OK", "NOT"));  // Noncompliant {{String.format() should not be used as a log message.}}
+		logger.error(logmsg());  // Noncompliant {{A method call should not be used as a log messages.}}
+		logger.error("This is " + "NOT" + " OK");
+		logger.error("Is this OK" + false);  // Noncompliant {{Avoid Object concatenating in log messages.}}
+		logger.info("this is ok {}", true);
+		logger.info(MarkerFactory.getIMarkerFactory().getMarker("test"), "msg");
+		logger.info(MarkerFactory.getIMarkerFactory().getMarker("test"), "msg " + false);  // Noncompliant {{Avoid Object concatenating in log messages.}}
+	}
+	
+	private String logmsg(){ return "dummy"; }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/Slf4jLogMessageCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/Slf4jLogMessageCheckTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
 public class Slf4jLogMessageCheckTest {
-	@Test
-	public void test() {
-		JavaCheckVerifier.verify("src/test/files/checks/Slf4jLogMessageCheck.java", new Slf4jLogMessageCheck());
-	}
+  @Test
+  public void test() {
+    JavaCheckVerifier.verify("src/test/files/checks/Slf4jLogMessageCheck.java", new Slf4jLogMessageCheck());
+  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/Slf4jLogMessageCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/Slf4jLogMessageCheckTest.java
@@ -1,0 +1,30 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+
+public class Slf4jLogMessageCheckTest {
+	@Test
+	public void test() {
+		JavaCheckVerifier.verify("src/test/files/checks/Slf4jLogMessageCheck.java", new Slf4jLogMessageCheck());
+	}
+}


### PR DESCRIPTION
Hi,

This new rule is to check if a log message for SLF4j Logger:
- Is not a method call
- Is not a String.format() method call
- Is not an Object concatenating
