### PR TITLE
SONARJAVA-3229 NPE SimpleClassNameCheck(S1942) when IdentifierTree of "var" type has a null parent

### DIFF
--- a/java-checks/src/test/files/checks/SimpleClassNameCheck.java
+++ b/java-checks/src/test/files/checks/SimpleClassNameCheck.java
@@ -12,6 +12,7 @@ class A {
   foo.bar.A field; // Noncompliant
   ;
   void notWildcardImport() {
+    var r = new java.util.ArrayList<String>(); // Noncompliant
     com.google.common.collect.ImmutableList list;      // Noncompliant
     com.google.common.collect.ImmutableList.Builder<Object> builder =  // Noncompliant [[startColumn=5;endColumn=44]]
       com.google.common.collect.ImmutableList.builder(); // Noncompliant {{Replace this fully qualified name with "ImmutableList"}}

--- a/java-frontend/src/main/java/org/sonar/java/model/JParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JParser.java
@@ -2402,8 +2402,7 @@ public class JParser {
             ((Annotation) o)
           ));
         }
-        boolean isVarType = e.getName().getNodeType() == ASTNode.SIMPLE_NAME && "var".equals(e.getName().getFullyQualifiedName());
-        JavaTree.AnnotatedTypeTree t = isVarType ? convertVarType(e) : (JavaTree.AnnotatedTypeTree) convertExpression(e.getName());
+        JavaTree.AnnotatedTypeTree t = e.isVar() ? convertVarType(e) : (JavaTree.AnnotatedTypeTree) convertExpression(e.getName());
         t.complete(annotations);
         // typeBinding is assigned by convertVarType or convertExpression
         return t;

--- a/java-frontend/src/main/java/org/sonar/java/model/JParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JParser.java
@@ -1208,6 +1208,12 @@ public class JParser {
     }
   }
 
+  private VarTypeTreeImpl convertVarType(SimpleType simpleType) {
+    VarTypeTreeImpl varTree = new VarTypeTreeImpl(firstTokenIn(simpleType.getName(), TerminalTokens.TokenNameIdentifier));
+    varTree.typeBinding = simpleType.resolveBinding();
+    return varTree;
+  }
+
   private IdentifierTreeImpl convertSimpleName(SimpleName e) {
     IdentifierTreeImpl t = new IdentifierTreeImpl(
       firstTokenIn(e, TerminalTokens.TokenNameIdentifier)
@@ -2396,15 +2402,10 @@ public class JParser {
             ((Annotation) o)
           ));
         }
-        JavaTree.AnnotatedTypeTree t = (JavaTree.AnnotatedTypeTree) convertExpression(e.getName());
-        if (t instanceof IdentifierTree && ((IdentifierTree) t).name().equals("var")) {
-          // TODO can't be annotated?
-          VarTypeTreeImpl t2 = new VarTypeTreeImpl((InternalSyntaxToken) ((IdentifierTree) t).identifierToken());
-          t2.typeBinding = e.resolveBinding();
-          return t2;
-        }
+        boolean isVarType = e.getName().getNodeType() == ASTNode.SIMPLE_NAME && "var".equals(e.getName().getFullyQualifiedName());
+        JavaTree.AnnotatedTypeTree t = isVarType ? convertVarType(e) : (JavaTree.AnnotatedTypeTree) convertExpression(e.getName());
         t.complete(annotations);
-        // typeBinding is assigned by convertExpression
+        // typeBinding is assigned by convertVarType or convertExpression
         return t;
       }
       case ASTNode.UNION_TYPE: {

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/VarTypeTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/VarTypeTreeImpl.java
@@ -21,21 +21,26 @@ package org.sonar.java.model.expression;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.sonar.java.model.AbstractTypedTree;
 import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TreeVisitor;
 import org.sonar.plugins.java.api.tree.VarTypeTree;
 
-public class VarTypeTreeImpl extends AbstractTypedTree implements VarTypeTree {
+public class VarTypeTreeImpl extends AbstractTypedTree implements VarTypeTree, JavaTree.AnnotatedTypeTree {
 
   private final InternalSyntaxToken varToken;
+
+  private List<AnnotationTree> annotations;
 
   public VarTypeTreeImpl(InternalSyntaxToken varToken) {
     super(Tree.Kind.VAR_TYPE);
     this.varToken = varToken;
+    this.annotations =  Collections.emptyList();
   }
 
   @Override
@@ -60,7 +65,12 @@ public class VarTypeTreeImpl extends AbstractTypedTree implements VarTypeTree {
 
   @Override
   public List<AnnotationTree> annotations() {
-    return Collections.emptyList();
+    return annotations;
+  }
+
+  @Override
+  public void complete(List<AnnotationTree> annotations) {
+    this.annotations =  Objects.requireNonNull(annotations);
   }
 
 }


### PR DESCRIPTION
A temporary `IdentifierTreeImpl` was created before being converted into `VarTypeTreeImpl`.
But the `IdentifierTreeImpl`, which is not in the AST (null parent), was wrongly added to the binding usage (in `JParser#createExpression(Expression node)`) and could be retrieved by rules like in ` SimpleClassNameCheck`.