### PR TITLE
SONARJAVA-1783 Add handling of  MessageFormat to rule S2275

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2275_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2275_java.html
@@ -1,7 +1,7 @@
 <p>Because <code>printf</code>-style format strings are interpreted at runtime, rather than validated by the Java compiler, they can contain errors
 that lead to unexpected behavior or runtime errors. This rule statically validates the good behavior of <code>printf</code>-style formats when calling
-the <code>format(...)</code> methods of <code>java.util.Formatter</code>, <code>java.lang.String</code>, <code>java.io.PrintStream</code> and
-<code>java.io.PrintWriter</code> classes and the <code>printf(...)</code> methods of <code>java.io.PrintStream</code>
+the <code>format(...)</code> methods of <code>java.util.Formatter</code>, <code>java.lang.String</code>, <code>java.io.PrintStream</code>,
+<code>MessageFormat</code>, and <code>java.io.PrintWriter</code> classes and the <code>printf(...)</code> methods of <code>java.io.PrintStream</code>
 or <code>java.io.PrintWriter</code> classes. </p>
 <h2>Noncompliant Code Example</h2>
 <pre>
@@ -17,6 +17,13 @@ String.format("%&lt; is equals to %d", 2);   //Noncompliant; the argument index 
 String.format("Is myObject null ? %b", myObject);   //Noncompliant; when a non-boolean argument is formatted with %b, it prints true for any nonnull value, and false for null. Even if intended, this is misleading. It's better to directly inject the boolean value (myObject == null in this case)
 String.format("value is " + value); // Noncompliant
 String s = String.format("string without arguments"); // Noncompliant
+
+MessageFormat.format("Result {1}.", value); // Noncompliant; Not enough arguments. (first element is {0})
+MessageFormat.format("Result '{0}'.", value); // Noncompliant; String contains no format specifiers. (quote are discarding format specifiers)
+MessageFormat.format("Result {{0}.", value); // Noncompliant; Unbalanced number of curly brace (single curly braces should be escaped)
+MessageFormat.format("Result ' {0}", value); // Noncompliant; Unbalanced number of quotes (single quote must be escaped)
+MessageFormat.format("Result {0}.", value, value);  // Noncompliant; 2nd argument is not used
+MessageFormat.format("Result {0}.", myObject.toString()); // Noncompliant; no need to call toString() on objects
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
@@ -32,6 +39,11 @@ String.format("%d is equals to %&lt;", 2);
 String.format("Is myObject null ? %b", myObject == null);
 String.format("value is %d", value);
 String s = "string without arguments";
+
+MessageFormat.format("Result {0}.", value);
+MessageFormat.format("Result '{0}'  =  {0}", value);
+MessageFormat.format("Result {0} &amp; {1}.", value, value);
+MessageFormat.format("Result {0}.", myObject);
 </pre>
 <h2>See</h2>
 <ul>

--- a/java-checks/src/test/files/checks/PrintfCheck.java
+++ b/java-checks/src/test/files/checks/PrintfCheck.java
@@ -1,5 +1,7 @@
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.text.FieldPosition;
+import java.text.MessageFormat;
 import java.util.Formatter;
 import java.util.GregorianCalendar;
 import java.util.Locale;
@@ -57,7 +59,7 @@ class A {
     ps.printf(loc, "string without arguments"); // Noncompliant  {{String contains no format specifiers.}}
     formatter.format("string without arguments"); // Noncompliant  {{String contains no format specifiers.}}
     formatter.format(loc, "string without arguments"); // Noncompliant  {{String contains no format specifiers.}}
-    
+
     pr.format("value is " + value); // Noncompliant {{Format specifiers should be used instead of string concatenation.}}
     pr.format(loc, "value is " + value); // Noncompliant {{Format specifiers should be used instead of string concatenation.}}
     pr.printf("value is " + value); // Noncompliant {{Format specifiers should be used instead of string concatenation.}}
@@ -75,9 +77,27 @@ class A {
     String.format("value is %d", value); // Compliant
 
     String.format("%0$s", "tmp"); // Noncompliant {{Arguments are numbered starting from 1.}}
-    
+
     String.format("Dude's Birthday: %1$tm %<te,%<tY", c); // Compliant
     String.format("Dude's Birthday: %1$tm %1$te,%1$tY", c); // Compliant
     String.format("log/protocol_%tY_%<tm_%<td_%<tH_%<tM_%<tS.zip", new java.util.Date());
+
+    MessageFormat messageFormat = new MessageFormat("{0}");
+    messageFormat.format(new Object(), new StringBuffer(), new FieldPosition(0)); // Compliant - Not considered
+    messageFormat.format(new Object()); // Compliant - Not considered
+    messageFormat.format("");  // Compliant - Not considered
+
+    MessageFormat.format("{0,number,$'#',##}", value); // Compliant
+    MessageFormat.format("Result ''{0}''.", 14); // Compliant
+    MessageFormat.format("Result '{0}'", 14); // Noncompliant {{String contains no format specifiers.}}
+    MessageFormat.format("Result ' {0}", 14); // Noncompliant {{Single quote "'" must be escaped.}}
+    MessageFormat.format("Result {{{0}}.", 14); // Noncompliant {{Single left curly braces "{" must be escaped.}}
+    MessageFormat.format("Result {0}!", myObject.toString()); // Noncompliant {{No need to call toString "method()" as formatting and string conversion is done by the Formatter.}}
+    MessageFormat.format("Result {0}!", myObject.hashCode()); // Compliant
+    MessageFormat.format("Result yeah!", 14); // Noncompliant {{String contains no format specifiers.}}
+    MessageFormat.format("Result {1}!", 14); // Noncompliant {{Not enough arguments.}}
+    MessageFormat.format("Result {0} and {1}!", 14); // Noncompliant {{Not enough arguments.}}
+    MessageFormat.format("Result {0} and {0}!", 14, 42); // Noncompliant {{2nd argument is not used.}}
+    MessageFormat.format("Result {0} and {1}!", 14, 42, 128); // Noncompliant {{3rd argument is not used.}}
   }
 }


### PR DESCRIPTION
Rule now detect call to "MessageFormat.format()" with:
- too few arguments;
- too many arguments;
- unbalanced quote or curly braces;
- useless calls to "toString()" in arguments.