### PR TITLE
S2599 FP vertx asyncAssertSuccess, asyncAssertFailure

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
@@ -80,7 +80,9 @@ public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileS
     // spring
     method("org.springframework.test.web.servlet.ResultActions", "andExpect").addParameter(ANY_TYPE),
     // JMockit
-    method("mockit.Verifications", "<init>").withAnyParameters());
+    method("mockit.Verifications", "<init>").withAnyParameters(),
+    // Eclipse Vert.x
+    method("io.vertx.ext.unit.TestContext", NameCriteria.startsWith("asyncAssert")).withoutParameter());
 
   private static final MethodMatcherCollection REACTIVE_X_TEST_METHODS = MethodMatcherCollection.create(
     method(TypeCriteria.subtypeOf("rx.Observable"), NameCriteria.is("test")).withAnyParameters(),

--- a/java-checks/src/test/files/checks/AssertionsInTestsCheck/VertX.java
+++ b/java-checks/src/test/files/checks/AssertionsInTestsCheck/VertX.java
@@ -99,6 +99,28 @@ class A {
   }
 
   @Test
+  public void test_asyncAssertSuccess1(TestContext contextVertx) {
+    contextVertx.asyncAssertSuccess();
+  }
+
+  @Test
+  public void test_asyncAssertSuccess2(TestContext contextVertx) { // Noncompliant
+    contextVertx.asyncAssertSuccess(result -> {
+    });
+  }
+
+  @Test
+  public void test_asyncAssertFailure1(TestContext contextVertx) {
+    contextVertx.asyncAssertFailure();
+  }
+
+  @Test
+  public void test_asyncAssertFailure2(TestContext contextVertx) { // Noncompliant
+    contextVertx.asyncAssertFailure(throwable -> {
+    });
+  }
+
+  @Test
   public void test_saveUser() { // Compliant even if this test may not be run correctly - assertion is present
     TestSuite suite = TestSuite.create("suite_user_save");
     HttpClient client = vertx.createHttpClient();


### PR DESCRIPTION
Vertx' TestContext has four methods for asynchonous assertions:
Two without arguments:
* asyncAssertSuccess()
* asyncAssertFailure()

Two with Handler arguments:
* asyncAssertSuccess(Handler<T> resultHandler)
* asyncAssertFailure(Handler<Throwable> causeHandler)

All four either resolve the Async or fail the test.

But the methods without arguments are the end of the test because no other code is executed
whereas the methods with Handler arguments continue with the handler code.

The methods without arguments are intended for cases where checking success or failure is sufficient,
therefore they should count as a S2599 assertion.

The methods with arguments are intended for cases where more testing is needed:
Either testing the result (or the Throwable of the failure) or by executing some
other operation. Therefore the methods with arguments should not count as a S2599
assertion.

Documentation: https://vertx.io/docs/vertx-unit/java/#_asynchronous_assertions