### PR TITLE
Allow diamond operator check to handle casts and expressions parenthesis

### DIFF
--- a/java-checks/src/test/files/checks/DiamondOperatorCheck_java_7.java
+++ b/java-checks/src/test/files/checks/DiamondOperatorCheck_java_7.java
@@ -35,6 +35,9 @@ class A {
     };
 
     MyUnknownVariable = new ArrayList<Object>(); // Compliant
+
+    Object data = new List[10];
+    ((List[])data)[2] = new ArrayList<String>();
   }
 
   List<Object> qix(boolean test) {

--- a/java-checks/src/test/files/checks/DiamondOperatorCheck_java_8.java
+++ b/java-checks/src/test/files/checks/DiamondOperatorCheck_java_8.java
@@ -36,6 +36,9 @@ class A {
     };
 
     MyUnknownVariable = new ArrayList<Object>(); // Compliant
+
+    Object data = new List[10];
+    ((List[])data)[2] = new ArrayList<String>();
   }
 
   List<Object> qix(boolean test) {

--- a/java-checks/src/test/files/checks/DiamondOperatorCheck_no_version.java
+++ b/java-checks/src/test/files/checks/DiamondOperatorCheck_no_version.java
@@ -35,6 +35,9 @@ class A {
     };
 
     MyUnknownVariable = new ArrayList<Object>(); // Compliant
+
+    Object data = new List[10];
+    ((List[])data)[2] = new ArrayList<String>();
   }
 
   List<Object> qix(boolean test) {


### PR DESCRIPTION
Previously diamond operator check was not able to handle `TYPE_CAST` and `PARENTHESIZED_EXPRESSION` when trying to get assigned variable.

That was causing unclear failure (`ClassCastException`) during analysis of code with such patterns.
Code example that was causing failure previously:
```
   ((List[])data)[2] = new HashMap<String,List<Integer>>();
```