### PR TITLE
Bugfix for S1312: Find loggers which are fully qualified.

### DIFF
--- a/its/ruling/src/test/resources/sonar-server/squid-S1312.json
+++ b/its/ruling/src/test/resources/sonar-server/squid-S1312.json
@@ -11,6 +11,9 @@
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/es/EsClient.java':[
 77,
 ],
+'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/platform/web/RootFilter.java':[
+49,
+],
 'org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/user/SecurityRealmFactory.java':[
 81,
 ],

--- a/java-checks/src/main/java/org/sonar/java/checks/LoggersDeclarationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/LoggersDeclarationCheck.java
@@ -26,6 +26,7 @@ import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Modifier;
 import org.sonar.plugins.java.api.tree.ModifiersTree;
@@ -102,10 +103,14 @@ public class LoggersDeclarationCheck extends BaseTreeVisitor implements JavaFile
   }
 
   private static boolean isLoggerType(Tree tree) {
-    if (!tree.is(Tree.Kind.IDENTIFIER)) {
+    IdentifierTree identifierTree = null;
+    if (tree.is(Tree.Kind.IDENTIFIER)) {
+      identifierTree = (IdentifierTree) tree;
+    } else if (tree.is(Tree.Kind.MEMBER_SELECT)) {
+      identifierTree = ((MemberSelectExpressionTree) tree).identifier ();
+    } else {
       return false;
     }
-    IdentifierTree identifierTree = (IdentifierTree) tree;
 
     return "Log".equals(identifierTree.name()) ||
       "Logger".equals(identifierTree.name());

--- a/java-checks/src/test/files/checks/LoggersDeclarationCheck.java
+++ b/java-checks/src/test/files/checks/LoggersDeclarationCheck.java
@@ -27,4 +27,7 @@ class A {
   
   private void logExclusions(String[] exclusions, Logger logger) { // Compliant
   }
+
+  protected final org.slf4j.Logger logger; // Noncompliant
+ 
 }


### PR DESCRIPTION
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

This is a minor fix for S1312, so it also detects fully qualified logger class names (e.g. org.slf4j.Logger). I haven't run the integration test suite, since this fix is very minor...