### PR TITLE
Check license compliance on Travis

### DIFF
--- a/check-license-compliance.sh
+++ b/check-license-compliance.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
+
+mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party -Dlicense.aggregateMissingLicensesFile=$(pwd)/missing-dep-licenses.properties -DuseMissingFile

--- a/missing-dep-licenses.properties
+++ b/missing-dep-licenses.properties
@@ -1,0 +1,6 @@
+# List the licenses which are not defined on third-party dependencies.
+# See check-license-compatibility.sh
+
+classworlds--classworlds--1.1-alpha-2=apache_v2
+org.codehaus.plexus--plexus-container-default--1.0-alpha-9-stable-1=apache_v2
+org.slf4j--slf4j-api--1.5.6=mit

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>44</version>
+    <version>45</version>
   </parent>
 
   <groupId>org.sonarsource.java</groupId>

--- a/third-party-licenses.sh
+++ b/third-party-licenses.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party -Dlicense.includedScopes=compile
-
-cat target/generated-sources/license/THIRD-PARTY.txt

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -euo pipefail
 
 function configureTravis {
@@ -16,6 +15,7 @@ case "$TEST" in
 CI)
   export DEPLOY_PULL_REQUEST=true
   regular_mvn_build_deploy_analyze
+  ./check-license-compliance.sh
   ;;
 
 *)


### PR DESCRIPTION
Upgrading to parent 45 allows to improve the verification of
license compliance of third-party dependencies.

The new script check-license-compliance.sh fails if a dependency
has a license that is not compatible with SonarSource policy.

See https://xtranet.sonarsource.com/display/DEV/Open+Source+Licenses
for more details.