### PR TITLE
SONARJAVA-2931 workaround bad classname in surefire reports

### DIFF
--- a/java-surefire/src/main/java/org/sonar/plugins/surefire/data/SurefireStaxHandler.java
+++ b/java-surefire/src/main/java/org/sonar/plugins/surefire/data/SurefireStaxHandler.java
@@ -64,8 +64,11 @@ public class SurefireStaxHandler {
 
   private static String getClassname(SMInputCursor testCaseCursor, String defaultClassname) throws XMLStreamException {
     String testClassName = testCaseCursor.getAttrValue("classname");
-    if(StringUtils.isNotBlank(testClassName) && testClassName.endsWith(")")) {
-      testClassName = testClassName.substring(0, testClassName.indexOf('('));
+    if (StringUtils.isNotBlank(testClassName) && testClassName.endsWith(")")) {
+      int openParenthesisIndex = testClassName.indexOf('(');
+      if (openParenthesisIndex > 0) {
+        testClassName = testClassName.substring(0, openParenthesisIndex);
+      }
     }
     return StringUtils.defaultIfBlank(testClassName, defaultClassname);
   }

--- a/java-surefire/src/test/java/org/sonar/plugins/surefire/data/SurefireStaxHandlerTest.java
+++ b/java-surefire/src/test/java/org/sonar/plugins/surefire/data/SurefireStaxHandlerTest.java
@@ -125,6 +125,13 @@ public class SurefireStaxHandlerTest {
     assertThat(publicClass.getTests(), is(4));
   }
 
+  @Test
+  public void output_of_junit_5_2_test_without_display_name() throws XMLStreamException {
+    parse("TEST-#29.xml");
+    assertThat(index.get(")").getTests(), is(1));
+  }
+
+
   private void parse(String path) throws XMLStreamException {
     StaxParser parser = new StaxParser(index);
     File xmlFile;

--- a/java-surefire/src/test/resources/org/sonar/plugins/surefire/data/SurefireStaxHandlerTest/TEST-#29.xml
+++ b/java-surefire/src/test/resources/org/sonar/plugins/surefire/data/SurefireStaxHandlerTest/TEST-#29.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name=")" tests="1" skipped="0" failures="0" errors="0" timestamp="2018-10-18T13:02:06" hostname="benzonico" time="0.002">
+  <properties/>
+  <testcase name="Test1(dynamicTest" classname=")" time="0.002"/>
+  <system-out><![CDATA[]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>


### PR DESCRIPTION
This can be produced by buggy junit 5.2 surefire reports
