### PR TITLE
Add gitattributes to force eol

### DIFF
--- a/java-frontend/src/test/files/.gitattributes
+++ b/java-frontend/src/test/files/.gitattributes
@@ -1,0 +1,1 @@
+Kanji.java text eol=lf


### PR DESCRIPTION
Test in [SonarComponents](https://github.com/SonarSource/sonar-java/blob/6ce6e52a01e3608c9d6058996da438ecef953d64/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java#L353-L353) requires LF line endings for size of the file to be consistent between platforms.

This PR enforces LF line endings with .gittatrributes file