### PR TITLE
SONARJAVA-1928 FP on S1172 when owner of the method extends Struts 1.…

### DIFF
--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -214,6 +214,11 @@
                   <artifactId>struts-core</artifactId>
                   <version>1.3.10</version>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.struts</groupId>
+                  <artifactId>struts-extras</artifactId>
+                  <version>1.3.10</version>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
             </configuration>

--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -209,6 +209,11 @@
                   <artifactId>jackson-annotations</artifactId>
                   <version>2.8.4</version>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.struts</groupId>
+                  <artifactId>struts-core</artifactId>
+                  <version>1.3.10</version>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
             </configuration>

--- a/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedMethodParameterCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedMethodParameterCheck.java
@@ -21,7 +21,6 @@ package org.sonar.java.checks.unused;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.apache.commons.lang.BooleanUtils;
@@ -44,6 +43,8 @@ import org.sonar.plugins.java.api.tree.ModifiersTree;
 import org.sonar.plugins.java.api.tree.NewArrayTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
+
+import java.util.ArrayList;
 
 @Rule(key = "S1172")
 public class UnusedMethodParameterCheck extends IssuableSubscriptionVisitor {
@@ -119,10 +120,10 @@ public class UnusedMethodParameterCheck extends IssuableSubscriptionVisitor {
       || (!ModifiersUtils.hasModifier(modifiers, Modifier.PRIVATE) && isEmptyOrThrowStatement(tree.block()));
   }
   
-  private static boolean isStrutsActionParameter(VariableTree methodTree) {
-    Type superClass = methodTree.symbol().enclosingClass().superClass();
+  private static boolean isStrutsActionParameter(VariableTree variableTree) {
+    Type superClass = variableTree.symbol().enclosingClass().superClass();
     return superClass != null && superClass.isSubtypeOf(STRUTS_ACTION_SUPERCLASS)
-      && EXCLUDED_STRUTS_ACTION_PARAMETER_TYPES.contains(methodTree.symbol().type().fullyQualifiedName());
+      && EXCLUDED_STRUTS_ACTION_PARAMETER_TYPES.contains(variableTree.symbol().type().fullyQualifiedName());
   }
 
   private static boolean isEmptyOrThrowStatement(BlockTree block) {

--- a/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedMethodParameterCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedMethodParameterCheck.java
@@ -121,7 +121,7 @@ public class UnusedMethodParameterCheck extends IssuableSubscriptionVisitor {
   
   private static boolean isStrutsActionParameter(VariableTree methodTree) {
     Type superClass = methodTree.symbol().enclosingClass().superClass();
-    return superClass != null && superClass.fullyQualifiedName().equals(STRUTS_ACTION_SUPERCLASS)
+    return superClass != null && superClass.isSubtypeOf(STRUTS_ACTION_SUPERCLASS)
       && EXCLUDED_STRUTS_ACTION_PARAMETER_TYPES.contains(methodTree.symbol().type().fullyQualifiedName());
   }
 

--- a/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
+++ b/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
@@ -185,6 +185,10 @@ class StrutsAction2 extends BaseAction {
   void bar(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) { // Compliant
     System.out.println(""); 
   }
+
+  void qiz(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpFakeResponse unusedResponse) { // Noncompliant {{Remove this unused method parameter "unusedResponse".}}
+    System.out.println("");
+  }
 }
 
 @interface MyAnnotation {}

--- a/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
+++ b/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
@@ -5,6 +5,11 @@ import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.List;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.action.ActionForm;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.struts.action.Action;
 
 class A extends B{
   void doSomething(int a, int b) { // Noncompliant {{Remove this unused method parameter "b".}} [[sc=31;ec=32]]
@@ -42,7 +47,7 @@ class C extends B {
 }
 
 class D extends C {
-  void foo(int b, int a) { // Noncompliant {{Remove this unused method parameter "b".}} [[sc=16;ec=17;secondary=45]]
+  void foo(int b, int a) { // Noncompliant {{Remove this unused method parameter "b".}} [[sc=16;ec=17;secondary=50]]
     System.out.println("");
   }
 }
@@ -150,6 +155,20 @@ class Annotations {
   @SuppressWarnings("unchecked")
   void uncheckedFoobar(List<?> list, int unused) { // Noncompliant {{Remove this unused method parameter "unused".}} [[sc=42;ec=48]]
     List<String> strings = (List<String>) list;
+  }
+}
+
+class StrutsAction extends Action {
+  void foo(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response, String s) { // Compliant
+    System.out.println(s); 
+  }
+  
+  void bar(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response, String unused) { // Noncompliant {{Remove this unused method parameter "unused".}}
+    System.out.println(""); 
+  }
+  
+  void qix(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) { // Compliant
+    System.out.println(""); 
   }
 }
 

--- a/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
+++ b/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
@@ -181,12 +181,21 @@ class StrutsAction2 extends BaseAction {
   void foo(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response, String unused) { // Noncompliant {{Remove this unused method parameter "unused".}}
     System.out.println(""); 
   }
-  
+
   void bar(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) { // Compliant
-    System.out.println(""); 
+    System.out.println("");
   }
 
   void qiz(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpFakeResponse unusedResponse) { // Noncompliant {{Remove this unused method parameter "unusedResponse".}}
+    System.out.println("");
+  }
+}
+
+class NotStrutsAction {
+  void bar(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) { // Noncompliant {{Remove this unused method parameter "response".}}
+    doSomething(mapping);
+    doSomething(form);
+    doSomething(request);
     System.out.println("");
   }
 }

--- a/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
+++ b/java-checks/src/test/files/checks/unused/UnusedMethodParameterCheck.java
@@ -10,6 +10,7 @@ import org.apache.struts.action.ActionForm;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.struts.action.Action;
+import org.apache.struts.actions.BaseAction;
 
 class A extends B{
   void doSomething(int a, int b) { // Noncompliant {{Remove this unused method parameter "b".}} [[sc=31;ec=32]]
@@ -47,7 +48,7 @@ class C extends B {
 }
 
 class D extends C {
-  void foo(int b, int a) { // Noncompliant {{Remove this unused method parameter "b".}} [[sc=16;ec=17;secondary=50]]
+  void foo(int b, int a) { // Noncompliant {{Remove this unused method parameter "b".}} [[sc=16;ec=17;secondary=51]]
     System.out.println("");
   }
 }
@@ -168,6 +169,20 @@ class StrutsAction extends Action {
   }
   
   void qix(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) { // Compliant
+    System.out.println(""); 
+  }
+  
+  void qiz(ActionMapping mapping, ActionForm form) { // Compliant
+    System.out.println(""); 
+  }
+}
+
+class StrutsAction2 extends BaseAction {
+  void foo(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response, String unused) { // Noncompliant {{Remove this unused method parameter "unused".}}
+    System.out.println(""); 
+  }
+  
+  void bar(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) { // Compliant
     System.out.println(""); 
   }
 }


### PR DESCRIPTION
* Avoiding a FP on S1172 (Unused Method Parameter Check). When a class is a subclass of `org.apache.struts.action.Action` (Struts 1.x) it has to add mandatory extra parameters.