### PR TITLE
SONARJAVA-1950 Fix Magic Number Check

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/MagicNumberCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/MagicNumberCheck.java
@@ -61,7 +61,7 @@ public class MagicNumberCheck extends BaseTreeVisitor implements JavaFileScanner
     this.context = context;
     this.authorizedNumbersList = new ArrayList<>();
     for (String s : authorizedNumbers.split(",")) {
-      authorizedNumbersList.add(new BigDecimal(s));
+      authorizedNumbersList.add(new BigDecimal(s.trim()));
     }
     scan(context.getTree());
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/MagicNumberCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/MagicNumberCheckTest.java
@@ -35,4 +35,11 @@ public class MagicNumberCheckTest {
     check.authorizedNumbers = "-1,0,1,2";
     JavaCheckVerifier.verify("src/test/files/checks/MagicNumberCheckCustom.java", check);
   }
+  
+  @Test
+  public void detectedWithAuthorizedNumberSpaces() {
+    MagicNumberCheck check = new MagicNumberCheck();
+    check.authorizedNumbers = " -1,0 , 1 ,2";
+    JavaCheckVerifier.verify("src/test/files/checks/MagicNumberCheckCustom.java", check);
+  }
 }


### PR DESCRIPTION
Authorized numbers must be trimmered to avoid NumberFormatException if there is any space.