### PR TITLE
SONARJAVA-2169 fail analysis if sonar.java.binaries is empty

### DIFF
--- a/its/performancing/src/test/java/JavaPerformanceTest.java
+++ b/its/performancing/src/test/java/JavaPerformanceTest.java
@@ -20,7 +20,7 @@
 import com.google.common.base.Preconditions;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
-import com.sonar.orchestrator.build.SonarRunner;
+import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.locator.FileLocation;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -48,9 +48,11 @@ public class JavaPerformanceTest {
   public void perform() throws IOException {
     ORCHESTRATOR.getServer().provisionProject("project", "project");
     ORCHESTRATOR.getServer().associateProjectToQualityProfile("project", "java", "no-rules");
-    SonarRunner build = SonarRunner.create(FileLocation.of("../sources/jdk6").getFile())
+    SonarScanner build = SonarScanner.create(FileLocation.of("../sources/jdk6").getFile())
       .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx1024m -server")
       .setProperty("sonar.importSources", "false")
+      // Dummy sonar.java.binaries to pass validation
+      .setProperty("sonar.java.binaries", "launcher")
       .setProperty("sonar.showProfiling", "true")
       .setProperty("sonar.preloadFileMetadata", "true")
       .setProjectKey("project")

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaClasspathTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaClasspathTest.java
@@ -149,18 +149,18 @@ public class JavaClasspathTest {
   }
 
   @Test
-  public void should_not_log_warnings_if_properties_not_set() {
+  public void should_log_warnings_if_binaries_missing() {
     SonarScanner scanner = ditProjectSonarScanner();
-    String logs = ORCHESTRATOR.executeBuild(scanner).getLogs();
-
-    assertThat(logs).doesNotContain("sonar.binaries and sonar.libraries are not supported since version 4.0 of sonar-java-plugin," +
-      " please use sonar.java.binaries and sonar.java.libraries instead");
-    assertThat(getNumberOfViolations(PROJECT_KEY_DIT)).isEqualTo(0);
+    BuildResult buildResult = ORCHESTRATOR.executeBuildQuietly(scanner);
+    String logs = buildResult.getLogs();
+    assertThat(logs).contains("Please provide compiled classes of your project with sonar.java.binaries property");
+    assertThat(buildResult.isSuccess()).isFalse();
   }
 
   @Test
   public void directory_of_classes_in_library_should_be_supported() throws Exception {
     SonarScanner scanner = ditProjectSonarScanner();
+    scanner.setProperty("sonar.java.binaries", "target");
     scanner.setProperty("sonar.java.libraries", "target/classes");
     ORCHESTRATOR.executeBuild(scanner);
     assertThat(getNumberOfViolations(PROJECT_KEY_DIT)).isEqualTo(1);

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaComplexityTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaComplexityTest.java
@@ -49,6 +49,7 @@ public class JavaComplexityTest {
     MavenBuild build = MavenBuild.create(TestUtils.projectPom("java-complexity"))
       .setCleanSonarGoals()
       .setProperty("sonar.dynamicAnalysis", "false")
+      .setProperty("sonar.java.binaries", "target")
       .setProperty("sonar.profile", "java-complexity");
     orchestrator.executeBuild(build);
   }

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
@@ -189,7 +189,8 @@ public class JavaTest {
       .setProperty("sonar.projectName", "jav-file-extension")
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")
       .setProperty("sonar.java.file.suffixes", ".txt,.foo")
-      .setProperty("sonar.sources", "src");
+      .setProperty("sonar.sources", "src")
+      .setProperty("sonar.java.binaries", "src");
     orchestrator.executeBuild(scan);
 
     assertThat(getMeasureAsInteger("jav-file-extension", "files")).isEqualTo(2);

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/SuppressWarningTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/SuppressWarningTest.java
@@ -56,6 +56,7 @@ public class SuppressWarningTest {
   public void suppressWarnings_nosonar() throws Exception {
     MavenBuild build = MavenBuild.create(TestUtils.projectPom("suppress-warnings"))
       .setCleanSonarGoals()
+      .setProperty("sonar.java.binaries", "target")
       .setProperty("sonar.profile", "suppress-warnings");
     ORCHESTRATOR.executeBuild(build);
 

--- a/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
@@ -202,6 +202,8 @@ public class JavaRulingTest {
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
       .setProperty("sonar.java.source", "1.5")
+      // Dummy sonar.java.binaries to pass validation
+      .setProperty("sonar.java.binaries", "launcher")
       .setProperty("sonar.inclusions", "java/**/*.java");
     executeBuildWithCommonProperties(build, projectName);
   }

--- a/java-frontend/src/main/java/org/sonar/java/AbstractJavaClasspath.java
+++ b/java-frontend/src/main/java/org/sonar/java/AbstractJavaClasspath.java
@@ -20,6 +20,7 @@
 package org.sonar.java;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.api.batch.BatchSide;
 import org.sonar.api.batch.fs.FileSystem;
@@ -100,6 +101,10 @@ public abstract class AbstractJavaClasspath {
 
   protected boolean hasJavaSources() {
     return fs.hasFiles(fs.predicates().and(fs.predicates().hasLanguage("java"), fs.predicates().hasType(fileType)));
+  }
+
+  protected boolean hasMoreThanOneJavaFile() {
+    return Iterables.size(fs.files(fs.predicates().and(fs.predicates().hasLanguage("java"), fs.predicates().hasType(fileType)))) > 1;
   }
 
   private Set<File> getFilesForPattern(Path baseDir, String pathPattern, boolean libraryProperty) {

--- a/java-frontend/src/main/java/org/sonar/java/JavaClasspath.java
+++ b/java-frontend/src/main/java/org/sonar/java/JavaClasspath.java
@@ -52,6 +52,9 @@ public class JavaClasspath extends AbstractJavaClasspath {
         throw new AnalysisException(
           "sonar.binaries and sonar.libraries are not supported since version 4.0 of sonar-java-plugin, please use sonar.java.binaries and sonar.java.libraries instead");
       }
+      if (binaries.isEmpty() && hasMoreThanOneJavaFile()) {
+        throw new AnalysisException("Please provide compiled classes of your project with sonar.java.binaries property");
+      }
       elements = new ArrayList<>(binaries);
       if (libraries.isEmpty() && hasJavaSources()) {
         LOG.warn("Bytecode of dependencies was not provided for analysis of source files, " +

--- a/java-frontend/src/test/java/org/sonar/java/JavaClasspathTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaClasspathTest.java
@@ -289,6 +289,27 @@ public class JavaClasspathTest {
   }
 
   @Test
+  public void empty_binaries_on_project_with_more_than_one_source_should_fail() throws Exception {
+    fs = new DefaultFileSystem(new File("src/test/files/classpath/"));
+    TestInputFileBuilder inputFile = new TestInputFileBuilder("", "plop.java");
+    inputFile.setType(InputFile.Type.MAIN);
+    inputFile.setLanguage("java");
+    fs.add(inputFile.build());
+    inputFile = new TestInputFileBuilder("", "bar.java");
+    inputFile.setType(InputFile.Type.MAIN);
+    inputFile.setLanguage("java");
+    fs.add(inputFile.build());
+    try {
+      javaClasspath = createJavaClasspath();
+      javaClasspath.getElements();
+      fail("Exception should have been raised");
+    } catch (AnalysisException ise) {
+      assertThat(ise.getMessage())
+        .isEqualTo("Please provide compiled classes of your project with sonar.java.binaries property");
+    }
+  }
+
+  @Test
   public void classpath_empty_if_only_test_files() throws Exception {
     fs = new DefaultFileSystem(new File("src/test/files/classpath/"));
     TestInputFileBuilder inputFile = new TestInputFileBuilder("", "plop.java");


### PR DESCRIPTION
Note : analysis do not fail if project contains only one source file. For ease of testing and because bytecode is not required in those cases.
