### PR TITLE
Add "includeSwitchBlocks" rule property to rule "S1142"

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/MethodWithExcessiveReturnsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/MethodWithExcessiveReturnsCheck.java
@@ -61,6 +61,7 @@ public class MethodWithExcessiveReturnsCheck extends IssuableSubscriptionVisitor
   public void scanFile(JavaFileScannerContext context) {
     super.scanFile(context);
     returnStatementCounter.clear();
+    switchStatementContextByMethod.clear();
   }
 
   @Override

--- a/java-checks/src/test/files/checks/MethodWithExcessiveReturnsCheck.java
+++ b/java-checks/src/test/files/checks/MethodWithExcessiveReturnsCheck.java
@@ -46,6 +46,34 @@ class A {
     return;
     return;
   }
+
+  int foo4(String path) { // Noncompliant {{Reduce the number of returns of this method 4, down to the maximum allowed 3.}}
+    switch (path) {
+      case "FOO":
+        return 1;
+      case "BAR":
+        return 2;
+      case "FIZ":
+        return 3;
+      default:
+        return 4;
+    }
+  }
+
+  int foo5(String path) { // Noncompliant {{Reduce the number of returns of this method 4, down to the maximum allowed 3.}}
+    switch (path) {
+      case "FOO":
+        return 1;
+      default:
+        switch (path) {
+          case "BAR":
+            return 2;
+          default:
+            return 3;
+        }
+    }
+    return 4;
+  }
 }
 interface B {
   default void method() { // Noncompliant {{Reduce the number of returns of this method 5, down to the maximum allowed 3.}}

--- a/java-checks/src/test/files/checks/MethodWithExcessiveReturnsCheckIgnoreSwitchBlocks.java
+++ b/java-checks/src/test/files/checks/MethodWithExcessiveReturnsCheckIgnoreSwitchBlocks.java
@@ -1,0 +1,112 @@
+class A {
+  int foo1(String path) { // Compliant
+    switch (path) {
+      case "FOO":
+        return 1;
+      case "BAR":
+        return 2;
+      case "FIZ":
+        return 3;
+      default:
+        return 4;
+    }
+    return 5;
+    return 6;
+    return 7;
+  }
+
+  int foo2(String path) { // Noncompliant {{Reduce the number of returns of this method 4, down to the maximum allowed 3.}}
+    switch (path) {
+      case "FOO":
+        return 1;
+      case "BAR":
+        return 2;
+      case "FIZ":
+        return 3;
+      default:
+        return 4;
+    }
+    return 5;
+    return 6;
+    return 7;
+    return 8;
+  }
+
+  int foo3(String path) { // Compliant
+    switch (path) {
+      case "FOO":
+        return 1;
+      default:
+        switch (path) {
+          case "BAR":
+            return 2;
+          default:
+            return 3;
+        }
+    }
+    return 4;
+    return 5;
+    return 6;
+  }
+
+  int foo4(String path) { // Noncompliant {{Reduce the number of returns of this method 4, down to the maximum allowed 3.}}
+    switch (path) {
+      case "FOO":
+        return 1;
+      default:
+        switch (path) {
+          case "BAR":
+            return 2;
+          default:
+            return 3;
+        }
+    }
+    return 4;
+    return 5;
+    return 6;
+    return 7;
+  }
+
+  int foo5(String path) { // Compliant
+    switch (path) {
+      case "FOO":
+        return 1;
+      default:
+        switch (path) {
+          case "BAR":
+            return 2;
+          default:
+            return 3;
+        }
+        return 4;
+        return 5;
+        return 6;
+        return 7;
+    }
+    return 8;
+    return 9;
+    return 10;
+  }
+
+  int foo6(String path) { // Noncompliant {{Reduce the number of returns of this method 4, down to the maximum allowed 3.}}
+    switch (path) {
+      case "FOO":
+        return 1;
+      default:
+        switch (path) {
+          case "BAR":
+            return 2;
+          default:
+            return 3;
+        }
+        return 4;
+      return 5;
+      return 6;
+      return 7;
+    }
+    return 8;
+    return 9;
+    return 10;
+    return 11;
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/MethodWithExcessiveReturnsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/MethodWithExcessiveReturnsCheckTest.java
@@ -36,4 +36,11 @@ public class MethodWithExcessiveReturnsCheckTest {
     JavaCheckVerifier.verify("src/test/files/checks/MethodWithExcessiveReturnsCheckCustom.java", check);
   }
 
+  @Test
+  public void ignoreSwitchBlocks() {
+    MethodWithExcessiveReturnsCheck check = new MethodWithExcessiveReturnsCheck();
+    check.includeSwitchBlocks = false;
+    JavaCheckVerifier.verify("src/test/files/checks/MethodWithExcessiveReturnsCheckIgnoreSwitchBlocks.java", check);
+  }
+
 }


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/sonarqube/_EOsh0bVA5Q

The change is backwards-compatible since the default setting for the new property enforces the current rule behavior.

The rationale for the added property is that some teams may want to add an exception for switch blocks if they find that

```
case
  return
case
  return
case
  return
```

is more readable than

```
init var
case
  set var
  break
case
  set var
  break
case
  set var
  break
return
```

![screen shot 2018-02-09 at 2 26 54 pm](https://user-images.githubusercontent.com/9969202/36053523-cf26e608-0da6-11e8-83af-f52147e256bb.png)

![screen shot 2018-02-09 at 2 36 48 pm](https://user-images.githubusercontent.com/9969202/36053477-b4c2fc20-0da6-11e8-8168-8cb3df7d3872.png)

