### PR TITLE
SONARJAVA-2928: add Selenide support to S2699

### DIFF
--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -557,6 +557,11 @@
                   <artifactId>commons-compress</artifactId>
                   <version>1.18</version>
                 </artifactItem>
+                <artifactItem>
+                  <groupId>com.codeborne</groupId>
+                  <artifactId>selenide</artifactId>
+                  <version>5.1.0</version>
+                </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
             </configuration>

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
@@ -41,6 +41,7 @@ import org.sonar.plugins.java.api.tree.Modifier;
 @Rule(key = "S2699")
 public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileScanner {
 
+  private static final String SHOULD = "should";
   private static final String VERIFY = "verify";
   private static final String ASSERT_NAME = "assert";
 
@@ -115,7 +116,10 @@ public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileS
     method("com.github.tomakehurst.wiremock.WireMockServer", VERIFY).withAnyParameters(),
     // Eclipse Vert.x
     method("io.vertx.ext.unit.TestContext", STARTS_WITH_ASSERT).withAnyParameters(),
-    method("io.vertx.ext.unit.TestContext", STARTS_WITH_FAIL).withAnyParameters());
+    method("io.vertx.ext.unit.TestContext", STARTS_WITH_FAIL).withAnyParameters(),
+    // Selenide
+    method( "com.codeborne.selenide.SelenideElement", NameCriteria.startsWith(SHOULD) ).withAnyParameters(),
+    method( "com.codeborne.selenide.ElementsCollection", NameCriteria.startsWith(SHOULD) ).withAnyParameters());
 
   private final Deque<Boolean> methodContainsAssertion = new ArrayDeque<>();
   private final Deque<Boolean> inUnitTest = new ArrayDeque<>();

--- a/java-checks/src/test/files/checks/AssertionsInTestsCheck/Junit4.java
+++ b/java-checks/src/test/files/checks/AssertionsInTestsCheck/Junit4.java
@@ -1,3 +1,6 @@
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Selenide;
 import java.util.List;
 import javax.annotation.Nullable;
 import junit.framework.TestCase;
@@ -114,6 +117,14 @@ public abstract class AssertionsInTestsCheckJunit4 {
   @Test
   public void mockito_assertion_verify_no_more_interactions() {
     Mockito.verifyNoMoreInteractions(Mockito.mock(List.class));
+  }
+
+  @Test
+  public void selenide_verify_should() {
+    Selenide.open("https://www.google.com/");
+    Selenide.$(By.name("q")).val("selenide").pressEnter();
+    Selenide.$$("#ires .g").shouldHave(CollectionCondition.sizeGreaterThan(1));
+    Selenide.$("#ires .g", 0).shouldHave(Condition.text("Selenide: concise UI tests in Java"));
   }
 
 


### PR DESCRIPTION
Added Selenide support to S2699 

Note that [SONARJAVA-2928](https://jira.sonarsource.com/browse/SONARJAVA-2927) expects only support for `com.codeborne.selenide.SelenideElement`, but `com.codeborne.selenide.ElementsCollection` should be considered as well (see associated unit test).

Also, [RSPEC-2699](https://jira.sonarsource.com/browse/RSPEC-2699) should be updated to include Selenide as well.
