### PR TITLE
S4719 add apache commons

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
@@ -61,16 +61,17 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
   private static final Map<String, String> ALIAS_TO_CONSTANT = createAliasToConstantNameMap();
 
   private static Map<String, String> createAliasToConstantNameMap() {
-    ImmutableMap.Builder<String, String> aliases = ImmutableMap.builder();
+    ImmutableMap.Builder<String, String> constantNames = ImmutableMap.builder();
     for (Charset charset : STANDARD_CHARSETS) {
-      aliases.put(charset.name(), charset.name());
+      String constantName = charset.name().replaceAll("-", "_");
+      constantNames.put(charset.name(), constantName);
 
       for (String alias : charset.aliases()) {
-        aliases.put(alias, charset.name());
+        constantNames.put(alias, constantName);
       }
     }
 
-    return aliases.build();
+    return constantNames.build();
   }
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
@@ -26,11 +26,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BinaryOperator;
+import java.util.stream.Stream;
 import org.sonar.check.Rule;
 import org.sonar.java.JavaVersionAwareVisitor;
 import org.sonar.java.checks.helpers.ConstantUtils;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
 import org.sonar.java.matcher.MethodMatcher;
+import org.sonar.java.resolve.JavaSymbol;
 import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.Arguments;
@@ -43,12 +46,31 @@ import org.sonar.plugins.java.api.tree.Tree;
 @Rule(key = "S4719")
 public class StandardCharsetsConstantsCheck extends AbstractMethodDetection implements JavaVersionAwareVisitor {
 
+  private static final String JAVA_IO_FILE = "java.io.File";
   private static final String JAVA_IO_INPUTSTREAM = "java.io.InputStream";
   private static final String JAVA_IO_OUTPUTSTREAM = "java.io.OutputStream";
   private static final String JAVA_IO_OUTPUTSTREAMWRITER = "java.io.OutputStreamWriter";
   private static final String JAVA_IO_INPUTSTREAMREADER = "java.io.InputStreamReader";
+  private static final String JAVA_IO_WRITER = "java.io.Writer";
+  private static final String JAVA_IO_READER = "java.io.Reader";
   private static final String JAVA_NIO_CHARSET = "java.nio.charset.Charset";
+  private static final String JAVA_NET_URI = "java.net.URI";
+  private static final String JAVA_NET_URL = "java.net.URL";
   private static final String JAVA_LANG_STRING = "java.lang.String";
+  private static final String JAVA_LANG_STRINGBUFFER = "java.lang.StringBuffer";
+  private static final String JAVA_LANG_CHARSEQUENCE = "java.lang.CharSequence";
+  private static final String JAVA_UTIL_COLLECTION = "java.util.Collection";
+  private static final String COMMONS_CODEC_CHARSETS = "org.apache.commons.codec.Charsets";
+  private static final String COMMONS_CODEC_HEX = "org.apache.commons.codec.binary.Hex";
+  private static final String COMMONS_CODEC_QUOTEDPRINTABLECODEC = "org.apache.commons.codec.net.QuotedPrintableCodec";
+  private static final String COMMONS_IO_CHARSETS = "org.apache.commons.io.Charsets";
+  private static final String COMMONS_IO_FILEUTILS = "org.apache.commons.io.FileUtils";
+  private static final String COMMONS_IO_IOUTILS = "org.apache.commons.io.IOUtils";
+  private static final String COMMONS_IO_CHARSEQUENCEINPUTSTREAM = "org.apache.commons.io.input.CharSequenceInputStream";
+  private static final String COMMONS_IO_READERINPUTSTREAM = "org.apache.commons.io.input.ReaderInputStream";
+  private static final String COMMONS_IO_REVERSEDLINESFILEREADER = "org.apache.commons.io.input.ReversedLinesFileReader";
+  private static final String COMMONS_IO_LOCKABLEFILEWRITER = "org.apache.commons.io.output.LockableFileWriter";
+  private static final String COMMONS_IO_WRITEROUTPUTSTREAM = "org.apache.commons.io.output.WriterOutputStream";
 
   private static final List<Charset> STANDARD_CHARSETS = Arrays.asList(
           StandardCharsets.ISO_8859_1,
@@ -103,11 +125,47 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
       MethodMatcher.create().typeDefinition(JAVA_NIO_CHARSET).name("forName").parameters(JAVA_LANG_STRING),
       MethodMatcher.create().typeDefinition(JAVA_LANG_STRING).name("getBytes").parameters(JAVA_LANG_STRING),
       MethodMatcher.create().typeDefinition(JAVA_LANG_STRING).name("getBytes").parameters(JAVA_NIO_CHARSET),
+      MethodMatcher.create().typeDefinition(COMMONS_CODEC_CHARSETS).name("toCharset").parameters(JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_CHARSETS).name("toCharset").parameters(JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_FILEUTILS).name("readFileToString").parameters(JAVA_IO_FILE, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_FILEUTILS).name("readLines").parameters(JAVA_IO_FILE, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_FILEUTILS).name("write").parameters(JAVA_IO_FILE, JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_FILEUTILS).name("write").parameters(JAVA_IO_FILE, JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING, "boolean"),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_FILEUTILS).name("writeStringToFile").parameters(JAVA_IO_FILE, JAVA_LANG_STRING, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_FILEUTILS).name("writeStringToFile").parameters(JAVA_IO_FILE, JAVA_LANG_STRING, JAVA_LANG_STRING, "boolean"),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("copy").parameters(JAVA_IO_INPUTSTREAM, JAVA_IO_WRITER, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("copy").parameters(JAVA_IO_READER, JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("lineIterator").parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("readLines").parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toByteArray").parameters(JAVA_IO_READER, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toCharArray").parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toInputStream").parameters(JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toInputStream").parameters(JAVA_LANG_STRING, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toString").parameters("byte[]", JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toString").parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toString").parameters(JAVA_NET_URI, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("toString").parameters(JAVA_NET_URL, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("write").parameters("byte[]", JAVA_IO_WRITER, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("write").parameters("char[]", JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("write").parameters(JAVA_LANG_CHARSEQUENCE, JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("write").parameters(JAVA_LANG_STRING, JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("write").parameters(JAVA_LANG_STRINGBUFFER, JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      MethodMatcher.create().typeDefinition(COMMONS_IO_IOUTILS).name("writeLines").parameters(JAVA_UTIL_COLLECTION, JAVA_LANG_STRING, JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
       constructor(JAVA_LANG_STRING).parameters("byte[]", JAVA_LANG_STRING),
       constructor(JAVA_LANG_STRING).parameters("byte[]", "int", "int", JAVA_LANG_STRING),
       constructor(JAVA_IO_INPUTSTREAMREADER).parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
-      constructor(JAVA_IO_OUTPUTSTREAMWRITER).parameters(JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING)
-    );
+      constructor(JAVA_IO_OUTPUTSTREAMWRITER).parameters(JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      constructor(COMMONS_IO_CHARSEQUENCEINPUTSTREAM).parameters(JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING),
+      constructor(COMMONS_IO_CHARSEQUENCEINPUTSTREAM).parameters(JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING, "int"),
+      constructor(COMMONS_IO_READERINPUTSTREAM).parameters(JAVA_IO_READER, JAVA_LANG_STRING),
+      constructor(COMMONS_IO_READERINPUTSTREAM).parameters(JAVA_IO_READER, JAVA_LANG_STRING, "int"),
+      constructor(COMMONS_IO_REVERSEDLINESFILEREADER).parameters(JAVA_IO_FILE, "int", JAVA_LANG_STRING),
+      constructor(COMMONS_IO_LOCKABLEFILEWRITER).parameters(JAVA_IO_FILE, JAVA_LANG_STRING),
+      constructor(COMMONS_IO_LOCKABLEFILEWRITER).parameters(JAVA_IO_FILE, JAVA_LANG_STRING, "boolean", JAVA_LANG_STRING),
+      constructor(COMMONS_IO_WRITEROUTPUTSTREAM).parameters(JAVA_IO_WRITER, JAVA_LANG_STRING),
+      constructor(COMMONS_IO_WRITEROUTPUTSTREAM).parameters(JAVA_IO_WRITER, JAVA_LANG_STRING, "int", "boolean"),
+      constructor(COMMONS_CODEC_HEX).parameters(JAVA_LANG_STRING),
+      constructor(COMMONS_CODEC_QUOTEDPRINTABLECODEC).parameters(JAVA_LANG_STRING));
   }
 
   private static MethodMatcher constructor(String type) {
@@ -116,32 +174,91 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
 
   @Override
   protected void onMethodInvocationFound(MethodInvocationTree mit) {
-    if (mit.symbol().name().equals("forName")) {
-      checkCharsetForNameCall(mit);
-    } else {
-      checkArguments(mit.arguments());
+    try {
+      checkCall(mit, mit.symbol(), mit.arguments());
+    } catch (IllegalStateException e) {
+      // TODO
+      throw new RuntimeException("Could not check invocation at " + mit.firstToken().line(), e);
     }
   }
 
   @Override
   protected void onConstructorFound(NewClassTree newClassTree) {
-    checkArguments(newClassTree.arguments());
-  }
-
-  private void checkCharsetForNameCall(MethodInvocationTree mit) {
-    ExpressionTree argument = mit.arguments().get(0);
-    String constantName = getConstantName(argument);
-    if (constantName != null) {
-      reportIssue(mit, "Replace Charset.forName() call with StandardCharsets." + constantName);
+    try {
+      checkCall(newClassTree, newClassTree.constructorSymbol(), newClassTree.arguments());
+    } catch (IllegalStateException e) {
+      // TODO
+      throw new RuntimeException("Could not check invocation at " + newClassTree.firstToken().line(), e);
     }
   }
 
-  private void checkArguments(Arguments arguments) {
-    ExpressionTree lastArgument = arguments.get(arguments.size() - 1);
-    String constantName = getConstantName(lastArgument);
+  private void checkCall(ExpressionTree callExpression, Symbol symbol, Arguments arguments) {
+    ExpressionTree charsetNameArgument = getCharsetNameArgument(symbol, arguments);
+
+    // TODO
+    //System.out.println(symbol.name() + " " + charsetNameArgument.firstToken().line() + ":" + charsetNameArgument.firstToken().column());
+
+    String constantName = getConstantName(charsetNameArgument);
     if (constantName != null) {
-      reportIssue(lastArgument, "Replace charset name argument with StandardCharsets." + constantName);
+      String methodRef = getMethodRef(symbol);
+      switch (methodRef) {
+        case "Charset.forName":
+          reportIssue(callExpression, "Replace Charset.forName() call with StandardCharsets." + constantName);
+          break;
+        case "Charsets.toCharset":
+          reportIssue(callExpression, "Replace Charsets.toCharset() call with StandardCharsets." + constantName);
+          break;
+        case "IOUtils.toString":
+          if (arguments.size() == 2 && arguments.get(0).symbolType().is("byte[]")) {
+            reportIssue(callExpression, "Replace IOUtils.toString() call with new String(..., StandardCharsets." + constantName + ");");
+          } else {
+            reportDefaultIssue(charsetNameArgument, constantName);
+          }
+          break;
+        default:
+          reportDefaultIssue(charsetNameArgument, constantName);
+          break;
+      }
     }
+  }
+
+  private void reportDefaultIssue(ExpressionTree charsetNameArgument, String constantName) {
+    reportIssue(charsetNameArgument, "Replace charset name argument with StandardCharsets." + constantName);
+  }
+
+  private ExpressionTree getCharsetNameArgument(Symbol symbol, Arguments arguments) {
+    BinaryOperator<ExpressionTree> reducer;
+
+    String symbolRef = getMethodRef(symbol);
+    switch (symbolRef) {
+      case "FileUtils.writeStringToFile":
+      case "IOUtils.toInputStream":
+      case "IOUtils.write":
+      case "IOUtils.writeLines":
+        reducer = (previous, current) -> current;
+        break;
+      case "LockableFileWriter.<init>":
+        reducer = (previous, current) -> previous;
+        break;
+      default:
+        reducer = (previous, current) -> {
+          throw new IllegalStateException("Could not identify which string argument of " + symbolRef + " is the charset name");
+        };
+    }
+
+    Stream<ExpressionTree> stringArgumentStream = arguments.stream().filter(argument -> argument.symbolType().is(JAVA_LANG_STRING));
+    return stringArgumentStream.reduce(reducer).orElseGet(() -> {
+      // No String argument, so this must be an overload that has a Charset argument
+      return arguments.get(arguments.size() - 1);
+    });
+  }
+
+  private String getMethodRef(Symbol symbol) {
+    return symbol.enclosingClass().name() + "." + symbol.name();
+  }
+
+  private String getFullyQualifiedMethodRef(Symbol symbol) {
+    return ((JavaSymbol.TypeJavaSymbol)symbol.owner()).getFullyQualifiedName() + "." + symbol.name();
   }
 
   private static String getConstantName(ExpressionTree argument) {

--- a/java-checks/src/test/files/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/test/files/checks/StandardCharsetsConstantsCheck.java
@@ -14,27 +14,27 @@ class A {
 
   void myMethod(byte[] bytes, int offset, int length, InputStream inputStream, OutputStream outputStream, String charsetName) {
     Charset c;
-    c = Charsets.ISO_8859_1; // Noncompliant
-    c = Charsets.US_ASCII; // Noncompliant
-    c = Charsets.UTF_16; // Noncompliant
-    c = Charsets.UTF_16BE; // Noncompliant
-    c = Charsets.UTF_16LE; // Noncompliant
-    c = Charsets.UTF_8; // Noncompliant
+    c = Charsets.ISO_8859_1; // Noncompliant {{Replace "com.google.common.base.Charsets.ISO_8859_1" with "StandardCharsets.ISO_8859_1".}} [[sc=18;ec=28]]
+    c = Charsets.US_ASCII; // Noncompliant {{Replace "com.google.common.base.Charsets.US_ASCII" with "StandardCharsets.US_ASCII".}}
+    c = Charsets.UTF_16; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16" with "StandardCharsets.UTF_16".}}
+    c = Charsets.UTF_16BE; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16BE" with "StandardCharsets.UTF_16BE".}}
+    c = Charsets.UTF_16LE; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16LE" with "StandardCharsets.UTF_16LE".}}
+    c = Charsets.UTF_8; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_8" with "StandardCharsets.UTF_8".}}
 
     // Canonical names of java.nio API and java.io/java.lang API
-    Charset.forName("ISO-8859-1"); // Noncompliant
-    Charset.forName("ISO_8859_1"); // Noncompliant
-    Charset.forName("US-ASCII"); // Noncompliant
-    Charset.forName("ASCII"); // Noncompliant
-    Charset.forName("UTF-16"); // Noncompliant
-    Charset.forName("UTF-16BE"); // Noncompliant
-    Charset.forName("UnicodeBigUnmarked"); // Noncompliant
-    Charset.forName("UTF-16LE"); // Noncompliant
-    Charset.forName("UnicodeLittleUnmarked"); // Noncompliant
-    Charset.forName("UTF-8"); // Noncompliant
-    Charset.forName("UTF8"); // Noncompliant
+    Charset.forName("ISO-8859-1"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.ISO_8859_1}} [[sc=5;ec=34]]
+    Charset.forName("ISO_8859_1"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.ISO_8859_1}}
+    Charset.forName("US-ASCII"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.US_ASCII}}
+    Charset.forName("ASCII"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.US_ASCII}}
+    Charset.forName("UTF-16"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_16}}
+    Charset.forName("UTF-16BE"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_16BE}}
+    Charset.forName("UnicodeBigUnmarked"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_16BE}}
+    Charset.forName("UTF-16LE"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_16LE}}
+    Charset.forName("UnicodeLittleUnmarked"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_16LE}}
+    Charset.forName("UTF-8"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_8}}
+    Charset.forName("UTF8"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_8}}
 
