### PR TITLE
SONARSEC-165 Fix uCFG array access inconsistency with primitives

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
@@ -36,6 +36,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.java.cfg.CFG;
 import org.sonar.java.cfg.VariableReadExtractor;
 import org.sonar.java.model.LiteralUtils;
+import org.sonar.java.resolve.ArrayJavaType;
 import org.sonar.java.resolve.JavaSymbol;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
@@ -287,6 +288,9 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
   }
 
   private void buildNewArrayInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, NewArrayTree tree) {
+    if (tree.type() != null  && !isObject(tree.type().symbolType())) {
+      return;
+    }
     Expression.Variable newArray = variableWithId(idGenerator.newIdFor(tree));
     blockBuilder.newObject(newArray, tree.symbolType().fullyQualifiedName(), location(tree));
     idGenerator.varForExpression(tree, newArray.id());
@@ -460,6 +464,9 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
   }
 
   private static boolean isObject(Type type) {
+    if (type.isArray()) {
+      return isObject(((ArrayJavaType)type).elementType());
+    }
     return !type.isPrimitive() && !type.isUnknown();
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
@@ -279,7 +279,7 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
       ArrayAccessExpressionTree arrayAccessExpressionTree = (ArrayAccessExpressionTree) element;
       if (isObject(arrayAccessExpressionTree.symbolType())) {
         Expression.Variable getValue = variableWithId(idGenerator.newId());
-        Expression array = idGenerator.lookupExpressionFor((arrayAccessExpressionTree).expression());
+        Expression array = idGenerator.lookupExpressionFor(arrayAccessExpressionTree.expression());
         blockBuilder.assignTo(getValue, arrayGet(array), location(element));
         idGenerator.varForExpression(element, getValue.id());
       }
@@ -290,13 +290,10 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     Expression.Variable newArray = variableWithId(idGenerator.newIdFor(tree));
     blockBuilder.newObject(newArray, tree.symbolType().fullyQualifiedName(), location(tree));
     idGenerator.varForExpression(tree, newArray.id());
-    List<ExpressionTree> initializers = tree.initializers();
-    if (!initializers.isEmpty() && isObject(initializers.get(0).symbolType())) {
-      initializers.forEach(i -> {
-        Expression argument = idGenerator.lookupExpressionFor(i);
-        blockBuilder.assignTo(variableWithId(idGenerator.newId()), arraySet(newArray, argument), location(tree));
-      });
-    }
+    tree.initializers().stream().filter(i -> isObject(i.symbolType())).forEach(i -> {
+      Expression argument = idGenerator.lookupExpressionFor(i);
+      blockBuilder.assignTo(variableWithId(idGenerator.newId()), arraySet(newArray, argument), location(tree));
+    });
   }
 
   private void buildConstructorInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, NewClassTree tree) {

--- a/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
@@ -36,6 +36,7 @@ import org.sonar.api.utils.log.Loggers;
 import org.sonar.java.cfg.CFG;
 import org.sonar.java.cfg.VariableReadExtractor;
 import org.sonar.java.model.LiteralUtils;
+import org.sonar.java.resolve.ArrayJavaType;
 import org.sonar.java.resolve.JavaSymbol;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
@@ -276,14 +277,20 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
       buildPlusAssignmentInvocation(blockBuilder, idGenerator, assignmentExpressionTree);
     } else if (element.is(ARRAY_ACCESS_EXPRESSION) && !element.parent().is(PLUS_ASSIGNMENT, ASSIGNMENT)) {
       // PLUS_ASSIGNMENT and ASSIGNMENT might imply an array set, otherwise an array access is always a get
-      Expression.Variable getValue = variableWithId(idGenerator.newId());
-      Expression array = idGenerator.lookupExpressionFor(((ArrayAccessExpressionTree)element).expression());
-      blockBuilder.assignTo(getValue, arrayGet(array), location(element));
-      idGenerator.varForExpression(element, getValue.id());
+      ArrayAccessExpressionTree arrayAccessExpressionTree = (ArrayAccessExpressionTree) element;
+      if (isObject(arrayAccessExpressionTree.symbolType())) {
+        Expression.Variable getValue = variableWithId(idGenerator.newId());
+        Expression array = idGenerator.lookupExpressionFor((arrayAccessExpressionTree).expression());
+        blockBuilder.assignTo(getValue, arrayGet(array), location(element));
+        idGenerator.varForExpression(element, getValue.id());
+      }
     }
   }
 
   private void buildNewArrayInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, NewArrayTree tree) {
+    if (tree.type() != null && !isObject(tree.type().symbolType())) {
+      return;
+    }
     Expression.Variable newArray = variableWithId(idGenerator.newIdFor(tree));
     blockBuilder.newObject(newArray, tree.symbolType().fullyQualifiedName(), location(tree));
     idGenerator.varForExpression(tree, newArray.id());
@@ -458,6 +465,9 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
   }
 
   private static boolean isObject(Type type) {
+    if (type.isArray()) {
+      return isObject(((ArrayJavaType) type).elementType().symbol().type());
+    }
     return !type.isPrimitive() && !type.isUnknown();
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
@@ -785,28 +785,21 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
-  public void array_of_primitives_ignore_get_and_set() {
-    Expression.Variable input = variableWithId("input");
-    Expression.Variable foo = variableWithId("foo");
-    Expression.Variable bar = variableWithId("bar");
+  public void array_of_primitives_ignore() {
     Expression.Variable aux0 = variableWithId("%0");
     Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([III)[B")
+    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([I[[III)[B")
         .addBasicBlock(newBasicBlock("1")
-            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 4, 17, 4, 29))
-            .assignTo(foo, call("__id").withArgs(aux0), new LocationInFile(FILE_KEY, 4,4,4,30))
-            .newObject(aux1, "$Array", new LocationInFile(FILE_KEY, 5, 16, 5, 24))
-            .assignTo(bar, call("__id").withArgs(aux1), new LocationInFile(FILE_KEY, 5,4,5,25))
-            .assignTo(aux2, call("A#baz([I[IB)V").withArgs(Expression.THIS, bar, input, constant("\"\"")), new LocationInFile(FILE_KEY, 6,4,6,27))
-            .ret(foo, new LocationInFile(FILE_KEY, 9, 4, 9, 15)))
+            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 5, 16, 5, 24))
+            .assignTo(aux1, call("A#baz([I[IB)V").withArgs(Expression.THIS, constant("\"\""), constant("\"\""), constant("\"\"")), new LocationInFile(FILE_KEY, 6,4,6,35))
+            .ret(constant("\"\""), new LocationInFile(FILE_KEY, 9, 4, 9, 15)))
         .build();
     assertCodeToUCfg("class A { \n" +
         "  private void baz(int[] a, int[] b, byte c) {}\n" +
-        "  private byte[] foo(int[] input, int i, int j) { \n" +
+        "  private byte[] foo(int[] input, int[][] multiDim, int i, int j) { \n" +
         "    byte[] foo = new byte[10];\n" +
-        "    int[] bar = { 1, 2 };\n" +
-        "    baz(bar, input, foo[0]);\n" +
+        "    int[] bar = { 1, 2 };\n" + // we cannot tell the type of the new array construct
+        "    baz(multiDim[0], input, foo[0]);\n" +
         "    foo[bar[0]] = foo[0];\n" +
         "    foo[j + 1] = (byte) ((input[i] >>> 8) & 0xff);\n" +
         "    return foo;\n" +
@@ -922,7 +915,7 @@ public class UCFGJavaVisitorTest {
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod(methodId)
         .addBasicBlock(newBasicBlock("1")
             .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,8,3,22))
-            .assignTo(aux1, call(methodId).withArgs(Expression.THIS, aux0, array, intA), new LocationInFile(FILE_KEY, 3,4,3,36))
+            .assignTo(aux1, call(methodId).withArgs(Expression.THIS, aux0, array, constant("\"\"")), new LocationInFile(FILE_KEY, 3,4,3,36))
             .assignTo(aux2, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,4,4,12))
             .assignTo(aux3, call("__concat").withArgs(aux2, foo), new LocationInFile(FILE_KEY, 4,4,4,19))
             .assignTo(aux4, call("__arraySet").withArgs(array, aux3), new LocationInFile(FILE_KEY, 4,4,4,19))

--- a/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
@@ -785,16 +785,29 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
-  public void array_getters_and_setters_on_primitives() {
+  public void array_of_primitives_ignore_get_and_set() {
+    Expression.Variable input = variableWithId("input");
     Expression.Variable foo = variableWithId("foo");
+    Expression.Variable bar = variableWithId("bar");
+    Expression.Variable aux0 = variableWithId("%0");
+    Expression.Variable aux1 = variableWithId("%1");
+    Expression.Variable aux2 = variableWithId("%2");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([III)[B")
         .addBasicBlock(newBasicBlock("1")
-            .ret(constant("\"\""), new LocationInFile(FILE_KEY, 6, 4, 6, 15)))
+            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 4, 17, 4, 29))
+            .assignTo(foo, call("__id").withArgs(aux0), new LocationInFile(FILE_KEY, 4,4,4,30))
+            .newObject(aux1, "$Array", new LocationInFile(FILE_KEY, 5, 16, 5, 24))
+            .assignTo(bar, call("__id").withArgs(aux1), new LocationInFile(FILE_KEY, 5,4,5,25))
+            .assignTo(aux2, call("A#baz([I[I)V").withArgs(Expression.THIS, bar, input), new LocationInFile(FILE_KEY, 6,4,6,19))
+            .ret(foo, new LocationInFile(FILE_KEY, 9, 4, 9, 15)))
         .build();
     assertCodeToUCfg("class A { \n" +
+        "  private void baz(int[] a, int[] b) {}\n" +
         "  private byte[] foo(int[] input, int i, int j) { \n" +
         "    byte[] foo = new byte[10];\n" +
-        "    foo[j] = (byte) (input[i] & 0xff);\n" +
+        "    int[] bar = { 1, 2 };\n" +
+        "    baz(bar, input);\n" +
+        "    foo[bar[0]] = (byte) (input[i] & 0xff);\n" +
         "    foo[j + 1] = (byte) ((input[i] >>> 8) & 0xff);\n" +
         "    return foo;\n" +
         "  }\n" +
@@ -882,7 +895,7 @@ public class UCFGJavaVisitorTest {
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod(methodId)
         .addBasicBlock(newBasicBlock("1")
             .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,8,3,22))
-            .assignTo(aux1, call(methodId).withArgs(Expression.THIS, aux0, array, constant("\"\"")), new LocationInFile(FILE_KEY, 3,4,3,36))
+            .assignTo(aux1, call(methodId).withArgs(Expression.THIS, aux0, array, intA), new LocationInFile(FILE_KEY, 3,4,3,36))
             .assignTo(aux2, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,4,4,12))
             .assignTo(aux3, call("__concat").withArgs(aux2, foo), new LocationInFile(FILE_KEY, 4,4,4,19))
             .assignTo(aux4, call("__arraySet").withArgs(array, aux3), new LocationInFile(FILE_KEY, 4,4,4,19))

--- a/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
@@ -785,6 +785,23 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
+  public void array_getters_and_setters_on_primitives() {
+    Expression.Variable foo = variableWithId("foo");
+    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([III)[B")
+        .addBasicBlock(newBasicBlock("1")
+            .ret(constant("\"\""), new LocationInFile(FILE_KEY, 6, 4, 6, 15)))
+        .build();
+    assertCodeToUCfg("class A { \n" +
+        "  private byte[] foo(int[] input, int i, int j) { \n" +
+        "    byte[] foo = new byte[10];\n" +
+        "    foo[j] = (byte) (input[i] & 0xff);\n" +
+        "    foo[j + 1] = (byte) ((input[i] >>> 8) & 0xff);\n" +
+        "    return foo;\n" +
+        "  }\n" +
+        "}", expectedUCFG);
+  }
+
+  @Test
   public void array_variable_declaration() {
     Expression.Variable foo = variableWithId("foo");
     Expression.Variable array = variableWithId("array");
@@ -860,22 +877,20 @@ public class UCFGJavaVisitorTest {
     Expression.Variable aux5 = variableWithId("%5");
     Expression.Variable aux6 = variableWithId("%6");
     Expression.Variable aux7 = variableWithId("%7");
-    Expression.Variable aux8 = variableWithId("%8");
     Expression.Variable s = variableWithId("s");
     String methodId = "A#foo(Ljava/lang/String;[Ljava/lang/String;[I)Ljava/lang/String;";
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod(methodId)
         .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(intA), new LocationInFile(FILE_KEY, 3,14,3,21))
-            .assignTo(aux1, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,8,3,22))
-            .assignTo(aux2, call(methodId).withArgs(Expression.THIS, aux1, array, intA), new LocationInFile(FILE_KEY, 3,4,3,36))
-            .assignTo(aux3, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,4,4,12))
-            .assignTo(aux4, call("__concat").withArgs(aux3, foo), new LocationInFile(FILE_KEY, 4,4,4,19))
-            .assignTo(aux5, call("__arraySet").withArgs(array, aux4), new LocationInFile(FILE_KEY, 4,4,4,19))
-            .assignTo(aux6, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 5,15,5,23))
-            .assignTo(s, call("__id").withArgs(aux6), new LocationInFile(FILE_KEY, 5,4,5,24))
-            .assignTo(aux7, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 6,11,6,19))
-            .assignTo(aux8, call("__concat").withArgs(aux7, s), new LocationInFile(FILE_KEY, 6,11,6,23))
-            .ret(aux8, new LocationInFile(FILE_KEY, 6, 4, 6, 24)))
+            .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,8,3,22))
+            .assignTo(aux1, call(methodId).withArgs(Expression.THIS, aux0, array, constant("\"\"")), new LocationInFile(FILE_KEY, 3,4,3,36))
+            .assignTo(aux2, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,4,4,12))
+            .assignTo(aux3, call("__concat").withArgs(aux2, foo), new LocationInFile(FILE_KEY, 4,4,4,19))
+            .assignTo(aux4, call("__arraySet").withArgs(array, aux3), new LocationInFile(FILE_KEY, 4,4,4,19))
+            .assignTo(aux5, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 5,15,5,23))
+            .assignTo(s, call("__id").withArgs(aux5), new LocationInFile(FILE_KEY, 5,4,5,24))
+            .assignTo(aux6, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 6,11,6,19))
+            .assignTo(aux7, call("__concat").withArgs(aux6, s), new LocationInFile(FILE_KEY, 6,11,6,23))
+            .ret(aux7, new LocationInFile(FILE_KEY, 6, 4, 6, 24)))
         .build();
     assertCodeToUCfg("class A { \n" +
         "  private String foo(String foo, String[] array, int[] intA) { \n" +


### PR DESCRIPTION
Instead of translating only arrayGet on primitive arrays (and not arraySet), ignore both arrayGet and arraySet.
Keep references to arrays in the uCFG.