### PR TITLE
Private lambda methods now detected and marked as used

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/targets/UnusedPrivateMethod.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/targets/UnusedPrivateMethod.java
@@ -80,4 +80,17 @@ public class UnusedPrivateMethod {
     }
   }
 
+
+  public int wrapForLambda() {
+    // this method is public, but it calls private method via lambda.
+    // this is the only place lambdaUsedPrivateMethod called.
+    java.util.ArrayList<Integer> list = new java.util.ArrayList<Integer>();
+    list.stream().forEach(this::lambdaUsedPrivateMethod);
+    return 0;
+  }
+
+  private int lambdaUsedPrivateMethod(int i) {
+    return 1;
+  }
+
 }


### PR DESCRIPTION
Hello there.
Currently, plugin isn't able to detect any lambda expressions, so many private methods are falsely marked as unused.
Here's small and non-intrusive PR, which solves this issue.
Build passed, unit-test input updated.
Thanks!