### PR TITLE
SONARJAVA-1336: Improve S128 to handle more situations

### DIFF
--- a/its/ruling/src/test/resources/jdk6/squid-S128.json
+++ b/its/ruling/src/test/resources/jdk6/squid-S128.json
@@ -45,6 +45,10 @@
 3660,
 3735,
 ],
+'jdk6:java/awt/geom/Path2D.java':[
+641,
+1366,
+],
 'jdk6:java/io/FilePermission.java':[
 482,
 ],
@@ -55,12 +59,11 @@
 115,
 157,
 ],
+'jdk6:java/net/PlainDatagramSocketImpl.java':[
+335,
+],
 'jdk6:java/net/SocketPermission.java':[
 557,
-],
-'jdk6:java/text/DecimalFormat.java':[
-1998,
-2048,
 ],
 'jdk6:java/text/MessageFormat.java':[
 465,
@@ -69,8 +72,8 @@
 289,
 ],
 'jdk6:java/util/regex/Pattern.java':[
-1803,
-2208,
+1879,
+1967,
 2643,
 ],
 }

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S128_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S128_java.html
@@ -39,6 +39,8 @@ switch (myVariable) {
     return;
   case 3:                                // Use of throw statement
     throw new IllegalStateException();
+  case 4:                                // Use of continue statement
+    continue;
   default:                               // For the last case, use of break statement is optional
     doSomethingElse();
 }

--- a/java-checks/src/test/files/checks/SwitchCaseWithoutBreakCheck.java
+++ b/java-checks/src/test/files/checks/SwitchCaseWithoutBreakCheck.java
@@ -1,12 +1,20 @@
 class A {
-  private void f() {
+
+  private A(boolean test) {
+    if (test)
+      throw new Exception();
+  }
+
+  private void f(byte b, char c) {
     int myVariable = 0;
     switch (myVariable) {
       case 0:
       case 1: // Noncompliant {{End this switch case with an unconditional break, return or throw statement.}} [[sc=7;ec=14]]
-        System.out.println();
+        System.out.println("Test");
       case 2: // Compliant
         break;
+      case (8 | 2): // Noncompliant {{End this switch case with an unconditional break, return or throw statement.}} [[sc=7;ec=20]]
+        System.out.println("Test");
       case 3: // Compliant
         return;
       case 4: // Compliant
@@ -24,12 +32,30 @@ class A {
           break;
         }
       }
+      case 12: // Compliant
+        try {
+          return new A(true);
+        } catch (Exception e) {
+          throw new RuntimeException("Wrapping", e);
+        }
+      case 13: // Noncompliant
+        try {
+          return new A(true);
+        } catch (Exception e) {
+          System.out.println("Error");
+        }
+      case 14: // Noncompliant
+        try {
+          int i = i / b;
+        } catch (Exception e) {
+          throw new RuntimeException("Wrapping", e);
+        }
       case 9: // Compliant
     }
 
     for (int i = 0; i < 1; i++) {
       switch (myVariable) {
-        case 0: // Noncompliant
+        case 0: // Compliant
           continue; // belongs to for loop
         case 1:
           break;
@@ -73,6 +99,110 @@ class A {
 
     switch(myVariable) {
 
+    }
+
+    switch (b) {
+      case (byte) 0: // Compliant
+        break;
+      case (byte) 1: // Noncompliant {{End this switch case with an unconditional break, return or throw statement.}} [[sc=7;ec=21]]
+        System.out.println("Test");
+      case 2: // Compliant
+        break;
+      case 3: // Noncompliant {{End this switch case with an unconditional break, return or throw statement.}} [[sc=7;ec=14]]
+        System.out.println("Test 2");
+      case 4:
+        break;
+    }
+
+    switch (c) {
+      case 'c': // Compliant
+        break;
+      case 'a': // Noncompliant {{End this switch case with an unconditional break, return or throw statement.}} [[sc=7;ec=16]]
+        System.out.println("Test");
+      case 'd': // Compliant
+        break;
+      case 'e': // Noncompliant {{End this switch case with an unconditional break, return or throw statement.}} [[sc=7;ec=16]]
+        System.out.println("Test 2");
+      case 'x':
+        break;
+    }
+  }
+}
+
+class S128 {
+
+  void compliantFlows() {
+    int i = 0;
+    switch (i) {
+      case 0:
+        System.out.println("OK");
+        break;
+      case 1: // Noncompliant
+        System.out.println("No floor ):");
+      default:
+        System.out.println("ERROR");
+        break;
+      case 2:
+        System.out.println("WARN");
+        break;
+    }
+  }
+
+}
+
+class Conditions {
+  public void test(int j) {
+    int i = 0;
+    switch (i) {
+      case 0: // Compliant
+        if (j == 0) {
+          break;
+        } else {
+          break;
+        }
+      case 1: { // Compliant
+        if (j != 0) {
+          break;
+        } else {
+          break;
+        }
+      }
+      case 2: // Compliant
+        if (j == 0)
+          break;
+        else
+          break;
+      case 3: { // Compliant
+        if (j != 0)
+          break;
+        else
+          break;
+      }
+      case 4: // Noncompliant
+        if (j == 0)
+          break;
+      case 5: // Compliant
+        break;
+      case 6: // Noncompliant
+        if (j == 0) {
+          System.out.println(j);
+        } else {
+          break;
+        }
+      case 8:
+        break;
+      default: // Noncompliant
+        if (j == 1)
+          break;
+      case 9:
+        break;
+      case 7: // Noncompliant
+        if (j == 0)
+          System.out.println(j);
+        else
+          break;
+      case 12: // Compliant, last case in statement
+        System.out.println(j);
     }
   }
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

Now handles the cases by analyzing the various paths. 
I played around with secondary issue marking a little but getting it to markdown the most precise location(or locations in case multiple branches fail the constraint) was starting to add more and more code. So I decided that within my solution adding secondary flagging would clutter the code too much.

Feel free to shoot this solution down if I failed to grasp on how to tackle this problem properly.

During development I found that adding an irrelevant block after the switch statement could influence which call were being made to `checkPreStatement` which I couldn't really explain. If you're interested in those see [this branch](https://github.com/Johnnei/sonar-java/tree/SONARJAVA-1336-weird-behaviour) example test case: `java-frontend/src/test/files/se/SwitchCaseWithoutBreakCheck.java` (Line 94). Edit: I've did some more research and found that swapping the CFG building of the case labels and body fixes the test, but breaks the CFG checker (creates empty blocks). Still seems weird to me
