### PR TITLE
rewrite try-catch-finally in runtime

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/cfg/LiveVariables.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/LiveVariables.java
@@ -100,6 +100,17 @@ public class
           blockOut.addAll(inOfSuccessor);
         }
       }
+
+      // Since we cut the catch entries, so add it to calculate variables.
+      if (block instanceof CFG.TryBlock) {
+        for (CFG.Block successor : ((CFG.TryBlock) block).catchEntries()) {
+          Set<Symbol> inOfSuccessor = in.get(successor);
+          if (inOfSuccessor != null) {
+            blockOut.addAll(inOfSuccessor);
+          }
+        }
+      }
+
       // in = gen and (out - kill)
       Set<Symbol> newIn = new HashSet<>(gen.get(block));
       newIn.addAll(Sets.difference(blockOut, kill.get(block)));
@@ -110,6 +121,15 @@ public class
       in.put(block, newIn);
       for (CFG.Block predecessor : block.predecessors()) {
         workList.addLast(predecessor);
+      }
+
+      // Since we cut the catch entries, so add it to calculate variables.
+      if (block.isCatchEntryBlock()) {
+        for (CFG.Block tryBlock : cfg.blocks()) {
+          if (tryBlock instanceof CFG.TryBlock && ((CFG.TryBlock) tryBlock).catchEntries().contains(block)) {
+            workList.addLast(tryBlock);
+          }
+        }
       }
     }
   }

--- a/java-frontend/src/main/java/org/sonar/java/resolve/MethodJavaType.java
+++ b/java-frontend/src/main/java/org/sonar/java/resolve/MethodJavaType.java
@@ -37,6 +37,10 @@ public class MethodJavaType extends JavaType {
     this.thrown = thrown;
   }
 
+  public List<JavaType> thrownTypes() {
+    return thrown;
+  }
+
   @Override
   public String toString() {
     return resultType == null ? "constructor" : ("returns " + resultType.toString());

--- a/java-frontend/src/main/java/org/sonar/java/resolve/Resolve.java
+++ b/java-frontend/src/main/java/org/sonar/java/resolve/Resolve.java
@@ -494,9 +494,6 @@ public class Resolve {
       return bestSoFar;
     }
     TypeSubstitution substitution = typeSubstitutionSolver.getTypeSubstitution(methodJavaSymbol, callSite, typeParams, argTypes);
-    if (substitution == null) {
-      return bestSoFar;
-    }
     List<JavaType> formals = ((MethodJavaType) methodJavaSymbol.type).argTypes;
     formals = typeSubstitutionSolver.applySiteSubstitutionToFormalParameters(formals, callSite);
     if(defSite != callSite) {

--- a/java-frontend/src/main/java/org/sonar/java/resolve/TypeSubstitutionSolver.java
+++ b/java-frontend/src/main/java/org/sonar/java/resolve/TypeSubstitutionSolver.java
@@ -66,7 +66,7 @@ public class TypeSubstitutionSolver {
       }
       if (!isValidSubtitution(substitution, site)) {
         // substitution discarded
-        return null;
+        substitution = new TypeSubstitution();
       }
     }
     return substitution;

--- a/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
@@ -31,6 +31,7 @@ import org.sonar.java.se.constraint.ObjectConstraint;
 import org.sonar.java.se.symbolicvalues.BinaryRelation;
 import org.sonar.java.se.symbolicvalues.SymbolicValue;
 import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 import javax.annotation.CheckForNull;
@@ -73,7 +74,8 @@ public class ProgramState {
       .put(SymbolicValue.TRUE_LITERAL, BooleanConstraint.TRUE)
       .put(SymbolicValue.FALSE_LITERAL, BooleanConstraint.FALSE),
     AVLTree.<ExplodedGraph.ProgramPoint, Integer>create(),
-    Lists.<SymbolicValue>newLinkedList());
+    Lists.<SymbolicValue>newLinkedList(),
+    null);
 
   private final PMap<ExplodedGraph.ProgramPoint, Integer> visitedPoints;
 
