### PR TITLE
SONARJAVA-2594 enqueue exit blocks in bytecode analysis

### DIFF
--- a/its/ruling/src/test/resources/jdk6/squid-S3516.json
+++ b/its/ruling/src/test/resources/jdk6/squid-S3516.json
@@ -1,0 +1,5 @@
+{
+'jdk6:java/util/Scanner.java':[
+801,
+],
+}

--- a/its/ruling/src/test/resources/sonar-server/squid-JsonWriterNotClosed.json
+++ b/its/ruling/src/test/resources/sonar-server/squid-JsonWriterNotClosed.json
@@ -1,4 +1,7 @@
 {
+'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/component/ws/AppAction.java':[
+111,
+],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/issue/ws/AuthorsAction.java':[
 63,
 ],
@@ -10,6 +13,9 @@
 ],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/language/ws/ListAction.java':[
 57,
+],
+'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/metric/ws/SearchAction.java':[
+86,
 ],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/platform/ws/IndexAction.java':[
 76,
@@ -43,9 +49,6 @@
 ],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/updatecenter/ws/InstalledPluginsAction.java':[
 57,
-],
-'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/user/ws/UpdateAction.java':[
-125,
 ],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/ws/ws/ResponseExampleAction.java':[
 70,

--- a/its/ruling/src/test/resources/sonar-server/squid-S2095.json
+++ b/its/ruling/src/test/resources/sonar-server/squid-S2095.json
@@ -1,6 +1,12 @@
 {
+'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/component/ws/AppAction.java':[
+111,
+],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/batch/BatchReportReaderImpl.java':[
 74,
+],
+'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/metric/ws/SearchAction.java':[
+86,
 ],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/source/index/FileSourcesUpdaterHelper.java':[
 53,

