### PR TITLE
SONARJAVA-3087 Update S3655 to consider Optional#isEmpty

### DIFF
--- a/java-frontend/src/test/files/se/OptionalGetBeforeIsPresentCheck.java
+++ b/java-frontend/src/test/files/se/OptionalGetBeforeIsPresentCheck.java
@@ -56,6 +56,10 @@ abstract class A {
     return s.isPresent() ? null : s.get(); // Noncompliant
   }
 
+  String isEmpty(Optional<String> s) {
+    return s.isEmpty() ? s.get() : null; // Noncompliant
+  }
+
   private void usingEmpty() {
     Optional<String> op = Optional.empty();
     op.get(); // Noncompliant
@@ -80,6 +84,30 @@ abstract class A {
     if (o != null) {
       op.get(); // Compliant - if o is not null, then the optional is necessarily present
     }
+  }
+
+  private void usingIsEmpty() {
+    Optional<Object> op = Optional.emtpy();
+    if (!op.isEmpty()) {
+      op.get(); // Compliant - dead code
+    }
+  }
+
+  private void usingIsEmpty2() {
+    Optional<Object> op = Optional.emtpy();
+    if (op.isEmpty()) {
+      // Noop
+    } else {
+      op.get(); // Compliant - dead code
+    }
+  }
+
+  void usingIsEmpty3() {
+    Optional<String> s = optional;
+    if (!s.isEmpty()) {
+      s.get(); // Compliant
+    }
+    s.get(); // Noncompliant
   }
 
   private void usingFilter1(Optional<String> op) {

--- a/java-frontend/src/test/files/se/OptionalGetBeforeIsPresentCheck.java
+++ b/java-frontend/src/test/files/se/OptionalGetBeforeIsPresentCheck.java
@@ -87,14 +87,14 @@ abstract class A {
   }
 
   private void usingIsEmpty() {
-    Optional<Object> op = Optional.emtpy();
+    Optional<Object> op = Optional.empty();
     if (!op.isEmpty()) {
       op.get(); // Compliant - dead code
     }
   }
 
   private void usingIsEmpty2() {
-    Optional<Object> op = Optional.emtpy();
+    Optional<Object> op = Optional.empty();
     if (op.isEmpty()) {
       // Noop
     } else {


### PR DESCRIPTION
Implementation of RSPEC-3655 should be updated to handle Optional#isEmpty method introduced in Java 11.
