### PR TITLE
SONARJAVA-3193: JUnit 5 Nested classes support for rule S3577

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -22,6 +22,7 @@ package org.sonar.java.checks.helpers;
 import java.util.HashSet;
 import java.util.Set;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 
 import static java.util.Arrays.asList;
@@ -35,8 +36,14 @@ public final class UnitTestUtils {
     "org.junit.jupiter.api.TestFactory",
     "org.junit.jupiter.api.TestTemplate",
     "org.junit.jupiter.params.ParameterizedTest"));
+  private static final String NESTED_ANNOTATION = "org.junit.jupiter.api.Nested";
 
   private UnitTestUtils() {
+  }
+
+  public static boolean hasNestedAnnotation(ClassTree tree) {
+    SymbolMetadata metadata = tree.symbol().metadata();
+    return metadata.isAnnotatedWith(NESTED_ANNOTATION);
   }
 
   public static boolean hasTestAnnotation(MethodTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/naming/BadTestClassNameCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/naming/BadTestClassNameCheck.java
@@ -68,8 +68,9 @@ public class BadTestClassNameCheck extends IssuableSubscriptionVisitor {
     }
     ClassTree classTree = (ClassTree) tree;
     IdentifierTree simpleName = classTree.simpleName();
-    if (hasInvalidName(simpleName) && hasTestMethod(classTree.members())) {
-      reportIssue(simpleName, "Rename class \"" + simpleName + "\" to match the regular expression: '" + format + "'");
+    if (hasInvalidName(simpleName) && isTestClass(classTree)) {
+      reportIssue(simpleName, "Rename class \"" + simpleName
+        + "\" to match the regular expression: '" + format + "'");
     }
   }
 
@@ -77,11 +78,28 @@ public class BadTestClassNameCheck extends IssuableSubscriptionVisitor {
     return className != null && !pattern.matcher(className.name()).matches();
   }
 
+  private boolean isTestClass(ClassTree classTree) {
+    return isTopLevelClass(classTree)
+      && (hasTestMethod(classTree.members()) || hasNestedClass(classTree));
+  }
+
+  private boolean isTopLevelClass(ClassTree classTree) {
+    return classTree.symbol().owner().isPackageSymbol();
+  }
+
   private static boolean hasTestMethod(List<Tree> members) {
     return members.stream()
       .filter(member -> member.is(Tree.Kind.METHOD))
       .map(MethodTree.class::cast)
       .anyMatch(UnitTestUtils::hasTestAnnotation);
+  }
+
+  private boolean hasNestedClass(ClassTree classTree) {
+    return classTree.members()
+      .stream()
+      .filter(member -> member.is(Tree.Kind.CLASS))
+      .map(ClassTree.class::cast)
+      .anyMatch(UnitTestUtils::hasNestedAnnotation);
   }
 
 }

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S3577_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/squid/S3577_java.html
@@ -1,14 +1,39 @@
 <p>Shared naming conventions allow teams to collaborate efficiently. This rule raises an issue when a test class name does not match the provided
 regular expression.</p>
+<p>Note that test class is only a top level class that contains a test annotated methods or nested annotated classes.</p>
 <h2>Noncompliant Code Example</h2>
 <p>With the default value: <code>^((Test|IT)[a-zA-Z0-9]+|[A-Z][a-zA-Z0-9]*(Test|IT|TestCase|ITCase))$</code></p>
 <pre>
 class Foo {  // Noncompliant
+  @Test
+  void check() {
+  }
+}
+
+class Bar {  // Noncompliant
+  @Nested
+  class PositiveCase {
+    @Test
+    void check() {
+    }
+  }
 }
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
 class FooTest {
+  @Test
+  void check() {
+  }
+}
+
+class BarIT {
+  @Nested
+  class PositiveCase {
+    @Test
+    void check() {
+    }
+  }
 }
 </pre>
 

--- a/java-checks/src/test/files/checks/naming/BadTestClassNameCheck.java
+++ b/java-checks/src/test/files/checks/naming/BadTestClassNameCheck.java
@@ -50,3 +50,19 @@ class JUnit5Noncompliant2 { // Noncompliant
   @org.junit.jupiter.api.RepeatedTest(2)
   void foo() {}
 }
+
+class JunitNestedTest {
+  @org.junit.jupiter.api.Nested
+  class Positive {
+    @org.junit.jupiter.api.Test
+    void foo() {}
+  }
+}
+
+class JunitNested { // Noncompliant
+  @org.junit.jupiter.api.Nested
+  class Negative {
+    @org.junit.jupiter.api.Test
+    void foo() {}
+  }
+}


### PR DESCRIPTION
Rule S3577 checks a name of the test to comply with naming scheme. It checks for a name if a class contains a test method. JUnit 5 introduced nested classes that should be excluded from this rule as they do not need to be searched by surefire/failsafe or other tests executors.

In this commit check has been changed to take account only top-level classes that contain tests and/or nested classes.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
