### PR TITLE
SONARJAVA-2874: Exclude Spring @RequestMapping shortcut annotations from too many parameters check rule

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/TooManyParametersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TooManyParametersCheck.java
@@ -53,6 +53,11 @@ public class TooManyParametersCheck extends BaseTreeVisitor implements JavaFileS
 
   private static final List<String> WHITE_LIST = ImmutableList.of(
     "org.springframework.web.bind.annotation.RequestMapping",
+    "org.springframework.web.bind.annotation.GetMapping",
+    "org.springframework.web.bind.annotation.PostMapping",
+    "org.springframework.web.bind.annotation.PutMapping",
+    "org.springframework.web.bind.annotation.DeleteMapping",
+    "org.springframework.web.bind.annotation.PatchMapping",
     "com.fasterxml.jackson.annotation.JsonCreator");
 
   @Override

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S107_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S107_java.html
@@ -14,6 +14,7 @@ public void doSomething(int param1, int param2, int param3, String param4) {
 }
 </pre>
 <h2>Exceptions</h2>
-<p>Methods annotated with Spring's <code>@RequestMapping</code> may have a lot of parameters, encapsulation being possible. Such methods are therefore
-ignored.</p>
+<p>Methods annotated with Spring's <code>@RequestMapping</code> (and related shortcut annotations, like
+    <code>@GetRequest</code>) or <code>@JsonCreator</code> may have a lot of parameters, encapsulation being possible.
+    Such methods are therefore ignored.</p>
 

--- a/java-checks/src/test/files/checks/TooManyParameters.java
+++ b/java-checks/src/test/files/checks/TooManyParameters.java
@@ -1,4 +1,9 @@
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 class TooManyParameters {
@@ -25,6 +30,46 @@ class MethodsUsingSpringRequestMapping {
   void foo(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
 
   @RequestMapping
+  void bar(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+}
+
+class MethodsUsingSpringGetMapping {
+  @org.springframework.web.bind.annotation.GetMapping
+  void foo(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+
+  @GetMapping
+  void bar(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+}
+
+class MethodsUsingSpringPostMapping {
+  @org.springframework.web.bind.annotation.PostMapping
+  void foo(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+
+  @PostMapping
+  void bar(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+}
+
+class MethodsUsingSpringPutMapping {
+  @org.springframework.web.bind.annotation.PutMapping
+  void foo(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+
+  @PutMapping
+  void bar(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+}
+
+class MethodsUsingSpringDeleteMapping {
+  @org.springframework.web.bind.annotation.DeleteMapping
+  void foo(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+
+  @DeleteMapping
+  void bar(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+}
+
+class MethodsUsingSpringPatchMapping {
+  @org.springframework.web.bind.annotation.PatchMapping
+  void foo(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
+
+  @PatchMapping
   void bar(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) {} // Compliant
 }
 


### PR DESCRIPTION
Updated the white list for `@GetMapping` and other shortcut annotations for `@RequestMapping`