### PR TITLE
S3067 NPE fix

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/synchronization/SynchronizationOnGetClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/synchronization/SynchronizationOnGetClassCheck.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static org.sonar.plugins.java.api.tree.Tree.Kind.IDENTIFIER;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.METHOD;
+import static org.sonar.plugins.java.api.tree.Tree.Kind.CONSTRUCTOR;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.METHOD_INVOCATION;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.SYNCHRONIZED_STATEMENT;
 
@@ -64,7 +65,7 @@ public class SynchronizationOnGetClassCheck extends IssuableSubscriptionVisitor 
   private static boolean isEnclosingClassFinal(ExpressionTree expressionTree) {
     if (expressionTree.is(IDENTIFIER)) {
       Tree parent = expressionTree.parent();
-      while (!parent.is(METHOD)) {
+      while (!parent.is(METHOD) && !parent.is(CONSTRUCTOR)) {
         parent = parent.parent();
       }
       return ((MethodTree) parent).symbol().owner().isFinal();

--- a/java-checks/src/test/files/checks/SynchronizationOnGetClassCheck.java
+++ b/java-checks/src/test/files/checks/SynchronizationOnGetClassCheck.java
@@ -1,4 +1,10 @@
 public class MyClass {
+
+  MyClass() {
+    synchronized (getClass()) { // Noncompliant [[sc=19;ec=29]] {{Synchronize on the static class name instead.}}
+    }
+  }
+
   public void methodInvocationSynchronizedExpr() {
     synchronized (getClass()) { // Noncompliant [[sc=19;ec=29]] {{Synchronize on the static class name instead.}}
     }
@@ -12,6 +18,11 @@ public class MyClass {
 
 
 public final class FinalClassIsCompliant {
+
+  FinalClassIsCompliant() {
+    synchronized (getClass()) { // Compliant
+    }
+  }
 
   public void doSomethingSynchronized() {
     synchronized (this.getClass()) { // Compliant


### PR DESCRIPTION
* An NPE occurs when synchronized on getClass() occurs in constructor.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
