### PR TITLE
 SONARJAVA-3065 & SONARJAVA-3066 Deprecate coverage per test

### DIFF
--- a/java-jacoco/pom.xml
+++ b/java-jacoco/pom.xml
@@ -97,6 +97,13 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- used to test org.sonar.plugins.jacoco.JaCoCoSensor.describe -->
+    <dependency>
+      <groupId>org.sonarsource.sonarlint.core</groupId>
+      <artifactId>sonarlint-core</artifactId>
+      <version>4.1.0.2218</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java-jacoco/src/main/java/org/sonar/plugins/jacoco/JaCoCoSensor.java
+++ b/java-jacoco/src/main/java/org/sonar/plugins/jacoco/JaCoCoSensor.java
@@ -86,7 +86,7 @@ public class JaCoCoSensor implements Sensor {
       reportMerged.getParentFile().mkdirs();
       JaCoCoReportMerger.mergeReports(reportMerged, reportPaths.toArray(new File[0]));
     }
-    new UnitTestAnalyzer(reportMerged, perspectives, javaResourceLocator, javaClasspath).analyse(context);
+    new UnitTestAnalyzer(reportMerged, perspectives, javaResourceLocator, javaClasspath, analysisWarnings).analyse(context);
   }
 
   private void warnAboutDeprecatedProperties(Configuration config) {

--- a/java-jacoco/src/main/java/org/sonar/plugins/jacoco/UnitTestAnalyzer.java
+++ b/java-jacoco/src/main/java/org/sonar/plugins/jacoco/UnitTestAnalyzer.java
@@ -42,6 +42,8 @@ import org.sonar.api.test.MutableTestCase;
 import org.sonar.api.test.MutableTestPlan;
 import org.sonar.api.test.MutableTestable;
 import org.sonar.api.test.Testable;
+import org.sonar.api.utils.Version;
+import org.sonar.java.AnalysisWarningsWrapper;
 import org.sonar.java.JavaClasspath;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 
@@ -50,17 +52,22 @@ public class UnitTestAnalyzer {
 
   private final ResourcePerspectives perspectives;
   private final JavaResourceLocator javaResourceLocator;
+  private final AnalysisWarningsWrapper analysisWarnings;
 
   private Map<String, File> classFilesCache;
   private JavaClasspath javaClasspath;
   private JacocoReportReader jacocoReportReader;
   private final File report;
+  private boolean supportCoverageByTest;
 
-  public UnitTestAnalyzer(File report, ResourcePerspectives perspectives, JavaResourceLocator javaResourceLocator, JavaClasspath javaClasspath) {
+  public UnitTestAnalyzer(File report, ResourcePerspectives perspectives, JavaResourceLocator javaResourceLocator,
+                          JavaClasspath javaClasspath,
+                          AnalysisWarningsWrapper analysisWarnings) {
     this.report = report;
     this.perspectives = perspectives;
     this.javaResourceLocator = javaResourceLocator;
     this.javaClasspath = javaClasspath;
+    this.analysisWarnings = analysisWarnings;
   }
 
   private static String fullyQualifiedClassName(String packageName, String simpleClassName) {
@@ -83,6 +90,7 @@ public class UnitTestAnalyzer {
   }
 
   public final void analyse(SensorContext context) {
+    supportCoverageByTest = !context.getSonarQubeVersion().isGreaterThanOrEqual(Version.create(7, 7));
     classFilesCache = Maps.newHashMap();
     for (File classesDir : javaClasspath.getBinaryDirs()) {
       populateClassFilesCache(classesDir, "");
@@ -137,10 +145,19 @@ public class UnitTestAnalyzer {
     if (analyzedResources == 0) {
       JaCoCoExtensions.LOG.warn("Coverage information was not collected. Perhaps you forget to include debug information into compiled classes?");
     } else if (collectedCoveragePerTest) {
-      JaCoCoExtensions.LOG.info("Information about coverage per test has been collected.");
-    } else if (newJacocoExecutionData != null) {
-      JaCoCoExtensions.LOG.info("No information about coverage per test.");
+      logDeprecationForCoveragePerTest();
     }
+  }
+
+  private void logDeprecationForCoveragePerTest() {
+    String msg;
+    if (supportCoverageByTest) {
+      msg = "'Coverage per Test' feature is deprecated. Consider removing sonar-jacoco-listeners from your configuration.";
+    } else {
+      msg = "'Coverage per Test' feature was removed from SonarQube. Remove sonar-jacoco-listeners listener configuration.";
+    }
+    JaCoCoExtensions.LOG.warn(msg);
+    analysisWarnings.addUnique(msg);
   }
 
   private boolean readCoveragePerTests(ExecutionDataVisitor executionDataVisitor) {
@@ -171,7 +188,7 @@ public class UnitTestAnalyzer {
     for (ISourceFileCoverage coverage : coverageBuilder.getSourceFiles()) {
       InputFile resource = getResource(coverage);
       if (resource != null) {
-        List<Integer> coveredLines =  coveredLines(coverage);
+        List<Integer> coveredLines = coveredLines(coverage);
         if (!coveredLines.isEmpty() && addCoverage(resource, testResource, testName, coveredLines)) {
           result = true;
         }

--- a/java-jacoco/src/test/java/org/sonar/plugins/jacoco/JaCoCoSensorTest.java
+++ b/java-jacoco/src/test/java/org/sonar/plugins/jacoco/JaCoCoSensorTest.java
@@ -122,7 +122,7 @@ public class JaCoCoSensorTest {
   public void test_read_execution_data_after_6_2_using_deprecated_prop() throws Exception {
     context.settings().setProperty(REPORT_PATH_PROPERTY, "jacoco.exec");
     runAnalysis();
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains("Property 'sonar.jacoco.reportPath' is deprecated. Please use 'sonar.jacoco.reportPaths' instead.");
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains("Property 'sonar.jacoco.reportPath' is deprecated. 'sonar.coverage.jacoco.xmlReportPaths' should be used instead (JaCoCo XML format).");
   }
 
   @Test
@@ -131,15 +131,15 @@ public class JaCoCoSensorTest {
     context.settings().setProperty(IT_REPORT_PATH_PROPERTY, "jacoco.exec");
     context.settings().setProperty(REPORT_PATHS_PROPERTY, "jacoco.exec");
     runAnalysis();
-    assertThat(logTester.logs(LoggerLevel.WARN)).doesNotContain("Property 'sonar.jacoco.reportPath' is deprecated. Please use 'sonar.jacoco.reportPaths' instead.");
-    assertThat(logTester.logs(LoggerLevel.WARN)).doesNotContain("Property 'sonar.jacoco.itReportPath' is deprecated. Please use 'sonar.jacoco.reportPaths' instead.");
+    assertThat(logTester.logs(LoggerLevel.WARN)).doesNotContain("Property 'sonar.jacoco.reportPath' is deprecated. 'sonar.coverage.jacoco.xmlReportPaths' should be used instead (JaCoCo XML format).");
+    assertThat(logTester.logs(LoggerLevel.WARN)).doesNotContain("Property 'sonar.jacoco.itReportPath' is deprecated. 'sonar.coverage.jacoco.xmlReportPaths' should be used instead (JaCoCo XML format).");
   }
 
   @Test
   public void test_read_execution_data_after_6_2_using_deprecated_it_prop() throws Exception {
     context.settings().setProperty(IT_REPORT_PATH_PROPERTY, "jacoco.exec");
     runAnalysis();
-    assertThat(logTester.logs(LoggerLevel.WARN)).contains("Property 'sonar.jacoco.itReportPath' is deprecated. Please use 'sonar.jacoco.reportPaths' instead.");
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains("Property 'sonar.jacoco.itReportPath' is deprecated. 'sonar.coverage.jacoco.xmlReportPaths' should be used instead (JaCoCo XML format).");
   }
 
   @Test

--- a/java-jacoco/src/test/java/org/sonar/plugins/jacoco/JaCoCoSensorTest.java
+++ b/java-jacoco/src/test/java/org/sonar/plugins/jacoco/JaCoCoSensorTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.sonar.api.SonarQubeSide;
+import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
@@ -247,6 +248,23 @@ public class JaCoCoSensorTest {
     context.settings().setProperty(REPORT_PATH_PROPERTY, jacocoExecutionData.getAbsolutePath());
     sensor.execute(context);
     verify(testCase).setCoverageBlock(testAbleFile, linesExpected);
+  }
+
+  @Test
+  public void log_deprecation_for_coverage_per_test() throws IOException {
+    testExecutionDataForLinesCoveredByTest("/org/sonar/plugins/jacoco/JaCoCov0_7_5_coverage_per_test/", newArrayList(3, 4, 5, 8, 12));
+    String msg = "'Coverage per Test' feature is deprecated. Consider removing sonar-jacoco-listeners from your configuration.";
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains(msg);
+    assertThat(analysisWarnings.warnings).contains(msg);
+  }
+
+  @Test
+  public void log_removal_for_coverage_per_test() throws IOException {
+    context.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(7,7), SonarQubeSide.SCANNER));
+    testExecutionDataForLinesCoveredByTest("/org/sonar/plugins/jacoco/JaCoCov0_7_5_coverage_per_test/", newArrayList(3, 4, 5, 8, 12));
+    String msg = "'Coverage per Test' feature was removed from SonarQube. Remove sonar-jacoco-listeners listener configuration.";
+    assertThat(logTester.logs(LoggerLevel.WARN)).contains(msg);
+    assertThat(analysisWarnings.warnings).contains(msg);
   }
 
   @Test


### PR DESCRIPTION
Do not squash, contains 2 tickets

SONARJAVA-3065 Deprecate coverage per test
SONARJAVA-3066 Update message for old deprecated JaCoCo properties