### PR TITLE
Add support for @Nested test classes (JUnit5)

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NoTestInTestClassCheck.java
@@ -164,10 +164,8 @@ public class NoTestInTestClassCheck extends IssuableSubscriptionVisitor {
       .flatMap(i -> getAllMembers(i.symbol()))
       .filter(m -> ((JavaSymbol.MethodJavaSymbol) m).isDefault());
     for (Symbol s : symbol.memberSymbols()) {
-      if (s instanceof Symbol.TypeSymbol) {
-        if (s.metadata().isAnnotatedWith("org.junit.jupiter.api.Nested")) {
-          members = Stream.concat(members, getAllMembers((Symbol.TypeSymbol) s));
-        }
+      if (s.isTypeSymbol() && s.metadata().isAnnotatedWith("org.junit.jupiter.api.Nested")) {
+        members = Stream.concat(members, getAllMembers((Symbol.TypeSymbol) s));
       }
     }
     members = Stream.concat(members, defaultMethodsFromInterfaces);

--- a/java-checks/src/main/java/org/sonar/java/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NoTestInTestClassCheck.java
@@ -163,6 +163,13 @@ public class NoTestInTestClassCheck extends IssuableSubscriptionVisitor {
     Stream<Symbol.MethodSymbol> defaultMethodsFromInterfaces = symbol.interfaces().stream()
       .flatMap(i -> getAllMembers(i.symbol()))
       .filter(m -> ((JavaSymbol.MethodJavaSymbol) m).isDefault());
+    for (Symbol s : symbol.memberSymbols()) {
+      if (s instanceof Symbol.TypeSymbol) {
+        if (s.metadata().isAnnotatedWith("org.junit.jupiter.api.Nested")) {
+          members = Stream.concat(members, getAllMembers((Symbol.TypeSymbol) s));
+        }
+      }
+    }
     members = Stream.concat(members, defaultMethodsFromInterfaces);
     return members;
   }

--- a/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
@@ -11,6 +11,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -209,3 +210,22 @@ class CustomAnnotationTest {
 
 @org.junit.platform.commons.annotation.Testable
 @interface CustomAnnotation {}
+
+class NestedTest { // Compliant
+  @Nested
+  class NestedClass {
+    @Test
+    public void foo() {
+      Assert.assertTrue(true);
+    }
+  }
+}
+
+class NoTestsInNestedTest { // Noncompliant {{Add some tests to this class.}}
+  @Nested
+  class NestedClass {
+    public void foo() {
+      Assert.assertTrue(true);
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
@@ -229,3 +229,4 @@ class NoTestsInNestedTest { // Noncompliant {{Add some tests to this class.}}
     }
   }
 }
+


### PR DESCRIPTION
This PR verifies that if there is a `@Nested` class with tests, SonarQube will not trigger a FP `S2187` : `Add some tests to this class.`

Also if there are no tests in the `@Nested` class, `S2187` still will be trigegred.