### PR TITLE
SONARJAVA-3134 Fix detection of silly String operations

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/SillyStringOperationsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SillyStringOperationsCheck.java
@@ -27,7 +27,6 @@ import javax.annotation.CheckForNull;
 
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.ConstantUtils;
-import org.sonar.java.checks.helpers.ExpressionsHelper;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
 import org.sonar.java.matcher.MethodMatcher;
 import org.sonar.java.matcher.TypeCriteria;
@@ -69,9 +68,6 @@ public class SillyStringOperationsCheck extends AbstractMethodDetection {
           .addParameter("int"),
         MethodMatcher.create().typeDefinition(STRING).name("matches")
           .addParameter(TypeCriteria.is(STRING)),
-        MethodMatcher.create().typeDefinition(STRING).name("replaceAll")
-          .addParameter(TypeCriteria.is(STRING))
-          .addParameter(TypeCriteria.is(STRING)),
         MethodMatcher.create().typeDefinition(STRING).name("replaceFirst")
           .addParameter(TypeCriteria.is(STRING))
           .addParameter(TypeCriteria.is(STRING)),
@@ -111,7 +107,6 @@ public class SillyStringOperationsCheck extends AbstractMethodDetection {
         case "startsWith":
           issue = checkStartsWith(str, args);
           break;
-        case "replaceAll":
         case "replaceFirst":
           issue = checkReplaceFirst(str, args);
           break;
@@ -182,6 +177,6 @@ public class SillyStringOperationsCheck extends AbstractMethodDetection {
 
   @CheckForNull
   private static String string(ExpressionTree tree) {
-    return ExpressionsHelper.getConstantValueAsString(tree).value();
+    return ConstantUtils.resolveAsStringConstant(tree);
   }
 }

--- a/java-checks/src/test/files/checks/SillyStringOperationsCheck.java
+++ b/java-checks/src/test/files/checks/SillyStringOperationsCheck.java
@@ -56,15 +56,6 @@ class A {
     str.startsWith(str);   // Noncompliant
     str.startsWith(other);
 
-    "".replaceAll("str", "");
-    "".replaceAll("", "str");     // Noncompliant {{Remove this "replaceAll" call; it has predictable results.}}
-    "".replaceAll("str", "str");  // Noncompliant
-    "".replaceAll(other, other);  // Noncompliant
-    "".replaceAll("str", "");
-    str.replaceAll(str, "str");   // Noncompliant
-    str.replaceAll("str", "str"); // Noncompliant
-    str.replaceAll(other, other); // Noncompliant
-
     "".replaceFirst("str", "");
     "".replaceFirst("", "str");     // Noncompliant {{Remove this "replaceFirst" call; it has predictable results.}}
     "".replaceFirst("str", "str");  // Noncompliant


### PR DESCRIPTION
* Avoid considering String#replaceAll:
  - Unwanted issues may be raised because of regular expressions.
* Fix resolution of String constant:
  - Use `ConstantUtils.resolveAsStringConstant` instead of `ExpressionsHelper.getConstantValueAsString`.