### PR TITLE
Update REF_MESSAGE of VolatileNonPrimitiveFieldCheck

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/VolatileNonPrimitiveFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/VolatileNonPrimitiveFieldCheck.java
@@ -33,7 +33,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 @Rule(key = "S3077")
 public class VolatileNonPrimitiveFieldCheck extends IssuableSubscriptionVisitor {
 
-  private static final String REF_MESSAGE = "Remove the \"volatile\" keyword from this field.";
+  private static final String REF_MESSAGE = "Remember that declaring a reference \"volatile\" does not guarantee safe publication of the members of the referenced object";
   private static final String ARRAY_MESSAGE = "Use an \"Atomic%sArray\" instead.";
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/VolatileNonPrimitiveFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/VolatileNonPrimitiveFieldCheck.java
@@ -33,7 +33,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 @Rule(key = "S3077")
 public class VolatileNonPrimitiveFieldCheck extends IssuableSubscriptionVisitor {
 
-  private static final String REF_MESSAGE = "Remember that declaring a reference \"volatile\" does not guarantee safe publication of the members of the referenced object";
+  private static final String REF_MESSAGE = "Remember that declaring a reference \"volatile\" does not guarantee safe publication of the members of the referenced object.";
   private static final String ARRAY_MESSAGE = "Use an \"Atomic%sArray\" instead.";
 
   @Override

--- a/java-checks/src/test/files/checks/VolatileNonPrimitiveFieldCheck.java
+++ b/java-checks/src/test/files/checks/VolatileNonPrimitiveFieldCheck.java
@@ -3,7 +3,7 @@ class A {
   private volatile int [] vInts;  // Noncompliant [[sc=11;ec=26]] {{Use an "AtomicIntegerArray" instead.}}
   private volatile long [] vLongs;  // Noncompliant [[sc=11;ec=27]] {{Use an "AtomicLongArray" instead.}}
   private volatile Object [] vObjects;  // Noncompliant [[sc=11;ec=29]] {{Use an "AtomicReferenceArray" instead.}}
-  private volatile MyObj myObj;  // Noncompliant [[sc=11;ec=25]] {{Remove the "volatile" keyword from this field.}}
+  private volatile MyObj myObj;  // Noncompliant [[sc=11;ec=25]] {{Remember that declaring a reference "volatile" does not guarantee safe publication of the members of the referenced object.}}
   private AtomicIntegerArray vInts2;
   private MyObj myObj2;
 
@@ -13,7 +13,7 @@ enum MyEnum {
   FOO;
   private volatile int vInts0;
   private volatile int [] vInts;  // Noncompliant [[sc=11;ec=26]] {{Use an "AtomicIntegerArray" instead.}}
-  private volatile MyObj myObj;  // Noncompliant [[sc=11;ec=25]] {{Remove the "volatile" keyword from this field.}}
+  private volatile MyObj myObj;  // Noncompliant [[sc=11;ec=25]] {{Remember that declaring a reference "volatile" does not guarantee safe publication of the members of the referenced object.}}
   private AtomicIntegerArray vInts2;
   private MyObj myObj2;
 


### PR DESCRIPTION
The original message is a bit too drastic and can confuse some developers and lead them straight into introducing concurrency issues:

> "Remove the \"volatile\" keyword from this field."

Replaced it with:

> "Remember that declaring a reference \"volatile\" does not guarantee safe publication of the members of the referenced object"