### PR TITLE
Introduce sanity test for rules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
             label 'linux'
           }
           steps {
+            runBuildWithProfile("sanity")
             runITs("ruling", "LATEST_RELEASE[7.9]")
           }
         }
@@ -54,6 +55,7 @@ pipeline {
             label 'windows'
           }
           steps {
+            runBuildWithProfile("sanity")
             runITs("ruling", "LATEST_RELEASE[7.9]")
           }
         }
@@ -101,6 +103,13 @@ pipeline {
         }
       }
     }
+  }
+}
+
+def runBuildWithProfile(PROFILE) {
+  withMaven(maven: MAVEN_TOOL) {
+    mavenSetBuildVersion()
+    runMaven(JDK_VERSION, "clean verify -P$PROFILE")
   }
 }
 

--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -12,6 +12,11 @@
 
   <name>SonarQube Java :: Checks</name>
 
+  <properties>
+    <!-- only executed when using 'sanity' profile -->
+    <excluded.tests>**/RulesSanityTest.java</excluded.tests>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
@@ -72,8 +77,16 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${excluded.tests}</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
         <executions>
           <execution>
             <id>copy</id>
@@ -82,6 +95,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
+              <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>io.netty</groupId>
@@ -582,7 +596,6 @@
                   <version>7.7</version>
                 </artifactItem>
               </artifactItems>
-              <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -600,6 +613,13 @@
       </activation>
       <properties>
         <argLine>-Xmx512m --add-modules jdk.incubator.httpclient</argLine>
+      </properties>
+    </profile>
+    <profile>
+      <!-- discard excluded sanity test to execute it during build -->
+      <id>sanity</id>
+      <properties>
+        <excluded.tests></excluded.tests>
       </properties>
     </profile>
   </profiles>

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionInThreadRunCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionInThreadRunCheck.java
@@ -20,7 +20,6 @@
 package org.sonar.java.checks;
 
 import com.google.common.collect.ImmutableList;
-
 import java.util.Collections;
 import java.util.List;
 import org.sonar.check.Rule;
