### PR TITLE
SONARJAVA-1604 FN on S3066 - Public final fields should be checked for their mutability

### DIFF
--- a/its/ruling/src/test/resources/sonar-server/squid-S3066.json
+++ b/its/ruling/src/test/resources/sonar-server/squid-S3066.json
@@ -1,0 +1,5 @@
+{
+'org.codehaus.sonar:sonar-server:src/main/java/org/sonar/server/qualityprofile/ActiveRule.java':[
+34,
+],
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/EnumMutableFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EnumMutableFieldCheck.java
@@ -65,7 +65,7 @@ public class EnumMutableFieldCheck extends IssuableSubscriptionVisitor {
     }
   }
   
-  private static boolean isNotStaticOrFinal(ModifiersTree modifiersTree) {
+  private static boolean isNotStaticOrFinal( ModifiersTree modifiersTree) {
     return !ModifiersUtils.hasModifier(modifiersTree, Modifier.STATIC)
       && !ModifiersUtils.hasModifier(modifiersTree, Modifier.FINAL);
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/EnumMutableFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EnumMutableFieldCheck.java
@@ -52,7 +52,7 @@ public class EnumMutableFieldCheck extends IssuableSubscriptionVisitor {
         VariableTree variableTree = (VariableTree) member;
         ModifiersTree modifiers = variableTree.modifiers();
         ModifierKeywordTree publicModifier = ModifiersUtils.getModifier(modifiers, Modifier.PUBLIC);
-        if (publicModifier != null && (isNotStaticOrFinal(variableTree,variableTree.modifiers())|| isMutableFinalMember(variableTree))) {
+        if (publicModifier != null && (isNotStaticOrFinal(variableTree.modifiers())|| isMutableFinalMember(variableTree))) {
           reportIssue(publicModifier, "Lower the visibility of this field.");
         }
       } else if (member.is(Tree.Kind.METHOD)) {
@@ -65,7 +65,7 @@ public class EnumMutableFieldCheck extends IssuableSubscriptionVisitor {
     }
   }
   
-  private static boolean isNotStaticOrFinal(VariableTree variableTree, ModifiersTree modifiersTree) {
+  private static boolean isNotStaticOrFinal(ModifiersTree modifiersTree) {
     return !ModifiersUtils.hasModifier(modifiersTree, Modifier.STATIC)
       && !ModifiersUtils.hasModifier(modifiersTree, Modifier.FINAL);
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/EnumMutableFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EnumMutableFieldCheck.java
@@ -65,7 +65,7 @@ public class EnumMutableFieldCheck extends IssuableSubscriptionVisitor {
     }
   }
   
-  private static boolean isNotStaticOrFinal( ModifiersTree modifiersTree) {
+  private static boolean isNotStaticOrFinal(ModifiersTree modifiersTree) {
     return !ModifiersUtils.hasModifier(modifiersTree, Modifier.STATIC)
       && !ModifiersUtils.hasModifier(modifiersTree, Modifier.FINAL);
   }

--- a/java-checks/src/test/files/checks/EnumMutableFieldCheck.java
+++ b/java-checks/src/test/files/checks/EnumMutableFieldCheck.java
@@ -7,7 +7,7 @@ public enum Continent {
   public static int countryCount2;  // compliant, static field
   private int landMass;
   public final com.google.common.collect.ImmutableList regions; // Compliant - immutable
-  private final java.util.Date dateNow;
+  private final java.util.Date date;
   
   Continent(int countryCount, int landMass) {
   }
@@ -55,6 +55,5 @@ public enum Continent3 {
     this.countryCount = countryCount;
     this.landMass = landMass;
     this.regions = new String[] {"Grazelands", "Molag Amur", "Sheogorad", "West Gash"};
-    this.dateNow = new Date();
   }
 }

--- a/java-checks/src/test/files/checks/EnumMutableFieldCheck.java
+++ b/java-checks/src/test/files/checks/EnumMutableFieldCheck.java
@@ -6,7 +6,9 @@ public enum Continent {
   public int countryCount;  // Noncompliant [[sc=3;ec=9]] {{Lower the visibility of this field.}}
   public static int countryCount2;  // compliant, static field
   private int landMass;
-
+  public final com.google.common.collect.ImmutableList regions; // Compliant - immutable
+  private final java.util.Date dateNow;
+  
   Continent(int countryCount, int landMass) {
   }
 
@@ -31,6 +33,7 @@ public enum Continent2 {
 
   private int countryCount;
   private int landMass;
+  public final java.util.List regions; // Noncompliant {{Lower the visibility of this field.}}
 
   Continent2(int countryCount, int landMass) {
 
@@ -45,11 +48,13 @@ public enum Continent3 {
 
   public final int countryCount; // Compliant - final
   private int landMass;
-  public final String[] regions; // False negative - mutable field!
-
+  public final String[] regions; // Noncompliant {{Lower the visibility of this field.}}
+  public final java.util.Date date; // Noncompliant {{Lower the visibility of this field.}}
+  
   Continent3(int countryCount, int landMass) {
     this.countryCount = countryCount;
     this.landMass = landMass;
     this.regions = new String[] {"Grazelands", "Molag Amur", "Sheogorad", "West Gash"};
+    this.dateNow = new Date();
   }
 }


### PR DESCRIPTION
* Now `public` `final `**mutable** fields are raising an issue.
* Mutable fields considered: `java.util.Collections`, `java.util.Date` and arrays.
* Collections extending [com.google.common.collect.ImmutableCollection](https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ImmutableCollection.html) are not considered mutable in the rule.