### PR TITLE
Fix build on windows OS due to path resolution and plugin size

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/PackageInfoCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PackageInfoCheck.java
@@ -37,7 +37,8 @@ public class PackageInfoCheck implements JavaFileScanner {
   public void scanFile(JavaFileScannerContext context) {
     File parentFile = context.getFile().getParentFile();
     if (!new File(parentFile, "package-info.java").isFile() && !directoriesWithoutPackageFile.contains(parentFile)) {
-      Path relativize = ((DefaultJavaFileScannerContext) context).getBaseDirectory().toPath().relativize(parentFile.toPath());
+      Path relativize = ((DefaultJavaFileScannerContext) context).getBaseDirectory().getAbsoluteFile().toPath()
+        .relativize(parentFile.getAbsoluteFile().toPath());
       context.addIssue(parentFile, PackageInfoCheck.this, -1, "Add a 'package-info.java' file to document the '" + relativize.toString() + "' package");
       directoriesWithoutPackageFile.add(parentFile);
     }

--- a/java-checks/src/test/java/org/sonar/java/checks/PackageInfoCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/PackageInfoCheckTest.java
@@ -64,7 +64,7 @@ public class PackageInfoCheckTest {
     SonarComponents sonarComponents = new SonarComponents(null, context.fileSystem(), null, null, null);
     sonarComponents.setSensorContext(context);
 
-    DefaultInputFile inputFile = new TestInputFileBuilder("", moduleBaseDir, file).setCharset(StandardCharsets.UTF_8)
+    DefaultInputFile inputFile = new TestInputFileBuilder("", file.getPath()).setCharset(StandardCharsets.UTF_8)
       .setContents(new String(Files.readAllBytes(file.toPath()))).build();
     context.fileSystem().add(inputFile);
     return sonarComponents;

--- a/java-checks/src/test/java/org/sonar/java/checks/PackageInfoCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/PackageInfoCheckTest.java
@@ -64,7 +64,7 @@ public class PackageInfoCheckTest {
     SonarComponents sonarComponents = new SonarComponents(null, context.fileSystem(), null, null, null);
     sonarComponents.setSensorContext(context);
 
-    DefaultInputFile inputFile = new TestInputFileBuilder("", file.getPath()).setCharset(StandardCharsets.UTF_8)
+    DefaultInputFile inputFile = new TestInputFileBuilder("", moduleBaseDir.getAbsoluteFile(), file.getAbsoluteFile()).setCharset(StandardCharsets.UTF_8)
       .setContents(new String(Files.readAllBytes(file.toPath()))).build();
     context.fileSystem().add(inputFile);
     return sonarComponents;

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -117,7 +117,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>7950000</maxsize>
+                  <maxsize>8000000</maxsize>
                   <minsize>7800000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>


### PR DESCRIPTION
For some reason, the `relativize` method does not generate same output on windows and linux OS:
Linux: Paths.get("").relativize(Paths.get("path")).toString() -> "path"
Windows: Paths.get("").relativize(Paths.get("path")).toString() -> "..\path"
This causes conflict when creating `TestInputFileBuilder` relying on existing files when the module directory is `new File("")` as it prepends the `..`, and file cannot be found