--- a/java-frontend/src/main/java/org/sonar/java/bytecode/cfg/BytecodeCFG.java
+++ b/java-frontend/src/main/java/org/sonar/java/bytecode/cfg/BytecodeCFG.java
@@ -34,13 +34,14 @@ import org.sonar.plugins.java.api.semantic.Type;
 
 public class BytecodeCFG {
   List<Block> blocks;
+  private final Block exitBlock;
 
   BytecodeCFG() {
     blocks = new ArrayList<>();
     // create exit block
-    Block exit = new Block(this);
-    exit.successors = Collections.emptyList();
-    blocks.add(exit);
+    exitBlock = new Block(this);
+    exitBlock.successors = Collections.emptyList();
+    blocks.add(exitBlock);
   }
 
   public CFG.IBlock<Instruction> entry() {
@@ -49,6 +50,10 @@ public class BytecodeCFG {
 
   public List<Block> blocks() {
     return blocks;
+  }
+
+  public Block exitBlock() {
+    return exitBlock;
   }
 
   public static class Block implements CFG.IBlock<Instruction> {

--- a/java-frontend/src/main/java/org/sonar/java/bytecode/se/BytecodeEGWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/bytecode/se/BytecodeEGWalker.java
@@ -834,6 +834,8 @@ public class BytecodeEGWalker {
       }
     }
     // exception was not handled or was handled only partially, enqueue exit block with exceptional SV
+    Preconditions.checkState(ps.peekValue() instanceof SymbolicValue.ExceptionalSymbolicValue,
+        "Exception shall be on top of the stack");
     ps.storeExitValue();
     enqueue(new ProgramPoint(exitBlock), ps);
   }

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -311,9 +311,7 @@ public class ExplodedGraphWalker {
     ExplodedGraph.Node savedNode = node;
     endOfExecutionPath.forEach(n -> {
       setNode(n);
-      if (!programState.exitingOnRuntimeException()) {
-        checkerDispatcher.executeCheckEndOfExecutionPath(constraintManager);
-      }
+      checkerDispatcher.executeCheckEndOfExecutionPath(constraintManager);
       if (!interrupted && methodBehavior != null) {
         methodBehavior.createYield(node);
       }

--- a/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
@@ -50,6 +50,7 @@ import org.sonar.java.se.symbolicvalues.BinarySymbolicValue;
 import org.sonar.java.se.symbolicvalues.RelationalSymbolicValue;
 import org.sonar.java.se.symbolicvalues.SymbolicValue;
 import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Type;
 
 public class ProgramState {
 
@@ -531,7 +532,11 @@ public class ProgramState {
   }
 
   public boolean exitingOnRuntimeException() {
-    return exitSymbolicValue instanceof SymbolicValue.ExceptionalSymbolicValue && ((SymbolicValue.ExceptionalSymbolicValue) exitSymbolicValue).exceptionType() == null;
+    if (exitSymbolicValue instanceof SymbolicValue.ExceptionalSymbolicValue) {
+      Type exceptionType = ((SymbolicValue.ExceptionalSymbolicValue) exitSymbolicValue).exceptionType();
+      return exceptionType == null || exceptionType.isSubtypeOf("java.lang.RuntimeException");
+    }
+    return false;
   }
 
   Set<LearnedConstraint> learnedConstraints(ProgramState parent) {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/CustomUnclosedResourcesCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/CustomUnclosedResourcesCheck.java
@@ -113,6 +113,9 @@ public class CustomUnclosedResourcesCheck extends SECheck {
 
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
+    if (context.getState().exitingOnRuntimeException()) {
+      return;
+    }
     ExplodedGraph.Node node = context.getNode();
     context.getState().getValuesWithConstraints(OPENED).forEach(sv -> processUnclosedSymbolicValue(node, sv));
   }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/InvariantReturnCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/InvariantReturnCheck.java
@@ -99,6 +99,9 @@ public class InvariantReturnCheck extends SECheck {
 
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
+    if (context.getState().exitingOnRuntimeException()) {
+      return;
+    }
     MethodInvariantContext methodInvariantContext = methodInvariantContexts.peek();
     if (!methodInvariantContext.methodToCheck) {
       return;

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/LocksNotUnlockedCheck.java
@@ -182,6 +182,9 @@ public class LocksNotUnlockedCheck extends SECheck {
 
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
+    if (context.getState().exitingOnRuntimeException()) {
+      return;
+    }
     ExplodedGraph.Node node = context.getNode();
     context.getState().getValuesWithConstraints(LockConstraint.LOCKED).stream()
       .flatMap(lockedSv -> FlowComputation.flowWithoutExceptions(node, lockedSv, LockConstraint.LOCKED::equals, LockConstraint.UNLOCKED::equals, LOCK_CONSTRAINT_DOMAIN).stream())

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/StreamNotConsumedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/StreamNotConsumedCheck.java
@@ -42,6 +42,10 @@ public class StreamNotConsumedCheck extends SECheck {
 
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
+    if (context.getState().exitValue() instanceof SymbolicValue.ExceptionalSymbolicValue) {
+      // don't report when exiting on exception
+      return;
+    }
     ProgramState state = context.getState();
     List<SymbolicValue> notConsumed = state.getValuesWithConstraints(NOT_CONSUMED);
     notConsumed.forEach(sv -> {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/UnclosedResourcesCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/UnclosedResourcesCheck.java
@@ -147,6 +147,9 @@ public class UnclosedResourcesCheck extends SECheck {
 
   @Override
   public void checkEndOfExecutionPath(CheckerContext context, ConstraintManager constraintManager) {
+    if (context.getState().exitingOnRuntimeException()) {
+      return;
+    }
     ExplodedGraph.Node node = context.getNode();
     Set<SymbolicValue> svToReport = symbolicValuesToReport(context);
     svToReport.forEach(sv -> processUnclosedSymbolicValue(node, sv));

--- a/java-frontend/src/main/java/org/sonar/java/se/xproc/ExceptionalCheckBasedYield.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/xproc/ExceptionalCheckBasedYield.java
@@ -131,7 +131,7 @@ public class ExceptionalCheckBasedYield extends ExceptionalYield {
   @Override
   public Type exceptionType(SemanticModel semanticModel) {
     Type exceptionType = super.exceptionType(semanticModel);
-    Preconditions.checkArgument(exceptionType != null, "Exception type is required");
+    Preconditions.checkArgument(!exceptionType.isUnknown(), "Exception type is required");
     return exceptionType;
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/xproc/ExceptionalYield.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/xproc/ExceptionalYield.java
@@ -19,21 +19,20 @@
  */
 package org.sonar.java.se.xproc;
 
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.sonar.java.resolve.SemanticModel;
+import org.sonar.java.resolve.Symbols;
 import org.sonar.java.se.ExplodedGraph;
 import org.sonar.java.se.ProgramState;
 import org.sonar.java.se.constraint.Constraint;
 import org.sonar.java.se.symbolicvalues.SymbolicValue;
 import org.sonar.plugins.java.api.semantic.Type;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ExceptionalYield extends MethodYield {
 
@@ -62,12 +61,12 @@ public class ExceptionalYield extends MethodYield {
     this.exceptionType = exceptionType;
   }
 
-  @CheckForNull
   public Type exceptionType(SemanticModel semanticModel) {
-    if(exceptionType == null) {
-      return null;
+    if (exceptionType == null) {
+      return Symbols.unknownType;
     }
-    return semanticModel.getClassType(exceptionType);
+    Type type = semanticModel.getClassType(this.exceptionType);
+    return type == null ? Symbols.unknownType : type;
   }
 
   @Override

--- a/java-frontend/src/test/java/org/sonar/java/bytecode/se/BytecodeEGWalkerExecuteTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/bytecode/se/BytecodeEGWalkerExecuteTest.java
@@ -135,7 +135,8 @@ public class BytecodeEGWalkerExecuteTest {
     behaviorCache.setFileContext(null, semanticModel);
     BytecodeEGWalker walker = new BytecodeEGWalker(behaviorCache, semanticModel);
     MethodBehavior methodBehavior = walker.getMethodBehavior("org.apache.commons.io.FileUtils#readFileToString(Ljava/io/File;)Ljava/lang/String;", classLoader);
-    assertThat(methodBehavior.yields()).hasSize(1);
+    assertThat(methodBehavior.happyPathYields().collect(Collectors.toList())).hasSize(1);
+    assertThat(methodBehavior.exceptionalPathYields().collect(Collectors.toList())).hasSize(2);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/bytecode/se/testdata/ExceptionEnqueue.java
+++ b/java-frontend/src/test/java/org/sonar/java/bytecode/se/testdata/ExceptionEnqueue.java
@@ -78,6 +78,37 @@ public abstract class ExceptionEnqueue {
     throw new RuntimeException();
   }
 
+  static boolean enqueueExitBlock() throws IOException {
+    throwSpecificException();
+    return false;
+  }
+
+  static boolean enqueueExitBlock2(ExceptionEnqueue ee) throws IOException {
+    try {
+      ee.throwIOException();
+    } catch (FileNotFoundException e) {
+      return true;
+    }
+    return false;
+  }
+
+  static boolean enqueueExitBlock3() throws IOException {
+    try {
+      throwSpecificException();
+    } finally {
+      int x = 0;
+    }
+    return false;
+  }
+
+  static boolean enqueueExitBlock4() {
+    try {
+      throwSpecificException();
+    } catch (Throwable e) {
+      return true;
+    }
+    return true;
+  }
 }
 
 

--- a/java-frontend/src/test/java/org/sonar/java/bytecode/se/testdata/ExceptionEnqueue.java
+++ b/java-frontend/src/test/java/org/sonar/java/bytecode/se/testdata/ExceptionEnqueue.java
@@ -107,7 +107,7 @@ public abstract class ExceptionEnqueue {
     } catch (Throwable e) {
       return true;
     }
-    return true;
+    return false;
   }
 }
 

--- a/java-frontend/src/test/java/org/sonar/java/se/BehaviorCacheTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/BehaviorCacheTest.java
@@ -21,7 +21,6 @@ package org.sonar.java.se;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Rule;
@@ -31,7 +30,6 @@ import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.java.resolve.SemanticModel;
 import org.sonar.java.se.checks.NullDereferenceCheck;
 import org.sonar.java.se.checks.SECheck;
-import org.sonar.java.se.constraint.ObjectConstraint;
 import org.sonar.java.se.xproc.ExceptionalYield;
 import org.sonar.java.se.xproc.MethodBehavior;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
@@ -124,7 +122,7 @@ public class BehaviorCacheTest {
 
     List<ExceptionalYield> exceptionalYields = behavior.exceptionalPathYields().collect(Collectors.toList());
     assertThat(exceptionalYields).hasSize(3);
-    assertThat(exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) == null)).hasSize(1);
+    assertThat(exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).isUnknown())).hasSize(1);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/se/xproc/ExceptionalCheckBasedYieldTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/xproc/ExceptionalCheckBasedYieldTest.java
@@ -69,7 +69,7 @@ public class ExceptionalCheckBasedYieldTest {
     assertThat(mb.happyPathYields().filter(y -> y.parametersConstraints.get(0).get(BooleanConstraint.class) == BooleanConstraint.FALSE)).hasSize(0);
 
     assertThat(mb.exceptionalPathYields()).hasSize(2);
-    assertThat(mb.exceptionalPathYields()).as("All the exceptional yields are runtime exceptions").allMatch(y -> y.exceptionType(semanticModel) == null);
+    assertThat(mb.exceptionalPathYields()).as("All the exceptional yields are runtime exceptions").allMatch(y -> y.exceptionType(semanticModel).isUnknown());
     assertThat(mb.exceptionalPathYields().filter(y -> y.parametersConstraints.get(0).get(BooleanConstraint.class) == BooleanConstraint.TRUE)).hasSize(1);
     assertThat(mb.exceptionalPathYields().filter(y -> y.parametersConstraints.get(0).get(BooleanConstraint.class) == BooleanConstraint.FALSE)).hasSize(1);
 
@@ -88,8 +88,8 @@ public class ExceptionalCheckBasedYieldTest {
 
     // still 2 exceptional path
     assertThat(mb.exceptionalPathYields()).hasSize(2);
-    assertThat(mb.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel) == null)).hasSize(1);
-    assertThat(mb.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel) != null)).hasSize(1);
+    assertThat(mb.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel).isUnknown())).hasSize(1);
+    assertThat(mb.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel).isClass())).hasSize(1);
     assertThat(mb.exceptionalPathYields().filter(y -> y.parametersConstraints.get(0).get(BooleanConstraint.class) == BooleanConstraint.FALSE)).hasSize(1);
 
     ExceptionalYield exceptionalYield = mb.exceptionalPathYields().filter(y -> y.parametersConstraints.get(0).get(BooleanConstraint.class) == BooleanConstraint.TRUE).findFirst().get();

--- a/java-frontend/src/test/java/org/sonar/java/se/xproc/ExceptionalYieldTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/xproc/ExceptionalYieldTest.java
@@ -29,6 +29,7 @@ import org.sonar.java.ast.parser.JavaParser;
 import org.sonar.java.bytecode.loader.SquidClassLoader;
 import org.sonar.java.resolve.SemanticModel;
 import org.sonar.java.se.Pair;
+import org.sonar.java.se.SETestUtils;
 import org.sonar.java.se.SymbolicExecutionVisitor;
 import org.sonar.java.se.constraint.BooleanConstraint;
 import org.sonar.java.se.constraint.ObjectConstraint;
@@ -96,19 +97,19 @@ public class ExceptionalYieldTest {
     assertThat(exceptionalYields).hasSize(3);
 
     // runtime exception
-    Optional<ExceptionalYield> runtimeException = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) == null).findFirst();
+    Optional<ExceptionalYield> runtimeException = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).isUnknown()).findFirst();
     assertThat(runtimeException.isPresent()).isTrue();
     MethodYield runtimeExceptionYield = runtimeException.get();
     assertThat(runtimeExceptionYield.parametersConstraints.get(0).get(BooleanConstraint.class)).isEqualTo(BooleanConstraint.FALSE);
 
     // exception from other method call
-    Optional<ExceptionalYield> implicitException = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) != null && y.exceptionType(semanticModel).is("org.foo.MyException2")).findFirst();
+    Optional<ExceptionalYield> implicitException = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).is("org.foo.MyException2")).findFirst();
     assertThat(implicitException.isPresent()).isTrue();
     MethodYield implicitExceptionYield = implicitException.get();
     assertThat(implicitExceptionYield.parametersConstraints.get(0).get(BooleanConstraint.class)).isEqualTo(BooleanConstraint.FALSE);
 
     // explicitly thrown exception
-    Optional<ExceptionalYield> explicitException = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) != null && y.exceptionType(semanticModel).is("org.foo.MyException1")).findFirst();
+    Optional<ExceptionalYield> explicitException = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).is("org.foo.MyException1")).findFirst();
     assertThat(explicitException.isPresent()).isTrue();
     MethodYield explicitExceptionYield = explicitException.get();
     assertThat(explicitExceptionYield.parametersConstraints.get(0).get(BooleanConstraint.class)).isEqualTo(BooleanConstraint.TRUE);
