### PR TITLE
SONARJAVA-1776: Store SV of field using this assignments

### DIFF
--- a/its/ruling/src/test/resources/jdk6/squid-S2259.json
+++ b/its/ruling/src/test/resources/jdk6/squid-S2259.json
@@ -97,6 +97,7 @@
 531,
 ],
 'jdk6:java/security/UnresolvedPermission.java':[
+370,
 558,
 ],
 'jdk6:java/sql/DriverManager.java':[

--- a/its/ruling/src/test/resources/jdk6/squid-S2583.json
+++ b/its/ruling/src/test/resources/jdk6/squid-S2583.json
@@ -13,6 +13,9 @@
 2241,
 2243,
 ],
+'jdk6:java/awt/List.java':[
+582,
+],
 'jdk6:java/awt/MenuBar.java':[
 168,
 ],

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -42,12 +42,13 @@ public final class ExpressionUtils {
    * @see #extractIdentifier(AssignmentExpressionTree)
    */
   public static boolean isSimpleAssignment(AssignmentExpressionTree tree) {
-    if (tree.is(Tree.Kind.ASSIGNMENT) && ExpressionUtils.skipParentheses(tree.variable()).is(Tree.Kind.IDENTIFIER)) {
-      return true;
+    if (!tree.is(Tree.Kind.ASSIGNMENT)) {
+      // This can't possibly be a simple assignment.
+      return false;
     }
 
-    ExpressionTree variable = tree.variable();
-    return variable.is(Tree.Kind.MEMBER_SELECT) && isThisAssignment((MemberSelectExpressionTree) variable);
+    ExpressionTree variable = ExpressionUtils.skipParentheses(tree.variable());
+    return variable.is(Tree.Kind.IDENTIFIER) || (variable.is(Tree.Kind.MEMBER_SELECT) && isThisAssignment((MemberSelectExpressionTree) variable));
   }
 
   public static IdentifierTree extractIdentifier(AssignmentExpressionTree tree) {
@@ -58,7 +59,7 @@ public final class ExpressionUtils {
 
     if (variable.is(Tree.Kind.MEMBER_SELECT)) {
       MemberSelectExpressionTree selectTree = (MemberSelectExpressionTree) variable;
-      if (isThisAssignment(selectTree)) {
+      if (isThisAssignment(selectTree)) { // FIXME(Johan): Is this check needed?
         return selectTree.identifier();
       }
     }

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -48,11 +48,11 @@ public final class ExpressionUtils {
     }
 
     ExpressionTree variable = ExpressionUtils.skipParentheses(tree.variable());
-    return variable.is(Tree.Kind.IDENTIFIER) || (variable.is(Tree.Kind.MEMBER_SELECT) && isThisAssignment((MemberSelectExpressionTree) variable));
+    return variable.is(Tree.Kind.IDENTIFIER) || (variable.is(Tree.Kind.MEMBER_SELECT) && isOwningInstanceAssignment((MemberSelectExpressionTree) variable));
   }
 
   public static boolean isSimpleAssignment(MemberSelectExpressionTree memberSelectExpressionTree) {
-      return isThisAssignment(memberSelectExpressionTree);
+    return isOwningInstanceAssignment(memberSelectExpressionTree);
   }
 
   public static IdentifierTree extractIdentifier(AssignmentExpressionTree tree) {
@@ -63,7 +63,7 @@ public final class ExpressionUtils {
 
     if (variable.is(Tree.Kind.MEMBER_SELECT)) {
       MemberSelectExpressionTree selectTree = (MemberSelectExpressionTree) variable;
-      if (isThisAssignment(selectTree)) { // FIXME(Johan): Is this check needed?
+      if (isOwningInstanceAssignment(selectTree)) {
         return selectTree.identifier();
       }
     }
@@ -72,14 +72,14 @@ public final class ExpressionUtils {
     throw new IllegalArgumentException("Can not extract identifier.");
   }
 
-  private static boolean isThisAssignment(MemberSelectExpressionTree tree) {
+  private static boolean isOwningInstanceAssignment(MemberSelectExpressionTree tree) {
     if (!tree.expression().is(Tree.Kind.IDENTIFIER)) {
       // This is no longer simple.
       return false;
     }
 
     SyntaxToken variableToken = tree.firstToken();
-    return variableToken != null && "this".equalsIgnoreCase(variableToken.text());
+    return variableToken != null && ("this".equalsIgnoreCase(variableToken.text()) || "super".equalsIgnoreCase(variableToken.text()));
   }
 
   public static ExpressionTree skipParentheses(ExpressionTree tree) {

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -51,6 +51,11 @@ public final class ExpressionUtils {
     return variable.is(Tree.Kind.IDENTIFIER) || (variable.is(Tree.Kind.MEMBER_SELECT) && isOwningInstanceAssignment((MemberSelectExpressionTree) variable));
   }
 
+  public static boolean isThisOrSuperSelect(AssignmentExpressionTree tree) {
+    ExpressionTree variable = ExpressionUtils.skipParentheses(tree.variable());
+    return variable.is(Tree.Kind.MEMBER_SELECT) && isOwningInstanceAssignment((MemberSelectExpressionTree) variable);
+  }
+
   public static boolean isSimpleAssignment(MemberSelectExpressionTree memberSelectExpressionTree) {
     return isOwningInstanceAssignment(memberSelectExpressionTree);
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -51,6 +51,10 @@ public final class ExpressionUtils {
     return variable.is(Tree.Kind.IDENTIFIER) || (variable.is(Tree.Kind.MEMBER_SELECT) && isThisAssignment((MemberSelectExpressionTree) variable));
   }
 
+  public static boolean isSimpleAssignment(MemberSelectExpressionTree memberSelectExpressionTree) {
+      return isThisAssignment(memberSelectExpressionTree);
+  }
+
   public static IdentifierTree extractIdentifier(AssignmentExpressionTree tree) {
     ExpressionTree variable = skipParentheses(tree.variable());
     if (variable.is(Tree.Kind.IDENTIFIER)) {

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -24,7 +24,6 @@ import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.ParenthesizedTree;
-import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
 
 public final class ExpressionUtils {
@@ -83,8 +82,8 @@ public final class ExpressionUtils {
       return false;
     }
 
-    SyntaxToken variableToken = tree.firstToken();
-    return variableToken != null && ("this".equalsIgnoreCase(variableToken.text()) || "super".equalsIgnoreCase(variableToken.text()));
+    String selectSourceName = ((IdentifierTree) tree.expression()).symbol().name();
+    return "this".equalsIgnoreCase(selectSourceName) || "super".equalsIgnoreCase(selectSourceName);
   }
 
   public static ExpressionTree skipParentheses(ExpressionTree tree) {

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -68,6 +68,11 @@ public final class ExpressionUtils {
   }
 
   private static boolean isThisAssignment(MemberSelectExpressionTree tree) {
+    if (!tree.expression().is(Tree.Kind.IDENTIFIER)) {
+      // This is no longer simple.
+      return false;
+    }
+
     SyntaxToken variableToken = tree.firstToken();
     return variableToken != null && "this".equalsIgnoreCase(variableToken.text());
   }

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -976,7 +976,19 @@ public class ExplodedGraphWalker {
       ProgramState.Pop unstackMSE = programState.unstackValue(1);
       programState = unstackMSE.state;
     }
-    SymbolicValue mseValue = constraintManager.createSymbolicValue(mse);
+
+    SymbolicValue mseValue = null;
+
+    // TODO(Johan): Should this have an exception for when the symbol is unknown?
+    if (ExpressionUtils.isSimpleAssignment(mse)) {
+      // If the variable is already known, stack that value instead of creating a new one.
+      mseValue = programState.getValue(mse.identifier().symbol());
+    }
+
+    if (mseValue == null) {
+      mseValue = constraintManager.createSymbolicValue(mse);
+    }
+
     programState = programState.stackValue(mseValue);
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -977,19 +977,13 @@ public class ExplodedGraphWalker {
       programState = unstackMSE.state;
     }
 
-    SymbolicValue mseValue = null;
-
-    // TODO(Johan): Should this have an exception for when the symbol is unknown?
     if (ExpressionUtils.isSimpleAssignment(mse)) {
-      // If the variable is already known, stack that value instead of creating a new one.
-      mseValue = programState.getValue(mse.identifier().symbol());
+      // This is just a glorified identifier statement. Handle it as such.
+      executeIdentifier(mse.identifier());
+    } else {
+      SymbolicValue mseValue = constraintManager.createSymbolicValue(mse);
+      programState = programState.stackValue(mseValue);
     }
-
-    if (mseValue == null) {
-      mseValue = constraintManager.createSymbolicValue(mse);
-    }
-
-    programState = programState.stackValue(mseValue);
   }
 
   public void clearStack(Tree tree) {

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -829,7 +829,7 @@ public class ExplodedGraphWalker {
     SymbolicValue value;
 
     boolean isSimpleAssignment = ExpressionUtils.isSimpleAssignment(tree);
-    if (isSimpleAssignment) {
+    if (isSimpleAssignment || ExpressionUtils.isThisOrSuperSelect(tree)) {
       unstack = programState.unstackValue(1);
       value = unstack.values.get(0);
     } else {
@@ -839,7 +839,7 @@ public class ExplodedGraphWalker {
 
     programState = unstack.state;
     programState = programState.stackValue(value);
-    if (isSimpleAssignment || tree.variable().is(Tree.Kind.IDENTIFIER)) {
+    if (isSimpleAssignment || ExpressionUtils.isThisOrSuperSelect(tree) || tree.variable().is(Tree.Kind.IDENTIFIER)) {
       programState = programState.put(ExpressionUtils.extractIdentifier(tree).symbol(), value);
     }
   }

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -828,8 +828,8 @@ public class ExplodedGraphWalker {
     ProgramState.Pop unstack;
     SymbolicValue value;
 
-    boolean isSimpleAssignment = ExpressionUtils.isSimpleAssignment(tree);
-    if (isSimpleAssignment || ExpressionUtils.isThisOrSuperSelect(tree)) {
+    boolean isSimpleAssignment = ExpressionUtils.isSimpleAssignment(tree) || ExpressionUtils.isSelectOnThisOrSuper(tree);
+    if (isSimpleAssignment) {
       unstack = programState.unstackValue(1);
       value = unstack.values.get(0);
     } else {
@@ -839,7 +839,7 @@ public class ExplodedGraphWalker {
 
     programState = unstack.state;
     programState = programState.stackValue(value);
-    if (isSimpleAssignment || ExpressionUtils.isThisOrSuperSelect(tree) || tree.variable().is(Tree.Kind.IDENTIFIER)) {
+    if (isSimpleAssignment || tree.variable().is(Tree.Kind.IDENTIFIER)) {
       programState = programState.put(ExpressionUtils.extractIdentifier(tree).symbol(), value);
     }
   }
@@ -977,8 +977,7 @@ public class ExplodedGraphWalker {
       programState = unstackMSE.state;
     }
 
-    if (ExpressionUtils.isSimpleAssignment(mse)) {
-      // This is just a glorified identifier statement. Handle it as such.
+    if (ExpressionUtils.isSelectOnThisOrSuper(mse)) {
       executeIdentifier(mse.identifier());
     } else {
       SymbolicValue mseValue = constraintManager.createSymbolicValue(mse);

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -825,11 +825,11 @@ public class ExplodedGraphWalker {
   }
 
   private void executeAssignement(AssignmentExpressionTree tree) {
-    ExpressionTree variable = tree.variable();
     ProgramState.Pop unstack;
     SymbolicValue value;
 
-    if (ExpressionUtils.isSimpleAssignment(tree)) {
+    boolean isSimpleAssignment = ExpressionUtils.isSimpleAssignment(tree);
+    if (isSimpleAssignment) {
       unstack = programState.unstackValue(1);
       value = unstack.values.get(0);
     } else {
@@ -839,10 +839,8 @@ public class ExplodedGraphWalker {
 
     programState = unstack.state;
     programState = programState.stackValue(value);
-    if (variable.is(Tree.Kind.IDENTIFIER)) {
-      // only local variables or fields are added to table of values
-      // FIXME SONARJAVA-1776 fields accessing using "this." should be handled
-      programState = programState.put(((IdentifierTree) variable).symbol(), value);
+    if (isSimpleAssignment || tree.variable().is(Tree.Kind.IDENTIFIER)) {
+      programState = programState.put(ExpressionUtils.extractIdentifier(tree).symbol(), value);
     }
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/DivisionByZeroCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/DivisionByZeroCheck.java
@@ -118,7 +118,7 @@ public class DivisionByZeroCheck extends SECheck {
       SymbolicValue var;
       SymbolicValue expr;
       if (ExpressionUtils.isSimpleAssignment(tree)) {
-        var = programState.getValue(((IdentifierTree) ExpressionUtils.skipParentheses(tree.variable())).symbol());
+        var = programState.getValue(ExpressionUtils.extractIdentifier(tree).symbol());
         expr = programState.peekValue();
       } else {
         symbolicValues = programState.peekValues(2);

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/NonNullSetToNullCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/NonNullSetToNullCheck.java
@@ -154,7 +154,7 @@ public class NonNullSetToNullCheck extends SECheck {
     @Override
     public void visitAssignmentExpression(AssignmentExpressionTree tree) {
       if (ExpressionUtils.isSimpleAssignment(tree)) {
-        IdentifierTree variable = (IdentifierTree) ExpressionUtils.skipParentheses(tree.variable());
+        IdentifierTree variable = ExpressionUtils.extractIdentifier(tree);
         Symbol symbol = variable.symbol();
         String nonNullAnnotation = nonNullAnnotation(symbol);
         if (nonNullAnnotation != null) {

--- a/java-frontend/src/test/files/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/files/model/ExpressionUtilsTest.java
@@ -1,0 +1,9 @@
+class SimpleAssignments {
+
+  Object myField;
+
+  public void mixedReference() {
+    myField = null;
+    this.myField = null;
+  }
+}

--- a/java-frontend/src/test/files/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/files/model/ExpressionUtilsTest.java
@@ -1,11 +1,12 @@
 class SimpleAssignments {
 
-  Object myField;
+  Integer myField;
 
   public void mixedReference() {
     myField = null; // Simple
     this.myField = null; // Simple
     this.getOtherInstance().myField = null; // Not simple
+    this.myField /= 5; // Not simple
   }
 
   public SimpleAssignments getOtherInstance() {

--- a/java-frontend/src/test/files/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/files/model/ExpressionUtilsTest.java
@@ -3,7 +3,12 @@ class SimpleAssignments {
   Object myField;
 
   public void mixedReference() {
-    myField = null;
-    this.myField = null;
+    myField = null; // Simple
+    this.myField = null; // Simple
+    this.getOtherInstance().myField = null; // Not simple
+  }
+
+  public SimpleAssignments getOtherInstance() {
+    return new SimpleAssignments();
   }
 }

--- a/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
@@ -772,7 +772,7 @@ public class Class extends SuperClass {
     if (field && this.field1 == field2) {
       if (this.field) { // Noncompliant
       }
-      if (field1 == this.field2) { //False negative Noncompliant
+      if (field1 == this.field2) { // Noncompliant
       }
     }
   }
@@ -814,16 +814,20 @@ public class Class extends SuperClass {
     // Noncompliant@+1 {{Change this condition so that it does not always evaluate to "false"}}
     if (field1 || field2) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
+    if (field1 && !field1) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+    }
+    if (this.field1 && !this.field1) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+    }
 
-    if (super.field && !super.field) { // false negative Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+    if (super.field && !super.field) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
     if (super.field && !this.field) { // Compliant
     }
 
     if (super.field && super.field1 == super.field2) {
-      if (super.field) { // false negative Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
+      if (super.field) { // Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
       }
-      if (super.field1 == super.field2) { // false negative Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
+      if (super.field1 == super.field2) { // Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
       }
       otherMethod();
       if (super.field) { // Compliant
@@ -837,7 +841,8 @@ public class Class extends SuperClass {
 
     super.field1 = false;
     super.field2 = super.field1;
-    if (super.field1 || super.field2) { // false negative Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+    // Noncompliant@+1 {{Change this condition so that it does not always evaluate to "false"}}
+    if (super.field1 || super.field2) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
 
     SuperClass instance1, instance2;

--- a/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
@@ -770,7 +770,7 @@ public class Class extends SuperClass {
 
   public test_instance_fields(boolean local, boolean local1, boolean local2) {
     if (field && this.field1 == field2) {
-      if (this.field) { // False negative Noncompliant
+      if (this.field) { // Noncompliant
       }
       if (field1 == this.field2) { //False negative Noncompliant
       }
@@ -811,6 +811,7 @@ public class Class extends SuperClass {
 
     this.field1 = false;
     this.field2 = this.field1;
+    // Noncompliant@+1 {{Change this condition so that it does not always evaluate to "false"}}
     if (field1 || field2) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
 
@@ -2040,7 +2041,7 @@ class SimpleAssignments {
 
   void foo() {
     this.myField = null;
-    if (this.myField == null) { // FIXME: false negative Noncompliant
+    if (this.myField == null) { // Noncompliant
     }
   }
 
@@ -2058,14 +2059,14 @@ class SimpleAssignments {
 
   void foobar() {
     myField = null;
-    if (this.myField == null) { // FIXME: false negative Noncompliant
+    if (this.myField == null) { // Noncompliant
     }
   }
 
   void foofoo() {
-    if (myField == this.myField) { // false negative Noncompliant
+    if (myField == this.myField) { // Noncompliant
     }
-    if (this.myField == myField) { // false negative Noncompliant
+    if (this.myField == myField) { // Noncompliant
     }
   }
 

--- a/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-frontend/src/test/files/se/ConditionAlwaysTrueOrFalseCheck.java
@@ -811,7 +811,7 @@ public class Class extends SuperClass {
 
     this.field1 = false;
     this.field2 = this.field1;
-    if (field1 || field2) { // false negative Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+    if (field1 || field2) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
     }
 
     if (super.field && !super.field) { // false negative Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
@@ -2031,6 +2031,57 @@ class CheckingLoops {
       if(x) { // Noncompliant {{Change this condition so that it does not always evaluate to "true"}}
         System.out.println("");
       }
+    }
+  }
+}
+
+class SimpleAssignments {
+  Object myField;
+
+  void foo() {
+    this.myField = null;
+    if (this.myField == null) { // FIXME: false negative Noncompliant
+    }
+  }
+
+  void foobarbar() {
+    myField = null;
+    if (myField == null) { // Noncompliant
+    }
+  }
+
+  void bar() {
+    this.myField = null;
+    if (myField == null) { // Noncompliant
+    }
+  }
+
+  void foobar() {
+    myField = null;
+    if (this.myField == null) { // FIXME: false negative Noncompliant
+    }
+  }
+
+  void foofoo() {
+    if (myField == this.myField) { // false negative Noncompliant
+    }
+    if (this.myField == myField) { // false negative Noncompliant
+    }
+  }
+
+  void foofoobar() {
+    Object myField = null;
+    if (myField == this.myField) { // Compliant
+    }
+    if (this.myField == myField) { // Compliant
+    }
+  }
+
+  void foobarfoo() {
+    SimpleAssignments a = new SimpleAssignments();
+    if (a.myField == myField) { // Compliant
+    }
+    if (a.myField == this.myField) { // Compliant
     }
   }
 }

--- a/java-frontend/src/test/files/se/DivisionByZeroCheck.java
+++ b/java-frontend/src/test/files/se/DivisionByZeroCheck.java
@@ -392,12 +392,12 @@ class Assignment {
   int myField;
 
   public int calculate(int i) {
-    this.myField *= 0;
-    return i / myField; // FIXME false negative Noncompliant
+    this.myField *= 0; // This is not a simple assignment and thus won't be correctly evaluated in member select.
+    return i / myField; // false negative Noncompliant
   }
 
   public int calculateTwo(int i) {
     myField *= 0;
-    return i / this.myField; // FIXME false negative Noncompliant
+    return i / this.myField; // Noncompliant
   }
 }

--- a/java-frontend/src/test/files/se/DivisionByZeroCheck.java
+++ b/java-frontend/src/test/files/se/DivisionByZeroCheck.java
@@ -393,7 +393,7 @@ class Assignment {
 
   public int calculate(int i) {
     this.myField *= 0; // This is not a simple assignment and thus won't be correctly evaluated in member select.
-    return i / myField; // false negative Noncompliant
+    return i / myField; // Noncompliant
   }
 
   public int calculateTwo(int i) {

--- a/java-frontend/src/test/files/se/DivisionByZeroCheck.java
+++ b/java-frontend/src/test/files/se/DivisionByZeroCheck.java
@@ -387,3 +387,17 @@ class A {
     lowBits = -lowBits;
   }
 }
+
+class Assignment {
+  int myField;
+
+  public int calculate(int i) {
+    this.myField *= 0;
+    return i / myField; // FIXME false negative Noncompliant
+  }
+
+  public int calculateTwo(int i) {
+    myField *= 0;
+    return i / this.myField; // FIXME false negative Noncompliant
+  }
+}

--- a/java-frontend/src/test/files/se/DivisionByZeroCheck.java
+++ b/java-frontend/src/test/files/se/DivisionByZeroCheck.java
@@ -392,7 +392,7 @@ class Assignment {
   int myField;
 
   public int calculate(int i) {
-    this.myField *= 0; // This is not a simple assignment and thus won't be correctly evaluated in member select.
+    this.myField *= 0;
     return i / myField; // Noncompliant
   }
 

--- a/java-frontend/src/test/files/se/NonNullSetToNullCheck.java
+++ b/java-frontend/src/test/files/se/NonNullSetToNullCheck.java
@@ -88,7 +88,7 @@ public class MainClass {
 
   public String returnColor() {
     if (secondary == null) {
-      this.primary = null; // FN does not handle fields accessed by this.
+      this.primary = null; // Noncompliant {{"primary" is marked "javax.annotation.Nonnull" but is set to null.}}
       return secondary;
     }
     return primary;

--- a/java-frontend/src/test/files/se/NullDereferenceCheck.java
+++ b/java-frontend/src/test/files/se/NullDereferenceCheck.java
@@ -725,12 +725,12 @@ class SimpleAssignments {
 
   void bar() {
     myField = null;
-    this.myField.toString(); // FIXME: false negative Noncompliant
+    this.myField.toString(); // Noncompliant
   }
 
   void gul() {
     this.myField = null;
-    this.myField.toString(); // FIXME: false negative Noncompliant
+    this.myField.toString(); // Noncompliant
   }
 
   void qix() {

--- a/java-frontend/src/test/files/se/NullDereferenceCheck.java
+++ b/java-frontend/src/test/files/se/NullDereferenceCheck.java
@@ -714,3 +714,27 @@ class FooBar {
     FooBar.bar(null, new byte[10]); // Compliant
   }
 }
+
+class SimpleAssignments {
+  Object myField;
+
+  void foo() {
+    this.myField = null;
+    myField.toString(); // Noncompliant
+  }
+
+  void bar() {
+    myField = null;
+    this.myField.toString(); // FIXME: false negative Noncompliant
+  }
+
+  void gul() {
+    this.myField = null;
+    this.myField.toString(); // FIXME: false negative Noncompliant
+  }
+
+  void qix() {
+    myField = null;
+    myField.toString(); // Noncompliant
+  }
+}

--- a/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -49,7 +49,9 @@ import static org.sonar.plugins.java.api.tree.Tree.Kind.ASSERT_STATEMENT;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.EQUAL_TO;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.IDENTIFIER;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.INT_LITERAL;
+import static org.sonar.plugins.java.api.tree.Tree.Kind.MEMBER_SELECT;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.METHOD_INVOCATION;
+import static org.sonar.plugins.java.api.tree.Tree.Kind.MULTIPLY_ASSIGNMENT;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.NEW_ARRAY;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.NEW_CLASS;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.NULL_LITERAL;
@@ -314,6 +316,7 @@ public class CFGTest {
         case ASSIGNMENT:
         case ARRAY_ACCESS_EXPRESSION:
         case LOGICAL_COMPLEMENT:
+        case MULTIPLY_ASSIGNMENT:
         case PLUS:
           break;
         default:
@@ -1086,6 +1089,41 @@ public class CFGTest {
         element(Tree.Kind.INT_LITERAL, 0),
         element(Tree.Kind.ASSIGNMENT),
         element(Tree.Kind.ASSIGNMENT)).successors(0));
+    checker.check(cfg);
+  }
+
+  @Test
+  public void compound_assignment() throws Exception {
+    CFG cfg = buildCFG("void foo() {\n" +
+      "  myField *= 0;\n" +
+      "}\n" +
+      "int myField;");
+
+    CFGChecker checker = checker(
+      block(
+        element(IDENTIFIER, "myField"),
+        element(INT_LITERAL, 0),
+        element(MULTIPLY_ASSIGNMENT)
+        ).successors(0));
+
+    checker.check(cfg);
+  }
+
+  @Test
+  public void compound_assignment_member_select() throws Exception {
+    CFG cfg = buildCFG("void foo() {\n" +
+      "  this.myField *= 0;\n" +
+      "}\n" +
+      "int myField;");
+
+    CFGChecker checker = checker(
+      block(
+        element(IDENTIFIER, "this"),
+        element(MEMBER_SELECT),
+        element(INT_LITERAL, 0),
+        element(MULTIPLY_ASSIGNMENT)
+      ).successors(0));
+
     checker.check(cfg);
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
@@ -101,10 +101,12 @@ public class ExpressionUtilsTest {
     List<AssignmentExpressionTree> assignments = findAssignmentExpressionTrees(methodTree);
 
     // This should reflect method 'mixedReference'.
-    assertThat(assignments).hasSize(3);
+    assertThat(assignments).hasSize(4);
     assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(0))).isTrue();
     assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(1))).isTrue();
     // Contains method invocation.
+    assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(2))).isFalse();
+    // Compound assignment
     assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(2))).isFalse();
 
     // The returned identifier should have the same symbol regardless of the explicit usage of this.

--- a/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
@@ -100,10 +100,12 @@ public class ExpressionUtilsTest {
     MethodTree methodTree = (MethodTree) ((ClassTree) tree.types().get(0)).members().get(1);
     List<AssignmentExpressionTree> assignments = findAssignmentExpressionTrees(methodTree);
 
-    // The method 'mixedReference' has 2 assignments. Both should be considered simple.
-    assertThat(assignments).hasSize(2);
+    // This should reflect method 'mixedReference'.
+    assertThat(assignments).hasSize(3);
     assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(0))).isTrue();
     assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(1))).isTrue();
+    // Contains method invocation.
+    assertThat(ExpressionUtils.isSimpleAssignment(assignments.get(2))).isFalse();
 
     // The returned identifier should have the same symbol regardless of the explicit usage of this.
     assertThat(ExpressionUtils.extractIdentifier(assignments.get(0)).symbol())


### PR DESCRIPTION
Note: This PR is not finished yet but as it's quite involved I'd like some early feedback to ensure that I'm staying on track.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

# Todo List
- [x] JDK6 Ruling test ( [jdk6:java/beans/DefaultPersistenceDelegate.java:220 NPE -> variable is used in method with nullcheck, OK or NO?)
- [x] FIXME @ ExpressionUtils.java
- [x] TODO @ ExplodedGraphWalker.java

# Ruling results:
- jdk6:java/awt/List.java:582: OK 
- jdk6:java/beans/DefaultPersistenceDelegate.java:220: Used in method with nullcheck (xproc). No clue why this changes now though.
- jdk6:java/security/UnresolvedPermission.java:370: FP. The if-mess on line 341 allows only for non-null values with equal length to pass. I think this should be resolved by backlearning [SONARJAVA-1791](https://jira.sonarsource.com/browse/SONARJAVA-1791).

# Scope decisions
- [x] Add handle super.field the same as this.field - Solved
- Handle Compound assignments: TBD (test/files/se/DivisionByZeroCheck.java:395). This requires more work on having some compound assignments being considered as simple statements across multiple code paths.
- [x] test/files/se/ConditionAlwaysTrueOrFalseCheck.java:778 - Solved