### PR TITLE
Update EGViewer in order to correctly display method yields and exceptional branching

### DIFF
--- a/java-frontend/src/test/java/org/sonar/java/se/ProgramStateDataProvider.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ProgramStateDataProvider.java
@@ -1,0 +1,80 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.se;
+
+import org.sonar.java.collections.PMap;
+import org.sonar.java.collections.PStack;
+import org.sonar.java.se.constraint.Constraint;
+import org.sonar.java.se.symbolicvalues.SymbolicValue;
+import org.sonar.plugins.java.api.semantic.Symbol;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ProgramStateDataProvider {
+
+  private final ProgramState ps;
+
+  public ProgramStateDataProvider(ProgramState ps) {
+    this.ps = ps;
+  }
+
+  public String values() {
+    return ps.values.toString();
+  }
+
+  public String constraints() {
+    List<String> result = new ArrayList<>();
+    ps.constraints.forEach((sv, pmap) -> result.add(sv.toString() + "=" + pmapToStream(pmap).map(Constraint::toString).collect(Collectors.toList()).toString()));
+    return result.stream().sorted().collect(Collectors.toList()).toString();
+  }
+
+  public String stack() {
+    /// Ugly hack to get the stack and not expose programState API. The stack should remain private to avoid uncontrolled usage in engine
+    try {
+      Field stackField = ps.getClass().getDeclaredField("stack");
+      stackField.setAccessible(true);
+      PStack<SymbolicValue> stack = (PStack<SymbolicValue>) stackField.get(ps);
+      return stack.toString();
+    } catch (Exception e) {
+      return "[]";
+    }
+  }
+
+  public String lastEvaluatedSymbol() {
+    Symbol lastEvaluatedSymbol = ps.getLastEvaluated();
+    return lastEvaluatedSymbol == null ? "none" : lastEvaluatedSymbol.toString();
+  }
+
+  private static Stream<Constraint> pmapToStream(@Nullable PMap<Class<? extends Constraint>, Constraint> pmap) {
+    if (pmap == null) {
+      return Stream.empty();
+    }
+    Stream.Builder<Constraint> result = Stream.builder();
+    pmap.forEach((d, c) -> result.add(c));
+    return result.build();
+  }
+
+}

--- a/java-frontend/src/test/resources/viewer/viewer.js
+++ b/java-frontend/src/test/resources/viewer/viewer.js
@@ -78,25 +78,24 @@ function loadDot(DOTstring, useProgramStates, displayAsTree) {
     }
 
     function getProgramState(nodeId) {
-      var programStateAsString;
+      var stackAsString, constraintsAsString, valuesAsString, lastEvaluatedSymbolAsString;
       data.nodes.forEach(function(node) {
         if (nodeId == node.id) {
-          programStateAsString = node.programState;
+          valuesAsString = node.psValues;
+          constraintsAsString = node.psConstraints;
+          stackAsString = node.psStack;
+          lastEvaluatedSymbolAsString = node.psLastEvaluatedSymbol;
         }
       });
 
-      // ugly hack to get differents parts of the program state based on its toString() method. 
-      // Should be refactored in order to get correctly each object
-      var groups = programStateAsString.split('{');
-      if (groups.length == 5) {
-        result = '<h3>Program State:</h3>';
-        result += '<table>';
-        result += tableLine('values',groups[1]);
-        result += tableLine('constraints', groups[2]);
-        result += tableLine('stack', groups[3]);
-        result += tableLine('lastEvaluatedSymbol', groups[4]);
-        result += '</table>';
-      }
+      result = '<h3>Program State:</h3>';
+      result += '<table>';
+      result += tableLine('values', valuesAsString);
+      result += tableLine('constraints', constraintsAsString);
+      result += tableLine('stack', stackAsString);
+      result += tableLine('lastEvaluatedSymbol', lastEvaluatedSymbolAsString);
+      result += '</table>';
+
       return result;
     }
 
@@ -116,11 +115,10 @@ function loadDot(DOTstring, useProgramStates, displayAsTree) {
     }
 
     function tableLine(label, value) {
-      return '<tr><td>' + label + '</td><td>' + clean(value) + '</td></tr>';
-    }
-
-    function clean(value) {
-      return value.substring(0, value.indexOf('}'));
+      if (value) {
+        return '<tr><td>' + label + '</td><td>' + value + '</td></tr>';
+      }
+      return "";
     }
   }
 };


### PR DESCRIPTION
Update the viewer with respect of recent evolution of the SE engine.

- Everytime a yield is used, the edge is now **purple**, and clickable to display the yield
- Everytime an exception is on the stack for a given node, the edge leading to that node is **red**
- Display in **red** the new nodes from the graph which have no parent, but are not the starting point (currently coming from checks creating exceptional yields)

Two examples:

![image](https://cloud.githubusercontent.com/assets/10588758/23177296/9314e08a-f866-11e6-862b-cddc3d0a060c.png)

![image](https://cloud.githubusercontent.com/assets/10588758/23177302/99eaaf3e-f866-11e6-875a-e25006a7a26d.png)