-    "".getBytes("UTF-8"); // Noncompliant
+    "".getBytes("UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}}
 
     new String(bytes, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
     new String(bytes, offset, length, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant

--- a/java-checks/src/test/files/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/test/files/checks/StandardCharsetsConstantsCheck.java
@@ -1,25 +1,49 @@
+import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.CharSequence;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
-import com.google.common.base.Charsets;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.FileUtils;
+import java.util.Collection;
 
 class A {
+  private byte[] bytes;
+  private char[] chars;
+  private int offset;
+  private int length;
+  private int bufferSize;
+  private int blockSize;
+  private boolean append;
+  private boolean writeImmediately;
+  private String dataString;
+  private String inputString;
+  private String lineEndingString;
+  private String lockDirString;
+  private String charsetName;
+  private InputStream inputStream;
+  private OutputStream outputStream;
+  private Reader reader;
+  private Writer writer;
+  private StringBuffer stringBuffer;
+  private CharSequence charSequence;
+  private Collection<?> collection;
+  private File file;
+  private URI uri;
+  private URL url;
 
-  void myMethod(byte[] bytes, int offset, int length, InputStream inputStream, OutputStream outputStream, String charsetName) {
-    Charset c;
-    c = Charsets.ISO_8859_1; // Noncompliant {{Replace "com.google.common.base.Charsets.ISO_8859_1" with "StandardCharsets.ISO_8859_1".}} [[sc=18;ec=28]]
-    c = Charsets.US_ASCII; // Noncompliant {{Replace "com.google.common.base.Charsets.US_ASCII" with "StandardCharsets.US_ASCII".}}
-    c = Charsets.UTF_16; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16" with "StandardCharsets.UTF_16".}}
-    c = Charsets.UTF_16BE; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16BE" with "StandardCharsets.UTF_16BE".}}
-    c = Charsets.UTF_16LE; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16LE" with "StandardCharsets.UTF_16LE".}}
-    c = Charsets.UTF_8; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_8" with "StandardCharsets.UTF_8".}}
+  void myMethod() {
+    com.google.common.base.Charsets.ISO_8859_1; // Noncompliant {{Replace "com.google.common.base.Charsets.ISO_8859_1" with "StandardCharsets.ISO_8859_1".}} [[sc=37;ec=47]]
+    com.google.common.base.Charsets.US_ASCII; // Noncompliant {{Replace "com.google.common.base.Charsets.US_ASCII" with "StandardCharsets.US_ASCII".}}
+    com.google.common.base.Charsets.UTF_16; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16" with "StandardCharsets.UTF_16".}}
+    com.google.common.base.Charsets.UTF_16BE; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16BE" with "StandardCharsets.UTF_16BE".}}
+    com.google.common.base.Charsets.UTF_16LE; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_16LE" with "StandardCharsets.UTF_16LE".}}
+    com.google.common.base.Charsets.UTF_8; // Noncompliant {{Replace "com.google.common.base.Charsets.UTF_8" with "StandardCharsets.UTF_8".}}
 
     // Canonical names of java.nio API and java.io/java.lang API
     Charset.forName("ISO-8859-1"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.ISO_8859_1}} [[sc=5;ec=34]]
@@ -34,6 +58,15 @@ class A {
     Charset.forName("UTF-8"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_8}}
     Charset.forName("UTF8"); // Noncompliant {{Replace Charset.forName() call with StandardCharsets.UTF_8}}
 
+    org.apache.commons.codec.Charsets.toCharset("UTF-8"); // Noncompliant {{Replace Charsets.toCharset() call with StandardCharsets.UTF_8}} [[sc=5;ec=57]]
+
+    org.apache.commons.io.Charsets.toCharset("UTF-8"); // Noncompliant {{Replace Charsets.toCharset() call with StandardCharsets.UTF_8}} [[sc=5;ec=54]]
+
+    org.apache.commons.io.IOUtils.toString(bytes, "UTF-8"); // Noncompliant {{Replace IOUtils.toString() call with new String(..., StandardCharsets.UTF_8);}} [[sc=5;ec=59]]
+    org.apache.commons.io.IOUtils.toString(inputStream, "UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}} [[sc=57;ec=64]]
+    org.apache.commons.io.IOUtils.toString(uri, "UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}} [[sc=49;ec=56]]
+    org.apache.commons.io.IOUtils.toString(url, "UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}} [[sc=49;ec=56]]
+
     "".getBytes("UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}}
 
     new String(bytes, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
@@ -42,13 +75,46 @@ class A {
     new InputStreamReader(inputStream, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
     new OutputStreamWriter(outputStream, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
 
+    new org.apache.commons.codec.binary.Hex("UTF-8"); // Noncompliant
+    new org.apache.commons.codec.net.QuotedPrintableCodec("UTF-8"); // Noncompliant
+
+    org.apache.commons.io.FileUtils.readFileToString(file, "UTF-8"); // Noncompliant
+    org.apache.commons.io.FileUtils.readLines(file, "UTF-8");  // Noncompliant
+    org.apache.commons.io.FileUtils.write(file, charSequence, "UTF-8"); // Noncompliant
+    org.apache.commons.io.FileUtils.write(file, charSequence, "UTF-8", append); // Noncompliant
+    org.apache.commons.io.FileUtils.writeStringToFile(file, dataString, "UTF-8"); // Noncompliant [[sc=73;ec=80]]
+    org.apache.commons.io.FileUtils.writeStringToFile(file, dataString, "UTF-8", append); // Noncompliant [[sc=73;ec=80]]
+    org.apache.commons.io.IOUtils.copy(inputStream, writer, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.copy(reader, outputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.lineIterator(inputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.readLines(inputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.toByteArray(reader, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.toCharArray(inputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.toInputStream(charSequence, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.toInputStream(inputString, "UTF-8"); // Noncompliant [[sc=62;ec=69]]
+    org.apache.commons.io.IOUtils.write(bytes, writer, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.write(chars, outputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.write(charSequence, outputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.write(dataString, outputStream, "UTF-8"); // Noncompliant [[sc=67;ec=74]]
+    org.apache.commons.io.IOUtils.write(stringBuffer, outputStream, "UTF-8"); // Noncompliant
+    org.apache.commons.io.IOUtils.writeLines(collection, lineEndingString, outputStream, "UTF-8"); // Noncompliant [[sc=90;ec=97]]
+    new org.apache.commons.io.input.CharSequenceInputStream(charSequence, "UTF-8"); // Noncompliant
+    new org.apache.commons.io.input.CharSequenceInputStream(charSequence, "UTF-8", bufferSize); // Noncompliant
+    new org.apache.commons.io.input.ReaderInputStream(reader, "UTF-8"); // Noncompliant
+    new org.apache.commons.io.input.ReaderInputStream(reader, "UTF-8", bufferSize); // Noncompliant
+    new org.apache.commons.io.input.ReversedLinesFileReader(file, blockSize, "UTF-8"); // Noncompliant
+    new org.apache.commons.io.output.LockableFileWriter(file, "UTF-8"); // Noncompliant
+    new org.apache.commons.io.output.LockableFileWriter(file, "UTF-8", append, lockDirString); // Noncompliant [[sc=63;ec=70]]
+    new org.apache.commons.io.output.WriterOutputStream(writer, "UTF-8"); // Noncompliant
+    new org.apache.commons.io.output.WriterOutputStream(writer, "UTF-8", bufferSize, writeImmediately); // Noncompliant
+
     // Compliant
-    c = StandardCharsets.ISO_8859_1;
-    c = StandardCharsets.US_ASCII;
-    c = StandardCharsets.UTF_16;
-    c = StandardCharsets.UTF_16BE;
-    c = StandardCharsets.UTF_16LE;
-    c = StandardCharsets.UTF_8;
+    StandardCharsets.ISO_8859_1;
+    StandardCharsets.US_ASCII;
+    StandardCharsets.UTF_16;
+    StandardCharsets.UTF_16BE;
+    StandardCharsets.UTF_16LE;
+    StandardCharsets.UTF_8;
 
     "".getBytes(charsetName);
     "".getBytes("Windows-1252");


### PR DESCRIPTION
### Content

This PR makes S4719 also cover methods in apache commons. Also, in a separate commit, it fixes a bug that led to wrong constant names being mentioned in reported issues (i.e. with dashes instead of underscores).


### Pull request guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
    - **_integration tests succeed, but [the ruling test fails](https://community.sonarsource.com/t/sonar-java-ruling-test-always-fails/4366?u=bannmann). however, it shows the same differences as `master` does._**
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
