### PR TITLE
Improve coverage for TriggeringSecuringHelper

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/JParserTestUtils.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/JParserTestUtils.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
-abstract class JParserTestUtils {
+public abstract class JParserTestUtils {
 
   static IdentifierTree variableFromLastReturnStatement(List<StatementTree> statements) {
     return (IdentifierTree) ((ReturnStatementTree) statements.get(statements.size() - 1)).expression();

--- a/java-checks/src/test/java/org/sonar/java/checks/security/TriggeringSecuringHelperTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/security/TriggeringSecuringHelperTest.java
@@ -1,0 +1,105 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.checks.security;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.sonar.java.checks.helpers.JParserTestUtils;
+import org.sonar.java.matcher.MethodMatcher;
+import org.sonar.java.model.declaration.ClassTreeImpl;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TriggeringSecuringHelperTest extends JParserTestUtils {
+
+  private final static MethodMatcher triggeringMethod = new MethodMatcher().typeDefinition("A").name("newInstance").withAnyParameters();
+
+  private TriggeringSecuringHelper simpleTriggeringSecuring = new TriggeringSecuringHelper(triggeringMethod) {
+
+    private final MethodMatcher securingMethod = new MethodMatcher().typeDefinition("A").name("securing").withAnyParameters();
+    private boolean isSecured = false;
+
+    @Override
+    public void resetState() {
+      isSecured = false;
+    }
+
+    @Override
+    public void processSecuringMethodInvocation(MethodInvocationTree mit) {
+      if (securingMethod.matches(mit)) {
+        isSecured = true;
+      }
+    }
+
+    @Override
+    public boolean isSecured() {
+      return isSecured;
+    }
+  };
+
+  @Test
+  public void test() {
+    CompilationUnitTree cut = parse(new File("src/test/resources/checks/security/TriggeringSecuringHelperTest.java"));
+    List<Tree> members = ((ClassTreeImpl) cut.types().get(1)).members();
+
+    // Field doesn't have enclosing method
+    assertFalse(containsUnsecuredTrigger(members.get(0)));
+
+    assertFalse(containsUnsecuredTrigger(members.get(1)));
+    assertFalse(containsUnsecuredTrigger(members.get(2)));
+    assertTrue(containsUnsecuredTrigger(members.get(3)));
+    assertTrue(containsUnsecuredTrigger(members.get(4)));
+    assertFalse(containsUnsecuredTrigger(members.get(5)));
+    assertTrue(containsUnsecuredTrigger(members.get(6)));
+  }
+
+  private boolean containsUnsecuredTrigger(Tree method) {
+    FindMethodInvocation methodInvocation = new FindMethodInvocation();
+    method.accept(methodInvocation);
+    for (MethodInvocationTree mit: methodInvocation.methodInvocationTrees) {
+      if (simpleTriggeringSecuring.test(mit)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static class FindMethodInvocation extends BaseTreeVisitor {
+    private List<MethodInvocationTree> methodInvocationTrees = new ArrayList<>();
+
+    @Override
+    public void visitMethodInvocation(MethodInvocationTree tree) {
+      methodInvocationTrees.add(tree);
+      super.visitMethodInvocation(tree);
+    }
+  }
+
+
+
+
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/security/TriggeringSecuringHelperTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/security/TriggeringSecuringHelperTest.java
@@ -34,7 +34,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TriggeringSecuringHelperTest extends JParserTestUtils {
+public class TriggeringSecuringHelperTest {
 
   private final static MethodMatcher triggeringMethod = new MethodMatcher().typeDefinition("A").name("newInstance").withAnyParameters();
 
@@ -63,7 +63,7 @@ public class TriggeringSecuringHelperTest extends JParserTestUtils {
 
   @Test
   public void test() {
-    CompilationUnitTree cut = parse(new File("src/test/resources/checks/security/TriggeringSecuringHelperTest.java"));
+    CompilationUnitTree cut = JParserTestUtils.parse(new File("src/test/resources/checks/security/TriggeringSecuringHelperTest.java"));
     List<Tree> members = ((ClassTreeImpl) cut.types().get(1)).members();
 
     // Field doesn't have enclosing method

--- a/java-checks/src/test/resources/checks/security/TriggeringSecuringHelperTest.java
+++ b/java-checks/src/test/resources/checks/security/TriggeringSecuringHelperTest.java
@@ -1,0 +1,48 @@
+class A {
+  static A newInstance() {
+    return new A();
+  }
+
+  void securing() {
+  }
+
+  void other() {
+  }
+}
+
+class B {
+  A a_0 = A.newInstance();
+
+  void securing_1() {
+    A a = A.newInstance();
+    a.securing();
+  }
+
+  void nothing_to_secure_2() {
+    int i = 1;
+    i++;
+  }
+
+  void unsecured_3() {
+    A a = A.newInstance();
+  }
+
+  void unsecured_4() {
+    A a = A.newInstance();
+    a.other();
+  }
+
+  void not_assigned_triggering_call_5() {
+    A.newInstance();
+  }
+
+  void not_correct_securing_6() {
+    A a = A.newInstance();
+    other();
+  }
+
+  void other() {
+  }
+
+  ;
+}


### PR DESCRIPTION
TriggeringSecuringHelper is currently partially used, but we expect it to be useful when we will tackle SONARJAVA-3296.
