### PR TITLE
Readme fix and markdown readability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ sonar-java/its/ruling/target/actual/
 ``` 
 into the directory with the expected issues
 ```
-sonar-java/its/ruling/src/test/resources/expected/
+sonar-java/its/ruling/src/test/resources/
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you have an idea for a rule but you are not sure that everyone needs it you c
 
 ## <a name="testing"></a>Testing
 
-To run tests locally follow these instructions
+To run tests locally follow these instructions.
 
 ### Build the Project and Run Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -51,68 +51,53 @@ To run tests locally follow these instructions
 
 To build the plugin and run its unit tests, execute this command from the project's root directory:
 
-```
-mvn clean install
-```
+    mvn clean install
 
 ### Integration Tests
 
 To run integration tests, you will need to create a properties file like the one shown below, and set the url pointing to its location in an environment variable named `ORCHESTRATOR_CONFIG_URL`.
 
-```
-# version of SonarQube Server
-sonar.runtimeVersion=5.6
+    # version of SonarQube Server
+    sonar.runtimeVersion=5.6
 
-orchestrator.updateCenterUrl=http://update.sonarsource.org/update-center-dev.properties
-```
+    orchestrator.updateCenterUrl=http://update.sonarsource.org/update-center-dev.properties
 
 With for instance the `ORCHESTRATOR_CONFIG_URL` variable being set as: 
 
-```
-ORCHESTRATOR_CONFIG_URL=file:///home/user/workspace/orchestrator.properties
-```
+    ORCHESTRATOR_CONFIG_URL=file:///home/user/workspace/orchestrator.properties
 
 #### Plugin Test
 
 The "Plugin Test" is an additional integration test which verifies plugin features such as metric calculation, coverage etc. To launch it:
 
-```
-mvn clean install -Pit-plugin
-```  
+    mvn clean install -Pit-plugin
 
 #### Ruling Test
 
 The "Ruling Test" is a special integration test which launches the analysis of a large code base, saves the issues created by the plugin in report files, and then compares those results to the set of expected issues (stored as JSON files).
 
-* To run the test, first make sure the submodules are checked out:
-```
-  git submodule init 
-  git submodule update
-```  
-* Launch ruling test 
-```
-cd its/ruling
-mvn clean install -DskipTests=false
-```  
+To run the test, first make sure the submodules are checked out:
+
+    git submodule init 
+    git submodule update
+
+Launch ruling test:
+
+    cd its/ruling
+    mvn clean install -DskipTests=false
 
 This test gives you the opportunity to examine the issues created by each rule and make sure they're what you expect. You can inspect new/lost issues checking web-pages mentioned in the logs at the end of analysis:
 
-```
-INFO  - HTML Issues Report generated: /path/to/project/sonar-java/its/sources/src/.sonar/issues-report/issues-report.html
-INFO  - Light HTML Issues Report generated: /path/to/project/sonar-java/its/sources/src/.sonar/issues-report/issues-report-light.html
-```
+    INFO  - HTML Issues Report generated: /path/to/project/sonar-java/its/sources/src/.sonar/issues-report/issues-report.html
+    INFO  - Light HTML Issues Report generated: /path/to/project/sonar-java/its/sources/src/.sonar/issues-report/issues-report-light.html
 
-If everything looks good to you, you can copy the file with the actual issues located at
+If everything looks good to you, you can copy the file with the actual issues located at:
 
-```
-its/ruling/target/actual/
-``` 
+    its/ruling/target/actual/
 
-into the directory with the expected issues
+Into the directory with the expected issues:
 
