### PR TITLE
Make MeasurerTest compatible with Windows.

### DIFF
--- a/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
@@ -27,6 +27,7 @@ import org.sonar.api.batch.fs.internal.DefaultFileSystem;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.issue.NoSonarFilter;
+import org.sonar.api.utils.PathUtils;
 import org.sonar.squidbridge.api.CodeVisitor;
 
 import java.io.File;
@@ -114,7 +115,7 @@ public class MeasurerTest {
    * Utility method to quickly get metric out of a file.
    */
   private void checkMetric(String filename, String metric, Number expectedValue) {
-    String relativePath = new File(baseDir, filename).getPath();
+    String relativePath = PathUtils.sanitize(new File(baseDir, filename).getPath());
     DefaultInputFile inputFile = new DefaultInputFile(context.module().key(), relativePath);
     inputFile.setModuleBaseDir(fs.baseDirPath());
     fs.add(inputFile);


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

The Windows file.seperator is '\' which causes a mismatch between the project key constructed in the assertions compared to one in DefaultInputFile.

This will allow 'mvn clean install' to cleanly run out of the box on windows.