@@ -134,12 +135,12 @@ public class ExceptionalYieldTest {
 
     List<ExceptionalYield> exceptionalYields = mb.exceptionalPathYields().collect(Collectors.toList());
     assertThat(exceptionalYields).hasSize(3);
-    assertThat(exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) == null).count()).isEqualTo(1);
+    assertThat(exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).isUnknown()).count()).isEqualTo(1);
 
-    MethodYield explicitExceptionYield = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) != null && y.exceptionType(semanticModel).is("org.foo.MyException1")).findAny().get();
+    MethodYield explicitExceptionYield = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).is("org.foo.MyException1")).findAny().get();
     assertThat(explicitExceptionYield.parametersConstraints.get(0).get(ObjectConstraint.class)).isEqualTo(ObjectConstraint.NULL);
 
-    MethodYield implicitExceptionYield = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel) != null && y.exceptionType(semanticModel).is("org.foo.MyException2")).findAny().get();
+    MethodYield implicitExceptionYield = exceptionalYields.stream().filter(y -> y.exceptionType(semanticModel).is("org.foo.MyException2")).findAny().get();
     assertThat(implicitExceptionYield.parametersConstraints.get(0).get(ObjectConstraint.class)).isEqualTo(ObjectConstraint.NOT_NULL);
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/se/xproc/MethodBehaviorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/xproc/MethodBehaviorTest.java
@@ -118,9 +118,9 @@ public class MethodBehaviorTest {
     assertThat(rethrowingException.yields()).hasSize(4);
     assertThat(rethrowingException.happyPathYields()).hasSize(1);
     assertThat(rethrowingException.exceptionalPathYields()).hasSize(3);
-    assertThat(rethrowingException.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel) == null)).hasSize(1);
-    assertThat(rethrowingException.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel) != null && y.exceptionType(semanticModel).is("java.lang.Exception"))).hasSize(1);
-    assertThat(rethrowingException.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel) != null && y.exceptionType(semanticModel).is("org.foo.MyException"))).hasSize(1);
+    assertThat(rethrowingException.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel).isUnknown())).hasSize(1);
+    assertThat(rethrowingException.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel).is("java.lang.Exception"))).hasSize(1);
+    assertThat(rethrowingException.exceptionalPathYields().filter(y -> y.exceptionType(semanticModel).is("org.foo.MyException"))).hasSize(1);
 
   }
 


### PR DESCRIPTION
Because exit blocks are now properly enqueued when doing bytecode analysis, many more yields will have known exception types, which required change in checks how exit from the method on exception is handled. Now this decision is delegated to the individual checks.