-```
-its/ruling/src/test/resources/
-```
+    its/ruling/src/test/resources/
 
 For example using the command:
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ This is the plugin for the [SonarQube](http://www.sonarqube.org/) platform which
 
 [![Build Status](https://api.travis-ci.org/SonarSource/sonar-java.svg)](https://travis-ci.org/SonarSource/sonar-java)
 
-## Features
+Features
+--------
 
 * 370+ rules (including 80+ bug detection)
 * Metrics (complexity, number of lines etc.)
 * Import of [test coverage reports](http://docs.sonarqube.org/display/PLUG/Code+Coverage+by+Unit+Tests+for+Java+Project)
 * [Custom rules](http://docs.sonarqube.org/display/DEV/Custom+Rules+for+Java)
 
-## Useful links
+Useful links
+------------
 
 * [Project homepage](http://docs.sonarqube.org/display/PLUG/Java+Plugin)
 * [Issue tracking](http://jira.sonarsource.com/browse/SONARJAVA)
@@ -22,12 +24,14 @@ This is the plugin for the [SonarQube](http://www.sonarqube.org/) platform which
 * [Google Group for feedback](https://groups.google.com/forum/#!forum/sonarqube)
 * [Demo project analysis](https://nemo.sonarqube.org/overview?id=org.sonarsource.sonarqube%3Asonarqube)
 
-## Have question or feedback?
+Have question or feedback?
+--------------------------
 
 To provide feedback (request a feature, report a bug etc.) use the [SonarQube Google Group](https://groups.google.com/forum/#!forum/sonarqube). Please do not forget to specify the language (Java!), plugin version and SonarQube version.
 If you have a question on how to use plugin (and the [docs](http://docs.sonarqube.org/display/PLUG/Java+Plugin) don't help you) direct it to [StackOverflow](http://stackoverflow.com/questions/tagged/sonarqube+java) tagged both `sonarqube` and `java`.
 
-## Contributing
+Contributing
+------------
 
 ### Topic in SonarQube Google Group
 
@@ -41,7 +45,9 @@ To submit a contribution, create a pull request for this repository. Please make
 
 If you have an idea for a rule but you are not sure that everyone needs it you can implement a [custom rule](http://docs.sonarqube.org/x/hQBJ) available only for you.
 
-## <a name="testing"></a>Testing
+<a name="testing"></a>
+Testing
+-------
 
 To run tests locally follow these instructions.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 SonarQube Java Analyzer [![Build Status](https://travis-ci.org/SonarSource/sonar-java.svg?branch=master)](https://travis-ci.org/SonarSource/sonar-java) 
 ==========
+
 This is the plugin for the [SonarQube](http://www.sonarqube.org/) platform which provides [static analysis](https://en.wikipedia.org/wiki/Static_program_analysis) of Java code. It will allow you to produce stable and easily supported code by helping you find and correct bugs, vulnerabilities and smells in your code.
 
 ### Build status
+
 ##### All branches
+
 [![Build Status](https://api.travis-ci.org/SonarSource/sonar-java.svg)](https://travis-ci.org/SonarSource/sonar-java)
 
-
 # Features
+
 * 370+ rules (including 80+ bug detection)
 * Metrics (complexity, number of lines etc.)
 * Import of [test coverage reports](http://docs.sonarqube.org/display/PLUG/Code+Coverage+by+Unit+Tests+for+Java+Project)
@@ -22,31 +25,40 @@ This is the plugin for the [SonarQube](http://www.sonarqube.org/) platform which
 * [Demo project analysis](https://nemo.sonarqube.org/overview?id=org.sonarsource.sonarqube%3Asonarqube)
 
 # Have question or feedback?
+
 To provide feedback (request a feature, report a bug etc.) use the [SonarQube Google Group](https://groups.google.com/forum/#!forum/sonarqube). Please do not forget to specify the language (Java!), plugin version and SonarQube version.
 If you have a question on how to use plugin (and the [docs](http://docs.sonarqube.org/display/PLUG/Java+Plugin) don't help you) direct it to [StackOverflow](http://stackoverflow.com/questions/tagged/sonarqube+java) tagged both `sonarqube` and `java`.
 
 # Contributing
 
 ### Topic in SonarQube Google Group
+
 To request a new feature, please create a new thread in [SonarQube Google Group](https://groups.google.com/forum/#!forum/sonarqube). Even if you plan to implement it yourself and submit it back to the community, please start a new thread first to be sure that we can use it.
 
 ### Pull Request (PR)
+
 To submit a contribution, create a pull request for this repository. Please make sure that you follow our [code style](https://github.com/SonarSource/sonar-developer-toolset#code-style) and all [tests](#testing) are passing (Travis build is created for each PR).
 
 ### Custom Rules
+
 If you have an idea for a rule but you are not sure that everyone needs it you can implement a [custom rule](http://docs.sonarqube.org/x/hQBJ) available only for you.
 
 # <a name="testing"></a>Testing
+
 To run tests locally follow these instructions
 
 ### Build the Project and Run Unit Tests
+
 To build the plugin and run its unit tests, execute this command from the project's root directory:
+
 ```
 mvn clean install
 ```
 
 ### Integration Tests
+
 To run integration tests, you will need to create a properties file like the one shown below, and set the url pointing to its location in an environment variable named `ORCHESTRATOR_CONFIG_URL`.
+
 ```
 # version of SonarQube Server
 sonar.runtimeVersion=5.6
@@ -55,17 +67,21 @@ orchestrator.updateCenterUrl=http://update.sonarsource.org/update-center-dev.pro
 ```
 
 With for instance the `ORCHESTRATOR_CONFIG_URL` variable being set as: 
+
 ```
 ORCHESTRATOR_CONFIG_URL=file:///home/user/workspace/orchestrator.properties
 ```
 
 #### Plugin Test
+
 The "Plugin Test" is an additional integration test which verifies plugin features such as metric calculation, coverage etc. To launch it:
+
 ```
 mvn clean install -Pit-plugin
 ```  
 
 #### Ruling Test
+
 The "Ruling Test" is a special integration test which launches the analysis of a large code base, saves the issues created by the plugin in report files, and then compares those results to the set of expected issues (stored as JSON files).
 
 * To run the test, first make sure the submodules are checked out:
@@ -80,16 +96,20 @@ mvn clean install -DskipTests=false
 ```  
 
 This test gives you the opportunity to examine the issues created by each rule and make sure they're what you expect. You can inspect new/lost issues checking web-pages mentioned in the logs at the end of analysis:
+
 ```
 INFO  - HTML Issues Report generated: /path/to/project/sonar-java/its/sources/src/.sonar/issues-report/issues-report.html
 INFO  - Light HTML Issues Report generated: /path/to/project/sonar-java/its/sources/src/.sonar/issues-report/issues-report-light.html
-
 ```
+
 If everything looks good to you, you can copy the file with the actual issues located at
+
 ```
 its/ruling/target/actual/
 ``` 
+
 into the directory with the expected issues
+
 ```
 its/ruling/src/test/resources/
 ```

--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ into the directory with the expected issues
 ```
 its/ruling/src/test/resources/
 ```
+
+For example using the command:
+
+    cp its/ruling/target/actual/* its/ruling/src/test/resources/

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ INFO  - Light HTML Issues Report generated: /path/to/project/sonar-java/its/sour
 ```
 If everything looks good to you, you can copy the file with the actual issues located at
 ```
-sonar-java/its/ruling/target/actual/
+its/ruling/target/actual/
 ``` 
 into the directory with the expected issues
 ```
-sonar-java/its/ruling/src/test/resources/
+its/ruling/src/test/resources/
 ```

--- a/README.md
+++ b/README.md
@@ -3,20 +3,18 @@ SonarQube Java Analyzer [![Build Status](https://travis-ci.org/SonarSource/sonar
 
 This is the plugin for the [SonarQube](http://www.sonarqube.org/) platform which provides [static analysis](https://en.wikipedia.org/wiki/Static_program_analysis) of Java code. It will allow you to produce stable and easily supported code by helping you find and correct bugs, vulnerabilities and smells in your code.
 
-### Build status
-
-##### All branches
+**Build status (all branches)**
 
 [![Build Status](https://api.travis-ci.org/SonarSource/sonar-java.svg)](https://travis-ci.org/SonarSource/sonar-java)
 
-# Features
+## Features
 
 * 370+ rules (including 80+ bug detection)
 * Metrics (complexity, number of lines etc.)
 * Import of [test coverage reports](http://docs.sonarqube.org/display/PLUG/Code+Coverage+by+Unit+Tests+for+Java+Project)
 * [Custom rules](http://docs.sonarqube.org/display/DEV/Custom+Rules+for+Java)
 
-# Useful links
+## Useful links
 
 * [Project homepage](http://docs.sonarqube.org/display/PLUG/Java+Plugin)
 * [Issue tracking](http://jira.sonarsource.com/browse/SONARJAVA)
@@ -24,12 +22,12 @@ This is the plugin for the [SonarQube](http://www.sonarqube.org/) platform which
 * [Google Group for feedback](https://groups.google.com/forum/#!forum/sonarqube)
 * [Demo project analysis](https://nemo.sonarqube.org/overview?id=org.sonarsource.sonarqube%3Asonarqube)
 
-# Have question or feedback?
+## Have question or feedback?
 
 To provide feedback (request a feature, report a bug etc.) use the [SonarQube Google Group](https://groups.google.com/forum/#!forum/sonarqube). Please do not forget to specify the language (Java!), plugin version and SonarQube version.
 If you have a question on how to use plugin (and the [docs](http://docs.sonarqube.org/display/PLUG/Java+Plugin) don't help you) direct it to [StackOverflow](http://stackoverflow.com/questions/tagged/sonarqube+java) tagged both `sonarqube` and `java`.
 
-# Contributing
+## Contributing
 
 ### Topic in SonarQube Google Group
 
@@ -43,7 +41,7 @@ To submit a contribution, create a pull request for this repository. Please make
 
 If you have an idea for a rule but you are not sure that everyone needs it you can implement a [custom rule](http://docs.sonarqube.org/x/hQBJ) available only for you.
 
-# <a name="testing"></a>Testing
+## <a name="testing"></a>Testing
 
 To run tests locally follow these instructions
 


### PR DESCRIPTION
* Fix the path of expected issues files, it was outdated and misleading. Also added `cp` command for easy copy-paste
* Adjust the markdown format to make it more readable (line breaks between formatting units) in plain text form
* Use indented code blocks instead of GitHub specific <code>```</code> fences: equivalent writing style but not GitHub specific, and more readable
* Use h1 style for title only, use h2 for the rest
* Don't skip heading levels like h3 -> h6, reorganize to always change one step at a time, like h3 -> h4
* Other minor improvements (punctuation, misc)
