### PR TITLE
add support for Hamcrest assertion with three arguments (squid:S2699)

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
@@ -79,6 +79,7 @@ public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileS
     methodWithoutParameter("org.assertj.core.api.Assertions", "shouldHaveThrown"),
     // hamcrest
     methodWithParameters("org.hamcrest.MatcherAssert", "assertThat").addParameter(ANY_TYPE).addParameter(ANY_TYPE),
+    methodWithParameters("org.hamcrest.MatcherAssert", "assertThat").addParameter(ANY_TYPE).addParameter(ANY_TYPE).addParameter(ANY_TYPE),
     // Mockito
     methodWithoutParameter(ORG_MOCKITO_MOCKITO, "verifyNoMoreInteractions"),
     methodWithoutParameter(ORG_MOCKITO_MOCKITO, "verifyZeroInteractions"),

--- a/java-checks/src/test/files/checks/AssertionsInTestsCheckHamcrest.java
+++ b/java-checks/src/test/files/checks/AssertionsInTestsCheckHamcrest.java
@@ -16,4 +16,9 @@ public class AssertionsInTestsCheckTest {
     org.hamcrest.MatcherAssert.assertThat(1, org.hamcrest.CoreMatchers.is(1));
   }
 
+  @Test
+  public void fakeTest2() {
+    org.hamcrest.MatcherAssert.assertThat("message", 1, org.hamcrest.CoreMatchers.is(1));
+  }
+
 }


### PR DESCRIPTION
Add support for Hamcrest assertion with three arguments for rule "Tests should include assertions - squid:S2699"