### PR TITLE
Make compatible with surefire reuseForks=false (round 2)

### DIFF
--- a/sonar-jacoco-listeners/src/main/java/org/sonar/java/jacoco/TestNGListener.java
+++ b/sonar-jacoco-listeners/src/main/java/org/sonar/java/jacoco/TestNGListener.java
@@ -28,17 +28,24 @@ import org.testng.ITestResult;
  */
 public class TestNGListener extends JUnitListener implements ITestListener {
 
+  /**
+   * Constructor used by the runner. Note the {@link JacocoController} is not yet requested.
+   */
   public TestNGListener() {
-    this(JacocoController.getInstance());
+    this(null);
   }
 
+  /**
+   * Only for there for injection from test.
+   */
   TestNGListener(JacocoController jacoco) {
     super(jacoco);
   }
 
   @Override
   public void onTestStart(ITestResult result) {
-    jacoco.onTestStart();
+    // Be sure the controller is loaded
+    getJacocoController().onTestStart(getName(result));
   }
 
   private static String getName(ITestResult result) {
@@ -47,22 +54,22 @@ public class TestNGListener extends JUnitListener implements ITestListener {
 
   @Override
   public void onTestSuccess(ITestResult result) {
-    jacoco.onTestFinish(getName(result));
+    jacoco.onTestFinish();
   }
 
   @Override
   public void onTestFailure(ITestResult result) {
-    jacoco.onTestFinish(getName(result));
+    jacoco.onTestFinish();
   }
 
   @Override
   public void onTestSkipped(ITestResult result) {
-    jacoco.onTestFinish(getName(result));
+    jacoco.onTestFinish();
   }
 
   @Override
   public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-    jacoco.onTestFinish(getName(result));
+    jacoco.onTestFinish();
   }
 
   @Override

--- a/sonar-jacoco-listeners/src/test/java/org/sonar/java/jacoco/JacocoControllerTest.java
+++ b/sonar-jacoco-listeners/src/test/java/org/sonar/java/jacoco/JacocoControllerTest.java
@@ -52,20 +52,20 @@ public class JacocoControllerTest {
 
   @Test
   public void test_onStart() throws Exception {
-    jacoco.onTestStart();
+    jacoco.onTestStart("test");
     InOrder inOrder = Mockito.inOrder(agent);
-    inOrder.verify(agent).setSessionId("");
     inOrder.verify(agent).dump(true);
+    inOrder.verify(agent).setSessionId("test");
     verifyNoMoreInteractions(agent);
   }
 
   @Test
   public void test_onFinish() throws Exception {
     when(agent.getExecutionData(false)).thenReturn(new byte[] {});
-    jacoco.onTestFinish("test");
+    jacoco.onTestFinish();
     InOrder inOrder = Mockito.inOrder(agent);
-    inOrder.verify(agent).setSessionId("test");
     inOrder.verify(agent).dump(true);
+    inOrder.verify(agent).setSessionId("");
     verifyNoMoreInteractions(agent);
   }
 
@@ -73,15 +73,16 @@ public class JacocoControllerTest {
   public void should_throw_exception_when_dump_failed() throws Exception {
     doThrow(IOException.class).when(agent).dump(anyBoolean());
     thrown.expect(JacocoControllerError.class);
-    jacoco.onTestFinish("test");
+    jacoco.onTestFinish();
   }
 
   @Test
   public void should_throw_exception_when_two_tests_started_in_parallel() {
-    jacoco.onTestStart();
+    jacoco.onTestStart("test1");
     thrown.expect(JacocoControllerError.class);
-    thrown.expectMessage("Looks like several tests executed in parallel in the same JVM, thus coverage per test can't be recorded correctly.");
-    jacoco.onTestStart();
+    thrown.expectMessage(
+        "Looks like several tests executed in parallel in the same JVM, thus coverage per test can't be recorded correctly.");
+    jacoco.onTestStart("test2");
   }
 
 }


### PR DESCRIPTION
JacocoController.getInstance() is executed too soon in case of surefire option reuseForks=false.
In this configuration, the listener is created without javaagent enabled. It is enabled only when the VM is forked while starting a test.
In addition I've fixed a small issue in case of broken test : the data was tagged as anonymous. Previous implementation saved the session id just before the dump, at the end of the tests.
This PR sets the SessionId immediatly when the tests starts.
This is cleaner/rebase version of #324

Tests have been updated, documentation added, and the whole has been tested for JUnit4 with both modes : reuse= false and reuse = true.