### PR TITLE
Fix perf: do not compute method yield when method exploration is interrupted

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -244,7 +244,7 @@ public class ExplodedGraphWalker {
       }
     }
 
-    handleEndOfExecutionPath();
+    handleEndOfExecutionPath(false);
     checkerDispatcher.executeCheckEndOfExecution();
     // Cleanup:
     workList = null;
@@ -268,7 +268,7 @@ public class ExplodedGraphWalker {
   }
 
   private void interrupted() {
-    handleEndOfExecutionPath();
+    handleEndOfExecutionPath(true);
     checkerDispatcher.interruptedExecution();
   }
 
@@ -278,14 +278,14 @@ public class ExplodedGraphWalker {
     programState = this.node.programState;
   }
 
-  private void handleEndOfExecutionPath() {
+  private void handleEndOfExecutionPath(boolean interrupted) {
     ExplodedGraph.Node savedNode = node;
     endOfExecutionPath.forEach(n -> {
       setNode(n);
       if (!programState.exitingOnRuntimeException()) {
         checkerDispatcher.executeCheckEndOfExecutionPath(constraintManager);
       }
-      if (methodBehavior != null) {
+      if (!interrupted && methodBehavior != null) {
         methodBehavior.createYield(node);
       }
     });

--- a/java-frontend/src/test/files/se/PartialMethodYieldMaxStep.java
+++ b/java-frontend/src/test/files/se/PartialMethodYieldMaxStep.java
@@ -1,0 +1,34 @@
+class A {
+  private Object foo(boolean b) {
+    if (!b) {
+      return new Object();
+    }
+    boolean a = true;
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+    a &= (b() == C);
+
+    if (a) { //BOOM : 2^n -1 states are generated (where n is the number of lines of &= assignements in the above code) -> fail fast by not even enqueuing nodes
+      return null;
+    }
+    return new Object();
+  }
+
+  private Object bar(boolean b) {
+    if (!b) {
+      return new Object();
+    }
+    return null;
+  }
+}

--- a/java-frontend/src/test/java/org/sonar/java/se/SymbolicExecutionVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/SymbolicExecutionVisitorTest.java
@@ -145,6 +145,20 @@ public class SymbolicExecutionVisitorTest {
   }
 
   @Test
+  public void interrupted_exploration_does_not_create_method_yields() throws Exception {
+    SymbolicExecutionVisitor sev = createSymbolicExecutionVisitor("src/test/files/se/PartialMethodYieldMaxStep.java");
+    assertThat(sev.behaviorCache.behaviors.entrySet()).hasSize(2);
+
+    MethodBehavior plopMethod = getMethodBehavior(sev, "foo");
+    assertThat(plopMethod.isComplete()).isFalse();
+    assertThat(plopMethod.yields()).isEmpty();
+
+    MethodBehavior barMethod = getMethodBehavior(sev, "bar");
+    assertThat(barMethod.isComplete()).isTrue();
+    assertThat(barMethod.yields()).hasSize(2);
+  }
+
+  @Test
   public void clear_stack_when_taking_exceptional_path_from_method_invocation() throws Exception {
     SymbolicExecutionVisitor sev = createSymbolicExecutionVisitor("src/test/files/se/CleanStackWhenRaisingException.java");
     List<MethodYield> yields = sev.behaviorCache.behaviors.values().iterator().next().yields();


### PR DESCRIPTION
Method behavior of interrupted exploration is never marked as completed, and mehtod behavior which have not been completed are never used. Therefore, no need to compute a yield when the method exploration is interrupted.