### PR TITLE
SONARJAVA-3079 Fix method resolution

### DIFF
--- a/java-checks/src/test/files/checks/AssertionsInTestsCheck/AssertJ.java
+++ b/java-checks/src/test/files/checks/AssertionsInTestsCheck/AssertJ.java
@@ -1,11 +1,13 @@
+import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Fail;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.BDDAssertions;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AssertionsInTestsCheckAssertJ {
+public abstract class AssertionsInTestsCheckAssertJ {
 
   interface Visitor {
     void visit(Object object);
@@ -182,6 +184,40 @@ public class AssertionsInTestsCheckAssertJ {
   @Test
   public void assertion_from_unknown_symbol() {
     org.sonarsource.unknown.symbol.UnknownClass.assertSomething();
+  }
+
+  abstract boolean booleanMethod();
+  abstract Object[] arrayMethod();
+  abstract java.util.List<String> listStringMethod();
+
+  @Test
+  public void bdd_assertions_with_boolean() { // Compliant
+    BDDAssertions.then(booleanMethod()).isTrue();
+  }
+
+  @Test
+  public void bdd_assertions_with_array_assert() { // Cmpliant
+    BDDAssertions.then(arrayMethod()).contains("A", "B");
+  }
+
+  @Test
+  public void bdd_assertions_with_list() { // Compliant
+    BDDAssertions.then(listStringMethod())
+      .contains("Bob", "Alice")
+      .doesNotContain("Maurice");
+  }
+
+  @Test
+  public void bdd_assertions_split_with_intermediate_assertion() { // Compliant
+    AbstractListAssert<?, ? extends List<? extends String>, String> thenResult = BDDAssertions.then(listStringMethod());
+    thenResult
+      .contains("Bob", "Alice")
+      .doesNotContain("Maurice");
+  }
+
+  @Test
+  public void bdd_assertions_example_without_assertion() { // Noncompliant - nothing is asserted here
+    BDDAssertions.then(listStringMethod());
   }
 
   @Test

--- a/java-frontend/src/test/files/sym/references/MostSpecificGenericMethodCall.java
+++ b/java-frontend/src/test/files/sym/references/MostSpecificGenericMethodCall.java
@@ -1,0 +1,16 @@
+package org.foo;
+
+abstract class A {
+
+  void tst(String[] p1, B<String> p2, boolean p3) {
+    foo(p1);
+    foo(p2);
+    foo(p3);
+  }
+
+  abstract <T> T foo(T t);
+  abstract <T> T[] foo(T[] t);
+  abstract <T> B<T> foo(B<? extends T> t);
+
+  static class B<X> { }
+}

--- a/java-frontend/src/test/java/org/sonar/java/resolve/SymbolTableTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/resolve/SymbolTableTest.java
@@ -1027,6 +1027,18 @@ public class SymbolTableTest {
   }
 
   @Test
+  public void most_specific_generic_method() throws Exception {
+    Result result = Result.createFor("references/MostSpecificGenericMethodCall");
+    JavaSymbol foo = result.symbol("foo", 11);
+    JavaSymbol fooArray = result.symbol("foo", 12);
+    JavaSymbol fooParameterized = result.symbol("foo", 13);
+
+    assertThat(result.reference(6, 5)).as("Method with Array type argument not resolved").isSameAs(fooArray);
+    assertThat(result.reference(7, 5)).as("Method with Parameterized type argument not resolved").isSameAs(fooParameterized);
+    assertThat(result.reference(8, 5)).isSameAs(foo);
+  }
+
+  @Test
   public void MethodCall() {
     Result result = Result.createFor("references/MethodCall");
     assertThat(result.reference(10, 5)).isSameAs(result.symbol("target"));


### PR DESCRIPTION
We are resolving the wrong one in such cases:

```java 
<T> List<T> foo(List<? extends T> t);
<T> T foo(T t);

...

void test(List<String> list) {
  foo(list); // wrongly resolved to the 2nd method instead of the first one 
}
```

https://docs.oracle.com/javase/specs/jls/se8/html/jls-18.html#jls-18.5.4