### PR TITLE
SONARJAVA-1221 Analyze test classes running with `Enclosed` runner

### DIFF
--- a/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
+++ b/java-checks/src/test/files/checks/NoTestInTestClassCheck.java
@@ -96,12 +96,7 @@ class OtherTest extends BaseTest {
   public void test2() {
   }
 }
-@org.junit.runner.RunWith(org.junit.experimental.runners.Enclosed.class)
-public class MyNewTest { // should not raise an issue
-}
-@RunWith(Enclosed.class)
-public class MyNew2Test { // no issue
-}
+
 @org.junit.runner.RunWith(cucumber.api.junit.Cucumber.class)
 public class MyCucumberTest { // should not raise an issue
 }

--- a/java-checks/src/test/files/checks/NoTestInTestClassCheckEnclosed.java
+++ b/java-checks/src/test/files/checks/NoTestInTestClassCheckEnclosed.java
@@ -56,3 +56,50 @@ class EnclosedWithStaticInnerClassTest { // Noncompliant {{Add some tests to thi
     }
   }
 }
+
+@RunWith(Enclosed.class)
+class EnclosedExtendsTestClassTest extends SimpleTest { // Noncompliant
+}
+
+@RunWith(Enclosed.class)
+class EnclosedWithInnerStaticClassExtendsTestClass { // no issue
+  public static class InnerClass extends SimpleTest {
+  }
+}
+
+@RunWith(Enclosed.class)
+class EnclosedWithInnerClassExtendsTest { // Noncompliant
+  class InnerClass extends SimpleTest {
+  }
+}
+
+@RunWith(Enclosed.class)
+class EnclosedExtendsWithInnerPublicClassTest extends TestsWithInnerPublicTest { // Compliant
+}
+
+@RunWith(Enclosed.class)
+class EnclosedExtendsWithInnerClassTest extends TestsWithInnerTest { // Noncompliant
+}
+
+
+class SimpleTest {
+  @Test
+  public void test() {
+  }
+}
+
+class TestsWithInnerPublicTest {
+  public static class InnerClass {
+    @Test
+    public void test() {
+    }
+  }
+}
+
+class TestsWithInnerTest { // Noncompliant
+  static class InnerClass {
+    @Test
+    public void test() {
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/NoTestInTestClassCheckEnclosed.java
+++ b/java-checks/src/test/files/checks/NoTestInTestClassCheckEnclosed.java
@@ -1,0 +1,58 @@
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+@org.junit.runner.RunWith(org.junit.experimental.runners.Enclosed.class)
+public class MyNewTest { // Noncompliant {{Add some tests to this class.}}
+}
+
+@RunWith(Enclosed.class)
+public class MyNew2Test { // Noncompliant {{Add some tests to this class.}}
+}
+
+@RunWith(Enclosed.class)
+public class EnclosedNoInnerClassesTest { // Noncompliant {{Add some tests to this class.}}
+  @Test
+  public void something() {
+  }
+
+  public void testSomething() {
+  }
+}
+
+@RunWith(Enclosed.class)
+class EnclosedIgnoreAbstractInnerClassTest { // Noncompliant {{Add some tests to this class.}}
+  abstract public static class IgnoredTest {
+    @Test
+    public void ignored() {
+    }
+  }
+}
+
+@RunWith(Enclosed.class)
+class EnclosedWithPublicStaticInnerClassTest { // no issue
+  public static class PublicStaticInner {
+    @Test
+    public void publicStaticInner() {
+    }
+  }
+}
+
+@RunWith(Enclosed.class)
+class EnclosedWithPublicInnerClassTest { // Noncompliant {{Add some tests to this class.}}
+  public class PublicInner {
+    @Test
+    public void publicInner() {
+    }
+  }
+}
+
+
+@RunWith(Enclosed.class)
+class EnclosedWithStaticInnerClassTest { // Noncompliant {{Add some tests to this class.}}
+  static class StaticInner {
+    @Test
+    public void staticInner() {
+    }
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/NoTestInTestClassCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/NoTestInTestClassCheckTest.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.java.checks;
 
-import org.junit.Test;
-import org.sonar.java.checks.verifier.JavaCheckVerifier;
-
 import java.io.File;
 import java.util.ArrayList;
+import org.junit.Test;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
 public class NoTestInTestClassCheckTest {
 
@@ -31,6 +30,12 @@ public class NoTestInTestClassCheckTest {
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/NoTestInTestClassCheck.java", new NoTestInTestClassCheck());
     JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/NoTestInTestClassCheck.java", new NoTestInTestClassCheck());
+  }
+
+  @Test
+  public void testEnclosed() {
+    JavaCheckVerifier.verify("src/test/files/checks/NoTestInTestClassCheckEnclosed.java", new NoTestInTestClassCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/NoTestInTestClassCheckEnclosed.java", new NoTestInTestClassCheck());
   }
 
   @Test


### PR DESCRIPTION
JUnit4 has introduced an `Enclosed` runner that runs all static inner
classes of the outer class.

This PR analyzes if there are tests in the inner classes to be run, and only
if there are none, `squid:S2187` will be triggered ( and report that there are
no tests in the outer class )