### PR TITLE
S1610 Autovalue builder support

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AbstractClassNoFieldShouldBeInterfaceCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AbstractClassNoFieldShouldBeInterfaceCheck.java
@@ -102,6 +102,6 @@ public class AbstractClassNoFieldShouldBeInterfaceCheck extends IssuableSubscrip
     return tree.modifiers().annotations().stream()
       .map(AnnotationTree::annotationType)
       .map(TypeTree::symbolType)
-      .noneMatch(type -> type.is("com.google.auto.value.AutoValue") || type.is("org.immutables.value.Value$Immutable"));
+      .noneMatch(type -> type.is("com.google.auto.value.AutoValue") || type.is("com.google.auto.value.AutoValue$Builder") || type.is("org.immutables.value.Value$Immutable"));
   }
 }

--- a/java-checks/src/test/files/checks/AbstractClassNoFieldShouldBeInterfaceCheck.java
+++ b/java-checks/src/test/files/checks/AbstractClassNoFieldShouldBeInterfaceCheck.java
@@ -62,6 +62,10 @@ abstract class Foo { // Compliant
     return new AutoValue_Foo(name);
   }
   abstract String name();
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder namer(String name);
+  }
 }
 
 @Value.Immutable


### PR DESCRIPTION
* Fix S1610 Autovalue support not taking @AutoValue.Builder
annotation into account and throws S1610 where it shouldn't

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
