### PR TITLE
Add onlyWhenNoDetailsProvided property to rule S1291 (NOSONAR).

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1291_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1291_java.html
@@ -1,4 +1,6 @@
 <p>Any issue to quality rule can be deactivated with the <code>NOSONAR</code> marker. This marker is pretty useful to exclude false-positive results
 but it can also be used abusively to hide real quality flaws.</p>
 <p>This rule raises an issue when <code>NOSONAR</code> is used.</p>
+<p>If option onlyWhenNoDetailsProvided is set, this rule only raises an isssue when <code>NOSONAR</code> is used alone with no further text on the comment line.<br/>
+Enable this option if your policy is to allow usage of <code>NOSONAR</code> but require that the developer adds further comments explaining why.</p>
 

--- a/java-checks/src/test/files/checks/NoSonar.java
+++ b/java-checks/src/test/files/checks/NoSonar.java
@@ -1,4 +1,5 @@
 public class HelloWorld {
 // Noncompliant {{Is //NOSONAR used to exclude false-positive or to hide real quality flaw ?}}
+/* NOSONAR */ // Noncompliant
 // OK
 }

--- a/java-checks/src/test/files/checks/NoSonarNoDetails.java
+++ b/java-checks/src/test/files/checks/NoSonarNoDetails.java
@@ -1,0 +1,14 @@
+public class HelloWorld {
+//NOSONAR this is a test message which makes this line // Compliant
+
+//NOSONAR
+// Noncompliant@-1
+
+//   NOSONAR    
+// Noncompliant@-1
+
+/* NOSONAR */  
+// Noncompliant@-1
+
+// OK
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/NoSonarCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/NoSonarCheckTest.java
@@ -27,6 +27,9 @@ public class NoSonarCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/NoSonar.java", new NoSonarCheck());
+    NoSonarCheck checkOnlyNoDetails = new NoSonarCheck();
+    checkOnlyNoDetails.onlyWhenNoDetailsProvided = true;
+    JavaCheckVerifier.verify("src/test/files/checks/NoSonarNoDetails.java", checkOnlyNoDetails);
   }
 
 }


### PR DESCRIPTION
Good evening,

I have modified rule S1291 (which detects usage of NOSONAR tags) to add a "onlyWhenNoDetailsProvided" property. 

When set to true, the rule only raises a violation if there isn't additional text besides the NOSONAR tag.
The goal is to allow usage of NOSONAR when (and only if) the developer adds details about why he thinks violations should be disabled on this line.

Sorry, I haven't been able to discuss this on the Google Group before submitting this PR (firewall blocks access to Google services, including Groups). I'll be happy to further discuss it here.

Best wishes for 2017,

Loïc

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- (N/A) If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

