### PR TITLE
Fix CatchOfThrowableOrErrorCheck as there are good use cases for catching Throwable

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1181_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S1181_java.json
@@ -1,5 +1,5 @@
 {
-  "title": "Throwable and Error should not be caught",
+  "title": "Error should not be caught",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/java-checks/src/test/files/checks/CatchOfThrowableOrErrorCheck.java
+++ b/java-checks/src/test/files/checks/CatchOfThrowableOrErrorCheck.java
@@ -5,7 +5,7 @@ class A extends Exception {
     Closer closer = Closer.create();
     try {
     } catch (RuntimeException e) {    // Compliant
-    } catch (Throwable e) {           // Noncompliant [[sc=14;ec=23]] {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Compliant
     } catch (Error e) {               // Noncompliant {{Catch Exception instead of Error.}}
     } catch (StackOverflowError e) {  // Compliant
     } catch (Foo |
@@ -14,24 +14,24 @@ class A extends Exception {
       try {
       } catch (Error e) {             // Noncompliant {{Catch Exception instead of Error.}}
       }
-    } catch (java.lang.Throwable e) { // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (java.lang.Throwable e) { // Compliant
     } catch (java.lang.Error e) {     // Noncompliant {{Catch Exception instead of Error.}}
     } catch (foo.Throwable e) {       // Compliant
     } catch (java.foo.Throwable e) {  // Compliant
     } catch (foo.lang.Throwable e) {  // Compliant
     } catch (java.lang.foo e) {       // Compliant
     } catch (foo.java.lang.Throwable e) { // Compliant
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Compliant
       throw e;
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Compliant
       throw new Exception(e).getCause();
     } catch (Throwable e) {           // Compliant
       throw closer.rethrow(e);
     } catch (java.lang.Throwable e) { // Compliant
       throw closer.rethrow(e);
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Compliant
       throw closer.rethrow(new Exception(e));
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Compliant
       Throwable myThrowable = new Throwable(e);
       throw closer.rethrow(myThrowable);
     } catch (Throwable e) {           // Compliant


### PR DESCRIPTION
The rule CatchOfThrowableOrErrorCheck should be fixed as there are good use cases for catching Throwable.
Please see some examples:
https://github.com/spring-projects/spring-framework/blob/master/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java#L74
https://github.com/apache/tomcat/blob/trunk/java/org/apache/catalina/core/StandardWrapperValve.java#L243

This rule should be fixed or people will break correct code.

One way to fix this rule is to only warn when catching Error as I do not know a valid use case for catching Error.

This pull request is not complete, I just submitted it as I did not found a way to create an issue.