### PR TITLE
fixed compliant solution for S2718

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/DateUtilsTruncateCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateUtilsTruncateCheck.java
@@ -47,7 +47,7 @@ public class DateUtilsTruncateCheck extends AbstractMethodDetection implements J
 
   @Override
   protected void onMethodInvocationFound(MethodInvocationTree mit) {
-    reportIssue(ExpressionUtils.methodName(mit), "Use \"Instant.truncatedTo\" instead." + context.getJavaVersion().java8CompatibilityMessage());
+    reportIssue(ExpressionUtils.methodName(mit), "Use \"ZonedDateTime.truncatedTo\" instead." + context.getJavaVersion().java8CompatibilityMessage());
   }
 
   private static MethodMatcher truncateMethodMatcher(String firstParameterType) {

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2718_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S2718_java.html
@@ -11,8 +11,10 @@ public Date trunc(Date date) {
 <pre>
 public Date trunc(Date date) {
   Instant instant = date.toInstant();
-  instant = instant.truncatedTo(ChronoUnit.SECONDS);
-  return Date.from(instant);
+  ZonedDateTime zonedDateTime = instant.atZone(ZoneId.systemDefault());
+  ZonedDateTime truncatedZonedDateTime = zonedDateTime.truncatedTo(ChronoUnit.SECONDS);
+  Instant truncatedInstant = truncatedZonedDateTime.toInstant();
+  return Date.from(truncatedInstant);
 }
 </pre>
 

--- a/java-checks/src/test/files/checks/DateUtilsTruncateCheck.java
+++ b/java-checks/src/test/files/checks/DateUtilsTruncateCheck.java
@@ -6,7 +6,7 @@ import static org.apache.commons.lang.time.DateUtils.truncate;
 
 class A {
   public void foo(Date date, Calendar calendar, Object object, int field) {
-    DateUtils.truncate(date, field);      // Noncompliant [[sc=15;ec=23]] {{Use "Instant.truncatedTo" instead.}}
+    DateUtils.truncate(date, field);      // Noncompliant [[sc=15;ec=23]] {{Use "ZonedDateTime.truncatedTo" instead.}}
     DateUtils.truncate(calendar, field);  // Noncompliant
     DateUtils.truncate(object, field);    // Noncompliant
     truncate(date, field);      // Noncompliant

--- a/java-checks/src/test/files/checks/DateUtilsTruncateCheck_no_version.java
+++ b/java-checks/src/test/files/checks/DateUtilsTruncateCheck_no_version.java
@@ -6,7 +6,7 @@ import static org.apache.commons.lang.time.DateUtils.truncate;
 
 class A {
   public void foo(Date date, Calendar calendar, Object object, int field) {
-    DateUtils.truncate(date, field);      // Noncompliant {{Use "Instant.truncatedTo" instead. (sonar.java.source not set. Assuming 8 or greater.)}}
+    DateUtils.truncate(date, field);      // Noncompliant {{Use "ZonedDateTime.truncatedTo" instead. (sonar.java.source not set. Assuming 8 or greater.)}}
     DateUtils.truncate(calendar, field);  // Noncompliant
     DateUtils.truncate(object, field);    // Noncompliant
     truncate(date, field);      // Noncompliant


### PR DESCRIPTION
The existing solution of S2718 rule (replace `DateUtils.truncate` method with faster one from java.time) changes the behavior because `DateUtils.truncate` method performs calculation in default time zone but Instant does in UTC. Use `ZonedDateTime.truncateTo` method instead to get the same behavior as commons-lang method. JSR-310 solution remains more than 2 times faster than the alternative one.