### PR TITLE
Revert all SonarSecurity 7.3 related commits:

### DIFF
--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>org.sonarsource.ucfg</groupId>
       <artifactId>sonar-ucfg</artifactId>
-      <version>1.2.0.100</version>
+      <version>1.1.0.55</version>
     </dependency>
   </dependencies>
 

--- a/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/UCFGJavaVisitor.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +44,6 @@ import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.Arguments;
-import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
@@ -53,7 +53,6 @@ import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
-import org.sonar.plugins.java.api.tree.NewArrayTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.ReturnStatementTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
@@ -65,16 +64,12 @@ import org.sonar.ucfg.LocationInFile;
 import org.sonar.ucfg.UCFG;
 import org.sonar.ucfg.UCFGBuilder;
 import org.sonar.ucfg.UCFGBuilder.BlockBuilder;
-import org.sonar.ucfg.UCFGBuilder.CallBuilder;
 import org.sonar.ucfg.UCFGtoProtobuf;
 
-import static org.sonar.plugins.java.api.tree.Tree.Kind.ARRAY_ACCESS_EXPRESSION;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.ASSIGNMENT;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.CONSTRUCTOR;
-import static org.sonar.plugins.java.api.tree.Tree.Kind.IDENTIFIER;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.MEMBER_SELECT;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.METHOD_INVOCATION;
-import static org.sonar.plugins.java.api.tree.Tree.Kind.NEW_ARRAY;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.NEW_CLASS;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.PLUS;
 import static org.sonar.plugins.java.api.tree.Tree.Kind.PLUS_ASSIGNMENT;
