### PR TITLE
SONARJAVA-3271 - S2201: also cover Guava Optional

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/IgnoredReturnValueCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IgnoredReturnValueCheck.java
@@ -70,6 +70,7 @@ public class IgnoredReturnValueCheck extends IssuableSubscriptionVisitor {
       .add("java.math.BigInteger")
       .add("java.math.BigDecimal")
       .add("java.util.Optional")
+      .add("com.google.common.base.Optional")
       .build();
 
   private static final Set<String> EXCLUDED_PREFIX = ImmutableSet.of("parse", "format", "decode", "valueOf");

--- a/java-checks/src/test/files/checks/IgnoredReturnValueCheck.java
+++ b/java-checks/src/test/files/checks/IgnoredReturnValueCheck.java
@@ -53,8 +53,11 @@ class A {
     ZonedDateTime.now(); // Noncompliant
     BigInteger.valueOf(12L).add(BigInteger.valueOf(12563159)); // Noncompliant
     BigDecimal.valueOf(12L).add(BigDecimal.valueOf(12563159)); // Noncompliant
+
     Optional<String> o = Optional.empty();
-    o.map(o -> o.toString()); // Noncompliant
+    o.map(s -> s.toString()); // Noncompliant
+    com.google.common.base.Optional<String> o2 = Optional.absent();
+    o2.transform(s -> s.toString()); // Noncompliant
 
     String s = "s";
     s.intern(); // Compliant
@@ -77,7 +80,7 @@ class A {
       Integer.parseInt(textToCheck, 10); // Noncompliant
       textToCheck.getBytes(java.nio.charset.Charset.forName("UTF-8")); // Noncompliant
       return true;
-    }finally {
+    } finally {
       // do something
     }
   }


### PR DESCRIPTION
Like `java.util.Optional`, Guava's `com.google.common.base.Optional` is immutable: its instance methods don't have side effects and their return values therefore should not be ignored. The same is true for its static methods which either return the singleton absent instance, instantiate an optional or return a filtered stream.

---

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
