### PR TITLE
Do not use fest-assert

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/DisallowedClassCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/DisallowedClassCheckTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.checks;
 
-import org.fest.assertions.Fail;
+import org.assertj.core.api.Fail;
 import org.junit.Test;
 import org.sonar.java.AnalysisException;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/ConstantUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/ConstantUtilsTest.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.java.checks.helpers.ConstantUtils.resolveAsIntConstant;
 
 public class ConstantUtilsTest {

--- a/java-frontend/src/test/java/org/sonar/java/bytecode/se/BytecodeEGWalkerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/bytecode/se/BytecodeEGWalkerTest.java
@@ -54,7 +54,7 @@ import org.sonar.java.se.xproc.MethodYield;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BytecodeEGWalkerTest {
 

--- a/java-frontend/src/test/java/org/sonar/java/bytecode/se/BytecodeSECheckTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/bytecode/se/BytecodeSECheckTest.java
@@ -46,7 +46,7 @@ import org.sonar.java.se.xproc.HappyPathYield;
 import org.sonar.java.se.xproc.MethodBehavior;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/java-frontend/src/test/java/org/sonar/java/resolve/ConstantTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/resolve/ConstantTest.java
@@ -33,7 +33,7 @@ import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConstantTest {
 

--- a/java-frontend/src/test/java/org/sonar/java/se/ExpectationsParserTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ExpectationsParserTest.java
@@ -21,7 +21,7 @@ package org.sonar.java.se;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.fest.assertions.Fail;
+import org.assertj.core.api.Fail;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.java.se.Expectations.IssueAttribute.END_COLUMN;
 import static org.sonar.java.se.Expectations.IssueAttribute.END_LINE;
 import static org.sonar.java.se.Expectations.IssueAttribute.FLOWS;
@@ -74,7 +74,7 @@ public class ExpectationsParserTest {
   public void invalid_attribute_name() {
     try {
       Expectations.Parser.parseIssue("// Noncompliant [[invalid]]", LINE);
-      Fail.fail();
+      Fail.fail("exception expected");
     } catch (AssertionError e) {
       assertThat(e).hasMessage("// Noncompliant attributes not valid: invalid");
     }
@@ -100,7 +100,7 @@ public class ExpectationsParserTest {
   public void end_line_attribute() {
     try {
       Expectations.Parser.parseIssue("// Noncompliant [[endLine=-1]] {{message}}", 0);
-      Fail.fail();
+      Fail.fail("exception expected");
     } catch (AssertionError e) {
       assertThat(e).hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
     }
@@ -153,7 +153,7 @@ public class ExpectationsParserTest {
   public void issue_and_flow_on_the_same_line() {
     Expectations.Parser.ParsedComment iaf = Expectations.Parser.parseIssue("// Noncompliant [[flows=id]] flow@id", LINE);
     assertThat(iaf.issue.get(Expectations.IssueAttribute.LINE)).isEqualTo(LINE);
-    assertThat((List<?>) iaf.issue.get(FLOWS)).contains("id");
+    assertThat((List) iaf.issue.get(FLOWS)).contains("id");
     assertThat(iaf.flows).hasSize(1);
     Expectations.FlowComment flow = iaf.flows.iterator().next();
     assertThat(flow.id).isEqualTo("id");

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,10 @@
         <artifactId>sslr-testing-harness</artifactId>
         <version>${sslr.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+          </exclusion>
           <!-- junit 4.12 depends on more recent hamcrest -->
           <exclusion>
             <artifactId>hamcrest-all</artifactId>


### PR DESCRIPTION
It was not supposed to be used after replacement on assertj
by commit 2e74eccc1be636c43092d96adb5b4825ac5812a2 (SONARJAVA-1970),
but again sneaked in, because was not excluded from dependencies.