### PR TITLE
S3331: compare cookie domain with public suffix

### DIFF
--- a/java-checks/src/test/files/checks/CookieDomainCheck.java
+++ b/java-checks/src/test/files/checks/CookieDomainCheck.java
@@ -3,14 +3,32 @@ import java.net.HttpCookie;
 class A {
  void foo() {
    Cookie myCookie = new Cookie("name", "val");
-   myCookie.setDomain(".com"); // Noncompliant [[sc=23;ec=29]] {{Specify at least a second-level cookie domain.}}
-   myCookie.setDomain(".myDomain.com"); // Compliant
+   myCookie.setDomain(".com"); // Noncompliant [[sc=23;ec=29]] {{Do not set cookies for 'com' as it is a public suffix.}}
+   myCookie.setDomain(".mydomain.com"); // Compliant
+
+   myCookie.setDomain(".co.uk"); // Noncompliant [[sc=23;ec=31]] {{Do not set cookies for 'co.uk' as it is a public suffix.}}
+   myCookie.setDomain(".taiki.hokkaido.jp"); // Noncompliant [[sc=23;ec=43]] {{Do not set cookies for 'taiki.hokkaido.jp' as it is a public suffix.}}
+   myCookie.setDomain(".github.io"); // Noncompliant [[sc=23;ec=35]] {{Do not set cookies for 'github.io' as it is a public suffix.}}
+   myCookie.setDomain(".javaee.github.io"); // Compliant
+
+   myCookie.setDomain(".unknowntosonar"); // Noncompliant [[sc=23;ec=40]] {{Specify at least a second-level cookie domain.}}
+   myCookie.setDomain(".mysite.unknowntosonar"); // Compliant
+
    myCookie.setDomain(""); // Compliant
  }
  void HttpCookie(String domain) {
    HttpCookie myCookie = new HttpCookie("name", "val");
    myCookie.setDomain(".com"); // Noncompliant
-   myCookie.setDomain(".myDomain.com"); // Compliant
+   myCookie.setDomain(".mydomain.com"); // Compliant
+
+   myCookie.setDomain(".co.uk"); // Noncompliant
+   myCookie.setDomain(".taiki.hokkaido.jp"); // Noncompliant
+   myCookie.setDomain(".github.io"); // Noncompliant
+   myCookie.setDomain(".javaee.github.io"); // Compliant
+
+   myCookie.setDomain(".unknowntosonar"); // Noncompliant
+   myCookie.setDomain(".mysite.unknowntosonar"); // Compliant
+
    myCookie.setDomain(domain); // Compliant
  }
 }


### PR DESCRIPTION
- Second-level domains are not guaranteed to be safe (e.g. ".co.uk"); check using public suffix list instead.
- Keep the "second level needed" check for unknown domains (new TLDs or intranet).

For background info, see the [Guava page for `InternetDomainName`](https://github.com/google/guava/wiki/InternetDomainNameExplained). Here is the key takeaway:

> You can use `InternetDomainName` (...) to determine what portion of a domain is likely to allow cookies to be set.
---
Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
