### PR TITLE
Private lambda methods now detected and marked as used

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/targets/UnusedPrivateMethod.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/targets/UnusedPrivateMethod.java
@@ -80,4 +80,17 @@ public class UnusedPrivateMethod {
     }
   }
 
+
+  public int wrapForLambda() {
+    // this method is public, but it calls private method via lambda.
+    // this is the only place lambdaUsedPrivateMethod called.
+    java.util.ArrayList<Integer> list = new java.util.ArrayList<Integer>();
+    list.stream().forEach(this::lambdaUsedPrivateMethod);
+    return 0;
+  }
+
+  private int lambdaUsedPrivateMethod(int i) {
+    return 1;
+  }
+
 }

--- a/java-frontend/src/main/java/org/sonar/java/bytecode/asm/AsmMethodVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/bytecode/asm/AsmMethodVisitor.java
@@ -83,8 +83,7 @@ public class AsmMethodVisitor extends MethodVisitor {
     if (bsmArgs.length >= 2) {
       if (bsmArgs[1] instanceof Handle) {
         Handle handle = (Handle) bsmArgs[1];
-        // Magic Number from ASM library, not sure if required at all.
-        if (handle.getTag() == 7) {
+        if (handle.getTag() == Opcodes.H_INVOKESPECIAL) {
           AsmClass ownerClass = asmClassProvider.getClass(handle.getOwner(), DETAIL_LEVEL.NOTHING);
           AsmMethod targetMethod = ownerClass.getMethodOrCreateIt(handle.getName() + handle.getDesc());
           method.addEdge(new AsmEdge(method, targetMethod, SourceCodeEdgeUsage.CALLS_METHOD, lineNumber));


### PR DESCRIPTION
Hello there.
Currently, plugin isn't able to detect any lambda expressions, so many private methods are falsely marked as unused.
Here's small and non-intrusive PR, which solves this issue.
Build passed, unit-test input updated.
Thanks!
P.S. Resubmitted to see whether OOM in previous build is a env issue.