@@ -82,14 +84,17 @@ public class ProgramState {
   private final PMap<SymbolicValue, Integer> references;
   private final PMap<SymbolicValue, Constraint> constraints;
 
+  private List<Type> currentExceptions;
+
   private ProgramState(PMap<Symbol, SymbolicValue> values, PMap<SymbolicValue, Integer> references,
     PMap<SymbolicValue, Constraint> constraints, PMap<ExplodedGraph.ProgramPoint, Integer> visitedPoints,
-    Deque<SymbolicValue> stack) {
+    Deque<SymbolicValue> stack, @Nullable List<Type> currentExceptions) {
     this.values = values;
     this.references = references;
     this.constraints = constraints;
     this.visitedPoints = visitedPoints;
     this.stack = stack;
+    this.currentExceptions = currentExceptions;
     constraintSize = 3;
   }
 
@@ -99,6 +104,7 @@ public class ProgramState {
     constraints = ps.constraints;
     constraintSize = ps.constraintSize;
     visitedPoints = ps.visitedPoints;
+    currentExceptions = ps.currentExceptions;
     stack = newStack;
   }
 
@@ -108,6 +114,7 @@ public class ProgramState {
     constraints = newConstraints;
     constraintSize = ps.constraintSize + 1;
     visitedPoints = ps.visitedPoints;
+    currentExceptions = ps.currentExceptions;
     this.stack = ps.stack;
   }
 
@@ -119,6 +126,21 @@ public class ProgramState {
 
   ProgramState clearStack() {
     return unstackValue(stack.size()).state;
+  }
+
+  ProgramState setCurrentExceptions(@Nullable List<Type> exceptions) {
+    if (exceptions != null && exceptions.isEmpty()) {
+      exceptions = null;
+    }
+
+    if (exceptions != currentExceptions) {
+      return new ProgramState(values, references, constraints, visitedPoints, stack, exceptions);
+    }
+    return this;
+  }
+
+  List<Type> currentExceptions() {
+    return currentExceptions;
   }
 
   public Pop unstackValue(int nbElements) {
@@ -197,7 +219,7 @@ public class ProgramState {
       }
       newReferences = increaseReference(newReferences, value);
       PMap<Symbol, SymbolicValue> newValues = values.put(symbol, value);
-      return new ProgramState(newValues, newReferences, constraints, visitedPoints, stack);
+      return new ProgramState(newValues, newReferences, constraints, visitedPoints, stack, currentExceptions);
     }
     return this;
   }
@@ -255,7 +277,7 @@ public class ProgramState {
         }
       }
     }
-    return newProgramState ? new ProgramState(newValues, newReferences, newConstraints, visitedPoints, stack) : this;
+    return newProgramState ? new ProgramState(newValues, newReferences, newConstraints, visitedPoints, stack, currentExceptions) : this;
   }
 
   public ProgramState cleanupConstraints() {
@@ -273,7 +295,7 @@ public class ProgramState {
         newReferences = newReferences.remove(symbolicValue);
       }
     }
