### PR TITLE
SONARJAVA-1835 S2275: FP on message format using '%n' but no parameter

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/PrintfCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PrintfCheck.java
@@ -112,12 +112,16 @@ public class PrintfCheck extends AbstractMethodDetection {
       return;
     }
     checkLineFeed(formatString, mit);
-    cleanupLineSeparator(params);
-    if (checkEmptyParams(mit, params)
-      || checkArgumentNumber(mit, argIndexes(params).size(), args.size())) {
+    if (checkEmptyParams(mit, params)) {
       return;
     }
-    verifyParameters(mit, args, params);
+    cleanupLineSeparator(params);
+    if (!params.isEmpty()) {
+      if (checkArgumentNumber(mit, argIndexes(params).size(), args.size())) {
+        return;
+      }
+      verifyParameters(mit, args, params);
+    }
   }
 
   private void handleMessageFormat(MethodInvocationTree mit, String formatString, List<ExpressionTree> args) {
@@ -264,11 +268,11 @@ public class PrintfCheck extends AbstractMethodDetection {
   }
 
   private static void cleanupLineSeparator(List<String> params) {
-    // Cleanup %n and %% values
+    // Cleanup %n values
     Iterator<String> iter = params.iterator();
     while (iter.hasNext()) {
       String param = iter.next();
-      if ("n".equals(param) || "%".equals(param)) {
+      if ("n".equals(param)) {
         iter.remove();
       }
     }
@@ -403,7 +407,10 @@ public class PrintfCheck extends AbstractMethodDetection {
           param.append(matcher.group(groupIndex));
         }
       }
-      params.add(param.toString());
+      String specifier = param.toString();
+      if(!"%".equals(specifier)) {
+        params.add(specifier);
+      }
     }
     return params;
   }

--- a/java-checks/src/test/files/checks/PrintfCheck.java
+++ b/java-checks/src/test/files/checks/PrintfCheck.java
@@ -19,7 +19,9 @@ class A {
     String.format("Too many arguments %d and %d", 1, 2, 3);  // Noncompliant {{3rd argument is not used.}}
     String.format("Not enough arguments %d and %d", 1);  // Noncompliant {{Not enough arguments.}}
     String.format("First Line\n %d", 1); // Noncompliant {{%n should be used in place of \n to produce the platform-specific line separator.}}
-    String.format("First Line");// Noncompliant {{String contains no format specifiers.}}
+    String.format("First Line");   // Noncompliant {{String contains no format specifiers.}}
+    String.format("First Line%%"); // Noncompliant {{String contains no format specifiers.}}
+    String.format("First Line%n"); // Compliant
     String.format("%< is equals to %d", 2);   // Noncompliant {{The argument index '<' refers to the previous format specifier but there isn't one.}}
     String.format("Is myObject null ? %b", myObject);   // Noncompliant {{Directly inject the boolean value.}}
     String.format("value is " + value); // Noncompliant {{Format specifiers should be used instead of string concatenation.}}


### PR DESCRIPTION
Change to support "%n":
- "checkEmptyParams" is called before "cleanupLineSeparator" to take into account "%n"

Change the way "%%" is handled:
- "getParameters" now ignore "%%", so no need to clean "%%" in "cleanupLineSeparator"