### PR TITLE
SONARJAVA-2888 Register warning when missing bytecode detected

### DIFF
--- a/external-reports/src/test/java/org/sonar/java/externalreport/SpotBugsSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/SpotBugsSensorTest.java
@@ -108,7 +108,7 @@ public class SpotBugsSensorTest {
     ExternalIssue first = externalIssues.get(0);
     assertThat(first.primaryLocation().inputComponent().key()).isEqualTo("spotbugs-project:src/main/java/org/myapp/Main.java");
     assertThat(first.ruleKey().rule()).isEqualTo("HE_EQUALS_USE_HASHCODE");
-    assertThat(first.ruleKey().repository()).isEqualTo("spotbugs");
+    assertThat(first.ruleKey().repository()).isEqualTo("external_spotbugs");
     assertThat(first.type()).isEqualTo(RuleType.CODE_SMELL);
     assertThat(first.severity()).isEqualTo(Severity.MAJOR);
     assertThat(first.remediationEffort().longValue()).isEqualTo(5L);
@@ -126,7 +126,7 @@ public class SpotBugsSensorTest {
     ExternalIssue first = externalIssues.get(0);
     assertThat(first.primaryLocation().inputComponent().key()).isEqualTo("spotbugs-project:src/main/java/org/myapp/Main.java");
     assertThat(first.ruleKey().rule()).isEqualTo("RSA_KEY_SIZE");
-    assertThat(first.ruleKey().repository()).isEqualTo("findsecbugs");
+    assertThat(first.ruleKey().repository()).isEqualTo("external_findsecbugs");
     assertThat(first.type()).isEqualTo(RuleType.VULNERABILITY);
     assertThat(first.severity()).isEqualTo(Severity.MAJOR);
     assertThat(first.remediationEffort().longValue()).isEqualTo(5L);

--- a/java-frontend/src/main/java/org/sonar/java/AnalysisWarningsWrapper.java
+++ b/java-frontend/src/main/java/org/sonar/java/AnalysisWarningsWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java;
+
+import org.sonar.api.batch.InstantiationStrategy;
+import org.sonar.api.batch.ScannerSide;
+import org.sonar.api.notifications.AnalysisWarnings;
+
+/**
+ * Wrap an AnalysisWarnings instance, available since SQ API 7.4.
+ * Do not load this class on older runtimes.
+ * Drop this class when the minimum supported version of SonarJava reaches 7.4.
+ */
+@ScannerSide
+@InstantiationStrategy("PER_BATCH")
+public class AnalysisWarningsWrapper {
+  private final AnalysisWarnings analysisWarnings;
+
+  public AnalysisWarningsWrapper(AnalysisWarnings analysisWarnings) {
+    this.analysisWarnings = analysisWarnings;
+  }
+
+  public void addUnique(String text) {
+    this.analysisWarnings.addUnique(text);
+  }
+}

--- a/java-frontend/src/main/java/org/sonar/java/JavaTestClasspath.java
+++ b/java-frontend/src/main/java/org/sonar/java/JavaTestClasspath.java
@@ -47,7 +47,7 @@ public class JavaTestClasspath extends AbstractJavaClasspath {
       Set<File> libraries = getFilesFromProperty(JavaClasspathProperties.SONAR_JAVA_TEST_LIBRARIES);
       if (libraries.isEmpty() && hasJavaSources()) {
         LOG.warn("Bytecode of dependencies was not provided for analysis of test files, you might end up with less precise results. " +
-          "Bytecode can be provided using sonar.java.test.libraries property");
+          "Bytecode can be provided using sonar.java.test.libraries property.");
       }
       elements = new ArrayList<>(binaries);
       elements.addAll(libraries);

--- a/java-frontend/src/test/java/org/sonar/java/AnalysisWarningsWrapperTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/AnalysisWarningsWrapperTest.java
@@ -1,0 +1,39 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java;
+
+import org.junit.Test;
+import org.sonar.api.notifications.AnalysisWarnings;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AnalysisWarningsWrapperTest {
+  @Test
+  public void delegate_to_analysisWarnings() {
+    AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
+
+    AnalysisWarningsWrapper wrapper = new AnalysisWarningsWrapper(analysisWarnings);
+
+    String warning = "some warning";
+    wrapper.addUnique(warning);
+    verify(analysisWarnings).addUnique(warning);
+  }
+}

--- a/java-frontend/src/test/java/org/sonar/java/JavaIssueTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaIssueTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.sonar.java.TestUtils.computeLineEndOffsets;
 
 public class JavaIssueTest {
 
@@ -45,8 +46,11 @@ public class JavaIssueTest {
   public void testIssueCreation() {
     TestInputFileBuilder tifb = new TestInputFileBuilder("module", "relPath");
     tifb.setLines(3);
-    tifb.setOriginalLineOffsets(new int[]{0, 10, 15});
-    tifb.setLastValidOffset(25);
+    int[] lineStartOffsets = {0, 10, 15};
+    int lastValidOffset = 25;
+    tifb.setOriginalLineStartOffsets(lineStartOffsets);
+    tifb.setOriginalLineEndOffsets(computeLineEndOffsets(lineStartOffsets, lastValidOffset));
+    tifb.setLastValidOffset(lastValidOffset);
     DefaultInputFile file = tifb.build();
     RuleKey ruleKey = RuleKey.of("squid", "ruleKey");
     SensorContext sensorContext = mock(SensorContext.class);
@@ -97,8 +101,11 @@ public class JavaIssueTest {
     TestInputFileBuilder tifb = new TestInputFileBuilder("module", "relPath");
     tifb.setModuleBaseDir(new java.io.File("").toPath());
     tifb.setLines(3);
-    tifb.setOriginalLineOffsets(new int[]{0, 10, 15});
-    tifb.setLastValidOffset(25);
+    int[] lineStartOffsets = {0, 10, 15};
+    int lastValidOffset = 25;
+    tifb.setOriginalLineStartOffsets(lineStartOffsets);
+    tifb.setOriginalLineEndOffsets(computeLineEndOffsets(lineStartOffsets, lastValidOffset));
+    tifb.setLastValidOffset(lastValidOffset);
     DefaultInputFile file = tifb.build();
     RuleKey ruleKey = RuleKey.of("squid", "ruleKey");
     SensorContext sensorContext = mock(SensorContext.class);

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -73,6 +73,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonar.java.TestUtils.computeLineEndOffsets;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SonarComponentsTest {
@@ -253,11 +254,13 @@ public class SonarComponentsTest {
     File file = new File("file.java");
     TestInputFileBuilder inputFile = new TestInputFileBuilder("", "file.java");
     inputFile.setLines(45);
-    int[] linesOffset = new int[45];
-    linesOffset[35] = 12;
-    linesOffset[42] = 1;
-    inputFile.setOriginalLineOffsets(linesOffset);
-    inputFile.setLastValidOffset(420);
+    int[] lineStartOffsets = new int[45];
+    lineStartOffsets[35] = 12;
+    lineStartOffsets[42] = 1;
+    int lastValidOffset = 420;
+    inputFile.setOriginalLineStartOffsets(lineStartOffsets);
+    inputFile.setOriginalLineEndOffsets(computeLineEndOffsets(lineStartOffsets, lastValidOffset));
+    inputFile.setLastValidOffset(lastValidOffset);
     fileSystem.add(inputFile.build());
 
     when(this.checks.ruleKey(any(JavaCheck.class))).thenReturn(mock(RuleKey.class));

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -1,0 +1,35 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java;
+
+public class TestUtils {
+  private TestUtils() {
+    // utility class, forbidden constructor
+  }
+
+  public static int[] computeLineEndOffsets(int[] lineStartOffsets, int lastValidOffset) {
+    int[] lineEndOffsets = new int[lineStartOffsets.length];
+    for (int i = 0; i < lineStartOffsets.length - 1; i++) {
+      lineEndOffsets[i] = lineStartOffsets[i + 1] - 1;
+    }
+    lineEndOffsets[lineEndOffsets.length - 1] = lastValidOffset - 1;
+    return lineEndOffsets;
+  }
+}

--- a/java-frontend/src/test/java/org/sonar/java/TestUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtilsTest.java
@@ -1,0 +1,32 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.java.TestUtils.computeLineEndOffsets;
+
+public class TestUtilsTest {
+  @Test
+  public void verify_computeLineEndOffsets() {
+    assertThat(computeLineEndOffsets(new int[]{0, 10, 15}, 100)).containsExactly(9, 14, 99);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
-    <sonar.version>7.3-alpha1</sonar.version>
+    <sonar.version>7.4-alpha2</sonar.version>
     <analyzer.commons.version>1.9.0.327</analyzer.commons.version>
     <orchestrator.version>3.21.0.1721</orchestrator.version>
     <sslr.version>1.23</sslr.version>


### PR DESCRIPTION
This work depends on new features in the SonarQube API. It can be merged after the API changes are part of a milestone / stable release (ETA Sep 28).

**Update:** the new ETA is Oct 10.