### PR TITLE
Prevent double warning icons

### DIFF
--- a/sonar-java-plugin/src/main/resources/static/documentation.md
+++ b/sonar-java-plugin/src/main/resources/static/documentation.md
@@ -33,7 +33,7 @@ Key | Value
 `sonar.java.test.libraries` | Comma-separated paths to files with third-party libraries (JAR or Zip files) used by your tests. (For example, this should include the junit jar). Wildcards can be used: `sonar.java.test.libraries=directory/**/*.jar`
 
 [[warning]]
-| ![](/images/exclamation.svg) Android users, Jack doesn't provide the required `.class` files.
+| Android users, Jack doesn't provide the required `.class` files.
 
 
 ## Turning issues off


### PR DESCRIPTION
Currently, double warning icons show up in the public documentation. The `[[warning]]` block will automatically add these icons, they don't have to be added manually.

See [SONAR-12374](https://jira.sonarsource.com/browse/SONAR-12374)