### PR TITLE
Fix license check

### DIFF
--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>com.fasterxml.woodstox</groupId>
       <artifactId>woodstox-core</artifactId>
-      <version>5.1.0</version>
     </dependency>
 
     <dependency>

--- a/java-jacoco-previous/pom.xml
+++ b/java-jacoco-previous/pom.xml
@@ -69,14 +69,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <!-- During release:perform, enable the "release" profile -->
-          <releaseProfiles>release</releaseProfiles>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>45</version>
+    <version>46.0.482</version>
   </parent>
 
   <groupId>org.sonarsource.java</groupId>


### PR DESCRIPTION
- use a pre release version of the parent POM
- remove unused plugin (release) which was removed from the parent POM