-    return newProgramState ? new ProgramState(values, newReferences, newConstraints, visitedPoints, stack) : this;
+    return newProgramState ? new ProgramState(values, newReferences, newConstraints, visitedPoints, stack, currentExceptions) : this;
   }
 
   public ProgramState resetFieldValues(ConstraintManager constraintManager) {
@@ -304,7 +326,7 @@ public class ProgramState {
       newValues = newValues.put(symbol, newValue);
       newReferences = increaseReference(newReferences, newValue);
     }
-    return new ProgramState(newValues, newReferences, constraints, visitedPoints, stack);
+    return new ProgramState(newValues, newReferences, constraints, visitedPoints, stack, currentExceptions);
   }
 
   public static boolean isField(Symbol symbol) {
@@ -321,7 +343,7 @@ public class ProgramState {
   }
 
   public ProgramState visitedPoint(ExplodedGraph.ProgramPoint programPoint, int nbOfVisit) {
-    return new ProgramState(values, references, constraints, visitedPoints.put(programPoint, nbOfVisit), stack);
+    return new ProgramState(values, references, constraints, visitedPoints.put(programPoint, nbOfVisit), stack, currentExceptions);
   }
 
   @CheckForNull

--- a/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
@@ -1078,26 +1078,26 @@ public static class Class extends SuperClass {
       b = true;
       c = true;
     } catch (Exception e) {
-      if (a) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+      if (a) { // unreachable
       }
-      if (b) {
+      if (b) { // unreachable
       }
       c = true;
       d = true;
     } catch (Exception e) {
-      if (a) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+      if (a) { // unreachable
       }
-      if (c) {
+      if (c) { // unreachable
       }
       d = true;
     }
     if (a) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
-    if (b) {
+    if (b) { // Noncompliant
     }
-    if (c) {
+    if (c) { // Noncompliant
     }
-    if (d) {
+    if (d) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
   }
 
@@ -1111,9 +1111,9 @@ public static class Class extends SuperClass {
     } finally {
       if (a) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
       }
-      if (b) {
+      if (b) {  // Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
       }
-      if (c) {
+      if (c) {  // Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
       }
       b = true;
     }

--- a/java-frontend/src/test/files/se/JdbcResourcesTestFile.java
+++ b/java-frontend/src/test/files/se/JdbcResourcesTestFile.java
@@ -54,7 +54,7 @@ public class JdbcSample {
       try (Statement statement = connection.createStatement();) {
         boolean hasResultSets = statement.execute(query);
         while (hasResultSets) {
-          ResultSet result = statement.getResultSet();
+          ResultSet result = statement.getResultSet(); // Noncompliant {{Close this "ResultSet".}}
           String name = result.getString(0);
           hasResultSets = statement.getMoreResults();
         }

--- a/java-frontend/src/test/files/se/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/test/files/se/LocksNotUnlockedCheck.java
@@ -58,7 +58,7 @@ public class MyClass {
   public void doTheOtherThing() {
     Lock lock = new ReentrantLock();
     try {
-      lock.tryLock();  // False negative Noncompliant
+      lock.tryLock();
       // do work...
       lock.unlock(); // an exception will keep this line from being reached
     } catch (ExceptionType e) {
@@ -234,7 +234,7 @@ public class MyClass {
   public void unlockingInTryCatch() {
     Lock lock = new ReentrantLock();
     try {
-      lock.lock(); // Noncompliant
+      lock.lock();
     } finally {
       try {
         lock.unlock();
@@ -247,7 +247,7 @@ public class MyClass {
   public void unlockingInTryCatchButMissed() {
     Lock lock = new ReentrantLock();
     try {
-      lock.lock(); // Noncompliant
+      lock.lock();
     } finally {
       try {
         lock.unlock();

--- a/java-frontend/src/test/files/se/MaxSteps.java
+++ b/java-frontend/src/test/files/se/MaxSteps.java
@@ -15,6 +15,8 @@ class A {
     a &= (b() == C);
     a &= (b() == C);
     a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
 
     if (a) { //BOOM : 2^n -1 states are generated (where n is the number of lines of &= assignements in the above code) -> fail fast by not even enqueuing nodes
     }

--- a/java-frontend/src/test/files/se/NullDereferenceCheck.java
+++ b/java-frontend/src/test/files/se/NullDereferenceCheck.java
@@ -238,12 +238,15 @@ class NullPointerTest {
     if (var2.equals("")) { } // Compliant
   }
 
+  private void potentiallyRaiseException() throws Exception {
+  }
+
   public void testTry() {
     Object object = null;
     try {
       object = new Object();
     } catch (Exception e) {
-      object.hashCode(); // Noncompliant
+      object.hashCode(); // unreachable
     } finally {
       object.hashCode();
     }

--- a/java-frontend/src/test/files/se/Reproducer.java
+++ b/java-frontend/src/test/files/se/Reproducer.java
@@ -93,13 +93,16 @@ class A {
   private void try_finally() {
     boolean success = false;
     try {
-      foo();
+      potentiallyRaiseException();
       success = true;
     } finally {
       if(success) {
 
       }
     }
+  }
+
+  void potentiallyRaiseException() throws Exception {
   }
 
   void foo() {
@@ -163,4 +166,27 @@ class A {
       default:;
     }
   }
+
+ public void test_try_catch_finally() {
+   try {
+     noExceptionThrown();
+   } catch (Exception e) {
+     new java.io.FileReader("xxx"); // no accessible
+   }
+
+   try {
+     try {
+         potentiallyRaiseException();
+     } finally {
+       new java.io.BufferedReader(a); // Noncompliant
+     }
+   } catch (Exception e) {
+     new java.io.BufferedReader(a); // Noncompliant
+   } finally {
+     new java.io.BufferedReader(a); // Noncompliant
+   }
+
+   throw new Exception();
+   new java.io.BufferedReader(a); // no accessible
+ }
 }

--- a/java-frontend/src/test/files/se/UnclosedResourcesCheck.java
+++ b/java-frontend/src/test/files/se/UnclosedResourcesCheck.java
@@ -51,7 +51,7 @@ public class A {
   public void whileLoopHandling() {
     FileInputStream stream = new FileInputStream("myFile"); // Noncompliant {{Close this "FileInputStream".}}
     while(needsMore()) {
-      stream = new FileInputStream("myFile");
+      stream = new FileInputStream("myFile"); // Noncompliant {{Close this "FileInputStream".}}
       stream.read();
       stream.close();
     }
@@ -148,7 +148,7 @@ public class A {
   }
   
   public void closePrimary(String fileName) throws IOException {
-    InputStream fileIn = new FileInputStream(fileName);
+    InputStream fileIn = new FileInputStream(fileName); // Noncompliant {{Close this "FileInputStream".}}
     BufferedInputStream bufferIn = new BufferedInputStream(fileIn);
     Reader reader = new InputStreamReader(bufferIn, "UTF-16");
     reader.read();
@@ -156,7 +156,7 @@ public class A {
   }
   
   public void closeSecondary(String fileName) throws IOException {
-    InputStream fileIn = new FileInputStream(fileName);
+    InputStream fileIn = new FileInputStream(fileName); // Noncompliant {{Close this "FileInputStream".}}
     BufferedInputStream bufferIn = new BufferedInputStream(fileIn);
     Reader reader = new InputStreamReader(bufferIn, "UTF-16");
     reader.read();
@@ -164,7 +164,7 @@ public class A {
   }
   
   public void closeTertiary(String fileName) throws IOException {
-    InputStream fileIn = new FileInputStream(fileName);
+    InputStream fileIn = new FileInputStream(fileName); // Noncompliant {{Close this "FileInputStream".}}
     BufferedInputStream bufferIn = new BufferedInputStream(fileIn);
     Reader reader = new InputStreamReader(bufferIn, "UTF-16");
     reader.read();
@@ -174,7 +174,7 @@ public class A {
   public void forLoopHandling(int maxLoop) {
     FileInputStream stream = new FileInputStream("myFile"); // Noncompliant {{Close this "FileInputStream".}}
     for(int i = 0; i < maxLoop; i++) {
-      stream = new FileInputStream("myFile");
+      stream = new FileInputStream("myFile"); // Noncompliant {{Close this "FileInputStream".}}
       stream.read();
       stream.close();
     }
@@ -184,7 +184,7 @@ public class A {
   public void forEachLoopHandling(List<Object> objects) {
     FileInputStream stream = new FileInputStream("myFile"); // Noncompliant {{Close this "FileInputStream".}}
     for(Object object : objects) {
-      stream = new FileInputStream("myFile");
+      stream = new FileInputStream("myFile"); // Noncompliant {{Close this "FileInputStream".}}
       stream.read();
       stream.close();
     }
@@ -389,7 +389,7 @@ public class A {
     FileInputStream is = new FileInputStream("/tmp/foo"); // Compliant - used as parameter of closeQuietly method
     try {
     } finally {
-      closeQuietly(new FileInputStream("/tmp/foo"), is);
+      closeQuietly(new BufferedReader(inputStream), is);
     }
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -1004,7 +1004,7 @@ public class CFGTest {
       block(
         element(Kind.VARIABLE, "bar"),
         element(Kind.TRY_STATEMENT)
-      ).successors(5, 4).exit(4),
+      ).successors(5),
       block(
         element(Kind.NEW_CLASS),
         element(Kind.IDENTIFIER, "bar"),
@@ -1017,7 +1017,7 @@ public class CFGTest {
         element(Kind.IDENTIFIER, "foo"),
         element(Kind.METHOD_INVOCATION)
       ).successors(2),
-      new BlockChecker(1, 0).exit(0),
+      new BlockChecker(1, 0).successors(1),
       block(
         element(Kind.IDENTIFIER, "bar"),
         element(Kind.METHOD_INVOCATION)
@@ -1044,13 +1044,13 @@ public class CFGTest {
     CFGChecker cfgChecker = checker(
       block(
         element(Tree.Kind.TRY_STATEMENT)
-      ).successors(3, 0),
+      ).successors(3),
       block(
         element(Tree.Kind.IDENTIFIER, "fileName"),
         element(Kind.NEW_CLASS),
         element(Kind.VARIABLE, "file"),
         element(Kind.TRY_STATEMENT)
-      ).successors(1, 2).exit(1),
+      ).successors(2),
       block(
         element(Tree.Kind.IDENTIFIER, "file"),
         element(Tree.Kind.METHOD_INVOCATION)
@@ -1070,7 +1070,7 @@ public class CFGTest {
     CFGChecker cfgChecker = checker(
         block(
             element(Tree.Kind.TRY_STATEMENT)
-        ).successors(1, 2).exit(1),
+        ).successors(2),
         block(
             element(Tree.Kind.CHAR_LITERAL, "''"),
             element(Tree.Kind.IDENTIFIER, "System"),
@@ -1089,7 +1089,7 @@ public class CFGTest {
     cfgChecker = checker(
         block(
             element(Tree.Kind.TRY_STATEMENT)
-        ).successors(2, 3, 4),
+        ).successors(2),
         block(
             element(Tree.Kind.CHAR_LITERAL, "'e'"),
             element(Tree.Kind.IDENTIFIER, "foo"),
@@ -1105,7 +1105,7 @@ public class CFGTest {
             element(Tree.Kind.IDENTIFIER, "System"),
             element(Tree.Kind.MEMBER_SELECT),
             element(Tree.Kind.METHOD_INVOCATION)
-        ).successors(1, 3, 4),
+        ).successors(1),
         block(
             element(Tree.Kind.CHAR_LITERAL, "'finally'"),
             element(Tree.Kind.IDENTIFIER, "System"),
@@ -1123,12 +1123,11 @@ public class CFGTest {
     cfgChecker = checker(
         block(
             element(Tree.Kind.TRY_STATEMENT)
-        ).successors(1, 2),
+        ).successors(0),
         block(
             element(Tree.Kind.IDENTIFIER, "e"),
             element(Tree.Kind.INSTANCE_OF)
-        ).terminator(Tree.Kind.IF_STATEMENT).ifTrue(0).ifFalse(0),
-        new BlockChecker(0, 2) // particular case of a block with multiple successors but no instructions.
+        ).terminator(Tree.Kind.IF_STATEMENT).ifTrue(0).ifFalse(0)
     );
     cfgChecker.check(cfg);
     cfg = buildCFG(
@@ -1139,12 +1138,12 @@ public class CFGTest {
     cfgChecker = checker(
         block(
             element(Tree.Kind.TRY_STATEMENT)
-        ).successors(2, 3).exit(2),
+        ).successors(3),
         terminator(Kind.RETURN_STATEMENT).successors(2).exit(2),
         block(
             element(Tree.Kind.IDENTIFIER, "foo"),
             element(Kind.METHOD_INVOCATION)
-        ).successors(0, 1).exit(0),
+        ).successors(1).exit(0),
         block(
             element(Tree.Kind.IDENTIFIER, "bar"),
             element(Kind.METHOD_INVOCATION)
@@ -1321,7 +1320,7 @@ public class CFGTest {
         "} catch(Exception e) { foo();} bar(); }");
     CFGChecker cfgChecker = checker(
       block(
-        element(Tree.Kind.TRY_STATEMENT)).successors(3, 5),
+        element(Tree.Kind.TRY_STATEMENT)).successors(5),
       block(
         element(Tree.Kind.IDENTIFIER, "action")).terminator(Kind.IF_STATEMENT).successors(2, 4),
       block(
@@ -1332,7 +1331,7 @@ public class CFGTest {
         element(Kind.METHOD_INVOCATION)).successors(1),
       block(
         element(Tree.Kind.IDENTIFIER, "doSomething"),
-        element(Kind.METHOD_INVOCATION)).successors(1, 3),
+        element(Kind.METHOD_INVOCATION)).successors(1),
       block(
         element(Tree.Kind.IDENTIFIER, "bar"),
         element(Kind.METHOD_INVOCATION)).successors(0));
@@ -1347,18 +1346,17 @@ public class CFGTest {
         "} catch(Exception e) { foo();} bar(); }");
     cfgChecker = checker(
       block(
-        element(Tree.Kind.TRY_STATEMENT)).successors(3, 5),
+        element(Tree.Kind.TRY_STATEMENT)).successors(4),
       block(
         element(Tree.Kind.IDENTIFIER, "doSomething"),
         element(Kind.METHOD_INVOCATION),
-        element(Tree.Kind.IDENTIFIER, "action")).terminator(Kind.IF_STATEMENT).successors(2, 4),
+        element(Tree.Kind.IDENTIFIER, "action")).terminator(Kind.IF_STATEMENT).successors(1, 3),
       block(
         element(Tree.Kind.IDENTIFIER, "performAction"),
-        element(Kind.METHOD_INVOCATION)).successors(2),
+        element(Kind.METHOD_INVOCATION)).successors(1),
       block(
         element(Tree.Kind.IDENTIFIER, "foo"),
         element(Kind.METHOD_INVOCATION)).successors(1),
-      new BlockChecker(1, 3),
       block(
         element(Tree.Kind.IDENTIFIER, "bar"),
         element(Kind.METHOD_INVOCATION)).successors(0));
@@ -1373,7 +1371,7 @@ public class CFGTest {
         "} finally { foo();} bar(); }");
     cfgChecker = checker(
       block(
-        element(Tree.Kind.TRY_STATEMENT)).successors(2, 5),
+        element(Tree.Kind.TRY_STATEMENT)).successors(5),
       block(
         element(Tree.Kind.IDENTIFIER, "action")).terminator(Kind.IF_STATEMENT).successors(3, 4),
       block(
@@ -1384,7 +1382,7 @@ public class CFGTest {
         element(Kind.METHOD_INVOCATION)).successors(2),
       block(
         element(Tree.Kind.IDENTIFIER, "foo"),
-        element(Kind.METHOD_INVOCATION)).successors(0, 1),
+        element(Kind.METHOD_INVOCATION)).successors(1),
       block(
         element(Tree.Kind.IDENTIFIER, "bar"),
         element(Kind.METHOD_INVOCATION)).successors(0));

--- a/java-frontend/src/test/java/org/sonar/java/se/ExplodedGraphWalkerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ExplodedGraphWalkerTest.java
@@ -94,7 +94,7 @@ public class ExplodedGraphWalkerTest {
           tree.accept(new ExplodedGraphWalker());
           fail("Too many states were processed !");
         } catch (ExplodedGraphWalker.MaximumStepsReachedException exception) {
-          assertThat(exception.getMessage()).startsWith("reached limit of 10000 steps for method");
+          assertThat(exception.getMessage()).startsWith("reached limit of 50000 steps for method");
         }
       }
     });
@@ -109,7 +109,7 @@ public class ExplodedGraphWalkerTest {
           tree.accept(new ExplodedGraphWalker());
           fail("Too many states were processed !");
         } catch (ExplodedGraphWalker.MaximumStepsReachedException exception) {
-          assertThat(exception.getMessage()).startsWith("reached maximum number of 10000 branched states");
+          assertThat(exception.getMessage()).startsWith("reached maximum number of 50000 branched states");
         }
       }
     });


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

try-catch-finally is a very complex and cannot be simulate in
CFG during file analysis.

So, this change rewrite it in runtime during modify
ExplodedGraphWalker.

It will detect exception dynamically, and handle the diff
branches.

Signed-off-by: piggyran