### PR TITLE
Bugfix: Lombok false positive on S1258

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To run integration tests, you will need to create a properties file like the one
     sonar.runtimeVersion=5.6
 
     orchestrator.updateCenterUrl=http://update.sonarsource.org/update-center-dev.properties
+    maven.localRepository=/home/bmurray/.m2/repository
 
 With for instance the `ORCHESTRATOR_CONFIG_URL` variable being set as: 
 

--- a/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
@@ -22,6 +22,7 @@ package org.sonar.java.filters;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.sonar.java.checks.AtLeastOneConstructorCheck;
 import org.sonar.java.checks.EqualsNotOverriddenInSubclassCheck;
 import org.sonar.java.checks.EqualsNotOverridenWithCompareToCheck;
 import org.sonar.java.checks.UtilityClassWithPublicConstructorCheck;
@@ -39,13 +40,20 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
     UnusedPrivateFieldCheck.class,
     EqualsNotOverriddenInSubclassCheck.class,
     EqualsNotOverridenWithCompareToCheck.class,
-    UtilityClassWithPublicConstructorCheck.class);
+    UtilityClassWithPublicConstructorCheck.class,
+    AtLeastOneConstructorCheck.class);
 
   private static final List<String> GENERATE_UNUSED_FIELD_RELATED_METHODS = ImmutableList.<String>builder()
     .add("lombok.Getter")
     .add("lombok.Setter")
     .add("lombok.Builder")
     .add("lombok.ToString")
+    .add("lombok.AllArgsConstructor")
+    .add("lombok.NoArgsConstructor")
+    .add("lombok.RequiredArgsConstructor")
+    .build();
+
+  private static final List<String> GENERATE_CONSTRUCTOR = ImmutableList.<String>builder()
     .add("lombok.AllArgsConstructor")
     .add("lombok.NoArgsConstructor")
     .add("lombok.RequiredArgsConstructor")
@@ -74,6 +82,12 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
       excludeLines(tree, UnusedPrivateFieldCheck.class);
     } else {
       acceptLines(tree, UnusedPrivateFieldCheck.class);
+    }
+
+    if (usesAnnotation(tree, GENERATE_CONSTRUCTOR)) {
+      excludeLines(tree, AtLeastOneConstructorCheck.class);
+    } else {
+      acceptLines(tree, AtLeastOneConstructorCheck.class);
     }
 
     if (generatesEquals) {

--- a/java-checks/src/test/files/filters/LombokFilter.java
+++ b/java-checks/src/test/files/filters/LombokFilter.java
@@ -1,91 +1,91 @@
 class Fields {
   @lombok.Getter
-  class Getter {
+  class Getter { // WithIssue
     private int foo; // NoIssue
   }
 
-  class Getter2 {
+  class Getter2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.Setter
-  class Setter {
+  class Setter { // WithIssue
     private int foo; // NoIssue
   }
 
-  class Setter2 {
+  class Setter2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.Data
-  class Data {
+  class Data { // WithIssue
     private int foo; // NoIssue
   }
 
-  class Data2 {
+  class Data2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.Value
-  class Value {
+  class Value { // WithIssue
     private int foo; // NoIssue
   }
 
-  class Value2 {
+  class Value2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.Builder
-  class Builder {
+  class Builder { // WithIssue
     private int foo; // NoIssue
   }
 
-  class Builder2 {
+  class Builder2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.ToString
-  class ToString {
+  class ToString { // WithIssue
     private int foo; // NoIssue
   }
 
-  class ToString2 {
+  class ToString2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.RequiredArgsConstructor
-  class RequiredArgsConstructor {
+  class RequiredArgsConstructor { // NoIssue
     private int foo; // NoIssue
   }
 
-  class RequiredArgsConstructor2 {
+  class RequiredArgsConstructor2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.AllArgsConstructor
-  class AllArgsConstructor {
+  class AllArgsConstructor { // NoIssue
     private int foo; // NoIssue
   }
 
-  class AllArgsConstructor2 {
+  class AllArgsConstructor2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.NoArgsConstructor
-  class NoArgsConstructor {
+  class NoArgsConstructor { // NoIssue
     private int foo; // NoIssue
   }
 
-  class NoArgsConstructor2 {
+  class NoArgsConstructor2 { // WithIssue
     private int foo; // WithIssue
   }
 
   @lombok.EqualsAndHashCode
-  class EqualsAndHashCode {
+  class EqualsAndHashCode { // WithIssue
     private int foo; // NoIssue
   }
 
-  class EqualsAndHashCode2 {
+  class EqualsAndHashCode2 { // WithIssue
     private int foo; // WithIssue
   }
 }


### PR DESCRIPTION
This PR fixes an false positive issue raised by analysis if one is using [Lombok Constructor annnotations](https://projectlombok.org/features/Constructor.html). The rule S1258 - `org.sonar.java.checks.AtLeastOneConstructorCheck` was not filtered properly by `org.sonar.java.filters.LombokFilter`.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
