### PR TITLE
S4719: also cover Scanner & ByteArrayOutputStream

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
@@ -57,6 +57,7 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
   private static final String JAVA_IO_OUTPUTSTREAM = "java.io.OutputStream";
   private static final String JAVA_IO_OUTPUTSTREAMWRITER = "java.io.OutputStreamWriter";
   private static final String JAVA_IO_INPUTSTREAMREADER = "java.io.InputStreamReader";
+  private static final String JAVA_IO_BYTE_ARRAY_OUTPUT_STREAM = "java.io.ByteArrayOutputStream";
   private static final String JAVA_IO_WRITER = "java.io.Writer";
   private static final String JAVA_IO_READER = "java.io.Reader";
   private static final String JAVA_NIO_CHARSET = "java.nio.charset.Charset";
@@ -66,6 +67,7 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
   private static final String JAVA_LANG_STRINGBUFFER = "java.lang.StringBuffer";
   private static final String JAVA_LANG_CHARSEQUENCE = "java.lang.CharSequence";
   private static final String JAVA_UTIL_COLLECTION = "java.util.Collection";
+  private static final String JAVA_UTIL_SCANNER = "java.util.Scanner";
 
   private static final String COMMONS_CODEC_CHARSETS = "org.apache.commons.codec.Charsets";
   private static final String COMMONS_CODEC_HEX = "org.apache.commons.codec.binary.Hex";
@@ -121,8 +123,8 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
     Symbol symbol = identifierTree.symbol();
     if (symbol.isVariableSymbol() && symbol.owner().type().is("com.google.common.base.Charsets")) {
       String identifier = identifierTree.name();
-      String aliasedIdentigier = identifier.replace("_", "-");
-      if (STANDARD_CHARSETS.stream().anyMatch(c -> c.name().equals(aliasedIdentigier))) {
+      String aliasedIdentifier = identifier.replace("_", "-");
+      if (STANDARD_CHARSETS.stream().anyMatch(c -> c.name().equals(aliasedIdentifier))) {
         reportIssue(identifierTree, "Replace \"com.google.common.base.Charsets." + identifier + "\" with \"StandardCharsets." + identifier + "\".");
       }
     }
@@ -134,6 +136,7 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
       method(JAVA_NIO_CHARSET, "forName").parameters(JAVA_LANG_STRING),
       method(JAVA_LANG_STRING, "getBytes").parameters(JAVA_LANG_STRING),
       method(JAVA_LANG_STRING, "getBytes").parameters(JAVA_NIO_CHARSET),
+      method(JAVA_IO_BYTE_ARRAY_OUTPUT_STREAM, TO_STRING).parameters(JAVA_LANG_STRING),
       method(COMMONS_CODEC_CHARSETS, "toCharset").parameters(JAVA_LANG_STRING),
       method(COMMONS_IO_CHARSETS, "toCharset").parameters(JAVA_LANG_STRING),
       method(COMMONS_IO_FILEUTILS, "readFileToString").parameters(JAVA_IO_FILE, JAVA_LANG_STRING),
@@ -164,6 +167,8 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
       constructor(JAVA_LANG_STRING).parameters(BYTE_ARRAY, INT, INT, JAVA_LANG_STRING),
       constructor(JAVA_IO_INPUTSTREAMREADER).parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
       constructor(JAVA_IO_OUTPUTSTREAMWRITER).parameters(JAVA_IO_OUTPUTSTREAM, JAVA_LANG_STRING),
+      constructor(JAVA_UTIL_SCANNER).parameters(JAVA_IO_INPUTSTREAM, JAVA_LANG_STRING),
+      constructor(JAVA_UTIL_SCANNER).parameters(JAVA_IO_FILE, JAVA_LANG_STRING),
       constructor(COMMONS_IO_CHARSEQUENCEINPUTSTREAM).parameters(JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING),
       constructor(COMMONS_IO_CHARSEQUENCEINPUTSTREAM).parameters(JAVA_LANG_CHARSEQUENCE, JAVA_LANG_STRING, INT),
       constructor(COMMONS_IO_READERINPUTSTREAM).parameters(JAVA_IO_READER, JAVA_LANG_STRING),

--- a/java-checks/src/test/files/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/test/files/checks/StandardCharsetsConstantsCheck.java
@@ -1,3 +1,4 @@
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -10,6 +11,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Scanner;
 
 class A {
   private Charset charset;
@@ -72,8 +74,12 @@ class A {
     new String(bytes, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
     new String(bytes, offset, length, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
 
+    (new ByteArrayOutputStream()).toString("UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}} [[sc=44;ec=51]]
     new InputStreamReader(inputStream, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
     new OutputStreamWriter(outputStream, org.apache.commons.lang.CharEncoding.UTF_8); // Noncompliant
+
+    new Scanner(inputStream, "UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}} [[sc=30;ec=37]]
+    new Scanner(file, "UTF-8"); // Noncompliant {{Replace charset name argument with StandardCharsets.UTF_8}} [[sc=23;ec=30]]
 
     new org.apache.commons.codec.binary.Hex("UTF-8"); // Noncompliant
     new org.apache.commons.codec.net.QuotedPrintableCodec("UTF-8"); // Noncompliant


### PR DESCRIPTION
S4719 previously did not yet cover `Scanner` & `ByteArrayOutputStream` APIs. Most likely, they were overlooked because they throw an `IllegalArgumentException` instead of the usual `UnsupportedEncodingException`.

----

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)