### PR TITLE
SONARJAVA-1963 remove syntaxNode from Constraint

### DIFF
--- a/its/ruling/src/test/resources/jdk6/squid-S2259.json
+++ b/its/ruling/src/test/resources/jdk6/squid-S2259.json
@@ -43,6 +43,9 @@
 'jdk6:java/awt/font/TextLayout.java':[
 2514,
 ],
+'jdk6:java/awt/font/TextLine.java':[
+952,
+],
 'jdk6:java/awt/font/TransformAttribute.java':[
 129,
 131,

--- a/its/ruling/src/test/resources/jdk6/squid-S2583.json
+++ b/its/ruling/src/test/resources/jdk6/squid-S2583.json
@@ -57,6 +57,9 @@
 'jdk6:java/net/Socket.java':[
 374,
 ],
+'jdk6:java/net/URI.java':[
+3333,
+],
 'jdk6:java/net/URL.java':[
 366,
 ],

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -81,6 +81,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -126,7 +127,7 @@ public class ExplodedGraphWalker {
   ConstraintManager constraintManager;
   private boolean cleanup = true;
   MethodBehavior methodBehavior;
-  private List<ExplodedGraph.Node> endOfExecutionPath;
+  private Set<ExplodedGraph.Node> endOfExecutionPath;
 
   public static class ExplodedGraphTooBigException extends RuntimeException {
 
@@ -189,7 +190,7 @@ public class ExplodedGraphWalker {
     methodTree = tree;
     constraintManager = new ConstraintManager();
     workList = new LinkedList<>();
-    endOfExecutionPath = new ArrayList<>();
+    endOfExecutionPath = new HashSet<>();
     if(DEBUG_MODE_ACTIVATED) {
       LOG.debug("Exploring Exploded Graph for method " + tree.simpleName().name() + " at line " + ((JavaTree) tree).getLine());
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -187,6 +187,7 @@ public class ExplodedGraphWalker {
     methodTree = tree;
     constraintManager = new ConstraintManager();
     workList = new LinkedList<>();
+    List<ExplodedGraph.Node> endOfExecutionPath = new ArrayList<>();
     if(DEBUG_MODE_ACTIVATED) {
       LOG.debug("Exploring Exploded Graph for method " + tree.simpleName().name() + " at line " + ((JavaTree) tree).getLine());
     }
@@ -207,7 +208,7 @@ public class ExplodedGraphWalker {
       programPosition = node.programPoint;
       programState = node.programState;
       if (programPosition.block.successors().isEmpty()) {
-        handleEndOfExecutionPath();
+        endOfExecutionPath.add(node);
         continue;
       }
       try {
@@ -233,6 +234,12 @@ public class ExplodedGraphWalker {
       }
     }
 
+    endOfExecutionPath.forEach(n -> {
+      node = n;
+      programPosition = node.programPoint;
+      programState = node.programState;
+      handleEndOfExecutionPath();
+    });
     checkerDispatcher.executeCheckEndOfExecution();
     // Cleanup:
     workList = null;

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -261,7 +261,7 @@ public class ExplodedGraphWalker {
       if (isEqualsMethod || parameterCanBeNull(variableSymbol, nullableParams)) {
         stateStream = stateStream.flatMap((ProgramState ps) ->
           Stream.concat(
-            sv.setConstraint(ps, ObjectConstraint.nullConstraint(variableTree)).stream(),
+            sv.setConstraint(ps, ObjectConstraint.nullConstraint()).stream(),
             sv.setConstraint(ps, ObjectConstraint.NOT_NULL).stream()
             ));
       } else if(nonNullParams) {
@@ -767,7 +767,7 @@ public class ExplodedGraphWalker {
     }
     // only check final field with an initializer
     if (initializer.is(Tree.Kind.NULL_LITERAL)) {
-      programState = programState.addConstraint(sv, ObjectConstraint.nullConstraint(initializer));
+      programState = programState.addConstraint(sv, ObjectConstraint.nullConstraint());
     } else if (initializer.is(Tree.Kind.NEW_CLASS) || initializer.is(Tree.Kind.NEW_ARRAY)) {
       programState = programState.addConstraint(sv, ObjectConstraint.NOT_NULL);
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
@@ -40,7 +40,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +72,7 @@ public class ProgramState {
       .put(SymbolicValue.TRUE_LITERAL, BooleanConstraint.TRUE)
       .put(SymbolicValue.FALSE_LITERAL, BooleanConstraint.FALSE),
     PCollections.emptyMap(),
-    Lists.<SymbolicValue>newLinkedList(),
+    Lists.newLinkedList(),
     null);
 
   private final PMap<ExplodedGraph.ProgramPoint, Integer> visitedPoints;
@@ -89,7 +88,7 @@ public class ProgramState {
 
   private ProgramState(PMap<Symbol, SymbolicValue> values, PMap<SymbolicValue, Integer> references,
     PMap<SymbolicValue, Constraint> constraints, PMap<ExplodedGraph.ProgramPoint, Integer> visitedPoints,
-    Deque<SymbolicValue> stack, SymbolicValue returnSymbolicValue) {
+    Deque<SymbolicValue> stack, @Nullable SymbolicValue returnSymbolicValue) {
     this.values = values;
     this.references = references;
     this.constraints = constraints;
@@ -376,30 +375,6 @@ public class ProgramState {
       }
     });
     return result;
-  }
-
-  public List<ObjectConstraint> getFieldConstraints(final Object state) {
-    final Set<SymbolicValue> valuesAssignedToFields = getFieldValues();
-    final List<ObjectConstraint> result = new ArrayList<>();
-    constraints.forEach((symbolicValue, valueConstraint) -> {
-      if (valueConstraint instanceof ObjectConstraint && !valuesAssignedToFields.contains(symbolicValue)) {
-        ObjectConstraint constraint = (ObjectConstraint) valueConstraint;
-        if (constraint.hasStatus(state)) {
-          result.add(constraint);
-        }
-      }
-    });
-    return result;
-  }
-
-  public Set<SymbolicValue> getFieldValues() {
-    final Set<SymbolicValue> fieldValues = new HashSet<>();
-    values.forEach((symbol, symbolicValue) -> {
-      if (isField(symbol)) {
-        fieldValues.add(symbolicValue);
-      }
-    });
-    return fieldValues;
   }
 
   public List<BinaryRelation> getKnownRelations() {

--- a/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
@@ -72,7 +72,7 @@ public class ProgramState {
       .put(SymbolicValue.TRUE_LITERAL, BooleanConstraint.TRUE)
       .put(SymbolicValue.FALSE_LITERAL, BooleanConstraint.FALSE),
     PCollections.emptyMap(),
-    Lists.newLinkedList(),
+    Lists.<SymbolicValue>newLinkedList(),
     null);
 
   private final PMap<ExplodedGraph.ProgramPoint, Integer> visitedPoints;
@@ -88,7 +88,7 @@ public class ProgramState {
 
   private ProgramState(PMap<Symbol, SymbolicValue> values, PMap<SymbolicValue, Integer> references,
     PMap<SymbolicValue, Constraint> constraints, PMap<ExplodedGraph.ProgramPoint, Integer> visitedPoints,
-    Deque<SymbolicValue> stack, @Nullable SymbolicValue returnSymbolicValue) {
+    Deque<SymbolicValue> stack, SymbolicValue returnSymbolicValue) {
     this.values = values;
     this.references = references;
     this.constraints = constraints;

--- a/java-frontend/src/main/java/org/sonar/java/se/SymbolicValueFactory.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/SymbolicValueFactory.java
@@ -20,9 +20,8 @@
 package org.sonar.java.se;
 
 import org.sonar.java.se.symbolicvalues.SymbolicValue;
-import org.sonar.plugins.java.api.tree.Tree;
 
 public interface SymbolicValueFactory {
 
-  SymbolicValue createSymbolicValue(int id, Tree syntaxNode);
+  SymbolicValue createSymbolicValue(int id);
 }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/ConditionAlwaysTrueOrFalseCheck.java
@@ -22,7 +22,6 @@ package org.sonar.java.se.checks;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-
 import org.sonar.check.Rule;
 import org.sonar.java.cfg.CFG;
 import org.sonar.java.se.CheckerContext;
@@ -49,11 +48,11 @@ public class ConditionAlwaysTrueOrFalseCheck extends SECheck {
     EvaluatedConditions ec = evaluatedConditions.pop();
     for (Tree condition : Sets.difference(ec.evaluatedToFalse.keySet(), ec.evaluatedToTrue.keySet())) {
       context.reportIssue(condition, this, "Change this condition so that it does not always evaluate to \"false\"",
-        ec.evaluatedToFalse.get(condition).stream().map(node -> SECheck.flow(node.parent(), node.programState.peekValue())).collect(Collectors.toSet()));
+        ec.evaluatedToFalse.get(condition).stream().map(node -> FlowComputation.flow(node.parent(), node.programState.peekValue())).collect(Collectors.toSet()));
     }
     for (Tree condition : Sets.difference(ec.evaluatedToTrue.keySet(), ec.evaluatedToFalse.keySet())) {
       context.reportIssue(condition, this, "Change this condition so that it does not always evaluate to \"true\"",
-        ec.evaluatedToTrue.get(condition).stream().map(node -> SECheck.flow(node.parent(), node.programState.peekValue())).collect(Collectors.toSet()));
+        ec.evaluatedToTrue.get(condition).stream().map(node -> FlowComputation.flow(node.parent(), node.programState.peekValue())).collect(Collectors.toSet()));
     }
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/CustomUnclosedResourcesCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/CustomUnclosedResourcesCheck.java
@@ -143,8 +143,8 @@ public class CustomUnclosedResourcesCheck extends SECheck {
       }
     }
 
-    protected void openResource(SymbolicValue sv, Tree syntaxNode) {
-      programState = programState.addConstraint(sv, new ObjectConstraint(false, false, syntaxNode, status.OPENED));
+    protected void openResource(SymbolicValue sv) {
+      programState = programState.addConstraint(sv, new ObjectConstraint(false, false, status.OPENED));
     }
 
     protected boolean isClosingResource(MethodInvocationTree mit) {
@@ -172,7 +172,7 @@ public class CustomUnclosedResourcesCheck extends SECheck {
     @Override
     public void visitMethodInvocation(MethodInvocationTree mit) {
       if (isOpeningResource(mit)) {
-        openResource(getTargetSV(mit), mit);
+        openResource(getTargetSV(mit));
       } else if (isClosingResource(mit)) {
         closeResource(getTargetSV(mit));
       } else {
@@ -213,14 +213,14 @@ public class CustomUnclosedResourcesCheck extends SECheck {
     @Override
     public void visitNewClass(NewClassTree newClassTree) {
       if (isCreatingResource(newClassTree)) {
-        openResource(programState.peekValue(), newClassTree);
+        openResource(programState.peekValue());
       }
     }
 
     @Override
     public void visitMethodInvocation(MethodInvocationTree mit) {
       if (isCreatingResource(mit)) {
-        openResource(programState.peekValue(), mit);
+        openResource(programState.peekValue());
       }
     }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/CustomUnclosedResourcesCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/CustomUnclosedResourcesCheck.java
@@ -106,7 +106,7 @@ public class CustomUnclosedResourcesCheck extends SECheck {
   }
 
   private void processUnclosedSymbolicValue(ExplodedGraph.Node node, SymbolicValue sv) {
-    List<JavaFileScannerContext.Location> flow = SECheck.flow(node, sv, ObjectConstraint.statusPredicate(status.OPENED));
+    List<JavaFileScannerContext.Location> flow = FlowComputation.flow(node, sv, ObjectConstraint.statusPredicate(status.OPENED));
     flow.stream()
       .filter(loc -> loc.syntaxNode.is(Tree.Kind.NEW_CLASS, Tree.Kind.METHOD_INVOCATION))
       .findFirst()

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/DivisionByZeroCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/DivisionByZeroCheck.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class DivisionByZeroCheck extends SECheck {
 
   private enum Status {
-    ZERO, NON_ZERO, UNDETERMINED
+    ZERO, NON_ZERO, UNDETERMINED;
   }
 
   /**

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/FlowComputation.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/FlowComputation.java
@@ -1,0 +1,135 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.se.checks;
+
+import org.sonar.java.se.ExplodedGraph;
+import org.sonar.java.se.constraint.Constraint;
+import org.sonar.java.se.symbolicvalues.BinarySymbolicValue;
+import org.sonar.java.se.symbolicvalues.SymbolicValue;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class FlowComputation {
+
+  private final Predicate<Constraint> addToFlow;
+  private final Predicate<Constraint> terminateTraversal;
+  private final List<JavaFileScannerContext.Location> flow = new ArrayList<>();
+  private final SymbolicValue symbolicValue;
+
+  private FlowComputation(SymbolicValue symbolicValue, Predicate<Constraint> addToFlow, Predicate<Constraint> terminateTraversal) {
+    this.addToFlow = addToFlow;
+    this.terminateTraversal = terminateTraversal;
+    this.symbolicValue = symbolicValue;
+  }
+
+  public static List<JavaFileScannerContext.Location> flow(ExplodedGraph.Node currentNode, SymbolicValue currentVal) {
+    return flow(currentNode, currentVal, constraint -> true);
+  }
+
+  public static List<JavaFileScannerContext.Location> flow(ExplodedGraph.Node currentNode, SymbolicValue currentVal, Predicate<Constraint> addToFlow) {
+    return flow(currentNode, currentVal, addToFlow, c -> false);
+  }
+
+  public static List<JavaFileScannerContext.Location> flow(ExplodedGraph.Node currentNode, SymbolicValue currentVal, Predicate<Constraint> addToFlow,
+    Predicate<Constraint> terminateTraversal) {
+    FlowComputation flowComputation = new FlowComputation(currentVal, addToFlow, terminateTraversal);
+
+    Symbol trackSymbol = currentNode.programState.getLastEvaluated();
+    if (currentVal instanceof BinarySymbolicValue) {
+      Set<JavaFileScannerContext.Location> binSVFlow = flowComputation.flowFromBinarySV(currentNode, (BinarySymbolicValue) currentVal, trackSymbol);
+      flowComputation.flow.addAll(binSVFlow);
+    }
+    flowComputation.run(currentNode, trackSymbol);
+    return flowComputation.flow;
+  }
+
+  private Set<JavaFileScannerContext.Location> flowFromBinarySV(ExplodedGraph.Node currentNode, BinarySymbolicValue binarySV, Symbol trackSymbol) {
+    HashSet<JavaFileScannerContext.Location> binSVFlow = new HashSet<>();
+    FlowComputation left = fork(binarySV.getLeftOp());
+    left.run(currentNode.parent(), trackSymbol);
+    binSVFlow.addAll(left.flow);
+    FlowComputation right = fork(binarySV.getRightOp());
+    right.run(currentNode.parent(), trackSymbol);
+    binSVFlow.addAll(right.flow);
+    return binSVFlow;
+  }
+
+  private FlowComputation fork(SymbolicValue symbolicValue) {
+    return new FlowComputation(symbolicValue, addToFlow, terminateTraversal);
+  }
+
+  private void run(@Nullable final ExplodedGraph.Node currentNode, @Nullable final Symbol trackSymbol) {
+    if (currentNode == null) {
+      return;
+    }
+
+    Symbol newTrackSymbol = trackSymbol;
+    if (currentNode.programPoint.syntaxTree() != null) {
+      newTrackSymbol = flowFromLearnedSymbols(currentNode, trackSymbol);
+      List<Constraint> learnedConstraints = flowFromLearnedConstraints(currentNode);
+      if (learnedConstraints.stream().anyMatch(terminateTraversal)) {
+        return;
+      }
+    }
+    run(currentNode.parent(), newTrackSymbol);
+  }
+
+  private List<Constraint> flowFromLearnedConstraints(ExplodedGraph.Node currentNode) {
+    List<Constraint> learnedConstraints = currentNode.getLearnedConstraints().stream()
+      .filter(lc -> lc.getSv().equals(symbolicValue))
+      .map(ExplodedGraph.Node.LearnedConstraint::getConstraint)
+      .collect(Collectors.toList());
+
+    if (learnedConstraints.stream().anyMatch(addToFlow)) {
+      flow.add(location(currentNode.parent()));
+    }
+    return learnedConstraints;
+  }
+
+  @Nullable
+  private Symbol flowFromLearnedSymbols(ExplodedGraph.Node currentNode, @Nullable Symbol trackSymbol) {
+    ExplodedGraph.Node parent = currentNode.parent();
+    if (trackSymbol == null || parent == null) {
+      return null;
+    }
+    Optional<Symbol> learnedSymbol = currentNode.getLearnedSymbols().stream()
+      .map(ExplodedGraph.Node.LearnedValue::getSymbol)
+      .filter(symbol -> symbol.equals(trackSymbol))
+      .findFirst();
+    if (learnedSymbol.isPresent()) {
+      flow.add(location(parent));
+      return parent.programState.getLastEvaluated();
+    }
+    return trackSymbol;
+  }
+
+  private static JavaFileScannerContext.Location location(ExplodedGraph.Node node) {
+    return new JavaFileScannerContext.Location("...", node.programPoint.syntaxTree());
+  }
+}

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/FlowComputation.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/FlowComputation.java
@@ -41,6 +41,7 @@ public class FlowComputation {
   private final Predicate<Constraint> terminateTraversal;
   private final List<JavaFileScannerContext.Location> flow = new ArrayList<>();
   private final SymbolicValue symbolicValue;
+  private final Set<ExplodedGraph.Node> visited = new HashSet<>();
 
   private FlowComputation(SymbolicValue symbolicValue, Predicate<Constraint> addToFlow, Predicate<Constraint> terminateTraversal) {
     this.addToFlow = addToFlow;
@@ -85,9 +86,10 @@ public class FlowComputation {
   }
 
   private void run(@Nullable final ExplodedGraph.Node currentNode, @Nullable final Symbol trackSymbol) {
-    if (currentNode == null) {
+    if (currentNode == null || visited.contains(currentNode)) {
       return;
     }
+    visited.add(currentNode);
 
     Symbol newTrackSymbol = trackSymbol;
     if (currentNode.programPoint.syntaxTree() != null) {
@@ -97,7 +99,9 @@ public class FlowComputation {
         return;
       }
     }
-    run(currentNode.parent(), newTrackSymbol);
+    for (ExplodedGraph.Node parent : currentNode.getParents()) {
+      run(parent, newTrackSymbol);
+    }
   }
 
   private List<Constraint> flowFromLearnedConstraints(ExplodedGraph.Node currentNode) {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
@@ -171,10 +171,10 @@ public class LocksNotUnlockedCheck extends SECheck {
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
     ExplodedGraph.Node node = context.getNode();
-    context.getState().getValuesWithConstraints(Status.LOCKED).keySet()
-      .forEach(sv -> SECheck.flow(node, sv, ObjectConstraint.statusPredicate(Status.LOCKED), ObjectConstraint.statusPredicate(Status.UNLOCKED)).stream()
-      .findFirst()
-      .ifPresent(loc -> reportIssue(reportOn(loc.syntaxNode), "Unlock this lock along all executions paths of this method.", Collections.emptySet())));
+    node.printAncestors();
+    context.getState().getValuesWithConstraints(Status.LOCKED).keySet().stream()
+      .flatMap(sv -> SECheck.flow(node, sv, ObjectConstraint.statusPredicate(Status.LOCKED), ObjectConstraint.statusPredicate(Status.UNLOCKED)).stream())
+      .forEach(loc -> reportIssue(reportOn(loc.syntaxNode), "Unlock this lock along all executions paths of this method.", Collections.emptySet()));
   }
 
   private static Tree reportOn(Tree syntaxNode) {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
@@ -171,9 +171,8 @@ public class LocksNotUnlockedCheck extends SECheck {
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
     ExplodedGraph.Node node = context.getNode();
-    node.printAncestors();
     context.getState().getValuesWithConstraints(Status.LOCKED).keySet().stream()
-      .flatMap(sv -> SECheck.flow(node, sv, ObjectConstraint.statusPredicate(Status.LOCKED), ObjectConstraint.statusPredicate(Status.UNLOCKED)).stream())
+      .flatMap(sv -> FlowComputation.flow(node, sv, ObjectConstraint.statusPredicate(Status.LOCKED), ObjectConstraint.statusPredicate(Status.UNLOCKED)).stream())
       .forEach(loc -> reportIssue(reportOn(loc.syntaxNode), "Unlock this lock along all executions paths of this method.", Collections.emptySet()));
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
@@ -53,12 +53,10 @@ public class LocksNotUnlockedCheck extends SECheck {
   private static class TryLockSymbolicValue extends SymbolicValue {
 
     private final SymbolicValue operand;
-    private final Tree syntaxNode;
 
-    public TryLockSymbolicValue(final int id, final SymbolicValue operand, final Tree syntaxNode) {
+    public TryLockSymbolicValue(final int id, final SymbolicValue operand) {
       super(id);
       this.operand = operand;
-      this.syntaxNode = syntaxNode;
     }
 
     @Override
@@ -69,9 +67,9 @@ public class LocksNotUnlockedCheck extends SECheck {
     @Override
     public List<ProgramState> setConstraint(ProgramState programState, BooleanConstraint booleanConstraint) {
       if (BooleanConstraint.TRUE.equals(booleanConstraint)) {
-        return ImmutableList.of(programState.addConstraint(operand, new ObjectConstraint(false, false, syntaxNode, Status.LOCKED)));
+        return ImmutableList.of(programState.addConstraint(operand, new ObjectConstraint(false, false, Status.LOCKED)));
       } else {
-        return ImmutableList.of(programState.addConstraint(operand, new ObjectConstraint(syntaxNode, Status.UNLOCKED)));
+        return ImmutableList.of(programState.addConstraint(operand, new ObjectConstraint(Status.UNLOCKED)));
       }
     }
 
@@ -90,8 +88,8 @@ public class LocksNotUnlockedCheck extends SECheck {
     }
 
     @Override
-    public SymbolicValue createSymbolicValue(int id, Tree syntaxNode) {
-      return new TryLockSymbolicValue(id, operand, syntaxNode);
+    public SymbolicValue createSymbolicValue(int id) {
+      return new TryLockSymbolicValue(id, operand);
     }
 
   }
@@ -144,9 +142,9 @@ public class LocksNotUnlockedCheck extends SECheck {
       if (!isMemberSelectActingOnField(target)) {
         final SymbolicValue symbolicValue = programState.getValue(target.symbol());
         if (LOCK_METHOD_NAME.equals(methodName) || TRY_LOCK_METHOD_NAME.equals(methodName)) {
-          programState = programState.addConstraint(symbolicValue, new ObjectConstraint(false, false, target, Status.LOCKED));
+          programState = programState.addConstraint(symbolicValue, new ObjectConstraint(false, false, Status.LOCKED));
         } else if (UNLOCK_METHOD_NAME.equals(methodName)) {
-          programState = programState.addConstraint(symbolicValue, new ObjectConstraint(target, Status.UNLOCKED));
+          programState = programState.addConstraint(symbolicValue, new ObjectConstraint(Status.UNLOCKED));
         }
       }
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/NullDereferenceCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/NullDereferenceCheck.java
@@ -93,7 +93,7 @@ public class NullDereferenceCheck extends SECheck {
       if (!SymbolicValue.NULL_LITERAL.equals(currentVal)) {
         val = currentVal;
       }
-      flows.add(SECheck.flow(context.getNode(), val));
+      flows.add(FlowComputation.flow(context.getNode(), val));
       context.reportIssue(syntaxNode, this, message, flows);
       return null;
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/NullDereferenceCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/NullDereferenceCheck.java
@@ -123,7 +123,7 @@ public class NullDereferenceCheck extends SECheck {
     SymbolicValue val = context.getState().peekValue();
     if (syntaxNode.is(Tree.Kind.METHOD_INVOCATION) && isAnnotatedCheckForNull((MethodInvocationTree) syntaxNode)) {
       List<ProgramState> states = new ArrayList<>();
-      states.addAll(val.setConstraint(context.getState(), ObjectConstraint.nullConstraint(syntaxNode)));
+      states.addAll(val.setConstraint(context.getState(), ObjectConstraint.nullConstraint()));
       states.addAll(val.setConstraint(context.getState(), ObjectConstraint.NOT_NULL));
       return states;
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/OptionalGetBeforeIsPresentCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/OptionalGetBeforeIsPresentCheck.java
@@ -105,7 +105,7 @@ public class OptionalGetBeforeIsPresentCheck extends SECheck {
     @Override
     public void visitMethodInvocation(MethodInvocationTree tree) {
       if (OPTIONAL_IS_PRESENT.matches(tree)) {
-        constraintManager.setValueFactory((id, node) -> new OptionalSymbolicValue(id, programState.peekValue()));
+        constraintManager.setValueFactory(id -> new OptionalSymbolicValue(id, programState.peekValue()));
       } else if (OPTIONAL_GET.matches(tree) && presenceHasNotBeenChecked(programState.peekValue())) {
         context.reportIssue(tree, check, "Call \"" + getIdentifierPart(tree.methodSelect()) + "isPresent()\" before accessing the value.");
         programState = null;

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/UnclosedResourcesCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/UnclosedResourcesCheck.java
@@ -208,7 +208,7 @@ public class UnclosedResourcesCheck extends SECheck {
     }
 
     @Override
-    public SymbolicValue createSymbolicValue(int counter, Tree syntaxNode) {
+    public SymbolicValue createSymbolicValue(int counter) {
       return new ResourceWrapperSymbolicValue(counter, value);
     }
 
@@ -356,7 +356,7 @@ public class UnclosedResourcesCheck extends SECheck {
       if (isOpeningResource(syntaxNode)) {
         final SymbolicValue instanceValue = programState.peekValue();
         if (!(instanceValue instanceof ResourceWrapperSymbolicValue)) {
-          programState = programState.addConstraint(instanceValue, new ObjectConstraint(false, false, syntaxNode, Status.OPENED));
+          programState = programState.addConstraint(instanceValue, new ObjectConstraint(false, false, Status.OPENED));
         }
       }
     }
@@ -372,7 +372,7 @@ public class UnclosedResourcesCheck extends SECheck {
         final ExpressionTree targetExpression = ((MemberSelectExpressionTree) syntaxNode.methodSelect()).expression();
         if (targetExpression.is(Tree.Kind.IDENTIFIER) && !isWithinTryHeader(syntaxNode)
           && (syntaxNode.symbol().isStatic() || isJdbcResourceCreation(targetExpression))) {
-          programState = programState.addConstraint(programState.peekValue(), new ObjectConstraint(false, false, syntaxNode, Status.OPENED));
+          programState = programState.addConstraint(programState.peekValue(), new ObjectConstraint(false, false, Status.OPENED));
         }
       }
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/UnclosedResourcesCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/UnclosedResourcesCheck.java
@@ -108,7 +108,7 @@ public class UnclosedResourcesCheck extends SECheck {
   }
 
   private void processUnclosedSymbolicValue(ExplodedGraph.Node node, SymbolicValue sv) {
-    List<JavaFileScannerContext.Location> flow = SECheck.flow(node, sv,
+    List<JavaFileScannerContext.Location> flow = FlowComputation.flow(node, sv,
       constraint -> constraint instanceof ObjectConstraint && ((ObjectConstraint) constraint).hasStatus(Status.OPENED));
     flow.stream()
       .filter(loc -> loc.syntaxNode.is(Tree.Kind.NEW_CLASS, Tree.Kind.METHOD_INVOCATION))

--- a/java-frontend/src/main/java/org/sonar/java/se/constraint/ConstraintManager.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/constraint/ConstraintManager.java
@@ -21,7 +21,6 @@ package org.sonar.java.se.constraint;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-
 import org.sonar.java.se.Pair;
 import org.sonar.java.se.ProgramState;
 import org.sonar.java.se.SymbolicValueFactory;
@@ -94,7 +93,7 @@ public class ConstraintManager {
         result = createIdentifierSymbolicValue((IdentifierTree) syntaxNode);
         break;
       default:
-        result = createDefaultSymbolicValue(syntaxNode);
+        result = createDefaultSymbolicValue();
     }
     counter++;
     return result;
@@ -116,7 +115,7 @@ public class ConstraintManager {
       SymbolicValue operand = values.get(0);
       result.computedFrom(ImmutableList.of(operand));
     } else {
-      result = createDefaultSymbolicValue(syntaxNode);
+      result = createDefaultSymbolicValue();
     }
     counter++;
     return result;
@@ -149,12 +148,12 @@ public class ConstraintManager {
         return SymbolicValue.FALSE_LITERAL;
       }
     }
-    return createDefaultSymbolicValue(identifier);
+    return createDefaultSymbolicValue();
   }
 
-  private SymbolicValue createDefaultSymbolicValue(Tree syntaxNode) {
+  private SymbolicValue createDefaultSymbolicValue() {
     SymbolicValue result;
-    result = symbolicValueFactory == null ? new SymbolicValue(counter) : symbolicValueFactory.createSymbolicValue(counter, syntaxNode);
+    result = symbolicValueFactory == null ? new SymbolicValue(counter) : symbolicValueFactory.createSymbolicValue(counter);
     symbolicValueFactory = null;
     return result;
   }

--- a/java-frontend/src/main/java/org/sonar/java/se/constraint/ObjectConstraint.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/constraint/ObjectConstraint.java
@@ -19,47 +19,39 @@
  */
 package org.sonar.java.se.constraint;
 
-import org.sonar.plugins.java.api.tree.Tree;
-
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.function.Predicate;
 
 public class ObjectConstraint implements Constraint {
 
-  public static final ObjectConstraint NOT_NULL = new ObjectConstraint(false, true, null, null);
+  public static final ObjectConstraint NOT_NULL = new ObjectConstraint(false, true, null);
 
   private final boolean isNull;
   private final boolean disposable;
-  private final Tree syntaxNode;
   @Nullable
   private final Object status;
 
-  public ObjectConstraint(Tree syntaxNode, Object status) {
-    this(false, true, syntaxNode, status);
+  public ObjectConstraint(Object status) {
+    this(false, true, status);
   }
 
-  public ObjectConstraint(boolean isNull, boolean disposable, @Nullable Tree syntaxNode, @Nullable Object status) {
+  public ObjectConstraint(boolean isNull, boolean disposable, @Nullable Object status) {
     this.isNull = isNull;
     this.disposable = disposable;
-    this.syntaxNode = syntaxNode;
     this.status = status;
   }
 
   public static ObjectConstraint nullConstraint() {
-    return nullConstraint(null);
-  }
-
-  public static ObjectConstraint nullConstraint(@Nullable Tree syntaxNode) {
-    return new ObjectConstraint(true, false, syntaxNode, null);
+    return new ObjectConstraint(true, false, null);
   }
 
   public ObjectConstraint inverse() {
-    return new ObjectConstraint(!isNull, disposable, syntaxNode, status);
+    return new ObjectConstraint(!isNull, disposable, status);
   }
 
   public ObjectConstraint withStatus(Object newStatus) {
-    return new ObjectConstraint(isNull, disposable, syntaxNode, newStatus);
+    return new ObjectConstraint(isNull, disposable, newStatus);
   }
 
   @Override
@@ -80,10 +72,6 @@ public class ObjectConstraint implements Constraint {
       return status == null;
     }
     return aState.equals(status);
-  }
-
-  public Tree syntaxNode() {
-    return syntaxNode;
   }
 
   @Override
@@ -107,14 +95,12 @@ public class ObjectConstraint implements Constraint {
       return false;
     }
     ObjectConstraint that = (ObjectConstraint) o;
-    return isNull == that.isNull &&
-      Objects.equals(syntaxNode, that.syntaxNode) &&
-      Objects.equals(status, that.status);
+    return isNull == that.isNull && Objects.equals(status, that.status);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(isNull, syntaxNode, status);
+    return Objects.hash(isNull, status);
   }
 
   public static Predicate<Constraint> statusPredicate(Object status) {

--- a/java-frontend/src/test/files/se/FlowComputation.java
+++ b/java-frontend/src/test/files/se/FlowComputation.java
@@ -1,0 +1,18 @@
+
+class A {
+  void combined(Object a) {
+    Object b = new Object();
+    if (a == null) { // flow@comb {{...}}
+      b = a; // flow@comb {{...}}
+      b.toString(); // Noncompliant [[flows=comb]]
+    }
+  }
+
+  void relationship(boolean a, boolean b) {
+    if(a < b) { // flow@rel {{...}}
+      if(b > a) { // Noncompliant [[flows=rel]] {{Change this condition so that it does not always evaluate to "true"}}
+      }
+    }
+  }
+}
+

--- a/java-frontend/src/test/files/se/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/test/files/se/LocksNotUnlockedCheck.java
@@ -46,7 +46,6 @@ public class MyClass {
     releaseLock();
   }
 
-  boolean foo;
   public void multipleLockState() {
     Lock lock = new ReentrantLock();
     if(foo) {
@@ -190,7 +189,7 @@ public class MyClass {
       lock.tryLock();
     }
     lock.unlock();
-    while (Random.nextBoolean()) {
+    while (foo) {
       lock.tryLock(); // Noncompliant
       lock =  new ReentrantLock();
     }

--- a/java-frontend/src/test/files/se/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/test/files/se/LocksNotUnlockedCheck.java
@@ -46,6 +46,7 @@ public class MyClass {
     releaseLock();
   }
 
+  boolean foo;
   public void multipleLockState() {
     Lock lock = new ReentrantLock();
     if(foo) {
@@ -189,7 +190,7 @@ public class MyClass {
       lock.tryLock();
     }
     lock.unlock();
-    while (foo) {
+    while (Random.nextBoolean()) {
       lock.tryLock(); // Noncompliant
       lock =  new ReentrantLock();
     }

--- a/java-frontend/src/test/files/se/LocksNotUnlockedCheckCache.java
+++ b/java-frontend/src/test/files/se/LocksNotUnlockedCheckCache.java
@@ -7,9 +7,33 @@ public class MyClass {
     Lock lock = new ReentrantLock();
     if(foo) {
       lock.lock();// Noncompliant
+      ifStmt();
     } else {
       lock.lock();// Noncompliant
+      elseStmt();
     }
+    end();
+  }
+
+  public void fourIssues() {
+    Lock lock = new ReentrantLock();
+    Lock lock2 = new ReentrantLock();
+    if(foo) {
+      lock.lock();// Noncompliant
+      ifStmt();
+    } else {
+      lock.lock();// Noncompliant
+      elseStmt();
+    }
+    end();
+    if(foo) {
+      lock2.lock();// Noncompliant
+      ifStmt();
+    } else {
+      lock2.lock();// Noncompliant
+      elseStmt();
+    }
+    end();
   }
 
 }

--- a/java-frontend/src/test/files/se/LocksNotUnlockedCheckCache.java
+++ b/java-frontend/src/test/files/se/LocksNotUnlockedCheckCache.java
@@ -1,0 +1,15 @@
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class MyClass {
+
+  public void thisReportsOnlyOneIssue() {
+    Lock lock = new ReentrantLock();
+    if(foo) {
+      lock.lock();// Noncompliant
+    } else {
+      lock.lock();// Noncompliant
+    }
+  }
+
+}

--- a/java-frontend/src/test/files/se/MaxStepsWithIssue.java
+++ b/java-frontend/src/test/files/se/MaxStepsWithIssue.java
@@ -1,0 +1,30 @@
+import java.io.*;
+import java.util.*;
+
+class A {
+  void plop() {
+    FileInputStream stream = new FileInputStream("myFile"); // Noncompliant  this is an FP, issue will be raised because we hit max steps before reaching the close
+    stream.read();
+
+    boolean a = true;
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+
+    if (a) { //BOOM : 2^n -1 states are generated (where n is the number of lines of &= assignements in the above code) -> fail fast by not even enqueuing nodes
+      stream.close();
+    }
+
+  }
+}

--- a/java-frontend/src/test/java/org/sonar/java/se/ConstraintTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ConstraintTest.java
@@ -42,13 +42,12 @@ public class ConstraintTest {
   @Test
   public void open_status() {
     final IdentifierTree tree = new IdentifierTreeImpl(new InternalSyntaxToken(1, 1, "id", Collections.<SyntaxTrivia>emptyList(), 0, 0, false));
-    ObjectConstraint constraint = new ObjectConstraint(tree, TestStatus.OPENED);
+    ObjectConstraint constraint = new ObjectConstraint(TestStatus.OPENED);
     assertThat(constraint.isNull()).as("Opened constraint is not null").isFalse();
     assertThat(constraint.isDisposable()).isTrue();
     assertThat(constraint.inverse().isNull()).as("Inverse of opened constraint is NULL").isTrue();
     assertThat(constraint.hasStatus(TestStatus.OPENED)).as("Opened constraint is 'opened'").isTrue();
     assertThat(constraint.hasStatus(TestStatus.CLOSED)).as("Opened constraint is not 'opened'").isFalse();
-    assertThat(constraint.syntaxNode()).as("Constraint's syntax node").isSameAs(tree);
     assertThat(constraint.toString()).as("Constraint's string").isEqualTo("NOT_NULL(OPENED)");
 
     constraint = constraint.withStatus(TestStatus.CLOSED);
@@ -84,7 +83,7 @@ public class ConstraintTest {
         return sv3;
       }
     };
-    ObjectConstraint constraint = new ObjectConstraint(null, TestStatus.OPENED);
+    ObjectConstraint constraint = new ObjectConstraint(TestStatus.OPENED);
     assertThat(state.getConstraintWithStatus(sv4, constraint)).isNull();
     state = state.addConstraint(sv3, constraint);
     assertThat(state.getConstraintWithStatus(sv4, TestStatus.OPENED)).isEqualTo(constraint);

--- a/java-frontend/src/test/java/org/sonar/java/se/ExplodedGraphWalkerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ExplodedGraphWalkerTest.java
@@ -152,6 +152,11 @@ public class ExplodedGraphWalkerTest {
   }
 
   @Test
+  public void test_maximum_steps_reached_with_issue() throws Exception {
+    JavaCheckVerifier.verify("src/test/files/se/MaxStepsWithIssue.java", new UnclosedResourcesCheck());
+  }
+
+  @Test
   public void test_maximum_number_nested_states() throws Exception {
     JavaCheckVerifier.verifyNoIssue("src/test/files/se/MaxNestedStates.java", new SymbolicExecutionVisitor(Collections.emptyList()) {
       @Override

--- a/java-frontend/src/test/java/org/sonar/java/se/MethodYieldTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/MethodYieldTest.java
@@ -107,7 +107,7 @@ public class MethodYieldTest {
 
     Symbol myVar = new JavaSymbol.VariableJavaSymbol(0, "myVar", (JavaSymbol) methodSymbol);
     ps = ps.put(myVar, sv2);
-    ps = ps.addConstraint(sv2, new ObjectConstraint(false, false, null, Status.A));
+    ps = ps.addConstraint(sv2, new ObjectConstraint(false, false, Status.A));
 
     // status of sv2 should be changed from A to B
     Collection<ProgramState> generatedStatesFromFirstYield = trueYield.statesAfterInvocation(Lists.newArrayList(sv1, sv2), Lists.newArrayList(), ps, () -> sv3);

--- a/java-frontend/src/test/java/org/sonar/java/se/MethodYieldTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/MethodYieldTest.java
@@ -251,15 +251,15 @@ public class MethodYieldTest {
     MethodBehavior methodBehavior = behaviorCache.values().iterator().next();
     assertThat(methodBehavior.yields()).hasSize(2);
     MethodYield[] expected = new MethodYield[] {
-      buildMethodYield(0, null, (Constraint) null),
-      buildMethodYield(-1, new ObjectConstraint(true, false, null), (Constraint) null)};
+      buildMethodYield(0, null),
+      buildMethodYield(-1, ObjectConstraint.nullConstraint())};
     assertThat(methodBehavior.yields()).contains((Object[]) expected);
   }
 
-  private MethodYield buildMethodYield(int resultIndex, @Nullable ObjectConstraint resultConstraint, Constraint... paramConstraints) {
-    MethodYield methodYield = new MethodYield(paramConstraints.length, false);
+  private MethodYield buildMethodYield(int resultIndex, @Nullable ObjectConstraint resultConstraint) {
+    MethodYield methodYield = new MethodYield(1, false);
     methodYield.resultIndex = resultIndex;
-    methodYield.parametersConstraints = paramConstraints;
+    methodYield.parametersConstraints = new Constraint[] {null};
     methodYield.exception = false;
     methodYield.resultConstraint = resultConstraint;
     return methodYield;

--- a/java-frontend/src/test/java/org/sonar/java/se/SymbolicValueFactoryTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/SymbolicValueFactoryTest.java
@@ -26,7 +26,6 @@ import org.sonar.java.se.constraint.ConstraintManager;
 import org.sonar.java.se.symbolicvalues.SymbolicValue;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia;
-import org.sonar.plugins.java.api.tree.Tree;
 
 import java.util.Collections;
 
@@ -45,7 +44,7 @@ public class SymbolicValueFactoryTest {
   private static class TestSymbolicValueFactory implements SymbolicValueFactory {
 
     @Override
-    public SymbolicValue createSymbolicValue(int id, Tree syntaxNode) {
+    public SymbolicValue createSymbolicValue(int id) {
       return new TestSymbolicValue(id);
     }
   }

--- a/java-frontend/src/test/java/org/sonar/java/se/checks/FlowComputationTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/checks/FlowComputationTest.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2016 SonarSource SA
+ * mailto:contact AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.se.checks;
+
+import org.junit.Test;
+import org.sonar.java.se.JavaCheckVerifier;
+
+public class FlowComputationTest {
+
+  @Test
+  public void learned_symbol() throws Exception {
+    JavaCheckVerifier.verify("src/test/files/se/FlowComputation.java", new NullDereferenceCheck(), new ConditionAlwaysTrueOrFalseCheck());
+  }
+
+
+}

--- a/java-frontend/src/test/java/org/sonar/java/se/checks/LocksNotUnlockedCheckTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/checks/LocksNotUnlockedCheckTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.se.checks;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.sonar.java.se.JavaCheckVerifier;
 
@@ -30,7 +29,6 @@ public class LocksNotUnlockedCheckTest {
     JavaCheckVerifier.verify("src/test/files/se/LocksNotUnlockedCheck.java", new LocksNotUnlockedCheck());
   }
 
-  @Ignore
   @Test
   public void object_constraint_cache_issues() throws Exception {
     JavaCheckVerifier.verify("src/test/files/se/LocksNotUnlockedCheckCache.java", new LocksNotUnlockedCheck());

--- a/java-frontend/src/test/java/org/sonar/java/se/checks/LocksNotUnlockedCheckTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/checks/LocksNotUnlockedCheckTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.java.se.checks;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.sonar.java.se.JavaCheckVerifier;
 
@@ -29,6 +30,7 @@ public class LocksNotUnlockedCheckTest {
     JavaCheckVerifier.verify("src/test/files/se/LocksNotUnlockedCheck.java", new LocksNotUnlockedCheck());
   }
 
+  @Ignore
   @Test
   public void object_constraint_cache_issues() throws Exception {
     JavaCheckVerifier.verify("src/test/files/se/LocksNotUnlockedCheckCache.java", new LocksNotUnlockedCheck());

--- a/java-frontend/src/test/java/org/sonar/java/se/checks/LocksNotUnlockedCheckTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/checks/LocksNotUnlockedCheckTest.java
@@ -28,4 +28,10 @@ public class LocksNotUnlockedCheckTest {
   public void test() {
     JavaCheckVerifier.verify("src/test/files/se/LocksNotUnlockedCheck.java", new LocksNotUnlockedCheck());
   }
+
+  @Test
+  public void object_constraint_cache_issues() throws Exception {
+    JavaCheckVerifier.verify("src/test/files/se/LocksNotUnlockedCheckCache.java", new LocksNotUnlockedCheck());
+
+  }
 }

--- a/java-frontend/src/test/java/org/sonar/java/se/checks/SECheckTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/checks/SECheckTest.java
@@ -38,7 +38,7 @@ public class SECheckTest {
     CFG cfg = CFGTest.buildCFG("void foo(boolean a) { if(a) {foo(true);} foo(false); }");
     ExplodedGraph.Node node = new ExplodedGraph.Node(new ExplodedGraph.ProgramPoint(cfg.blocks().get(3), 0), mock(ProgramState.class));
     node.addParent(new ExplodedGraph.Node(new ExplodedGraph.ProgramPoint(cfg.blocks().get(2), 2), mock(ProgramState.class)));
-    List<JavaFileScannerContext.Location> flow = SECheck.flow(node, new SymbolicValue(12));
+    List<JavaFileScannerContext.Location> flow = FlowComputation.flow(node, new SymbolicValue(12));
     assertThat(flow).isEmpty();
   }
 


### PR DESCRIPTION
Removes `syntaxNode` from `Constraint`. This changes the identity (`hashcode`) of `Constraint` and thus identity of `Node`. Which has the effect that the cache is used more often because we can internalize more nodes of the EG. 
However this change lead to two issues
1. when reporting the issue, flows need to be computed using all parents of the node. 
2. when calling endOfExecutionPath (EEP) , not all of the parents of the node are calculated

To solve #1 I first moved `SECheck#flow` to separate class and simplified the algorithm to use just recursion instead of mix of custom stack and recursive approaches. After I modified to use all parents to compute flow.
To solve #2 I deffer the call of EEP until the EG is fully explored or exploration is interrupted. This is achieved by maintaining a list of exit nodes in EGWalker.
