### PR TITLE
Rule S1188: Add separate parameter for lambdas

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AnonymousClassesTooBigCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AnonymousClassesTooBigCheck.java
@@ -37,10 +37,15 @@ public class AnonymousClassesTooBigCheck extends BaseTreeVisitor implements Java
 
   private static final int DEFAULT_MAX = 20;
 
-  @RuleProperty(key = "Max",
-    description = "Maximum allowed lines in an anonymous class/lambda",
+  @RuleProperty(key = "Max (Anonymous Class)",
+    description = "Maximum allowed lines in an anonymous class",
     defaultValue = "" + DEFAULT_MAX)
-  public int max = DEFAULT_MAX;
+  public int maxAnonymousClass = DEFAULT_MAX;
+
+  @RuleProperty(key = "Max (Lambda)",
+    description = "Maximum allowed lines in a lambda",
+    defaultValue = "" + DEFAULT_MAX)
+  public int maxLambda = DEFAULT_MAX;
 
   private JavaFileScannerContext context;
   /**
@@ -59,9 +64,9 @@ public class AnonymousClassesTooBigCheck extends BaseTreeVisitor implements Java
   public void visitNewClass(NewClassTree tree) {
     if (tree.classBody() != null && !isEnumConstantBody) {
       int lines = getNumberOfLines(tree.classBody());
-      if (lines > max) {
+      if (lines > maxAnonymousClass) {
         context.reportIssue(this, tree.newKeyword(), tree.identifier(),
-          "Reduce this anonymous class number of lines from " + lines + " to at most " + max + ", or make it a named class.");
+          "Reduce this anonymous class number of lines from " + lines + " to at most " + maxAnonymousClass + ", or make it a named class.");
       }
     }
     isEnumConstantBody = false;
@@ -77,12 +82,12 @@ public class AnonymousClassesTooBigCheck extends BaseTreeVisitor implements Java
   @Override
   public void visitLambdaExpression(LambdaExpressionTree lambdaExpressionTree) {
     int lines = getNumberOfLines(lambdaExpressionTree);
-    if (lines > max) {
+    if (lines > maxLambda) {
       SyntaxToken firstToken = lambdaExpressionTree.firstToken();
       SyntaxToken lastSyntaxToken = lambdaExpressionTree.lastToken();
       JavaFileScannerContext.Location lastTokenLocation = new JavaFileScannerContext.Location(lines + " lines", lastSyntaxToken);
       context.reportIssue(this, firstToken, lambdaExpressionTree.arrowToken(),
-        "Reduce this lambda expression number of lines from " + lines + " to at most " + max + ".", Lists.newArrayList(lastTokenLocation), null);
+        "Reduce this lambda expression number of lines from " + lines + " to at most " + maxLambda + ".", Lists.newArrayList(lastTokenLocation), null);
     }
     super.visitLambdaExpression(lambdaExpressionTree);
   }

--- a/java-checks/src/test/files/checks/AnonymousClassesTooBigCheckCustom.java
+++ b/java-checks/src/test/files/checks/AnonymousClassesTooBigCheckCustom.java
@@ -42,7 +42,9 @@ class A {
     Callable<Integer> c0 = ()-> {
       return 1;
     };
-    Callable<Integer> c1 = ()-> { // Noncompliant [[sc=28;ec=32;secondary=52]] {{Reduce this lambda expression number of lines from 8 to at most 6.}}
+    Callable<Integer> c1 = ()-> { // Noncompliant [[sc=28;ec=32;secondary=54]] {{Reduce this lambda expression number of lines from 10 to at most 8.}}
+      System.out.println();
+      System.out.println();
       System.out.println();
       System.out.println();
       System.out.println();
@@ -52,13 +54,24 @@ class A {
     };
 
     Callable<Integer> c2 = ()-> 1 + 2;
-    Callable<Integer> c3 = ()-> 1 + 2+ // Noncompliant [[sc=28;ec=32;secondary=61]] {{Reduce this lambda expression number of lines from 7 to at most 6.}}
+    Callable<Integer> c3 = ()-> 1 + 2+ // Noncompliant [[sc=28;ec=32;secondary=65]] {{Reduce this lambda expression number of lines from 9 to at most 8.}}
         2 +
         3 * 4 +
         5+
         3+
         1+
+        2+
+        3+
         1;
+
+    Callable<Integer> c4 = () -> {
+      System.out.println();
+      System.out.println();
+      System.out.println();
+      System.out.println();
+      System.out.println();
+      return 1;
+    };
 
     Runnable r2 = () -> System.out.println("Hello world two!");
     

--- a/java-checks/src/test/java/org/sonar/java/checks/AnonymousClassesTooBigCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AnonymousClassesTooBigCheckTest.java
@@ -32,7 +32,8 @@ public class AnonymousClassesTooBigCheckTest {
   @Test
   public void custom() {
     AnonymousClassesTooBigCheck check = new AnonymousClassesTooBigCheck();
-    check.max = 6;
+    check.maxAnonymousClass = 6;
+    check.maxLambda = 8;
     JavaCheckVerifier.verify("src/test/files/checks/AnonymousClassesTooBigCheckCustom.java", check);
   }
 


### PR DESCRIPTION
The length of a body of a lambda expression and an anonymous class should be
treated differently: Anonymous classes may contain more than a single method
and should be permitted to have a longer body. Lambdas on the other hand
should be short and concise and thus require a different setting.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.

Post in Sonar Source Community: [S1188 should differentiate between lambdas and anonymous classes](https://community.sonarsource.com/t/java-s1188-should-differentiate-between-lambdas-and-anonymous-classes/7437)
