### PR TITLE
Alow custom rules to externalize metadata

### DIFF
--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaRulesDefinition.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaRulesDefinition.java
@@ -61,6 +61,28 @@ public class JavaRulesDefinition implements RulesDefinition {
     repository.done();
   }
 
+  /**
+   * Override this method to externalize rule metadata
+   *
+   * @param metadataKey the rule key for a given rule
+   * @return a URL to the JSON-formatted file containing rule metadata, or null
+   * if it can't be found
+   */
+  protected URL getMetadataUrl(String metadataKey) {
+    return ExternalDescriptionLoader.class.getResource(RESOURCE_BASE_PATH + "/" + metadataKey + "_java.json");
+  }
+
+  /**
+   * Override this method to externalize rule description
+   *
+   * @param metadataKey the rule key for a given rule
+   * @return a URL to a UTF-8 file that will be read into the rule description,
+   * or null if it can't be found
+   */
+  protected URL getHtmlDescriptionUrl(String metadataKey) {
+    return JavaRulesDefinition.class.getResource(RESOURCE_BASE_PATH + "/" + metadataKey + "_java.html");
+  }
+
   @VisibleForTesting
   protected void newRule(Class<?> ruleClass, NewRepository repository) {
 
@@ -96,7 +118,7 @@ public class JavaRulesDefinition implements RulesDefinition {
   }
 
   private void addMetadata(NewRule rule, String metadataKey) {
-    URL resource = ExternalDescriptionLoader.class.getResource(RESOURCE_BASE_PATH + "/" + metadataKey + "_java.json");
+    URL resource = getMetadataUrl(metadataKey);
     if (resource != null) {
       RuleMetatada metatada = gson.fromJson(readResource(resource), RuleMetatada.class);
       rule.setSeverity(metatada.defaultSeverity.toUpperCase());
@@ -111,8 +133,8 @@ public class JavaRulesDefinition implements RulesDefinition {
     }
   }
 
-  private static void addHtmlDescription(NewRule rule, String metadataKey) {
-    URL resource = JavaRulesDefinition.class.getResource(RESOURCE_BASE_PATH + "/" + metadataKey + "_java.html");
+  private void addHtmlDescription(NewRule rule, String metadataKey) {
+    URL resource = getHtmlDescriptionUrl(metadataKey);
     if (resource != null) {
       rule.setHtmlDescription(readResource(resource));
     }


### PR DESCRIPTION
Move resource loading into protected methods, so custom rules can
override JavaRulesDefinition and externalize metadata.

Currently, if custom rule definitions try to extend JavaRulesDefinition, then
they can't externalize metadata the same way builtin rules do, because
that class only loads resources from its own library.

This small change would allow subclasses to load resources from their
own libraries.

Signed-off-by: Uri Shatil <uri.shatil@gmail.com>

Please ensure your pull request adheres to the following guidelines: 

- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
