### PR TITLE
Fix ClassCastException which could occur with new semantic

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -104,8 +104,10 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
       if (throwsNoSuchElementException(((Symbol.MethodSymbol) symbol).thrownTypes())) {
         return true;
       }
-      MethodJavaType methodJavaType = (MethodJavaType) ExpressionUtils.methodName(methodInvocationTree).symbolType();
-      return throwsNoSuchElementException(methodJavaType.thrownTypes());
+      Type methodType = ExpressionUtils.methodName(methodInvocationTree).symbolType();
+        // not covered with new semantic - thrown types from method symbol are already correct
+      return methodType instanceof MethodJavaType
+        && throwsNoSuchElementException(((MethodJavaType) methodType).thrownTypes());
     }
 
     private static boolean throwsNoSuchElementException(List<? extends Type> thrownTypes) {


### PR DESCRIPTION
For `ArrayForVarArgCheck` I duplicated the logic which was using the `MethodJavaType`. When dropping old semantic, we will be able to drop all this code and therefore get rid of the duplication.