### PR TITLE
Remove useless declaration of dependency

### DIFF
--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -51,10 +51,6 @@
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-xml-parsing</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.sonarsource.analyzer-commons</groupId>
-      <artifactId>sonar-analyzer-test-commons</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Declaration of dependency on `sonar-analyzer-test-commons` in `java-checks` with a default scope `compile` seems useless, and leads to following warning during build

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.sonarsource.java:java-checks:jar:6.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.sonarsource.analyzer-commons:sonar-analyzer-test-commons:jar -> duplicate declaration of version (?) @ line 94, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
