### PR TITLE
SONARJAVA-2939 S2093 throws IllegalStateException: 'continue' statement not in loop or switch statement

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/TryWithResourcesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TryWithResourcesCheck.java
@@ -80,7 +80,7 @@ public class TryWithResourcesCheck extends IssuableSubscriptionVisitor implement
     }
 
     if (blockParent != null) {
-      CFG cfg = CFG.buildCFG(Collections.singletonList(blockParent));
+      CFG cfg = CFG.buildCFG(Collections.singletonList(blockParent), true);
       if (!cfg.blocks().isEmpty()) {
         return newFollowedByTryStatement(cfg.blocks().get(0));
       }

--- a/java-checks/src/test/files/checks/TryWithResourcesCheck.java
+++ b/java-checks/src/test/files/checks/TryWithResourcesCheck.java
@@ -137,4 +137,15 @@ class A {
       a1.close();
     }
   }
+
+  void method_with_while_continue(boolean a) {
+    while (a) {
+      new java.io.BufferedInputStream(null, 4096);
+      try { // Noncompliant
+      } finally {
+        continue;
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
The rule uses the internal API "CFG.buildCFG" to create the cfg of none method tree that contains 'break' or 'continue' without the loop context.
