### PR TITLE
Execute 'Sanity' test independantly rather than during ruling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,14 @@ pipeline {
     }
     stage('QA') {
       parallel {
+        stage('sanity/linux') {
+          agent {
+            label 'linux'
+          }
+          steps {
+            runBuildWithProfile("sanity")
+          }
+        }
         stage('plugin/DOGFOOD/linux') {
           agent {
             label 'linux'
@@ -45,7 +53,6 @@ pipeline {
             label 'linux'
           }
           steps {
-            runBuildWithProfile("sanity")
             runITs("ruling", "LATEST_RELEASE[7.9]")
           }
         }
@@ -55,7 +62,6 @@ pipeline {
             label 'windows'
           }
           steps {
-            runBuildWithProfile("sanity")
             runITs("ruling", "LATEST_RELEASE[7.9]")
           }
         }
@@ -122,7 +128,6 @@ def runITs(TEST, SQ_VERSION) {
     }
   }
 }
-
 
 def runQAOS() {
   withMaven(maven: MAVEN_TOOL) {


### PR DESCRIPTION
This test executes (almost) all the rules against all the test
files writen to test each rule individually.
It makes little sense to execute this test during ruling. Wile
related to rules, it tests rule's ability to cover complex
constructs tested by other rules, rather than non-regression.