### PR TITLE
Fix syntax errors in test files

### DIFF
--- a/java-checks/src/test/files/checks/CloneMethodCallsSuperCloneCheck.java
+++ b/java-checks/src/test/files/checks/CloneMethodCallsSuperCloneCheck.java
@@ -55,7 +55,6 @@ class G1 extends G0 {
   protected Object clone() throws CloneNotSupportedException { // Noncompliant {{Use super.clone() to create and seed the cloned instance to be returned.}}
     super();
     int c = super.clone;
-    new Foo().super.clone();
     return super.clone("foo");
   }
 

--- a/java-checks/src/test/files/checks/ToStringUsingBoxingCheck.java
+++ b/java-checks/src/test/files/checks/ToStringUsingBoxingCheck.java
@@ -20,7 +20,6 @@ class A {
     new Integer.Foo().toString(); // Compliant
 
     foo++; // Compliant
-    Object o = new Integer(0).this; // Compliant
     (foo).toString(); // Compliant
     foo();
   }


### PR DESCRIPTION
According to Java Language Specification
".super" and ".this" can be preceded only by type name.