### PR TITLE
add assertj Java6 assertions

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
@@ -77,6 +77,7 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
     // AssertJ 2.X
     assertThatOnType("org.assertj.core.api.Assertions"),
     assertThatOnType("org.assertj.core.api.AbstractStandardSoftAssertions"),
+    assertThatOnType("org.assertj.core.api.Java6Assertions"),
     // AssertJ 3.X
     assertThatOnType("org.assertj.core.api.StrictAssertions"),
     // Truth 0.29

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertionsCompletenessCheck.java
@@ -78,6 +78,7 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
     assertThatOnType("org.assertj.core.api.Assertions"),
     assertThatOnType("org.assertj.core.api.AbstractStandardSoftAssertions"),
     assertThatOnType("org.assertj.core.api.Java6Assertions"),
+    assertThatOnType("org.assertj.core.api.Java6AbstractStandardSoftAssertions"),
     // AssertJ 3.X
     assertThatOnType("org.assertj.core.api.StrictAssertions"),
     // Truth 0.29


### PR DESCRIPTION
Java6Assertions operate the same way as Assertions

```
public class Java6Assertions
extends Object
Assertions compatible with Android. Duplicated from Assertions.

public class Java6AbstractStandardSoftAssertions
extends AbstractSoftAssertions
AbstractStandardSoftAssertions compatible with Android. Duplicated from AbstractStandardSoftAssertions.
```

ref:
 - http://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/Java6Assertions.html
 - http://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/Java6AbstractStandardSoftAssertions.html

Please ensure your pull request adheres to the following guidelines: 

- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)