### PR TITLE
FP on S1118 with Lombok constructors

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
@@ -21,17 +21,22 @@ package org.sonar.java.filters;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import org.sonar.java.checks.AtLeastOneConstructorCheck;
 import org.sonar.java.checks.EqualsNotOverriddenInSubclassCheck;
 import org.sonar.java.checks.EqualsNotOverridenWithCompareToCheck;
 import org.sonar.java.checks.UtilityClassWithPublicConstructorCheck;
 import org.sonar.java.checks.unused.UnusedPrivateFieldCheck;
 import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.Tree;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class LombokFilter extends BaseTreeVisitorIssueFilter {
@@ -98,7 +103,7 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
       acceptLines(tree, EqualsNotOverridenWithCompareToCheck.class);
     }
 
-    if (usesAnnotation(tree, GENERATE_PRIVATE_CONSTRUCTOR)) {
+    if (generatesPrivateConstructor(tree)) {
       excludeLines(tree, UtilityClassWithPublicConstructorCheck.class);
     } else {
       acceptLines(tree, UtilityClassWithPublicConstructorCheck.class);
@@ -115,5 +120,43 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
       }
     }
     return false;
+  }
+
+  private boolean generatesPrivateConstructor(ClassTree classTree) {
+    if (usesAnnotation(classTree, GENERATE_PRIVATE_CONSTRUCTOR)) {
+      return true;
+    }
+    SymbolMetadata metadata = classTree.symbol().metadata();
+    for (String annotation : GENERATE_CONSTRUCTOR) {
+      if (metadata.isAnnotatedWith(annotation) && generatesPrivateAccess(metadata, annotation)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean generatesPrivateAccess(SymbolMetadata metadata, String annotation) {
+    for (SymbolMetadata.AnnotationValue annotationValue : metadata.valuesForAnnotation(annotation)) {
+      if (Objects.equals(annotationValue.name(), "access") && Objects.equals(getAccessLevelValue(annotationValue.value()), "PRIVATE")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Nullable
+  private static String getAccessLevelValue(Object value) {
+    String retentionValue = null;
+    if (value instanceof Tree) {
+      Tree tree = (Tree) value;
+      if (tree.is(Tree.Kind.MEMBER_SELECT)) {
+        retentionValue = ((MemberSelectExpressionTree) tree).identifier().name();
+      } else if (tree.is(Tree.Kind.IDENTIFIER)) {
+        retentionValue = ((IdentifierTree) tree).name();
+      }
+    } else if (value instanceof Symbol.VariableSymbol) {
+      retentionValue = ((Symbol.VariableSymbol) value).name();
+    }
+    return retentionValue;
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class LombokFilter extends BaseTreeVisitorIssueFilter {
@@ -126,11 +127,14 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
       return true;
     }
     SymbolMetadata metadata = classTree.symbol().metadata();
-    return GENERATE_CONSTRUCTOR.stream().anyMatch(annotation -> generatesPrivateAccess(metadata, annotation));
+    return GENERATE_CONSTRUCTOR.stream()
+            .map(metadata::valuesForAnnotation)
+            .filter(Objects::nonNull)
+            .anyMatch(LombokFilter::generatesPrivateAccess);
   }
 
-  private static boolean generatesPrivateAccess(SymbolMetadata metadata, String annotation) {
-    return metadata.isAnnotatedWith(annotation) && metadata.valuesForAnnotation(annotation).stream().anyMatch(av -> "access".equals(av.name()) && "PRIVATE".equals(getAccessLevelValue(av.value())));
+  private static boolean generatesPrivateAccess(List<SymbolMetadata.AnnotationValue> values) {
+    return values.stream().anyMatch(av -> "access".equals(av.name()) && "PRIVATE".equals(getAccessLevelValue(av.value())));
   }
 
   @Nullable

--- a/java-checks/src/test/files/filters/LombokFilter.java
+++ b/java-checks/src/test/files/filters/LombokFilter.java
@@ -183,3 +183,49 @@ static class UtilityClass {
     }
   }
 }
+
+static class UtilityClassWithPublicConstructorCheck {
+  private UtilityClassWithPublicConstructorCheck() {
+  }
+
+  static class A { // WithIssue
+    public static void foo() {
+    }
+  }
+
+  @lombok.NoArgsConstructor
+  public static class B { // WithIssue
+    public static void foo() {
+    }
+  }
+
+  @lombok.RequiredArgsConstructor
+  public static class C { // WithIssue
+    public static void foo() {
+    }
+  }
+
+  @lombok.AllArgsConstructor
+  public static class D { // WithIssue
+    public static void foo() {
+    }
+  }
+
+  @lombok.NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+  static class E { // NoIssue
+    public static void foo() {
+    }
+  }
+
+  @lombok.RequiredArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+  static class F { // NoIssue
+    public static void foo() {
+    }
+  }
+
+  @lombok.AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+  static class G { // NoIssue
+    public static void foo() {
+    }
+  }
+}


### PR DESCRIPTION
This fixes false positives of S1118 ("Utility classes should not have public constructors") regarding lombok-generated constructors; see my post at https://groups.google.com/forum/#!topic/sonarqube/hu2sITqPyQs

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
    - **_My local ruling test failed, but had exactly the same results as with `master`._**
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
    - **_There was no reaction to my post, so there is no Jira ticket._**