@@ -85,13 +80,13 @@ import static org.sonar.ucfg.UCFGBuilder.variableWithId;
 public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner {
   private static final Logger LOG = Loggers.get(JavaSquid.class);
   private final File protobufDirectory;
-  String javaFileKey;
+  String fileKey;
   private int index = 0;
 
   public UCFGJavaVisitor(File workdir) {
     this.protobufDirectory = new File(new File(workdir, "ucfg"), "java");
     if (protobufDirectory.exists()) {
-      // set index to the number of files, to avoid overwriting previous files
+      // set index to number of file, to avoid overwriting previous files
       index = protobufDirectory.list().length;
     } else {
       protobufDirectory.mkdirs();
@@ -100,7 +95,7 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
 
   @Override
   public void scanFile(JavaFileScannerContext context) {
-    this.javaFileKey = context.getFileKey();
+    this.fileKey = context.getFileKey();
     if (context.getSemanticModel() == null) {
       return;
     }
@@ -125,15 +120,15 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
   protected void serializeUCFG(MethodTree tree, CFG cfg) {
     try {
       UCFG uCFG = buildUCfg(tree, cfg);
-      UCFGtoProtobuf.toProtobufFile(uCFG, ucfgFilePath());
+      UCFGtoProtobuf.toProtobufFile(uCFG, filePath());
     } catch (Exception e) {
-      String msg = String.format("Cannot generate ucfg for file %s for method at line %d", javaFileKey, tree.firstToken().line());
+      String msg = String.format("Cannot generate ucfg in file %s for method at line %d", fileKey, tree.firstToken().line());
       LOG.error(msg, e);
       throw new AnalysisException(msg, e);
     }
   }
 
-  private String ucfgFilePath() {
+  private String filePath() {
     String absolutePath = new File(protobufDirectory, "ucfg_" + index + ".proto").getAbsolutePath();
     index++;
     return absolutePath;
@@ -152,7 +147,7 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
 
     BlockBuilder entryBlockBuilder = buildBasicBlock(cfg.entry(), methodTree, idGenerator);
 
-    if (hasAnnotatedParameters(methodTree)) {
+    if (getAnnotatedStringParameters(methodTree).count() > 0) {
       builder.addStartingBlock(buildParameterAnnotationsBlock(methodTree, idGenerator, cfg));
       builder.addBasicBlock(entryBlockBuilder);
     } else {
@@ -169,53 +164,30 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     LocationInFile parametersLocation = location(methodTree.openParenToken(), methodTree.closeParenToken());
     UCFGBuilder.BlockBuilder blockBuilder = UCFGBuilder.newBasicBlock("paramAnnotations", parametersLocation);
 
-    List<AnnotationTree> methodAnnotations = methodTree.modifiers().annotations();
-    getObjectParameters(methodTree).forEach(parameter -> buildBlockForParameter(parameter, methodAnnotations, blockBuilder, idGenerator));
+    getAnnotatedStringParameters(methodTree).forEach(parameter -> buildBlockForParameter(parameter, blockBuilder, idGenerator));
 
     Label nextBlockLabel = UCFGBuilder.createLabel(Integer.toString(cfg.entry().id()));
     blockBuilder.jumpTo(nextBlockLabel);
     return blockBuilder;
   }
 
-  private void buildBlockForParameter(VariableTree parameter, List<AnnotationTree> methodAnnotations, BlockBuilder blockBuilder, IdentifierGenerator idGenerator) {
+  private void buildBlockForParameter(VariableTree parameter, BlockBuilder blockBuilder, IdentifierGenerator idGenerator) {
     Expression.Variable parameterVariable = variableWithId(idGenerator.lookupIdFor(parameter.symbol()));
+    List<AnnotationTree> annotationList = parameter.modifiers().annotations();
     List<Expression> annotationVariables = new ArrayList<>();
 
-    List<AnnotationTree> annotations = new ArrayList<>();
-    annotations.addAll(methodAnnotations);
-    annotations.addAll(parameter.modifiers().annotations());
-
-    if (annotations.isEmpty()) {
-      // method is not annotated && parameter is not annotated
-      return;
-    }
-
-    // at least one annotation should be applied to the parameter
-    annotations.forEach(annotationTree -> {
-      Expression.Variable var = variableWithId(idGenerator.newId());
+    annotationList.forEach(annotationTree -> {
+      Expression.Variable var = variableWithId(idGenerator.newIdFor(annotationTree));
       annotationVariables.add(var);
-      blockBuilder.assignTo(var, annotateCall(annotationTree, parameterVariable), location(annotationTree));
+      blockBuilder.assignTo(var, call(annotationTree.annotationType().symbolType().fullyQualifiedName()).withArgs(parameterVariable), location(annotationTree));
     });
 
     Expression[] args = annotationVariables.toArray(new Expression[annotationVariables.size()]);
     blockBuilder.assignTo(parameterVariable, call("__annotation").withArgs(args), location(parameter.simpleName()));
   }
 
-  private static CallBuilder annotateCall(AnnotationTree annotation, Expression.Variable annotatedVariable) {
-    Expression.Constant fullyQualifiedName = constant(annotation.symbolType().fullyQualifiedName());
-    return call("__annotate").withArgs(fullyQualifiedName, annotatedVariable);
-  }
-
-  private static boolean hasAnnotatedParameters(MethodTree methodTree) {
-    List<VariableTree> objectParameters = getObjectParameters(methodTree).collect(Collectors.toList());
-    if (objectParameters.isEmpty()) {
-      return false;
-    }
-    return !methodTree.modifiers().annotations().isEmpty() || objectParameters.stream().anyMatch(parameter -> !parameter.modifiers().annotations().isEmpty());
-  }
-
-  private static Stream<VariableTree> getObjectParameters(MethodTree methodTree) {
-    return methodTree.parameters().stream().filter(parameter -> isObject(parameter.type().symbolType()));
+  private static Stream<VariableTree> getAnnotatedStringParameters(MethodTree methodTree) {
+    return methodTree.parameters().stream().filter(parameter -> isString(parameter.type().symbolType())).filter(parameter -> !parameter.modifiers().annotations().isEmpty());
   }
 
   private UCFGBuilder.BlockBuilder buildBasicBlock(CFG.Block javaBlock, MethodTree methodTree, IdentifierGenerator idGenerator) {
@@ -227,7 +199,7 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     if (terminator != null && terminator.is(Tree.Kind.RETURN_STATEMENT)) {
       ExpressionTree returnedExpression = ((ReturnStatementTree) terminator).expression();
       Expression retExpr = constant(IdentifierGenerator.CONST);
-      if (methodTree.returnType() != null && isObject(methodTree.returnType().symbolType())) {
+      if (methodTree.returnType() != null && isString(methodTree.returnType().symbolType())) {
         retExpr = idGenerator.lookupExpressionFor(returnedExpression);
       }
       blockBuilder.ret(retExpr, location(terminator));
@@ -245,13 +217,14 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
   }
 
   private void buildCall(Tree element, UCFGBuilder.BlockBuilder blockBuilder, IdentifierGenerator idGenerator) {
-    if (isObjectVarDeclaration(element)) {
+    if (isStringVarDecl(element)) {
       VariableTree variableTree = (VariableTree) element;
 
       String lhs = idGenerator.lookupIdFor(variableTree.simpleName());
       if (!idGenerator.isConst(lhs)) {
-        Expression source = idGenerator.lookupExpressionFor(variableTree.initializer());
-        blockBuilder.assignTo(variableWithId(lhs), UCFGBuilder.call("__id").withArgs(source), location(element));
+        ExpressionTree initializer = variableTree.initializer();
+        String source = idGenerator.lookupIdFor(initializer);
+        blockBuilder.assignTo(variableWithId(lhs), UCFGBuilder.call("__id").withArgs(variableWithId(source)), location(element));
       }
       return;
     }
@@ -262,41 +235,28 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     } else if (element.is(NEW_CLASS)) {
       NewClassTree newClassTree = (NewClassTree) element;
       buildConstructorInvocation(blockBuilder, idGenerator, newClassTree);
-    } else if (element.is(NEW_ARRAY)) {
-      NewArrayTree newArrayTree = (NewArrayTree) element;
-      buildNewArrayInvocation(blockBuilder, idGenerator, newArrayTree);
-    } else if (element.is(PLUS)) {
-      BinaryExpressionTree binaryExpressionTree = (BinaryExpressionTree) element;
-      buildConcatenationInvocation(blockBuilder, idGenerator, binaryExpressionTree);
-    } else if (element.is(ASSIGNMENT)) {
-      AssignmentExpressionTree assignmentExpressionTree = (AssignmentExpressionTree) element;
-      buildAssignmentInvocation(blockBuilder, idGenerator, assignmentExpressionTree);
-    } else if (element.is(PLUS_ASSIGNMENT)) {
-      AssignmentExpressionTree assignmentExpressionTree = (AssignmentExpressionTree) element;
-      buildPlusAssignmentInvocation(blockBuilder, idGenerator, assignmentExpressionTree);
-    } else if (element.is(ARRAY_ACCESS_EXPRESSION) && !element.parent().is(PLUS_ASSIGNMENT, ASSIGNMENT)) {
-      // PLUS_ASSIGNMENT and ASSIGNMENT might imply an array set, otherwise an array access is always a get
-      ArrayAccessExpressionTree arrayAccessExpressionTree = (ArrayAccessExpressionTree) element;
-      if (isObject(arrayAccessExpressionTree.symbolType())) {
-        Expression.Variable getValue = variableWithId(idGenerator.newId());
-        Expression array = idGenerator.lookupExpressionFor(arrayAccessExpressionTree.expression());
-        blockBuilder.assignTo(getValue, arrayGet(array), location(element));
-        idGenerator.varForExpression(element, getValue.id());
+    } else if (element.is(PLUS, PLUS_ASSIGNMENT, ASSIGNMENT) && isString(((ExpressionTree) element).symbolType())) {
+      if (element.is(PLUS)) {
+        BinaryExpressionTree binaryExpressionTree = (BinaryExpressionTree) element;
+        Expression lhs = idGenerator.lookupExpressionFor(binaryExpressionTree.leftOperand());
+        Expression rhs = idGenerator.lookupExpressionFor(binaryExpressionTree.rightOperand());
+        Expression.Variable var = variableWithId(idGenerator.newIdFor(binaryExpressionTree));
+        blockBuilder.assignTo(var, call("__concat").withArgs(lhs, rhs), location(element));
+      } else if (element.is(PLUS_ASSIGNMENT)) {
+        Expression var = idGenerator.lookupExpressionFor(((AssignmentExpressionTree) element).variable());
+        Expression expr = idGenerator.lookupExpressionFor(((AssignmentExpressionTree) element).expression());
+        if (!var.isConstant()) {
+          idGenerator.varForExpression(element, ((Expression.Variable) var).id());
+          blockBuilder.assignTo((Expression.Variable) var, call("__concat").withArgs(var, expr), location(element));
+        }
+      } else if (element.is(ASSIGNMENT)) {
+        Expression var = idGenerator.lookupExpressionFor(((AssignmentExpressionTree) element).variable());
+        Expression expr = idGenerator.lookupExpressionFor(((AssignmentExpressionTree) element).expression());
+        if (!var.isConstant()) {
+          blockBuilder.assignTo((Expression.Variable) var, call("__id").withArgs(expr), location(element));
+        }
       }
     }
-  }
-
-  private void buildNewArrayInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, NewArrayTree tree) {
-    if (tree.type() != null  && !isObject(tree.type().symbolType())) {
-      return;
-    }
-    Expression.Variable newArray = variableWithId(idGenerator.newIdFor(tree));
-    blockBuilder.newObject(newArray, tree.symbolType().fullyQualifiedName(), location(tree));
-    idGenerator.varForExpression(tree, newArray.id());
-    tree.initializers().stream().filter(i -> isObject(i.symbolType())).forEach(i -> {
-      Expression argument = idGenerator.lookupExpressionFor(i);
-      blockBuilder.assignTo(variableWithId(idGenerator.newId()), arraySet(newArray, argument), location(tree));
-    });
   }
 
   private void buildConstructorInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, NewClassTree tree) {
@@ -305,16 +265,10 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
       return;
     }
 
-    Expression.Variable newInstance = variableWithId(idGenerator.newIdFor(tree));
-    blockBuilder.newObject(newInstance, tree.symbolType().fullyQualifiedName(), location(tree.identifier()));
-
-    List<Expression> arguments = new ArrayList<>();
-    arguments.add(newInstance);
-    arguments.addAll(argumentIds(idGenerator, tree.arguments()));
-
-    blockBuilder.assignTo(variableWithId(idGenerator.newId()),
-        UCFGBuilder.call(signatureFor((Symbol.MethodSymbol) constructorSymbol)).withArgs(arguments.toArray(new Expression[0])),
-        location(tree));
+    if(isString(constructorSymbol.owner().type()) || tree.arguments().stream().map(ExpressionTree::symbolType).anyMatch(UCFGJavaVisitor::isString)) {
+      List<Expression> arguments = argumentIds(idGenerator, tree.arguments());
+      buildAssignCall(blockBuilder, idGenerator, arguments, tree, (Symbol.MethodSymbol) constructorSymbol);
+    }
   }
 
   private void buildMethodInvocation(UCFGBuilder.BlockBuilder blockBuilder, IdentifierGenerator idGenerator, MethodInvocationTree tree) {
@@ -322,68 +276,21 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
       return;
     }
 
-    List<Expression> arguments = new ArrayList<>();
-    if (tree.symbol().isStatic()) {
-      arguments.add(new Expression.ClassName(tree.symbol().type().fullyQualifiedName()));
-    } else if (tree.methodSelect().is(MEMBER_SELECT)) {
-      arguments.add(idGenerator.lookupExpressionFor(((MemberSelectExpressionTree) tree.methodSelect()).expression()));
-    } else if (tree.methodSelect().is(IDENTIFIER)) {
-      arguments.add(Expression.THIS);
-    }
-    arguments.addAll(argumentIds(idGenerator, tree.arguments()));
+    List<Expression> arguments = null;
 
-    buildAssignCall(blockBuilder, idGenerator, arguments, tree, (Symbol.MethodSymbol) tree.symbol());
-  }
-
-  private void buildConcatenationInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, BinaryExpressionTree tree) {
-    if (!isObject(tree.symbolType())) {
-      return;
-    }
-    Expression leftOperand = idGenerator.lookupExpressionFor(tree.leftOperand());
-    Expression rightOperand = idGenerator.lookupExpressionFor(tree.rightOperand());
-    Expression.Variable var = variableWithId(idGenerator.newIdFor(tree));
-    blockBuilder.assignTo(var, concat(leftOperand, rightOperand), location(tree));
-  }
-
-  private void buildAssignmentInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, AssignmentExpressionTree tree) {
-    if (!isObject(tree.symbolType())) {
-      return;
-    }
-    ExpressionTree lhsTree = tree.variable();
-    ExpressionTree rhsTree = tree.expression();
-    Expression rightSide = lookupExpression(blockBuilder, idGenerator, rhsTree);
-    if (lhsTree.is(ARRAY_ACCESS_EXPRESSION)) {
-      Expression leftSide = idGenerator.lookupExpressionFor(((ArrayAccessExpressionTree)lhsTree).expression());
-      // when an assignment implies both get and set on arrays, the get must be stored in an auxiliary local variable
-      blockBuilder.assignTo(variableWithId(idGenerator.newId()), arraySet(leftSide, rightSide), location(tree));
-    } else {
-      Expression leftSide = idGenerator.lookupExpressionFor(lhsTree);
-      if (leftSide instanceof  Expression.Variable) {
-        blockBuilder.assignTo((Expression.Variable) leftSide, call("__id").withArgs(rightSide), location(tree));
+    if (isString(tree.symbol().owner().type())) {
+      // myStr.myMethod(args) -> myMethod(myStr, args)
+      arguments = new ArrayList<>();
+      if (tree.methodSelect().is(MEMBER_SELECT)) {
+        arguments.add(idGenerator.lookupExpressionFor(((MemberSelectExpressionTree) tree.methodSelect()).expression()));
       }
+      arguments.addAll(argumentIds(idGenerator, tree.arguments()));
+    } else if (isString(tree.symbolType()) || tree.arguments().stream().map(ExpressionTree::symbolType).anyMatch(UCFGJavaVisitor::isString)) {
+      arguments = argumentIds(idGenerator, tree.arguments());
     }
-  }
 
-  private void buildPlusAssignmentInvocation(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, AssignmentExpressionTree tree) {
-    if (!isObject(tree.symbolType())) {
-      return;
-    }
-    ExpressionTree lhsTree = tree.variable();
-    ExpressionTree rhsTree = tree.expression();
-    // '+=' is the only expression which can imply two gets and one set on an array
-    Expression leftSide = lookupExpression(blockBuilder, idGenerator, lhsTree);
-    Expression rightSide = lookupExpression(blockBuilder, idGenerator, rhsTree);
-    if (leftSide instanceof Expression.Variable) {
-      if (lhsTree.is(ARRAY_ACCESS_EXPRESSION)) {
-        Expression.Variable concatAux = variableWithId(idGenerator.newId());
-        blockBuilder.assignTo(concatAux, concat(leftSide, rightSide), location(tree));
-        blockBuilder.assignTo(variableWithId(idGenerator.newId()),
-            arraySet(idGenerator.lookupExpressionFor(((ArrayAccessExpressionTree)lhsTree).expression()), concatAux),
-            location(tree));
-      } else {
-        idGenerator.varForExpression(tree, ((Expression.Variable) leftSide).id());
-        blockBuilder.assignTo((Expression.Variable) leftSide, concat(leftSide, rightSide), location(tree));
-      }
+    if (arguments != null) {
+      buildAssignCall(blockBuilder, idGenerator, arguments, tree, (Symbol.MethodSymbol) tree.symbol());
     }
   }
 
@@ -394,32 +301,6 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
 
   private static List<Expression> argumentIds(IdentifierGenerator idGenerator, Arguments arguments) {
     return arguments.stream().map(idGenerator::lookupExpressionFor).collect(Collectors.toList());
-  }
-
-  /**
-   * An array access expression depends on context - it might be a get or a set.
-   * This method should be used for the contexts where it is clear that the array access (if present) is a get.
-   */
-  private Expression lookupExpression(BlockBuilder blockBuilder, IdentifierGenerator idGenerator, ExpressionTree expressionTree) {
-    if (expressionTree.is(ARRAY_ACCESS_EXPRESSION)) {
-      Expression array = idGenerator.lookupExpressionFor(((ArrayAccessExpressionTree)expressionTree).expression());
-      Expression.Variable aux = variableWithId(idGenerator.newId());
-      blockBuilder.assignTo(aux, arrayGet(array), location(expressionTree));
-      return aux;
-    }
-    return idGenerator.lookupExpressionFor(expressionTree);
-  }
-
-  private static UCFGBuilder.CallBuilder arrayGet(Expression array) {
-    return call("__arrayGet").withArgs(array);
-  }
-
-  private static UCFGBuilder.CallBuilder arraySet(Expression targetArray, Expression value) {
-    return call("__arraySet").withArgs(targetArray, value);
-  }
-
-  private static UCFGBuilder.CallBuilder concat(Expression... args) {
-    return call("__concat").withArgs(args);
   }
 
   private static String signatureFor(Symbol.MethodSymbol methodSymbol) {
@@ -441,53 +322,46 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     return location(firstTree);
   }
 
+
   private LocationInFile location(Tree tree) {
     return location(tree.firstToken(), tree.lastToken());
   }
 
   private LocationInFile location(SyntaxToken firstToken, SyntaxToken lastToken) {
     return new LocationInFile(
-      javaFileKey,
+      fileKey,
       firstToken.line(), firstToken.column(),
       lastToken.line(), lastToken.column() + lastToken.text().length()
     );
   }
 
-  private static boolean isObjectVarDeclaration(Tree tree) {
+  private static boolean isStringVarDecl(Tree tree) {
     if (!tree.is(Tree.Kind.VARIABLE)) {
       return false;
     }
 
     VariableTree var = (VariableTree) tree;
-    return isObject(var.type().symbolType());
+    return isString(var.type().symbolType());
   }
 
-  private static boolean isObject(Type type) {
-    if (type.isArray()) {
-      Type elementType = ((Type.ArrayType)type).elementType();
-      if (elementType == null) {
-        // SONARJAVA-2835 : the type for multi-dimension array initializers is null
-        return false;
-      }
-      return isObject(elementType);
-    }
-    return !type.isPrimitive() && !type.isUnknown();
+  private static boolean isString(Type type) {
+    return type.is("java.lang.String");
   }
 
   public static class IdentifierGenerator {
 
     private static final String CONST = "\"\"";
 
-    private final Map<Symbol, String> objectVars;
+    private final Map<Symbol, String> vars;
     private final Map<Tree, String> temps;
     private int counter;
 
     public IdentifierGenerator(MethodTree methodTree) {
-      Set<Symbol> objectParameters = methodTree.parameters().stream().filter(p -> isObject(p.symbol().type())).map(VariableTree::symbol).collect(Collectors.toSet());
+      List<Symbol> parameters = methodTree.parameters().stream().map(VariableTree::symbol).collect(Collectors.toList());
       VariableReadExtractor variableReadExtractor = new VariableReadExtractor(methodTree.symbol(), false);
       methodTree.accept(variableReadExtractor);
-      Set<Symbol> objectLocals = variableReadExtractor.usedVariables().stream().filter(s -> isObject(s.type())).collect(Collectors.toSet());
-      objectVars = Sets.union(objectParameters, objectLocals).stream().collect(Collectors.toMap(s -> s, Symbol::name));
+      Set<Symbol> locals = variableReadExtractor.usedVariables().stream().filter(s -> s.type().is("java.lang.String")).collect(Collectors.toSet());
+      vars = Sets.union(new HashSet<>(parameters), locals).stream().collect(Collectors.toMap(s -> s, Symbol::name));
       temps = new HashMap<>();
       counter = 0;
     }
@@ -497,7 +371,12 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     }
 
     public String newIdFor(@Nullable Tree tree) {
-      return temps.computeIfAbsent(tree, t -> newId());
+      String id = lookupIdFor(tree);
+      if (isConst(id)) {
+        return temps.computeIfAbsent(tree, t -> newId());
+      } else {
+        return id;
+      }
     }
 
     private String newId() {
@@ -509,12 +388,8 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     public Expression lookupExpressionFor(@Nullable Tree tree) {
       String id = lookupIdFor(tree);
       if (isConst(id)) {
-        if (tree != null) {
-          if (tree.is(Tree.Kind.STRING_LITERAL)) {
-            return constant(LiteralUtils.trimQuotes(((LiteralTree) tree).value()));
-          } else if (tree.is(IDENTIFIER) && ((IdentifierTree) tree).name().equals("this")) {
-            return Expression.THIS;
-          }
+        if (tree != null && tree.is(Tree.Kind.STRING_LITERAL)) {
+          return constant(LiteralUtils.trimQuotes(((LiteralTree) tree).value()));
         }
         return constant(id);
       }
@@ -524,7 +399,7 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     public String lookupIdFor(@Nullable Tree tree) {
       if (tree == null) {
         return CONST;
-      } else if (tree.is(IDENTIFIER)) {
+      } else if (tree.is(Tree.Kind.IDENTIFIER)) {
         return lookupIdFor(((IdentifierTree) tree).symbol());
       } else {
         return temps.getOrDefault(tree, CONST);
@@ -532,7 +407,7 @@ public class UCFGJavaVisitor extends BaseTreeVisitor implements JavaFileScanner 
     }
 
     public String lookupIdFor(Symbol symbol) {
-      return objectVars.getOrDefault(symbol, CONST);
+      return vars.getOrDefault(symbol, CONST);
     }
 
     public void varForExpression(Tree element, String id) {

--- a/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/UCFGJavaVisitorTest.java
@@ -22,14 +22,8 @@ package org.sonar.java;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.BeforeClass;
@@ -49,10 +43,10 @@ import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.ucfg.BasicBlock;
 import org.sonar.ucfg.Expression;
+import org.sonar.ucfg.Instruction;
 import org.sonar.ucfg.LocationInFile;
 import org.sonar.ucfg.UCFG;
 import org.sonar.ucfg.UCFGBuilder;
-import org.sonar.ucfg.UCFGElement.Instruction;
 import org.sonar.ucfg.UCFGtoProtobuf;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +54,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.sonar.ucfg.UCFGBuilder.call;
 import static org.sonar.ucfg.UCFGBuilder.constant;
 import static org.sonar.ucfg.UCFGBuilder.newBasicBlock;
-import static org.sonar.ucfg.UCFGBuilder.variableWithId;
 
 public class UCFGJavaVisitorTest {
 
@@ -78,7 +71,7 @@ public class UCFGJavaVisitorTest {
 
   @Test
   public void visit_java_file() {
-    Expression.Variable arg = variableWithId("arg");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1").ret(arg, new LocationInFile(FILE_KEY, 1,37,1,48)))
       .build();
@@ -87,8 +80,7 @@ public class UCFGJavaVisitorTest {
 
   @Test
   public void assign_to_field() {
-    // fields are ignored (will change with SONARSEC-121)
-    Expression.Variable arg = variableWithId("arg");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1").ret(arg, new LocationInFile(FILE_KEY, 1,69,1,80)))
       .build();
@@ -96,38 +88,10 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
-  public void plus_assign_to_field() {
-    // fields are ignored (will change with SONARSEC-121)
-    Expression.Variable arg = variableWithId("arg");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1").ret(arg, new LocationInFile(FILE_KEY, 1,70,1,81)))
-        .build();
-    assertCodeToUCfg("class A { String field; String method(String arg) {this.field += arg; return arg;}}", expectedUCFG);
-  }
-
-  @Test
-  public void plus_assign_to_array_field() {
-    // in case of array access, fields are not ignored
-    // this will change with SONARSEC-121
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(constant("\"\"")), new LocationInFile(FILE_KEY, 1,53,1,66))
-            .assignTo(aux1, call("__concat").withArgs(aux0, arg), new LocationInFile(FILE_KEY, 1,53,1,73))
-            .assignTo(aux2, call("__arraySet").withArgs(constant("\"\""), aux1), new LocationInFile(FILE_KEY, 1,53,1,73))
-            .ret(arg, new LocationInFile(FILE_KEY, 1, 75, 1, 86)))
-        .build();
-    assertCodeToUCfg("class A { String[] field; String method(String arg) {this.field[0] += arg; return arg;}}", expectedUCFG);
-  }
-
-  @Test
   public void void_method_with_flow() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var0 = variableWithId("%0");
-    Expression.Variable var1 = variableWithId("%1");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable var0 = UCFGBuilder.variableWithId("%0");
+    Expression.Variable var1 = UCFGBuilder.variableWithId("%1");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)V").addMethodParam(arg)
       .addStartingBlock(newBasicBlock("1").assignTo(var1, call("java.lang.String#toString()Ljava/lang/String;").withArgs(arg), new LocationInFile(FILE_KEY, 1,72,1,86))
         .jumpTo(UCFGBuilder.createLabel("0")))
@@ -140,43 +104,28 @@ public class UCFGJavaVisitorTest {
 
   @Test
   public void create_assign_call_for_method_invocation() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var = variableWithId("%0");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable var = UCFGBuilder.variableWithId("%0");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Object;)Ljava/lang/String;").addMethodParam(arg)
-      .addBasicBlock(newBasicBlock("1").assignTo(var, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(arg), new LocationInFile(FILE_KEY, 1,44,1,58))
+      .addBasicBlock(newBasicBlock("1").assignTo(var, call("java.lang.Object#toString()Ljava/lang/String;"), new LocationInFile(FILE_KEY, 1,44,1,58))
         .ret(var, new LocationInFile(FILE_KEY, 1,37,1,59)))
       .build();
     assertCodeToUCfg("class A { String method(Object arg) {return arg.toString();}}", expectedUCFG);
   }
 
   @Test
-  public void invocation_on_string() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable temp = variableWithId("%0");
+  public void filter_invocation_unrelated_to_string() {
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(temp, call("java.lang.String#toString()Ljava/lang/String;").withArgs(arg), new LocationInFile(FILE_KEY, 1, 45, 1, 59))
-            .ret(temp, new LocationInFile(FILE_KEY, 1, 38, 1, 60)))
-        .build();
-    assertCodeToUCfg("class A { String method(String arg) { return arg.toString();}}", expectedUCFG);
-  }
-
-  @Test
-  public void invocation_on_object() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable temp = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Object;)Ljava/lang/String;").addMethodParam(arg)
-      .addBasicBlock(newBasicBlock("1")
-          .assignTo(temp, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(arg), new LocationInFile(FILE_KEY, 1,62,1,76))
-          .ret(temp, new LocationInFile(FILE_KEY, 1, 55, 1, 77)))
+      .addBasicBlock(newBasicBlock("1").ret(arg, new LocationInFile(FILE_KEY, 1,61,1,72)))
       .build();
-    assertCodeToUCfg("class A { String method(Object arg) {int var; var = 2; return arg.toString(); }}", expectedUCFG);
+    assertCodeToUCfg("class A { String method(String arg) {Object o; o.hashCode(); return arg;}}", expectedUCFG);
   }
 
   @Test
   public void build_concatenate_elements() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var = variableWithId("%0");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable var = UCFGBuilder.variableWithId("%0");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1").assignTo(var, call("__concat").withArgs(constant("Myconst"), arg), new LocationInFile(FILE_KEY, 1,43,1,56))
         .ret(var,new LocationInFile(FILE_KEY, 1,36,1,57)))
@@ -191,194 +140,31 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
-  public void build_concatenate_heterogenous_elements() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__concat").withArgs(constant("\"\""), arg), new LocationInFile(FILE_KEY, 1,43,1,53))
-            .assignTo(aux1, call("__concat").withArgs(aux0, constant("\"\"")), new LocationInFile(FILE_KEY, 1,43,1,58))
-            .ret(aux1,new LocationInFile(FILE_KEY, 1,36,1,59)))
-        .build();
-    assertCodeToUCfg("class A {String method(String arg) {return true + arg + 42;}}", expectedUCFG);
-
-    expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1").assignTo(arg, call("__concat").withArgs(arg, constant("\"\"")), new LocationInFile(FILE_KEY, 1,43,1,50))
-            .ret(arg, new LocationInFile(FILE_KEY, 1,36,1,51)))
-        .build();
-    assertCodeToUCfg("class A {String method(String arg) {return arg+=42;}}", expectedUCFG);
-  }
-
-  @Test
-  public void build_primitive_types_to_constants() {
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux4 = variableWithId("%4");
-    Expression.Variable aux5 = variableWithId("%5");
-    Expression.Variable s = variableWithId("s");
-    Expression.Variable aux6 = variableWithId("%6");
-    Expression.Variable aux7 = variableWithId("%7");
-    Expression.Variable aux8 = variableWithId("%8");
-    Expression.Variable aux9 = variableWithId("%9");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(ZBCS)Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.io.PrintStream#print(I)V").withArgs(constant("\"\""), constant("\"\"")), new LocationInFile(FILE_KEY, 7,4,7,26))
-            .assignTo(aux1, call("java.io.PrintStream#print(Z)V").withArgs(constant("\"\""), constant("\"\"")), new LocationInFile(FILE_KEY, 8,4,8,26))
-            .assignTo(aux2, call("__concat").withArgs(constant(""), constant("\"\"")), new LocationInFile(FILE_KEY, 9,15,9,24))
-            .assignTo(aux3, call("__concat").withArgs(aux2, constant("\"\"")), new LocationInFile(FILE_KEY, 9,15,9,31))
-            .assignTo(aux4, call("__concat").withArgs(aux3, constant("\"\"")), new LocationInFile(FILE_KEY, 9,15,9,38))
-            .assignTo(aux5, call("__concat").withArgs(aux4, constant("\"\"")), new LocationInFile(FILE_KEY, 9,15,9,45))
-            .assignTo(s, call("__id").withArgs(aux5), new LocationInFile(FILE_KEY, 9,4,9,46))
-            .assignTo(aux6, call("__concat").withArgs(s, constant("\"\"")), new LocationInFile(FILE_KEY, 10,11,10,19))
-            .assignTo(aux7, call("__concat").withArgs(aux6, constant("\"\"")), new LocationInFile(FILE_KEY, 10,11,10,26))
-            .assignTo(aux8, call("__concat").withArgs(aux7, constant("\"\"")), new LocationInFile(FILE_KEY, 10,11,10,33))
-            .assignTo(aux9, call("__concat").withArgs(aux8, constant("\"\"")), new LocationInFile(FILE_KEY, 10,11,10,40))
-            .ret(aux9, new LocationInFile(FILE_KEY, 10,4,10,41)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  String method(boolean arg1, byte arg2, char arg3, short arg4) {\n" +
-        "    int var5 = 12;\n" +
-        "    long var6 = 12L;\n" +
-        "    float var7 = 1.0;\n" +
-        "    double var8 = 1.0;\n" +
-        "    System.out.print(var5);\n" +
-        "    System.out.print(arg1);\n" +
-        "    String s = \"\" + var5 + var6 + var7 + var8;\n" +
-        "    return s + arg1 + arg2 + arg3 + arg4;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
   public void build_parameter_annotations() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable aux0 = UCFGBuilder.variableWithId("%0");
+    Expression.Variable aux1 = UCFGBuilder.variableWithId("%1");
+    Expression.Variable aux2 = UCFGBuilder.variableWithId("%2");
 
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("paramAnnotations")
-        .assignTo(aux0, call("__annotate").withArgs(constant("javax.annotation.Nullable"), arg), new LocationInFile(FILE_KEY, 3, 6, 3, 32))
-        .assignTo(aux1, call("__annotate").withArgs(constant("org.springframework.web.bind.annotation.RequestParam"), arg), new LocationInFile(FILE_KEY, 4, 6, 4, 61))
-        .assignTo(aux2, call("__annotate").withArgs(constant("org.springframework.format.annotation.DateTimeFormat"), arg), new LocationInFile(FILE_KEY, 5, 6, 5, 59))
-        .assignTo(arg, call("__annotation").withArgs(aux0, aux1, aux2), new LocationInFile(FILE_KEY, 6, 13, 6, 16))
+        .assignTo(aux0, call("javax.annotation.Nullable").withArgs(arg), new LocationInFile(FILE_KEY, 1, 24, 1, 50))
+        .assignTo(aux1, call("org.springframework.web.bind.annotation.RequestParam").withArgs(arg), new LocationInFile(FILE_KEY, 1, 51, 1, 106))
+        .assignTo(aux2, call("org.springframework.format.annotation.DateTimeFormat").withArgs(arg), new LocationInFile(FILE_KEY, 1, 107, 1, 160))
+        .assignTo(arg, call("__annotation").withArgs(aux0, aux1, aux2), new LocationInFile(FILE_KEY, 1, 168, 1, 171))
         .jumpTo(UCFGBuilder.createLabel("1")))
       .addBasicBlock(
         newBasicBlock("1")
-          .ret(constant("foo"), new LocationInFile(FILE_KEY, 7, 4, 7, 17)))
+          .ret(constant("foo"), new LocationInFile(FILE_KEY, 1, 175, 1, 188)))
       .build();
-    assertCodeToUCfg(
-      "class A {\n"
-        + "  String method(\n"
-        + "      @javax.annotation.Nullable\n"
-        + "      @org.springframework.web.bind.annotation.RequestParam()\n"
-        + "      @org.springframework.format.annotation.DateTimeFormat\n"
-        + "      String arg) {\n"
-        + "    return \"foo\";\n"
-        + "  }\n"
-        + "}",
-      expectedUCFG);
-  }
-
-  @Test
-  public void build_two_parameters_annotations() {
-    Expression.Variable arg0 = variableWithId("arg0");
-    Expression.Variable arg1 = variableWithId("arg1");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/String;").addMethodParam(arg0).addMethodParam(arg1)
-      .addBasicBlock(newBasicBlock("paramAnnotations")
-        .assignTo(aux0, call("__annotate").withArgs(constant("javax.annotation.Nullable"), arg0), new LocationInFile(FILE_KEY, 3, 6, 3, 32))
-        .assignTo(arg0, call("__annotation").withArgs(aux0), new LocationInFile(FILE_KEY, 3, 40, 3, 44))
-        .assignTo(aux1, call("__annotate").withArgs(constant("javax.annotation.Nullable"), arg1), new LocationInFile(FILE_KEY, 4, 6, 4, 32))
-        .assignTo(arg1, call("__annotation").withArgs(aux1), new LocationInFile(FILE_KEY, 4, 41, 4, 45))
-        .jumpTo(UCFGBuilder.createLabel("1")))
-      .addBasicBlock(
-        newBasicBlock("1")
-          .ret(constant("foo"), new LocationInFile(FILE_KEY, 5, 4, 5, 17)))
-      .build();
-    assertCodeToUCfg("class A {\n"
-      + "  String method(\n"
-      + "      @javax.annotation.Nullable String arg0,\n"
-      + "      @javax.annotation.Nullable Integer arg1) {\n"
-      + "    return \"foo\";\n"
-      + "  }\n"
-      + "}", expectedUCFG);
-  }
-
-  @Test
-  public void build_method_annotations() {
-    Expression.Variable arg0 = variableWithId("arg0");
-    Expression.Variable arg1 = variableWithId("arg1");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/String;").addMethodParam(arg0).addMethodParam(arg1)
-      .addBasicBlock(newBasicBlock("paramAnnotations")
-        .assignTo(aux0, call("__annotate").withArgs(constant("org.springframework.format.annotation.DateTimeFormat"), arg0), new LocationInFile(FILE_KEY, 2, 2, 2, 55))
-        .assignTo(aux1, call("__annotate").withArgs(constant("javax.annotation.Nullable"), arg0), new LocationInFile(FILE_KEY, 4, 6, 4, 32))
-        .assignTo(arg0, call("__annotation").withArgs(aux0, aux1), new LocationInFile(FILE_KEY, 4, 40, 4, 44))
-        .assignTo(aux2, call("__annotate").withArgs(constant("org.springframework.format.annotation.DateTimeFormat"), arg1), new LocationInFile(FILE_KEY, 2, 2, 2, 55))
-        .assignTo(arg1, call("__annotation").withArgs(aux2), new LocationInFile(FILE_KEY, 5, 14, 5, 18))
-        .jumpTo(UCFGBuilder.createLabel("1")))
-      .addBasicBlock(
-        newBasicBlock("1")
-          .ret(constant("foo"), new LocationInFile(FILE_KEY, 6, 4, 6, 17)))
-      .build();
-    assertCodeToUCfg("class A {\n"
-      + "  @org.springframework.format.annotation.DateTimeFormat\n"
-      + "  String method(\n"
-      + "      @javax.annotation.Nullable String arg0,\n"
-      + "      Integer arg1) {\n"
-      + "    return \"foo\";\n"
-      + "  }\n"
-      + "}", expectedUCFG);
-  }
-
-  @Test
-  public void build_method_annotations_only_on_annotated() {
-    Expression.Variable arg0 = variableWithId("arg0");
-    Expression.Variable arg1 = variableWithId("arg1");
-    Expression.Variable aux0 = variableWithId("%0");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg0).addMethodParam(arg1)
-      .addBasicBlock(newBasicBlock("paramAnnotations")
-        .assignTo(aux0, call("__annotate").withArgs(constant("javax.annotation.Nullable"), arg0), new LocationInFile(FILE_KEY, 3, 6, 3, 32))
-        .assignTo(arg0, call("__annotation").withArgs(aux0), new LocationInFile(FILE_KEY, 3, 40, 3, 44))
-        .jumpTo(UCFGBuilder.createLabel("1")))
-      .addBasicBlock(
-        newBasicBlock("1")
-          .ret(constant("foo"), new LocationInFile(FILE_KEY, 5, 4, 5, 17)))
-      .build();
-    assertCodeToUCfg("class A {\n"
-      + "  String method(\n"
-      + "      @javax.annotation.Nullable String arg0,\n"
-      + "      String arg1) {\n" // should not be annotated
-      + "    return \"foo\";\n"
-      + "  }\n"
-      + "}", expectedUCFG);
+    assertCodeToUCfg("class A { String method(@javax.annotation.Nullable @org.springframework.web.bind.annotation.RequestParam() @org.springframework.format.annotation.DateTimeFormat String arg) { return \"foo\";}}", expectedUCFG);
   }
 
   @Test
   public void unknown_method() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
 
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/util/Set;)V").addMethodParam(arg)
-      .addBasicBlock(newBasicBlock("1")
-        .assignTo(aux0, call("java.util.Collection#stream()Ljava/util/stream/Stream;").withArgs(arg), new LocationInFile(FILE_KEY, 6, 4, 6, 16))
-        .assignTo(aux1, call("java.util.stream.Stream#flatMap(Ljava/util/function/Function;)Ljava/util/stream/Stream;").withArgs(aux0, constant("\"\"")), new LocationInFile(FILE_KEY, 6, 4, 7, 34))
-        .assignTo(aux2,
-            call("java.util.stream.Collectors#toCollection(Ljava/util/function/Supplier;)Ljava/util/stream/Collector;").withArgs(new Expression.ClassName("java.util.stream.Collectors"), constant("\"\"")),
-            new LocationInFile(FILE_KEY, 8, 15, 8, 58))
-        .jumpTo(UCFGBuilder.createLabel("0")))
       .addBasicBlock(newBasicBlock("0")
         .ret(constant("implicit return"), new LocationInFile(FILE_KEY, 9, 2, 9, 3)))
       .build();
@@ -403,138 +189,51 @@ public class UCFGJavaVisitorTest {
     assertCodeToUCfg(source, expectedUCFG);
   }
 
-  @Test
-  public void explicit_usage_of_this() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo()Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(Expression.THIS), new LocationInFile(FILE_KEY, 3, 11, 3, 26))
-            .ret(aux0, new LocationInFile(FILE_KEY, 3, 4, 3, 27)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo() { \n" +
-        "    return this.toString();\n" +
-        "  }\n" +
-        "}", expectedUCFG);
+  private void assertUnknownMethodCalled(String source) {
+    CompilationUnitTree cut = getCompilationUnitTreeWithSemantics(source);
+    UnknownMethodVisitor unknownMethodVisitor = new UnknownMethodVisitor();
+    unknownMethodVisitor.visitCompilationUnit(cut);
+    assertThat(unknownMethodVisitor.unknownMethodCount).isGreaterThan(0);
   }
 
   @Test
-  public void ignore_usage_of_super() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo()Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(constant("\"\"")), new LocationInFile(FILE_KEY, 3, 11, 3, 27))
-            .ret(aux0, new LocationInFile(FILE_KEY, 3, 4, 3, 28)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo() { \n" +
-        "    return super.toString();\n" +
-        "  }\n" +
-        "}", expectedUCFG);
+  public void build_two_parameters_annotations() {
+    Expression.Variable arg0 = UCFGBuilder.variableWithId("arg0");
+    Expression.Variable arg1 = UCFGBuilder.variableWithId("arg1");
+    Expression.Variable aux0 = UCFGBuilder.variableWithId("%0");
+    Expression.Variable aux1 = UCFGBuilder.variableWithId("%1");
+
+    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg0).addMethodParam(arg1)
+      .addBasicBlock(newBasicBlock("paramAnnotations")
+        .assignTo(aux0, call("javax.annotation.Nullable").withArgs(arg0), new LocationInFile(FILE_KEY, 1, 24, 1, 50))
+        .assignTo(arg0, call("__annotation").withArgs(aux0), new LocationInFile(FILE_KEY, 1, 58, 1, 62))
+        .assignTo(aux1, call("javax.annotation.Nullable").withArgs(arg1), new LocationInFile(FILE_KEY, 1, 64, 1, 90))
+        .assignTo(arg1, call("__annotation").withArgs(aux1), new LocationInFile(FILE_KEY, 1, 98, 1, 102))
+        .jumpTo(UCFGBuilder.createLabel("1")))
+      .addBasicBlock(
+        newBasicBlock("1")
+          .ret(constant("foo"), new LocationInFile(FILE_KEY, 1, 106, 1, 119)))
+      .build();
+    assertCodeToUCfg("class A { String method(@javax.annotation.Nullable String arg0, @javax.annotation.Nullable String arg1) { return \"foo\";}}", expectedUCFG);
   }
 
   @Test
-  public void create_multiple_auxiliaries_for_same_expression() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(constant("\"\"")), new LocationInFile(FILE_KEY, 3, 4, 3, 20))
-            .assignTo(aux1, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(constant("\"\"")), new LocationInFile(FILE_KEY, 4, 4, 4, 20))
-            .assignTo(aux2, call("__concat").withArgs(constant("\"\""), arg), new LocationInFile(FILE_KEY, 5,15,5,25))
-            .assignTo(aux3, call("__concat").withArgs(constant("\"\""), arg), new LocationInFile(FILE_KEY, 6,15,6,25))
-            .ret(constant(""), new LocationInFile(FILE_KEY, 7, 4, 7, 14)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String arg) { \n" +
-        "    super.toString();\n" +
-        "    super.toString();\n" +
-        "    String x = true + arg;\n" +
-        "    String y = true + arg;\n" +
-        "    return \"\";\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
+  public void ignore_parameter_annotations_for_non_string() {
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
 
-  @Test
-  public void implicit_usage_of_this() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo()Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(Expression.THIS), new LocationInFile(FILE_KEY, 3, 11, 3, 21))
-            .ret(aux0, new LocationInFile(FILE_KEY, 3, 4, 3, 22)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo() { \n" +
-        "    return toString();\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void explicit_static_method_call() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Integer;)Ljava/lang/String;")
-        .addStartingBlock(
-            newBasicBlock("1")
-                .assignTo(aux0, call("java.util.Objects#toString(Ljava/lang/Object;)Ljava/lang/String;").withArgs(new Expression.ClassName("java.util.Objects"), arg),
-                    new LocationInFile(FILE_KEY, 3,11,3,42))
-                .ret(aux0, new LocationInFile(FILE_KEY, 3,4,3,43)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  String method(Integer arg) {\n" +
-        "    return java.util.Objects.toString(arg);\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void ignore_primitives_and_interfaces() {
-    Expression.Variable arg = variableWithId("foo");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo(Ljava/lang/String;)V").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("0")
-            .ret(constant("implicit return"), new LocationInFile(FILE_KEY, 7, 2, 7, 3)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private void foo(String foo) { \n" +
-        "    int x = 1 + 1;\n" +
-        "    x += 1;\n" +
-        "    Consumer<String> c = s -> System.out.println(s);\n" +
-        "    c.accept(\"foo\");\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void build_assignment_for_object() {
-    Expression.Variable arg1 = variableWithId("arg1");
-    Expression.Variable arg2 = variableWithId("arg2");
-    Expression.Variable var = variableWithId("var");
-    Expression.Variable aux = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/String;").addMethodParam(arg1)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(var, call("__id").withArgs(arg1), new LocationInFile(FILE_KEY, 1,50,1,68))
-            .assignTo(var, call("__id").withArgs(arg2), new LocationInFile(FILE_KEY, 1,87,1,97))
-            .assignTo(aux, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(var), new LocationInFile(FILE_KEY, 1,117,1,131))
-            .ret(aux, new LocationInFile(FILE_KEY, 1,110,1,132)))
-        .build();
-
-    assertCodeToUCfg("class A {String method(Object arg1, Object arg2) {Object var = arg1; int foo; int bar; var = arg2; foo = bar; return var.toString();}}", expectedUCFG);
+    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Integer;)Ljava/lang/String;").addMethodParam(arg)
+      .addBasicBlock(newBasicBlock("1")
+        .ret(constant("foo"), new LocationInFile(FILE_KEY, 1, 66, 1, 79)))
+      .build();
+    assertCodeToUCfg("class A { String method(@javax.annotation.Nullable Integer arg) { return \"foo\";}}", expectedUCFG);
   }
 
   @Test
   public void build_assignment_for_string() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable arg2 = variableWithId("arg2");
-    Expression.Variable var1 = variableWithId("var1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg).addMethodParam(arg2)
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable arg2 = UCFGBuilder.variableWithId("arg2");
+    Expression.Variable var1 = UCFGBuilder.variableWithId("var1");
+    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1")
         .assignTo(var1, call("__id").withArgs(arg), new LocationInFile(FILE_KEY, 1,49,1,67))
         .assignTo(var1, call("__id").withArgs(arg2), new LocationInFile(FILE_KEY, 1,88,1,99))
@@ -544,21 +243,8 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
-  public void variable_declaration_without_initializer() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var1 = variableWithId("var1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(var1, call("__id").withArgs(constant("\"\"")), new LocationInFile(FILE_KEY, 1,36,1,48))
-            .assignTo(var1, call("__id").withArgs(arg), new LocationInFile(FILE_KEY, 1,49,1,59))
-            .ret(var1, new LocationInFile(FILE_KEY, 1,61,1,73)))
-        .build();
-    assertCodeToUCfg("class A {String method(String arg) {String var1; var1 = arg; return var1;}}", expectedUCFG);
-  }
-
-  @Test
   public void constructor_with_return() {
-    Expression.Variable arg = variableWithId("arg");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#<init>(Ljava/lang/String;)V").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1")
         .ret(constant("\"\""), new LocationInFile(FILE_KEY, 3,4,3,11)))
@@ -572,8 +258,8 @@ public class UCFGJavaVisitorTest {
 
   @Test
   public void location_in_source_file_should_be_preserved() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var = variableWithId("%0");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable var = UCFGBuilder.variableWithId("%0");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1")
         .assignTo(var, call("java.lang.String#toString()Ljava/lang/String;").withArgs(arg), new LocationInFile(FILE_KEY, 2,0,2,14))
@@ -584,19 +270,19 @@ public class UCFGJavaVisitorTest {
 
   @Test
   public void basic_block_location() {
-    Expression.Variable arg = variableWithId("arg");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/String;").addMethodParam(arg)
       .addBasicBlock(newBasicBlock("1").ret(arg, new LocationInFile(FILE_KEY, 3,5,3,16)))
       .build();
-    UCFG ucfg = assertCodeToUCfg("class A {\n  String method(String arg) {\n     return arg;\n}}", expectedUCFG).values().iterator().next();
+    UCFG ucfg = assertCodeToUCfg("class A {\n  String method(String arg) {\n     return arg;\n}}", expectedUCFG);
     assertThat(ucfg.entryBlocks()).hasSize(1);
     assertThat(ucfg.entryBlocks().iterator().next().locationInFile()).isEqualTo(new LocationInFile(FILE_KEY, 3, 12, 3, 15));
   }
 
   @Test
   public void string_length_invocation() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var0 = variableWithId("%0");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable var0 = UCFGBuilder.variableWithId("%0");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)I").addMethodParam(arg)
       .addStartingBlock(newBasicBlock("1").assignTo(var0, call("java.lang.String#length()I").withArgs(arg), new LocationInFile(FILE_KEY, 1,41,1,53))
         .ret(constant("\"\""), new LocationInFile(FILE_KEY, 1,34,1,54)))
@@ -605,24 +291,13 @@ public class UCFGJavaVisitorTest {
   }
 
   @Test
-  public void object_to_string_invocation() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var0 = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Integer;)Ljava/lang/String;").addMethodParam(arg)
-      .addStartingBlock(newBasicBlock("1").assignTo(var0, call("java.lang.Integer#toString()Ljava/lang/String;").withArgs(arg), new LocationInFile(FILE_KEY, 1, 45, 1, 59))
-        .ret(var0, new LocationInFile(FILE_KEY, 1, 38, 1, 60)))
-      .build();
-    assertCodeToUCfg("class A { String method(Integer arg) {return arg.toString();}}", expectedUCFG);
-  }
-
-  @Test
   public void static_method_call_without_object() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable var0 = variableWithId("%0");
+    Expression.Variable arg = UCFGBuilder.variableWithId("arg");
+    Expression.Variable var0 = UCFGBuilder.variableWithId("%0");
     UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Integer;)I").addMethodParam(arg)
       .addStartingBlock(
         newBasicBlock("1")
-          .assignTo(var0, call("java.lang.String#valueOf(Ljava/lang/Object;)Ljava/lang/String;").withArgs(new Expression.ClassName("java.lang.String"), arg),
+          .assignTo(var0, call("java.lang.String#valueOf(Ljava/lang/Object;)Ljava/lang/String;").withArgs(arg),
             new LocationInFile(FILE_KEY, 4,11,4,23))
         .ret(constant("\"\""), new LocationInFile(FILE_KEY, 4,4,4,24)))
       .build();
@@ -634,498 +309,32 @@ public class UCFGJavaVisitorTest {
       "}", expectedUCFG);
   }
 
-  @Test
-  public void constructor_call_as_initializer() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable instance = variableWithId("instance");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/Integer;").addMethodParam(arg)
-      .addStartingBlock(newBasicBlock("1")
-        .newObject(aux0, "java.lang.Integer", new LocationInFile(FILE_KEY, 3, 27, 3, 34))
-        .assignTo(aux1, call("java.lang.Integer#<init>(Ljava/lang/String;)V").withArgs(aux0, arg), new LocationInFile(FILE_KEY, 3,23,3,39))
-        .assignTo(instance, call("__id").withArgs(aux0), new LocationInFile(FILE_KEY, 3,4,3,40))
-        .ret(instance, new LocationInFile(FILE_KEY, 4,4,4,20)))
-      .build();
-    assertCodeToUCfg("class A { \n" +
-      "  Integer method(String arg) {\n" +
-      "    Integer instance = new Integer(arg);\n" +
-      "    return instance;\n" +
-      "  }\n" +
-      "}", expectedUCFG);
+  private void assertCodeToUCfgAndLocations(String source, UCFG expectedUCFG) {
+    assertCodeToUCfg(source, expectedUCFG, true);
   }
 
-  @Test
-  public void constructor_calls_assigned_to_same_local_variable() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable instance = variableWithId("instance");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/Integer;").addMethodParam(arg)
-        .addStartingBlock(newBasicBlock("1")
-            .assignTo(instance, call("__id").withArgs(constant("\"\"")), new LocationInFile(FILE_KEY, 3,4,3,21))
-            .newObject(aux0, "java.lang.Integer", new LocationInFile(FILE_KEY, 4, 19, 4, 26))
-            .assignTo(aux1, call("java.lang.Integer#<init>(Ljava/lang/String;)V").withArgs(aux0, arg), new LocationInFile(FILE_KEY, 4,15,4,31))
-            .assignTo(instance, call("__id").withArgs(aux0), new LocationInFile(FILE_KEY, 4,4,4,31))
-            .newObject(aux2, "java.lang.Integer", new LocationInFile(FILE_KEY, 5, 19, 5, 26))
-            .assignTo(aux3, call("java.lang.Integer#<init>(Ljava/lang/String;)V").withArgs(aux2, arg), new LocationInFile(FILE_KEY, 5,15,5,31))
-            .assignTo(instance, call("__id").withArgs(aux2), new LocationInFile(FILE_KEY, 5,4,5,31))
-            .ret(instance, new LocationInFile(FILE_KEY, 6,4,6,20)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  Integer method(String arg) {\n" +
-        "    Integer instance;\n" +
-        "    instance = new Integer(arg);\n" +
-        "    instance = new Integer(arg);\n" +
-        "    return instance;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
+  private UCFG assertCodeToUCfg(String source, UCFG expectedUCFG) {
+    return assertCodeToUCfg(source, expectedUCFG, false);
   }
 
-  @Test
-  public void constructor_call_inside_constructor_call() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable instance = variableWithId("instance");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/Integer;").addMethodParam(arg)
-        .addStartingBlock(newBasicBlock("1")
-            .newObject(aux0, "java.lang.Integer", new LocationInFile(FILE_KEY, 3, 39, 3, 46))
-            .assignTo(aux1, call("java.lang.Integer#<init>(Ljava/lang/String;)V").withArgs(aux0, arg), new LocationInFile(FILE_KEY, 3,35,3,51))
-            .newObject(aux2, "java.lang.Integer", new LocationInFile(FILE_KEY, 3, 27, 3, 34))
-            .assignTo(aux3, call("java.lang.Integer#<init>(I)V").withArgs(aux2, aux0), new LocationInFile(FILE_KEY, 3,23,3,52))
-            .assignTo(instance, call("__id").withArgs(aux2), new LocationInFile(FILE_KEY, 3,4,3,53))
-            .ret(instance, new LocationInFile(FILE_KEY, 4,4,4,20)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  Integer method(String arg) {\n" +
-        "    Integer instance = new Integer(new Integer(arg));\n" +
-        "    return instance;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void constructor_call_returned() {
-    Expression.Variable arg = variableWithId("arg");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/String;)Ljava/lang/Integer;").addMethodParam(arg)
-        .addStartingBlock(newBasicBlock("1")
-            .newObject(aux0, "java.lang.Integer", new LocationInFile(FILE_KEY, 3, 15, 3, 22))
-            .assignTo(aux1, call("java.lang.Integer#<init>(Ljava/lang/String;)V").withArgs(aux0, arg), new LocationInFile(FILE_KEY, 3,11,3,27))
-            .ret(aux0, new LocationInFile(FILE_KEY, 3,4,3,28)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  Integer method(String arg) {\n" +
-        "    return new Integer(arg);\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void method_argument_expressions_get_stored_in_auxiliary_local_variables() {
-    Expression.Variable argument1 = variableWithId("arg1");
-    Expression.Variable argument2 = variableWithId("arg2");
-    Expression.Variable argument3 = variableWithId("arg3");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux4 = variableWithId("%4");
-
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#method(Ljava/lang/Object;[Ljava/lang/String;LA$Foo;)Ljava/lang/String;")
-        .addMethodParam(argument1).addMethodParam(argument2).addMethodParam(argument3)
-        .addStartingBlock(newBasicBlock("1")
-            .newObject(aux0, "java.lang.Integer", new LocationInFile(FILE_KEY, 4, 35, 4, 42))
-            .assignTo(aux1, call("java.lang.Integer#<init>(I)V").withArgs(aux0, constant("\"\"")), new LocationInFile(FILE_KEY, 4,31,4,45))
-            .assignTo(aux2, call("java.lang.Object#toString()Ljava/lang/String;").withArgs(argument1), new LocationInFile(FILE_KEY, 4,47,4,62))
-            .assignTo(aux3, call("__arrayGet").withArgs(argument2), new LocationInFile(FILE_KEY, 4,64,4,71))
-            // field access will change with SONARSEC-121
-            .assignTo(aux4, call("java.lang.String#format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;")
-                    .withArgs(new Expression.ClassName("java.lang.String"), constant("%s"), aux0, aux2, aux3, constant("\"\"")),
-                new LocationInFile(FILE_KEY, 4,11,4,82))
-            .ret(aux4, new LocationInFile(FILE_KEY, 4,4,4,83)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  class Foo { String foo; }\n" +
-        "  String method(Object arg1, String[] arg2, Foo arg3) {\n" +
-        "    return String.format(\"%s\", new Integer(1), arg1.toString(), arg2[0], arg3.foo);\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_getters_and_setters() {
-    Expression.Variable foo = variableWithId("foo");
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo(Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/String;").addMethodParam(foo).addMethodParam(array)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arraySet").withArgs(array, foo), new LocationInFile(FILE_KEY, 3,4,3,18))
-            .assignTo(aux1, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,10,4,18))
-            .assignTo(foo, call("__id").withArgs(aux1), new LocationInFile(FILE_KEY, 4,4,4,18))
-            .ret(foo, new LocationInFile(FILE_KEY, 5, 4, 5, 15)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String foo, String[] array) { \n" +
-        "    array[0] = foo;\n" +
-        "    foo = array[0];\n" +
-        "    return foo;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_of_primitives_ignore() {
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([I[[III)[B")
-        .addBasicBlock(newBasicBlock("1")
-            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 5, 16, 5, 24))
-            .assignTo(aux1, call("A#baz([I[IB)V").withArgs(Expression.THIS, constant("\"\""), constant("\"\""), constant("\"\"")), new LocationInFile(FILE_KEY, 6,4,6,35))
-            .ret(constant("\"\""), new LocationInFile(FILE_KEY, 9, 4, 9, 15)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private void baz(int[] a, int[] b, byte c) {}\n" +
-        "  private byte[] foo(int[] input, int[][] multiDim, int i, int j) { \n" +
-        "    byte[] foo = new byte[10];\n" +
-        "    int[] bar = { 1, 2 };\n" + // we cannot tell the type of the new array construct
-        "    baz(multiDim[0], input, foo[0]);\n" +
-        "    foo[bar[0]] = foo[0];\n" +
-        "    foo[j + 1] = (byte) ((input[i] >>> 8) & 0xff);\n" +
-        "    return foo;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_of_primitive_mixed_with_object_sets_only_objects() {
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux5 = variableWithId("%5");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo(Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/Object;")
-        .addBasicBlock(newBasicBlock("1")
-            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 4, 21, 4, 48))
-            .assignTo(variableWithId("%1"), call("__arraySet").withArgs(aux0, variableWithId("tainted")), new LocationInFile(FILE_KEY, 4, 21, 4, 48))
-            .assignTo(variableWithId("%2"), call("__arraySet").withArgs(aux0, variableWithId("i")), new LocationInFile(FILE_KEY, 4, 21, 4, 48))
-            .assignTo(array, call("__id").withArgs(aux0), new LocationInFile(FILE_KEY, 4, 4, 4, 49))
-            .assignTo(aux3, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 5,8,5,16))
-            .assignTo(variableWithId("%4"), call("A#baz(Ljava/lang/Object;)V").withArgs(Expression.THIS, aux3), new LocationInFile(FILE_KEY, 5,4,5,17))
-            .assignTo(aux5, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 6,11,6,19))
-            .ret(aux5, new LocationInFile(FILE_KEY, 6, 4, 6, 20)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private void baz(Object o) {};\n" +
-        "  private Object foo(String tainted, Integer i) { \n" +
-        "    Object[] array = {0, tainted, 10.0, true, i};\n" +
-        "    baz(array[0]);\n" +
-        "    return array[1];\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_variable_declaration() {
-    Expression.Variable foo = variableWithId("foo");
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux4 = variableWithId("%4");
-    Expression.Variable aux5 = variableWithId("%5");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo(Ljava/lang/String;)[Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 3, 21, 3, 28))
-            .assignTo(aux1, call("__arraySet").withArgs(aux0, foo), new LocationInFile(FILE_KEY, 3, 21, 3, 28))
-            .assignTo(array, call("__id").withArgs(aux0), new LocationInFile(FILE_KEY, 3,4,3,29))
-            .newObject(aux2, "$Array", new LocationInFile(FILE_KEY, 4, 12, 4, 39))
-            .assignTo(aux3, call("__arraySet").withArgs(aux2, foo), new LocationInFile(FILE_KEY, 4,12,4,39))
-            .assignTo(aux4, call("__arraySet").withArgs(aux2, constant("bar")), new LocationInFile(FILE_KEY, 4,12,4,39))
-            .assignTo(array, call("__id").withArgs(aux2), new LocationInFile(FILE_KEY, 4,4,4,39))
-            .newObject(aux5, "$Array", new LocationInFile(FILE_KEY, 5, 12, 5, 25))
-            .assignTo(array, call("__id").withArgs(aux5), new LocationInFile(FILE_KEY, 5,4,5,25))
-            .ret(array, new LocationInFile(FILE_KEY, 6, 4, 6, 17)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String[] foo(String foo) { \n" +
-        "    String[] array = { foo };\n" +
-        "    array = new String[] { foo, \"bar\" };\n" +
-        "    array = new String[1];\n" +
-        "    return array;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_multidimensional_initialization() {
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux6 = variableWithId("%6");
-    UCFG expectedFooUCFG = UCFGBuilder.createUCFGForMethod("A#foo()[[[Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 2, 60, 2, 73))
-            .assignTo(variableWithId("%1"), call("__arraySet").withArgs(aux0, constant("one")), new LocationInFile(FILE_KEY, 2, 60, 2, 73))
-            .assignTo(variableWithId("%2"), call("__arraySet").withArgs(aux0, constant("two")), new LocationInFile(FILE_KEY, 2, 60, 2, 73))
-            .newObject(aux3, "$Array", new LocationInFile(FILE_KEY, 2, 59, 2, 74))
-            .newObject(variableWithId("%4"), "$Array", new LocationInFile(FILE_KEY, 2,77,2,79))
-            .newObject(variableWithId("%5"), "$Array", new LocationInFile(FILE_KEY, 2,76,2,80))
-            .newObject(aux6, "$Array", new LocationInFile(FILE_KEY, 2, 41, 2, 81))
-            .ret(aux6, new LocationInFile(FILE_KEY, 2, 34, 2, 82)))
-        .build();
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    UCFG expectedBarUCFG = UCFGBuilder.createUCFGForMethod("A#bar()[[I")
-        .addBasicBlock(newBasicBlock("1")
-            .newObject(aux0, "$Array", new LocationInFile(FILE_KEY, 4, 47, 4, 50))
-            .newObject(aux1, "$Array", new LocationInFile(FILE_KEY, 4, 52, 4, 57))
-            .newObject(aux2, "$Array", new LocationInFile(FILE_KEY, 4, 45, 4, 58))
-            .ret(constant("\"\""), new LocationInFile(FILE_KEY, 5, 4, 5, 17)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        // SONARJAVA-2835 : the type for multi-dimension array initializers is null
-        "  private String[][][] foo() {" +
-        "    return new String[][][] {{{\"one\",\"two\"}}, {{}}}; \n" +
-        "  }\n" +
-        "  private int[][] bar() {" +
-        "    int[][] array = { {1}, {1,2}}; \n" +  // we cannot tell the type of the new array construct
-        "    return array;\n" +
-        "  }\n" +
-        "}", expectedFooUCFG, expectedBarUCFG);
-  }
-
-  @Test
-  public void array_multidimensional_getters_and_setters() {
-    Expression.Variable foo = variableWithId("foo");
-    Expression.Variable multiDim = variableWithId("multiDim");
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux4 = variableWithId("%4");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo(Ljava/lang/String;[[Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arraySet").withArgs(multiDim, array), new LocationInFile(FILE_KEY, 3,4,3,23))
-            .assignTo(aux1, call("__arrayGet").withArgs(multiDim), new LocationInFile(FILE_KEY, 4,4,4,15))
-            .assignTo(aux2, call("__arraySet").withArgs(aux1, foo), new LocationInFile(FILE_KEY, 4,4,4,24))
-            .assignTo(aux3, call("__arrayGet").withArgs(multiDim), new LocationInFile(FILE_KEY, 5,10,5,21))
-            .assignTo(aux4, call("__arrayGet").withArgs(aux3), new LocationInFile(FILE_KEY, 5,10,5,24))
-            .assignTo(foo, call("__id").withArgs(aux4), new LocationInFile(FILE_KEY, 5,4,5,24))
-            .ret(foo, new LocationInFile(FILE_KEY, 6, 4, 6, 15)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String foo, String[][] multiDim, String[] array) { \n" +
-        "    multiDim[0] = array;\n" +
-        "    multiDim[0][1] = foo;\n" +
-        "    foo = multiDim[0][0];\n" +
-        "    return foo;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_getters_and_setters_in_expressions() {
-    Expression.Variable foo = variableWithId("foo");
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable intA = variableWithId("intA");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux4 = variableWithId("%4");
-    Expression.Variable aux5 = variableWithId("%5");
-    Expression.Variable aux6 = variableWithId("%6");
-    Expression.Variable aux7 = variableWithId("%7");
-    Expression.Variable s = variableWithId("s");
-    String methodId = "A#foo(Ljava/lang/String;[Ljava/lang/String;[I)Ljava/lang/String;";
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod(methodId)
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,8,3,22))
-            .assignTo(aux1, call(methodId).withArgs(Expression.THIS, aux0, array, constant("\"\"")), new LocationInFile(FILE_KEY, 3,4,3,36))
-            .assignTo(aux2, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,4,4,12))
-            .assignTo(aux3, call("__concat").withArgs(aux2, foo), new LocationInFile(FILE_KEY, 4,4,4,19))
-            .assignTo(aux4, call("__arraySet").withArgs(array, aux3), new LocationInFile(FILE_KEY, 4,4,4,19))
-            .assignTo(aux5, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 5,15,5,23))
-            .assignTo(s, call("__id").withArgs(aux5), new LocationInFile(FILE_KEY, 5,4,5,24))
-            .assignTo(aux6, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 6,11,6,19))
-            .assignTo(aux7, call("__concat").withArgs(aux6, s), new LocationInFile(FILE_KEY, 6,11,6,23))
-            .ret(aux7, new LocationInFile(FILE_KEY, 6, 4, 6, 24)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String foo, String[] array, int[] intA) { \n" +
-        "    foo(array[intA[0]], array, intA);\n" +
-        "    array[0] += foo;\n" +
-        "    String s = array[1];\n" +
-        "    return array[0] + s;\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_in_expressions_with_multiple_access() {
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    Expression.Variable aux2 = variableWithId("%2");
-    Expression.Variable aux3 = variableWithId("%3");
-    Expression.Variable aux4 = variableWithId("%4");
-    Expression.Variable aux5 = variableWithId("%5");
-    Expression.Variable aux6 = variableWithId("%6");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([Ljava/lang/String;)Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,4,3,12))
-            .assignTo(aux1, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,16,3,24))
-            .assignTo(aux2, call("__concat").withArgs(aux0, aux1), new LocationInFile(FILE_KEY, 3,4,3,24))
-            .assignTo(aux3, call("__arraySet").withArgs(array, aux2), new LocationInFile(FILE_KEY, 3,4,3,24))
-            .assignTo(aux4, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,11,4,19))
-            .assignTo(aux5, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 4,22,4,30))
-            .assignTo(aux6, call("__concat").withArgs(aux4, aux5), new LocationInFile(FILE_KEY, 4,11,4,30))
-            .ret(aux6, new LocationInFile(FILE_KEY, 4,4,4,31)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String[] array) { \n" +
-        "    array[0] += array[0];\n" +
-        "    return array[0] + array[0];\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_assign_to_array() {
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([Ljava/lang/String;)Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,15,3,23))
-            .assignTo(aux1, call("__arraySet").withArgs(array, aux0), new LocationInFile(FILE_KEY, 3,4,3,23))
-            .ret(constant("foo"), new LocationInFile(FILE_KEY, 4,4,4,17)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String[] array) { \n" +
-        "    array[0] = array[1];\n" +
-        "    return \"foo\";\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_access_return() {
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([Ljava/lang/String;)Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,11,3,19))
-            .ret(aux0, new LocationInFile(FILE_KEY, 3,4,3,20)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String[] array) { \n" +
-        "    return array[0];\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void array_access_method_call() {
-    Expression.Variable array = variableWithId("array");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG expectedUCFG = UCFGBuilder.createUCFGForMethod("A#foo([Ljava/lang/String;)Ljava/lang/String;")
-        .addBasicBlock(newBasicBlock("1")
-            .assignTo(aux0, call("__arrayGet").withArgs(array), new LocationInFile(FILE_KEY, 3,11,3,19))
-            .assignTo(aux1, call("java.lang.String#toString()Ljava/lang/String;").withArgs(aux0), new LocationInFile(FILE_KEY, 3,11,3,30))
-            .ret(aux1, new LocationInFile(FILE_KEY, 3,4,3,31)))
-        .build();
-    assertCodeToUCfg("class A { \n" +
-        "  private String foo(String[] array) { \n" +
-        "    return array[0].toString();\n" +
-        "  }\n" +
-        "}", expectedUCFG);
-  }
-
-  @Test
-  public void constructor_chaining() {
-    Expression.Variable collection = variableWithId("collection");
-    Expression.Variable s = variableWithId("s");
-    Expression.Variable aux0 = variableWithId("%0");
-    Expression.Variable aux1 = variableWithId("%1");
-    UCFG firstConstructor = UCFGBuilder.createUCFGForMethod("A#<init>(Ljava/util/Collection;)V")
-        .addStartingBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.util.ArrayList#<init>(Ljava/util/Collection;)V")
-                .withArgs(Expression.THIS, collection), new LocationInFile(FILE_KEY, 3,2,3,19))
-            .jumpTo(UCFGBuilder.createLabel("0")))
-        .addBasicBlock(newBasicBlock("0")
-            .ret(constant("implicit return"), new LocationInFile(FILE_KEY, 4,0,4,1)))
-        .build();
-    UCFG secondConstructor = UCFGBuilder.createUCFGForMethod("A#<init>(Ljava/lang/String;)V")
-        .addStartingBlock(newBasicBlock("1")
-            .assignTo(aux0, call("java.util.Arrays#asList([Ljava/lang/Object;)Ljava/util/List;")
-                .withArgs(new Expression.ClassName("java.util.Arrays"), s), new LocationInFile(FILE_KEY, 6,7,6,33))
-            .assignTo(aux1, call("A#<init>(Ljava/util/Collection;)V")
-                .withArgs(Expression.THIS, aux0), new LocationInFile(FILE_KEY, 6,2,6,34))
-            .jumpTo(UCFGBuilder.createLabel("0")))
-        .addBasicBlock(newBasicBlock("0")
-            .ret(constant("implicit return"), new LocationInFile(FILE_KEY, 7,0,7,1)))
-        .build();
-    assertCodeToUCfg("class A extends java.util.ArrayList<String> {\n" +
-        "public A(java.util.Collection<String> collection) {\n" +
-        "  super(collection);\n" +
-        "}\n" +
-        "public A(String s) {\n" +
-        "  this(java.util.Arrays.asList(s));\n" +
-        "}\n" +
-        "}", firstConstructor, secondConstructor);
-  }
-
-  private void assertUnknownMethodCalled(String source) {
-    CompilationUnitTree cut = getCompilationUnitTreeWithSemantics(source);
-    UnknownMethodVisitor unknownMethodVisitor = new UnknownMethodVisitor();
-    unknownMethodVisitor.visitCompilationUnit(cut);
-    assertThat(unknownMethodVisitor.unknownMethodCount).isGreaterThan(0);
-  }
-
-  private void assertCodeToUCfgAndLocations(String source, UCFG... expectedUCFGs) {
-    assertCodeToUCfg(source, true, expectedUCFGs);
-  }
-
-  private Map<String, UCFG>  assertCodeToUCfg(String source, UCFG... expectedUCFGs) {
-    return assertCodeToUCfg(source, false, expectedUCFGs);
-  }
-
-  private Map<String, UCFG> assertCodeToUCfg(String source, boolean testLocations, UCFG... expectedUCFGs) {
-    Map<String, UCFG> actualUCFGs  = createUCFG(source);
-    for (UCFG expectedUCFG : expectedUCFGs) {
-      UCFG actualUCFG = actualUCFGs.get(expectedUCFG.methodId());
-      // actualUCFG will be null in case there's no UCFG with the expected methodId
-      assertThat(actualUCFG).isNotNull();
-      assertThat(actualUCFG.methodId()).isEqualTo(expectedUCFG.methodId());
-      assertThat(actualUCFG.basicBlocks()).isEqualTo(expectedUCFG.basicBlocks());
-      assertThat(actualUCFG.basicBlocks().values().stream().flatMap(b -> b.instructions().stream()))
-          .containsExactlyElementsOf(expectedUCFG.basicBlocks().values().stream().flatMap(b -> b.instructions().stream()).collect(Collectors.toList()));
-      assertThat(actualUCFG.basicBlocks().values().stream().map(BasicBlock::terminator))
-          .containsExactlyElementsOf(expectedUCFG.basicBlocks().values().stream().map(BasicBlock::terminator).collect(Collectors.toList()));
-      assertThat(actualUCFG.entryBlocks()).isEqualTo(expectedUCFG.entryBlocks());
-      assertThat(toLocationStream(actualUCFG).noneMatch(l -> l == UCFGBuilder.LOC)).isTrue();
-      if (testLocations) {
-        Stream<LocationInFile> locStream = toLocationStream(actualUCFG);
-        assertThat(locStream).containsExactlyElementsOf(toLocationStream(expectedUCFG).collect(Collectors.toList()));
-      }
+  private UCFG assertCodeToUCfg(String source, UCFG expectedUCFG, boolean testLocations) {
+    UCFG actualUCFG = createUCFG(source);
+    assertThat(actualUCFG.methodId()).isEqualTo(expectedUCFG.methodId());
+    assertThat(actualUCFG.basicBlocks()).isEqualTo(expectedUCFG.basicBlocks());
+    assertThat(actualUCFG.basicBlocks().values().stream().flatMap(b->b.calls().stream()))
+      .containsExactlyElementsOf(expectedUCFG.basicBlocks().values().stream().flatMap(b->b.calls().stream()).collect(Collectors.toList()));
+    assertThat(actualUCFG.basicBlocks().values().stream().map(BasicBlock::terminator))
+      .containsExactlyElementsOf(expectedUCFG.basicBlocks().values().stream().map(BasicBlock::terminator).collect(Collectors.toList()));
+    assertThat(actualUCFG.entryBlocks()).isEqualTo(expectedUCFG.entryBlocks());
+    assertThat(toLocationStream(actualUCFG).noneMatch(l->l == UCFGBuilder.LOC)).isTrue();
+    if(testLocations) {
+      Stream<LocationInFile> locStream = toLocationStream(actualUCFG);
+      assertThat(locStream).containsExactlyElementsOf(toLocationStream(expectedUCFG).collect(Collectors.toList()));
     }
-    return actualUCFGs;
+    return actualUCFG;
   }
 
-  private Map<String, UCFG> createUCFG(String source) {
+  private UCFG createUCFG(String source) {
     File java_ucfg_dir = new File(new File(tmp.getRoot(), "ucfg"), "java");
     if(java_ucfg_dir.isDirectory()) {
       for (File file : java_ucfg_dir.listFiles()) {
@@ -1134,25 +343,17 @@ public class UCFGJavaVisitorTest {
     }
     CompilationUnitTree cut = getCompilationUnitTreeWithSemantics(source);
     UCFGJavaVisitor UCFGJavaVisitor = new UCFGJavaVisitor(tmp.getRoot());
-    UCFGJavaVisitor.javaFileKey = FILE_KEY;
+    UCFGJavaVisitor.fileKey = FILE_KEY;
     UCFGJavaVisitor.visitCompilationUnit(cut);
 
-    Map<String, UCFG> result = new HashMap<String, UCFG>();
+    UCFG actualUCFG = null;
     try {
-      DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(java_ucfg_dir.getAbsolutePath()), new DirectoryStream.Filter<Path>() {
-        @Override
-        public boolean accept(final Path entry) {
-          return entry.toFile().getName().matches("ucfg_(.*).proto");
-        }
-      });
-      for (Path path : stream) {
-        UCFG ucfg = UCFGtoProtobuf.fromProtobufFile(path.toFile());
-        result.put(ucfg.methodId(), ucfg);
-      }
+      File ucfg = new File(java_ucfg_dir, "ucfg_0.proto");
+      actualUCFG = UCFGtoProtobuf.fromProtobufFile(ucfg);
     } catch (IOException e) {
       e.printStackTrace();
     }
-    return result;
+    return actualUCFG;
   }
 
   @Test
@@ -1165,11 +366,11 @@ public class UCFGJavaVisitorTest {
     }
     CompilationUnitTree cut = getCompilationUnitTreeWithSemantics("class A {String fun() {return \"\";}} ");
     UCFGJavaVisitor UCFGJavaVisitor = new UCFGJavaVisitor(tmp.getRoot());
-    UCFGJavaVisitor.javaFileKey = FILE_KEY;
+    UCFGJavaVisitor.fileKey = FILE_KEY;
     UCFGJavaVisitor.visitCompilationUnit(cut);
 
     UCFGJavaVisitor = new UCFGJavaVisitor(tmp.getRoot());
-    UCFGJavaVisitor.javaFileKey = FILE_KEY;
+    UCFGJavaVisitor.fileKey = FILE_KEY;
     UCFGJavaVisitor.visitCompilationUnit(cut);
 
     String[] list = java_ucfg_dir.list();
@@ -1185,7 +386,7 @@ public class UCFGJavaVisitorTest {
         fail("should not serialize a UCFG of a method with unknown parameters");
       }
     };
-    UCFGJavaVisitor.javaFileKey = FILE_KEY;
+    UCFGJavaVisitor.fileKey = FILE_KEY;
     // method with unknown arg
     CompilationUnitTree cut = getCompilationUnitTreeWithSemantics("class A {void foo(UnkownType t) {return t;}}");
     UCFGJavaVisitor.visitCompilationUnit(cut);
@@ -1234,41 +435,30 @@ public class UCFGJavaVisitorTest {
 
   @Test
   public void null_literal_should_produce_a_constant_expression() {
-    UCFG ucfg = createUCFG("class A {String foo(String s) {return foo(null);}}").values().iterator().next();
+    UCFG ucfg = createUCFG("class A {String foo(String s) {return foo(null);}}");
     BasicBlock basicBlock = ucfg.entryBlocks().iterator().next();
-    // first argument is "this"
-    Expression argExpression = ((Instruction.AssignCall)basicBlock.instructions().get(0)).getArgExpressions().get(1);
+    Expression argExpression = basicBlock.calls().get(0).getArgExpressions().get(0);
     assertThat(argExpression.isConstant()).isTrue();
   }
 
   @Test
   public void string_literal_should_produce_a_constant_expression() {
-    UCFG ucfg = createUCFG("class A {String foo(String s) {return foo(\"plop\");}}").values().iterator().next();
+    UCFG ucfg = createUCFG("class A {String foo(String s) {return foo(\"plop\");}}");
     BasicBlock basicBlock = ucfg.entryBlocks().iterator().next();
-    // first argument is "this"
-    Expression argExpression = ((Instruction.AssignCall)basicBlock.instructions().get(0)).getArgExpressions().get(1);
+    Expression argExpression = basicBlock.calls().get(0).getArgExpressions().get(0);
     assertThat(argExpression.isConstant()).isTrue();
   }
 
   @Test
   public void constructors_should_have_a_ucfg() {
-    UCFG ucfg = createUCFG("class A { Object foo(String s) {new A(s); new Object(); new Unknown(\"\"); return new String();} A(String s) {} }")
-        .get("A#foo(Ljava/lang/String;)Ljava/lang/Object;");
+    UCFG ucfg = createUCFG("class A { Object foo(String s) {new A(s); new Object(); new Unknown(\"\"); return new String();} A(String s) {} }");
     assertThat(ucfg.methodId()).isEqualTo("A#foo(Ljava/lang/String;)Ljava/lang/Object;");
-    List<Instruction> calls = ucfg.entryBlocks().iterator().next().instructions();
-    assertThat(calls).hasSize(6);
-    Instruction.NewObject newInstance0 = (Instruction.NewObject)calls.get(0);
-    Instruction.AssignCall newInstanceAssignCall0 = (Instruction.AssignCall)calls.get(1);
-    assertThat(newInstance0.instanceType()).isEqualTo("A");
-    assertThat(newInstanceAssignCall0.getMethodId()).isEqualTo("A#<init>(Ljava/lang/String;)V");
-    Instruction.NewObject newInstance1 = (Instruction.NewObject)calls.get(2);
-    Instruction.AssignCall newInstanceAssignCall1 = (Instruction.AssignCall)calls.get(3);
-    assertThat(newInstance1.instanceType()).isEqualTo("java.lang.Object");
-    assertThat(newInstanceAssignCall1.getMethodId()).isEqualTo("java.lang.Object#<init>()V");
-    Instruction.NewObject newInstance2 = (Instruction.NewObject)calls.get(4);
-    Instruction.AssignCall newInstanceAssignCall2 = (Instruction.AssignCall)calls.get(5);
-    assertThat(newInstance2.instanceType()).isEqualTo("java.lang.String");
-    assertThat(newInstanceAssignCall2.getMethodId()).isEqualTo("java.lang.String#<init>()V");
+    List<Instruction.AssignCall> calls = ucfg.entryBlocks().iterator().next().calls();
+    assertThat(calls).hasSize(2);
+    Instruction.AssignCall assignCall0 = calls.get(0);
+    assertThat(assignCall0.getMethodId()).isEqualTo("A#<init>(Ljava/lang/String;)V");
+    Instruction.AssignCall assignCall1 = calls.get(1);
+    assertThat(assignCall1.getMethodId()).isEqualTo("java.lang.String#<init>()V");
   }
 
   private CompilationUnitTree getCompilationUnitTreeWithSemantics(String source) {
@@ -1278,7 +468,7 @@ public class UCFGJavaVisitorTest {
   }
 
   private Stream<LocationInFile> toLocationStream(UCFG UCFG) {
-    return UCFG.basicBlocks().values().stream().flatMap(b -> Stream.concat(b.instructions().stream().map(Instruction::location), Stream.of(b.terminator().location())));
+    return UCFG.basicBlocks().values().stream().flatMap(b -> Stream.concat(b.calls().stream().map(Instruction::location), Stream.of(b.terminator().location())));
   }
 
   private static class UnknownMethodVisitor extends BaseTreeVisitor {


### PR DESCRIPTION
c15c37e780ed216286db00ed737b7249741a6004 - SONARSEC-175 UCFGJavaVisitor should handle multi-dim array initialization (#2127)
3eb97bd71fbf3884602588835179b35e7d3ed08b - SONARSEC-165 Fix uCFG array access inconsistency with primitives (#2118)
ec0029838e3d73c00cfde6c5000ea7e113b6fb3d - Use static import in tests
cbefb33e4d919ebdbdf5a6abd793c2a1490f8401 - SONARSEC-154 Fix case of parameter not annotated when annotations are present
6f96f40d180595b0fb4d65daf6bb0b863ae318d5 - SONARSEC-158 Array variable declaration should be translated to uCFG
8da9efe949a1536f6a3c2e0d133eb40def65a30e - SONARSEC-154 Handle method annotations propagated to parameters
2f6042d625107238607b0a832ee6d4126e38e895 - SONARSEC-154 Update handling of annotations to use '__annotate()'
f858d9a56ab0d25cd0cf1c465e87604ffe07dbba - SONARSEC-156 variable declaration initialization - lookup for expressions
ce8a9d365d70bc040a681edbf0f0c50ab73e2b83 - SONARSEC-113 - add UT for uCFG translation of constructor chaining
bce3a6aac8b203cf417d44072de6d66e47324a96 - SONARSEC-131 Translate array accesses to uCFG (#2109)
6a2843e017bcd75c8876b2745a66e20815b5f945 - Update to latest version of SonarUCFG (#2111)
ab8f6a285f577ea16d2cfe652ff12403b24e4d9c - SONARSEC-107 Translate all primitive types in method calls to constants (#2105)
abb29c0088d10e3a63ed60d95de1380026bc11d7 - SONARSEC-123 Translate method arguments to simple expressions (#2103)
8cdd2a36e007b2e87cd2a2def40acc381149b567 - SONARSEC-106 Translate constructor calls to uCFG (#2102)
0c74fe35f68d0678fd1767e2d54c521196f2f23f - Improve UCFGJavaVisitor coverage (#2100)
4effe4035380e092037ca65bdc715e40494ec516 - SONARSEC-103 Add target object as first argument to method call in uCFG (#2097)
