### PR TITLE
SONARJAVA-1793: Add support for Truth framework assertions.

### DIFF
--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -18,7 +18,7 @@
       <artifactId>java-frontend</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-checks-testkit</artifactId>
@@ -192,6 +192,11 @@
                   <groupId>org.easymock</groupId>
                   <artifactId>easymock</artifactId>
                   <version>3.4</version>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.google.truth</groupId>
+                  <artifactId>truth</artifactId>
+                  <version>0.29</version>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-jars</outputDirectory>

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
@@ -37,6 +37,7 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
 
   private static final String FEST_ASSERT_SUPERTYPE = "org.fest.assertions.Assert";
   private static final String ASSERTJ_SUPERTYPE = "org.assertj.core.api.AbstractAssert";
+  private static final String TRUTH_SUPERTYPE = "com.google.common.truth.TestVerb";
   private static final MethodMatcher MOCKITO_VERIFY = MethodMatcher.create()
     .typeDefinition("org.mockito.Mockito").name("verify").withNoParameterConstraint();
 
@@ -51,7 +52,9 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
     assertThatOnType("org.assertj.core.api.Assertions"),
     assertThatOnType("org.assertj.core.api.AbstractStandardSoftAssertions"),
     // AssertJ 3.X
-    assertThatOnType("org.assertj.core.api.StrictAssertions")
+    assertThatOnType("org.assertj.core.api.StrictAssertions"),
+    // Truth 0.29
+    methodWithName("com.google.common.truth.Truth", NameCriteria.startsWith("assert"))
   );
 
   private static final MethodMatcherCollection FEST_LIKE_EXCLUSIONS = MethodMatcherCollection.create(
@@ -64,7 +67,8 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
     methodWithName(ASSERTJ_SUPERTYPE, NameCriteria.startsWith("using")),
     methodWithName(ASSERTJ_SUPERTYPE, NameCriteria.startsWith("with")),
     methodWithName(ASSERTJ_SUPERTYPE, NameCriteria.is("describedAs")),
-    methodWithName(ASSERTJ_SUPERTYPE, NameCriteria.is("overridingErrorMessage"))
+    methodWithName(ASSERTJ_SUPERTYPE, NameCriteria.is("overridingErrorMessage")),
+    methodWithName(TRUTH_SUPERTYPE, NameCriteria.is("that"))
   );
 
   private Boolean chainedToAnyMethodButFestExclusions = null;

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
@@ -45,6 +45,7 @@ import java.util.List;
 public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileScanner {
 
   private static final String VERIFY = "verify";
+  private static final String ASSERT_NAME = "assert";
   private static final String ASSERT_THAT_NAME = "assertThat";
   private static final String ORG_MOCKITO_MOCKITO = "org.mockito.Mockito";
 
@@ -61,10 +62,10 @@ public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileS
 
   private static final MethodMatcherCollection ASSERTION_INVOCATION_MATCHERS = MethodMatcherCollection.create(
     // junit
-    methodWithoutParameter("org.junit.Assert", NameCriteria.startsWith("assert")),
+    methodWithoutParameter("org.junit.Assert", NameCriteria.startsWith(ASSERT_NAME)),
     methodWithoutParameter("org.junit.Assert", "fail"),
     methodWithoutParameter("org.junit.rules.ExpectedException", NameCriteria.startsWith("expect")),
-    methodWithoutParameter(TypeCriteria.subtypeOf("junit.framework.Assert"), NameCriteria.startsWith("assert")),
+    methodWithoutParameter(TypeCriteria.subtypeOf("junit.framework.Assert"), NameCriteria.startsWith(ASSERT_NAME)),
     methodWithoutParameter(TypeCriteria.subtypeOf("junit.framework.Assert"), STARTS_WITH_FAIL),
     // fest 1.x
     methodWithoutParameter(TypeCriteria.subtypeOf("org.fest.assertions.GenericAssert"), ANY_NAME),
@@ -89,7 +90,9 @@ public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileS
     // EasyMock
     methodWithoutParameter("org.easymock.EasyMock", VERIFY),
     methodWithoutParameter(TypeCriteria.subtypeOf("org.easymock.IMocksControl"), VERIFY),
-    methodWithoutParameter(TypeCriteria.subtypeOf("org.easymock.EasyMockSupport"), "verifyAll")
+    methodWithoutParameter(TypeCriteria.subtypeOf("org.easymock.EasyMockSupport"), "verifyAll"),
+    // Truth Framework
+    methodWithoutParameter("com.google.common.truth.Truth", NameCriteria.startsWith(ASSERT_NAME))
   );
 
   private final Deque<Boolean> methodContainsAssertion = new ArrayDeque<>();

--- a/java-checks/src/test/files/checks/AssertionsCompletenessCheck.java
+++ b/java-checks/src/test/files/checks/AssertionsCompletenessCheck.java
@@ -2,6 +2,7 @@ import org.fest.assertions.BooleanAssert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.fest.assertions.Assertions;
+import com.google.common.truth.Truth;
 
 import java.util.Comparator;
 import java.util.List;
@@ -82,5 +83,16 @@ class AssertionsCompleteness {
     org.assertj.core.api.SoftAssertions softly = new org.assertj.core.api.SoftAssertions();
     softly.assertThat(1); // Noncompliant
     softly.assertAll();
+  }
+
+  @Test
+  public void testTruthFramework() {
+    boolean b = true;
+    Truth.assertThat(b).isTrue();
+    String s = "Hello Truth Framework World!";
+    Truth.assertThat(s).contains("Hello");
+    Truth.assertThat(b); // Noncompliant
+    Truth.assertWithMessage("Invalid option").that(b).isFalse();
+    Truth.assertWithMessage("Invalid option").that(b); // Noncompliant
   }
 }

--- a/java-checks/src/test/files/checks/AssertionsInTestsCheckTruth.java
+++ b/java-checks/src/test/files/checks/AssertionsInTestsCheckTruth.java
@@ -1,0 +1,37 @@
+import com.google.common.truth.Truth;
+import org.junit.Test;
+
+public class AssertionsInTestsCheckTest {
+
+  @Test
+  public void test0() { // Compliant
+    boolean b = true;
+    // do something
+    Truth.assertThat(b).isTrue();
+  }
+
+  @Test
+  public void test1() { // Compliant
+    String s = "Hello Truth Framework World!";
+
+    Truth.assertThat(s).contains("Hello");
+  }
+
+  @Test
+  public void test3() { // Compliant
+    boolean b = true;
+    Truth.assertThat(b);
+  }
+
+  @Test
+  public void test4() { // Compliant
+    boolean b = true;
+    Truth.assertWithMessage("Invalid option").that(b).isFalse();
+  }
+
+  @Test
+  public void test5() { // Compliant
+    boolean b = true;
+    Truth.assertWithMessage("Invalid option").that(b);
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/AssertionsInTestsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AssertionsInTestsCheckTest.java
@@ -56,4 +56,9 @@ public class AssertionsInTestsCheckTest {
     JavaCheckVerifier.verify("src/test/files/checks/AssertionsInTestsCheckEasyMock.java", check);
   }
 
+  @Test
+  public void truth() {
+    JavaCheckVerifier.verifyNoIssue("src/test/files/checks/AssertionsInTestsCheckTruth.java", check);
+  }
+
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

A method invocation on the 'Subject' base-type of the Truth framework will
be considered as an assertion call.