### PR TITLE
SONARJAVA-3086 Support Java 9 immutable collections in S2384 and S2386

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/MutableMembersUsageCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/MutableMembersUsageCheck.java
@@ -60,7 +60,9 @@ public class MutableMembersUsageCheck extends BaseTreeVisitor implements JavaFil
 
   private static final MethodMatcherCollection UNMODIFIABLE_COLLECTION_CALL = MethodMatcherCollection.create(
     MethodMatcher.create().typeDefinition("java.util.Collections").name(NameCriteria.startsWith("unmodifiable")).withAnyParameters(),
-    MethodMatcher.create().typeDefinition("java.util.Collections").name(NameCriteria.startsWith("singleton")).withAnyParameters()
+    MethodMatcher.create().typeDefinition("java.util.Collections").name(NameCriteria.startsWith("singleton")).withAnyParameters(),
+    MethodMatcher.create().typeDefinition("java.util.Set").name("of").withAnyParameters(),
+    MethodMatcher.create().typeDefinition("java.util.List").name("of").withAnyParameters()
   );
 
   private JavaFileScannerContext context;

--- a/java-checks/src/main/java/org/sonar/java/checks/PublicStaticMutableMembersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PublicStaticMutableMembersCheck.java
@@ -71,6 +71,10 @@ public class PublicStaticMutableMembersCheck extends IssuableSubscriptionVisitor
     .add(MethodMatcher.create().typeDefinition("java.util.Collections").name(NameCriteria.startsWith("singleton")).withAnyParameters())
     .add(MethodMatcher.create().typeDefinition("java.util.Collections").name(NameCriteria.startsWith("empty")).withAnyParameters())
     .add(MethodMatcher.create().typeDefinition(TypeCriteria.anyType()).name(NameCriteria.startsWith("unmodifiable")).withAnyParameters())
+       // Java 9
+    .add(MethodMatcher.create().typeDefinition("java.util.Set").name("of").withAnyParameters())
+    .add(MethodMatcher.create().typeDefinition("java.util.List").name("of").withAnyParameters())
+    .add(MethodMatcher.create().typeDefinition("java.util.Map").name("of").withAnyParameters())
       // apache commons 3.X
     .add(MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("org.apache.commons.collections.map.UnmodifiableMap")).name(DECORATE).withAnyParameters())
     .add(MethodMatcher.create().typeDefinition(TypeCriteria.subtypeOf("org.apache.commons.collections.set.UnmodifiableSet")).name(DECORATE).withAnyParameters())

--- a/java-checks/src/test/files/checks/MutableMembersUsageCheck.java
+++ b/java-checks/src/test/files/checks/MutableMembersUsageCheck.java
@@ -1,11 +1,5 @@
-import java.util.Date;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.LinkedList;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.*;
 import com.google.common.collect.ImmutableCollection;
-import java.util.Collections;
 
 class A {
   private String[] strings;
@@ -137,6 +131,10 @@ class Fields {
   private static final List<String> UNMODIFIABLE = Collections.unmodifiableList(Arrays.asList("A", "B", "C"));
   private static final List<String> UNMODIFIABLE2;
   private static final Object UNMODIFIABLE_OBJECT;
+
+  private static final List<String> IMMUTABLE_LIST = List.of(1, 2, 3);
+  private static final Set<String> IMMUTABLE_SET = Set.of("a");
+
   static {
     UNMODIFIABLE2 = Collections.unmodifiableList(Arrays.asList("A", "B", "C"));
     UNMODIFIABLE_OBJECT = UNMODIFIABLE2;
@@ -165,6 +163,14 @@ class Fields {
 
   public List<String> bar1() {
     return unmodifiable_not_final; // Noncompliant
+  }
+
+  public List<String> immutableList() {
+    return IMMUTABLE_LIST;
+  }
+
+  public Set<String> immutableSet() {
+    return IMMUTABLE_SET;
   }
 
   public List<String> bar2() {

--- a/java-checks/src/test/files/checks/PublicStaticMutableMembersCheck.java
+++ b/java-checks/src/test/files/checks/PublicStaticMutableMembersCheck.java
@@ -71,6 +71,11 @@ public class A {
   public static final Map MAP = new HashMap(); // Noncompliant
   public static final Map otherMap = MAP; // Noncompliant
 
+  public static final Map<String, String> IMMUTABLE_MAP = Map.of("a", "A");
+  public static final List<String> IMMUTABLE_LIST = List.of("hello");
+  public static final Set<String> IMMUTABLE_SET = Set.of("hello");
+
+
   static {
     MAP.put("a", "b");
     MAP.put("c", "d");


### PR DESCRIPTION
Note that in S2384 I am deliberately not adding `java.util.Map` because it creates lot of new issues unrelated to this ticket. We might create a new ticket to have the support of `java.util.Map` in this rule.