@@ -50,6 +49,9 @@ public class AssertionInThreadRunCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
+    if (!hasSemantic()) {
+      return;
+    }
     MethodTree methodTree = (MethodTree) tree;
     BlockTree block = methodTree.block();
     if (block != null && isRunMethod(methodTree)) {

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
@@ -113,6 +113,10 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
 
   @Override
   public void scanFile(final JavaFileScannerContext context) {
+    if (context.getSemanticModel() == null) {
+      // requires semantic
+      return;
+    }
     this.context = context;
     scan(context.getTree());
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsInTestsCheck.java
@@ -101,6 +101,10 @@ public class AssertionsInTestsCheck extends BaseTreeVisitor implements JavaFileS
 
   @Override
   public void scanFile(final JavaFileScannerContext context) {
+    if (context.getSemanticModel() == null) {
+      // requires semantic
+      return;
+    }
     this.context = context;
     assertionInMethod.clear();
     scan(context.getTree());

--- a/java-checks/src/main/java/org/sonar/java/checks/CallSuperInTestCaseCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CallSuperInTestCaseCheck.java
@@ -19,6 +19,11 @@
  */
 package org.sonar.java.checks;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -30,12 +35,6 @@ import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 @Rule(key = "S2188")
 public class CallSuperInTestCaseCheck extends IssuableSubscriptionVisitor {
@@ -49,6 +48,9 @@ public class CallSuperInTestCaseCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
+    if (!hasSemantic()) {
+      return;
+    }
     MethodTree methodTree = (MethodTree) tree;
     Symbol.MethodSymbol methodSymbol = methodTree.symbol();
     boolean isMethodInJunit3 = isWithinJunit3TestCase(methodSymbol) && isSetUpOrTearDown(methodSymbol);

--- a/java-checks/src/main/java/org/sonar/java/checks/IgnoredTestsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IgnoredTestsCheck.java
@@ -52,6 +52,9 @@ public class IgnoredTestsCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
+    if (!hasSemantic()) {
+      return;
+    }
     MethodTree methodTree = (MethodTree) tree;
     SymbolMetadata symbolMetadata = methodTree.symbol().metadata();
     if (isSilentlyIgnored(symbolMetadata, "org.junit.Ignore") || isSilentlyIgnored(symbolMetadata, "org.junit.jupiter.api.Disabled")) {

--- a/java-checks/src/main/java/org/sonar/java/checks/PrintfMisuseCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PrintfMisuseCheck.java
@@ -163,6 +163,10 @@ public class PrintfMisuseCheck extends AbstractPrintfChecker {
       }else {
         index++;
       }
+      if (argIndex >= args.size()) {
+        // indexes are obviously wrong - will be caught by S2275 (PrintfFailCheck)
+        return;
+      }
       ExpressionTree argExpressionTree = args.get(argIndex);
       unusedArgs.remove(argExpressionTree);
       Type argType = argExpressionTree.symbolType();

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/Javadoc.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/Javadoc.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.java.ast.visitors.PublicApiChecker;
 import org.sonar.plugins.java.api.tree.ClassTree;
@@ -227,6 +228,7 @@ public final class Javadoc {
     return part.trim().isEmpty() || PLACEHOLDERS.contains(part.trim());
   }
 
+  @CheckForNull
   private static String exceptionName(TypeTree typeTree) {
     switch (typeTree.kind()) {
       case IDENTIFIER:
@@ -234,7 +236,9 @@ public final class Javadoc {
       case MEMBER_SELECT:
         return ExpressionsHelper.concatenate((MemberSelectExpressionTree) typeTree);
       default:
-        throw new IllegalStateException("Exceptions can not be specified other than with an identifier or a fully qualified name.");
+        // Exceptions can not be specified other than with an identifier or a fully qualified name.
+        // in SonarLint context, however, you may end up with something which does not compile
+        return null;
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -147,7 +147,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       IdentifierTree assignmentVariable = (IdentifierTree) assignment.variable();
       Symbol assignmentVariableSymbol = assignmentVariable.symbol();
       boolean isMatchedType = isCookieClass(assignmentVariable.symbolType()) || isCookieClass(assignment.expression().symbolType());
-      if (isMatchedType && isSecureParamFalse((NewClassTree) assignment.expression())) {
+      if (isMatchedType && isSecureParamFalse((NewClassTree) assignment.expression()) && !assignmentVariableSymbol.isUnknown()) {
         unsecuredCookies.put((Symbol.VariableSymbol) assignmentVariableSymbol, (NewClassTree) assignment.expression());
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedTestRuleCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedTestRuleCheck.java
@@ -20,6 +20,9 @@
 package org.sonar.java.checks.unused;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -27,10 +30,6 @@ import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 @Rule(key = "S2924")
 public class UnusedTestRuleCheck extends IssuableSubscriptionVisitor {
@@ -47,6 +46,9 @@ public class UnusedTestRuleCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
+    if (!hasSemantic()) {
+      return;
+    }
     ClassTree classTree = (ClassTree) tree;
     for (Tree member : classTree.members()) {
       if (member.is(Tree.Kind.VARIABLE)) {

--- a/java-checks/src/test/files/checks/AnonymousClassesTooBigCheck.java
+++ b/java-checks/src/test/files/checks/AnonymousClassesTooBigCheck.java
@@ -1,6 +1,6 @@
 class A {
   private void f() {
-    int a = new Comparable();
+    Object a = new Comparable();
 
     new Comparable<T>() { // 1
       private void f() { // 2

--- a/java-checks/src/test/files/checks/AnonymousClassesTooBigCheckCustom.java
+++ b/java-checks/src/test/files/checks/AnonymousClassesTooBigCheckCustom.java
@@ -1,6 +1,6 @@
 class A {
   private void f() {
-    int a = new Comparable();
+    Object a = new Comparable();
 
     new Comparable<T>() { // 1
       private void f() { // 2

--- a/java-checks/src/test/files/checks/AssertionInThreadRunCheck.java
+++ b/java-checks/src/test/files/checks/AssertionInThreadRunCheck.java
@@ -23,7 +23,7 @@ abstract class B {
     org.junit.Assert.assertTrue(true);
     org.junit.jupiter.api.Assertions.assertTrue(true);
   }
-  abstract foo();
+  abstract void foo();
 }
 
 class C extends junit.framework.TestCase {

--- a/java-checks/src/test/files/checks/ConstantsShouldBeStaticFinalCheck.java
+++ b/java-checks/src/test/files/checks/ConstantsShouldBeStaticFinalCheck.java
@@ -3,7 +3,7 @@ class A {
   private final static int f2 = 0;                      // Compliant
   private static final int f3 = 0;                      // Compliant
   public final int f4 = MyEnumOrInterface.MY_CONSTANT;  // Noncompliant
-  private final int f5 = new Date();                    // Compliant
+  private final int f5 = new Integer(42);               // Compliant
   private final int f6 = foo();                         // Compliant
   private int f7 = 0;                                   // Compliant
   private int f8;                                       // Compliant

--- a/java-checks/src/test/files/checks/ParameterReassignedToCheck.java
+++ b/java-checks/src/test/files/checks/ParameterReassignedToCheck.java
@@ -1,7 +1,7 @@
 class A {
   public void f() {
   }
-  abstract method();
+  abstract void method();
   public void f(int a) {
     a = 0; // Noncompliant [[sc=5;ec=6]] {{Introduce a new variable instead of reusing the parameter "a".}}
     a += 1; // Noncompliant {{Introduce a new variable instead of reusing the parameter "a".}}

--- a/java-checks/src/test/files/checks/PrintfMisuseCheck.java
+++ b/java-checks/src/test/files/checks/PrintfMisuseCheck.java
@@ -23,6 +23,8 @@ class A {
     String.format("Display %2$d and then %2$d", 1, 2);   // Noncompliant {{first argument is not used.}}
     String.format("Too many arguments %d and %d", 1, 2, 3);  // Noncompliant {{3rd argument is not used.}}
     String.format("Not enough arguments %d and %d", 1);
+    String.format("%1$d %2$d %9$-3.3s", 1, 2, "hello");  // Compliant - not eough arguments but this will be caught by other rule
+    String.format("%12$s", 1, 2, "hello");  // Compliant - not eough arguments but this will be caught by other rule
     String.format("First Line\n %d", 1); // Noncompliant {{%n should be used in place of \n to produce the platform-specific line separator.}}
     String.format("First Line");   // Noncompliant {{String contains no format specifiers.}}
     String.format("First Line%%"); // Noncompliant {{String contains no format specifiers.}}

--- a/java-checks/src/test/files/checks/UndocumentedApiCheck/UndocumentedApi.java
+++ b/java-checks/src/test/files/checks/UndocumentedApiCheck/UndocumentedApi.java
@@ -280,7 +280,7 @@ public class MyRunner extends Foo {
    */
   public interface Foo {
 
-    public foo(); // Noncompliant
+    public void foo(); // Noncompliant
 
   }
 

--- a/java-checks/src/test/files/checks/UndocumentedApiCheck/UndocumentedApiCustom.java
+++ b/java-checks/src/test/files/checks/UndocumentedApiCheck/UndocumentedApiCustom.java
@@ -268,7 +268,7 @@ public class MyRunner extends Foo {
    */
   public interface Foo {
 
-    public foo();
+    public void foo();
 
   }
 

--- a/java-checks/src/test/files/checks/UndocumentedApiCheck/UndocumentedApiExclusion.java
+++ b/java-checks/src/test/files/checks/UndocumentedApiCheck/UndocumentedApiExclusion.java
@@ -269,7 +269,7 @@ public class MyRunner extends Foo {
    */
   public interface Foo {
 
-    public foo();
+    public void foo();
 
   }
 

--- a/java-checks/src/test/files/checks/helpers/JavadocTest.java
+++ b/java-checks/src/test/files/checks/helpers/JavadocTest.java
@@ -111,6 +111,10 @@ class A<B, C, E> {
   private int genericExceptionThrownUndocumented() throws Exception {
     return 0;
   }
+
+  private int invalidThrownExceptionUndocumented() throws Exception<String> {
+    return 0;
+  }
 }
 
 /**

--- a/java-checks/src/test/files/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/test/files/checks/security/SecureCookieCheck.java
@@ -99,6 +99,8 @@ class A {
 
     field6 = new HttpCookie("name, value"); // Noncompliant
 
+    unknown = new HttpCookie("name, value"); // Noncompliant
+
     return new HttpCookie("name", "value"); // Noncompliant
   }
 

--- a/java-checks/src/test/files/checks/spring/SpringBeansShouldBeAccessibleCheck/ComponentScan/A.java
+++ b/java-checks/src/test/files/checks/spring/SpringBeansShouldBeAccessibleCheck/ComponentScan/A.java
@@ -8,7 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Component
 class A1 { // Compliant
-  A1();
+  A1() { }
+
   @Service
   public class A2Inner { // Compliant
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/AssertionInThreadRunCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AssertionInThreadRunCheckTest.java
@@ -27,5 +27,6 @@ public class AssertionInThreadRunCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/AssertionInThreadRunCheck.java", new AssertionInThreadRunCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/AssertionInThreadRunCheck.java", new AssertionInThreadRunCheck());
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/AssertionsCompletenessCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AssertionsCompletenessCheckTest.java
@@ -26,6 +26,7 @@ public class AssertionsCompletenessCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/AssertionsCompletenessCheck.java", new AssertionsCompletenessCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/AssertionsCompletenessCheck.java", new AssertionsCompletenessCheck());
   }
 
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/AssertionsInTestsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AssertionsInTestsCheckTest.java
@@ -75,6 +75,11 @@ public class AssertionsInTestsCheckTest {
   }
 
   @Test
+  public void testNoIssuesWithout() {
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/AssertionsInTestsCheck/Junit3.java", check);
+  }
+
+  @Test
   public void testWithEmptyCustomAssertionMethods() {
     check.customAssertionMethods = "";
     JavaCheckVerifier.verify("src/test/files/checks/AssertionsInTestsCheck/Junit3.java", check);

--- a/java-checks/src/test/java/org/sonar/java/checks/CallSuperInTestCaseCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CallSuperInTestCaseCheckTest.java
@@ -27,5 +27,6 @@ public class CallSuperInTestCaseCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/CallSuperInTestCaseCheck.java", new CallSuperInTestCaseCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/CallSuperInTestCaseCheck.java", new CallSuperInTestCaseCheck());
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/ConstructorCallingOverridableCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ConstructorCallingOverridableCheckTest.java
@@ -27,5 +27,6 @@ public class ConstructorCallingOverridableCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/ConstructorCallingOverridableCheck.java", new ConstructorCallingOverridableCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/ConstructorCallingOverridableCheck.java", new ConstructorCallingOverridableCheck());
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/IgnoredTestsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/IgnoredTestsCheckTest.java
@@ -27,5 +27,6 @@ public class IgnoredTestsCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/IgnoredTestsCheck.java", new IgnoredTestsCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/IgnoredTestsCheck.java", new IgnoredTestsCheck());
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/RulesSanityTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/RulesSanityTest.java
@@ -1,0 +1,273 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.checks;
+
+import com.sonar.sslr.api.RecognitionException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.internal.SonarRuntimeImpl;
+import org.sonar.api.utils.AnnotationUtils;
+import org.sonar.api.utils.Version;
+import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.java.SonarComponents;
+import org.sonar.java.ast.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridgeForTests;
+import org.sonar.plugins.java.api.JavaCheck;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class RulesSanityTest {
+
+  @Rule
+  public final LogTester logTester = new LogTester();
+
+  private static final String TARGET_CLASSES = "target/test-classes";
+  private static final String TEST_FILES_DIRECTORY = "src/test/files";
+  private static final String DEFAULT_TEST_JARS_DIRECTORY = "target/test-jars";
+  private static final String TEST_FILES_EXTRA_CLASSES = "src/test/resources/";
+
+  /**
+   * Ignore template rules, as they requires configuration
+   */
+  private static final Set<String> TEMPLATE_RULES_KEYS = new HashSet<>(Arrays.asList(
+    "S124", // CommentRegularExpressionCheck
+    "S2253", // DisallowedMethodCheck
+    "S3417", // DisallowedDependenciesCheck - XML
+    "S3688", // DisallowedClassCheck
+    "S3546", // CustomUnclosedResourcesCheck - SE-based
+    "S4011" // DisallowedConstructorCheck
+  ));
+
+  private static final Set<String> EXCLUDED_RULES = Collections.singleton(
+    "S4032" // UselessPackageInfoCheck - which does some file-based tests (parent)
+  );
+
+  /**
+   * Verifies that playing all the checks on all the test files does not trigger any exceptions.
+   *
+   * This relies on the fact that a lot of tricky cases are covered in unit tests, on a rule by rule and case by case basis.
+   * It does not prevent other rules to fail if similar construct of the language, but not yet encountered. 
+   */
+  @Test
+  public void test() throws Exception {
+    logTester.setLevel(LoggerLevel.WARN);
+
+    List<JavaCheck> checks = getJavaCheckInstances();
+    assertThat(checks).isNotEmpty();
+
+    List<InputFile> inputFiles = getJavaInputFiles();
+    assertThat(inputFiles.size()).isGreaterThanOrEqualTo(checks.size());
+
+    List<File> classpath = getClassPath();
+    assertThat(classpath).isNotEmpty();
+
+    List<SanityCheckException> exceptions = scanFiles(inputFiles, checks, classpath);
+    if (!exceptions.isEmpty()) {
+      System.out.println(processExceptions(exceptions));
+      fail(String.format("Should have been able to execute all the rules on all the test files. %d file(s) made at least 1 rule fail.", exceptions.size()));
+    }
+  }
+
+  private static String processExceptions(List<SanityCheckException> exceptions) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("At least one rule failed for the following ").append(exceptions.size()).append(" file(s):\n\n");
+
+    int i = 1;
+    for (SanityCheckException sanityCheckException : exceptions) {
+      sb.append(i).append(")")
+        .append("\t").append("File: \"").append(sanityCheckException.inputFile).append("\"\n")
+        .append("\t").append("Rule: \"").append(sanityCheckException.failingCheck).append("\"\n")
+        .append("\t").append("Exception: \"").append(sanityCheckException.realCause).append("\"\n")
+        .append("\n");
+      i++;
+    }
+
+    return sb.toString();
+  }
+
+  private static List<JavaCheck> getJavaCheckInstances() {
+    List<Class<? extends JavaCheck>> checkClasses = new ArrayList<>();
+    checkClasses.addAll(CheckList.getJavaChecks());
+    checkClasses.addAll(CheckList.getJavaTestChecks());
+
+    List<JavaCheck> javaChecks = new ArrayList<>();
+    for (Class<? extends JavaCheck> checkClass : checkClasses) {
+      String ruleKey = AnnotationUtils.getAnnotation(checkClass, org.sonar.check.Rule.class).key();
+      if (TEMPLATE_RULES_KEYS.contains(ruleKey) || EXCLUDED_RULES.contains(ruleKey)) {
+        // FIXME initialize a new template rule with some default parameter ?!
+      } else {
+        try {
+          javaChecks.add(checkClass.newInstance());
+        } catch (Exception e) {
+          fail(String.format("Unable to initialize rule %s", ruleKey), e);
+        }
+      }
+    }
+
+    return javaChecks;
+  }
+
+  private static List<InputFile> getJavaInputFiles() {
+    return getFilesRecursively(new File(TEST_FILES_DIRECTORY).toPath(), "java").stream()
+      .map(File::getAbsolutePath)
+      .filter(RulesSanityTest::isNotParsingErrorFile)
+      .map(RulesSanityTest::inputFile)
+      .collect(Collectors.toList());
+  }
+
+  private static boolean isNotParsingErrorFile(String filename) {
+    return !(filename.contains("ParsingError") || filename.contains("ParseError"));
+  }
+
+  private static List<File> getClassPath() {
+    List<File> classpath = new ArrayList<>();
+    classpath = getFilesRecursively(new File(DEFAULT_TEST_JARS_DIRECTORY).toPath(), "jar", "zip");
+    classpath.add(new File(TARGET_CLASSES));
+    classpath.add(new File(TEST_FILES_EXTRA_CLASSES));
+    return classpath;
+  }
+
+  private static List<File> getFilesRecursively(Path root, String... extensions) {
+    final List<File> files = new ArrayList<>();
+
+    FileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path filePath, BasicFileAttributes attrs) {
+        for (String extension : extensions) {
+          if (filePath.toString().endsWith("." + extension)) {
+            files.add(filePath.toFile());
+            break;
+          }
+        }
+        return FileVisitResult.CONTINUE;
+      }
+
+      @Override
+      public FileVisitResult visitFileFailed(Path file, IOException exc) {
+        return FileVisitResult.CONTINUE;
+      }
+    };
+
+    try {
+      Files.walkFileTree(root, visitor);
+    } catch (IOException e) {
+      // we already ignore errors in the visitor
+    }
+
+    return files;
+  }
+
+  private static List<SanityCheckException> scanFiles(List<InputFile> inputFiles, List<JavaCheck> checks, List<File> classpath) {
+    List<SanityCheckException> exceptions = new ArrayList<>();
+    SonarComponents sonarComponents = sonarComponents(inputFiles);
+    for (InputFile inputFile : inputFiles) {
+      try {
+        VisitorsBridgeForTests visitorsBridge = new VisitorsBridgeForTests(checks, classpath, sonarComponents);
+        JavaAstScanner.scanSingleFileForTests(inputFile, visitorsBridge);
+      } catch (Exception e) {
+        exceptions.add(new SanityCheckException(inputFile, e));
+      }
+    }
+    return exceptions;
+  }
+
+  private static class SanityCheckException extends Exception {
+    private static final long serialVersionUID = 1934785706394840975L;
+    private final InputFile inputFile;
+    private final Throwable realCause;
+    @Nullable
+    private final String failingCheck;
+
+    public SanityCheckException(InputFile inputFile, Exception analysisException) {
+      super(String.format("Unable to analyse file %s", inputFile.filename()), analysisException);
+      this.inputFile = inputFile;
+      this.realCause = analysisException.getCause();
+      this.failingCheck = parseStackForCheck(realCause);
+
+    }
+
+    private String parseStackForCheck(Throwable realCause2) {
+      String stackTrace = ExceptionUtils.getStackTrace(realCause);
+      return Arrays.stream(stackTrace.split("\n"))
+        // try to retrieve the rule class name in 'checks' package
+        .filter(line -> line.contains("org.sonar.java.checks."))
+        // check that it's a rule
+        .filter(line -> line.substring(0, line.lastIndexOf(".java:")).endsWith("Check"))
+        .findFirst()
+        // drop parenthesis to get location
+        .map(line -> line.substring(line.lastIndexOf('(') + 1, line.length() - 1))
+        .orElse(null);
+    }
+  }
+
+  private static SonarComponents sonarComponents(List<InputFile> inputFiles) {
+    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    context.setSettings(new MapSettings().setProperty("sonar.java.failOnException", true));
+    DefaultFileSystem fileSystem = context.fileSystem();
+    SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null) {
+      @Override
+      public boolean reportAnalysisError(RecognitionException re, InputFile inputFile) {
+        return false;
+      }
+    };
+    sonarComponents.setSensorContext(context);
+    inputFiles.forEach(inputFile -> fileSystem.add(inputFile));
+    return sonarComponents;
+  }
+
+  private static DefaultInputFile inputFile(String filename) {
+    File file = new File(filename);
+    try {
+      return new TestInputFileBuilder("", file.getPath())
+        .setContents(new String(Files.readAllBytes(file.toPath()), UTF_8))
+        .setCharset(UTF_8)
+        .setLanguage("java")
+        .build();
+    } catch (Exception e) {
+      throw new IllegalStateException(String.format("Unable to lead file '%s", file.getAbsolutePath()));
+    }
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/RulesSanityTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/RulesSanityTest.java
@@ -49,7 +49,9 @@ import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.AnnotationUtils;
 import org.sonar.api.utils.Version;
 import org.sonar.api.utils.log.LogTester;
+import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.api.utils.log.Loggers;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.model.VisitorsBridgeForTests;
@@ -60,6 +62,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 public class RulesSanityTest {
+
+  private static final Logger LOG = Loggers.get(RulesSanityTest.class);
 
   @Rule
   public final LogTester logTester = new LogTester();
@@ -106,7 +110,7 @@ public class RulesSanityTest {
 
     List<SanityCheckException> exceptions = scanFiles(inputFiles, checks, classpath);
     if (!exceptions.isEmpty()) {
-      System.out.println(processExceptions(exceptions));
+      LOG.error(processExceptions(exceptions));
       fail(String.format("Should have been able to execute all the rules on all the test files. %d file(s) made at least 1 rule fail.", exceptions.size()));
     }
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/StringToPrimitiveConversionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringToPrimitiveConversionCheckTest.java
@@ -27,6 +27,7 @@ public class StringToPrimitiveConversionCheckTest {
   @Test
   public void test() {
     JavaCheckVerifier.verify("src/test/files/checks/StringToPrimitiveConversionCheck.java", new StringToPrimitiveConversionCheck());
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/StringToPrimitiveConversionCheck.java", new StringToPrimitiveConversionCheck());
   }
 
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/UndocumentedApiCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UndocumentedApiCheckTest.java
@@ -20,11 +20,9 @@
 package org.sonar.java.checks;
 
 import org.junit.Test;
-import org.sonar.java.AnalysisException;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class UndocumentedApiCheckTest {
 
@@ -77,8 +75,7 @@ public class UndocumentedApiCheckTest {
   public void testInvalidDeclaredException() {
     UndocumentedApiCheck check = new UndocumentedApiCheck();
     check.forClasses = "";
-    assertThatExceptionOfType(AnalysisException.class).isThrownBy(() -> {
-      JavaCheckVerifier.verify("src/test/files/checks/UndocumentedApiCheck/UndocumentedApiInvalidException.java", check);
-    }).withCause(new IllegalStateException("Exceptions can not be specified other than with an identifier or a fully qualified name."));
+    JavaCheckVerifier.verifyNoIssue("src/test/files/checks/UndocumentedApiCheck/UndocumentedApiInvalidException.java", check);
   }
 }
+

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/JavadocTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/JavadocTest.java
@@ -46,6 +46,7 @@ public class JavadocTest {
   private static Javadoc fullParamsDescriptionJavadoc;
   private static Javadoc genericExceptionThrownJavadoc;
   private static Javadoc genericExceptionThrownUndocumented;
+  private static Javadoc invalidThrownExceptionUndocumented;
 
   @BeforeClass
   public static void setup() {
@@ -64,6 +65,7 @@ public class JavadocTest {
     fullParamsDescriptionJavadoc = new Javadoc(methods.get("fullParamsDescription"));
     genericExceptionThrownJavadoc = new Javadoc(methods.get("genericExceptionThrown"));
     genericExceptionThrownUndocumented = new Javadoc(methods.get("genericExceptionThrownUndocumented"));
+    invalidThrownExceptionUndocumented = new Javadoc(methods.get("invalidThrownExceptionUndocumented"));
 
     emptyJavadocs = methods.keySet().stream()
       .filter(name -> name.startsWith("emptyJavadoc"))
@@ -113,6 +115,7 @@ public class JavadocTest {
     assertThat(fullParamsDescriptionJavadoc.undocumentedThrownExceptions()).isEmpty();
     assertThat(genericExceptionThrownJavadoc.undocumentedThrownExceptions()).containsExactlyInAnyOrder("ObjectStreamException", "InvalidObjectException");
     assertThat(genericExceptionThrownUndocumented.undocumentedThrownExceptions()).containsExactlyInAnyOrder("Exception");
+    assertThat(invalidThrownExceptionUndocumented.undocumentedThrownExceptions()).isEmpty();
     assertThat(emptyJavadocs.stream().map(Javadoc::undocumentedThrownExceptions)).hasSize(6).allMatch(List::isEmpty);
   }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/unused/UnusedTestRuleCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/unused/UnusedTestRuleCheckTest.java
@@ -34,4 +34,9 @@ public class UnusedTestRuleCheckTest {
     JavaCheckVerifier.verify("src/test/files/checks/unused/UnusedTestRuleCheck_JUnit5.java", new UnusedTestRuleCheck());
   }
 
+  @Test
+  public void test_no_issues_without_semantic() {
+    JavaCheckVerifier.verifyNoIssueWithoutSemantic("src/test/files/checks/unused/UnusedTestRuleCheck_JUnit5.java", new UnusedTestRuleCheck());
+  }
+
 }


### PR DESCRIPTION
Verifies that playing all the checks on all the test files does not trigger any exceptions.

This relies on the fact that a lot of tricky cases are covered in unit tests, on a rule by rule and case by case basis.
It does not prevent other rules to fail if similar construct of the language, but not yet encountered. 