### PR TITLE
SONARJAVA-3312 FN for S2755: improve detection of XXE attacks

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/se/checks/XxeProcessingCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/XxeProcessingCheck.java
@@ -306,7 +306,7 @@ public class XxeProcessingCheck extends SECheck {
 
       if (TRANSFERRING_METHOD_CALLS.anyMatch(mit)) {
         // transfer same SV to the result of the method invocation.
-        constraintManager.setValueFactory(() -> programState.peekValue());
+        constraintManager.setValueFactory(() -> programState.peekValue(mit.arguments().size()));
       } else if (FEATURES_AND_PROPERTIES_SETTERS.anyMatch(mit)) {
         // check secured by attribute or feature
         Arguments arguments = mit.arguments();

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/XxeProperty.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/XxeProperty.java
@@ -34,12 +34,16 @@ public interface XxeProperty {
 
   XxePropertyHolder properties();
 
-  default String propertyName() {
-    return properties().propertyName;
+  default boolean isNamed(String name) {
+    return properties().propertyName.equals(name);
   }
 
   default Constraint securedConstraint() {
     return properties().secured;
+  }
+
+  default Constraint namedConstraint() {
+    return properties().named;
   }
 
   default boolean isSecuring(@Nullable SymbolicValue sv1, ExpressionTree arg1) {
@@ -81,10 +85,13 @@ public interface XxeProperty {
     private final BiPredicate<SymbolicValue, ExpressionTree> unsecuring;
     private final Constraint unsecured;
 
-    public XxePropertyHolder(String propertyName,
+    private final Constraint named;
+
+    public XxePropertyHolder(String propertyName, Constraint named,
       BiPredicate<SymbolicValue, ExpressionTree> securing, Constraint secured,
       BiPredicate<SymbolicValue, ExpressionTree> unsecuring, Constraint unsecured) {
       this.propertyName = propertyName;
+      this.named = named;
       this.securing = securing;
       this.secured = secured;
       this.unsecuring = unsecuring;
@@ -93,10 +100,10 @@ public interface XxeProperty {
   }
 
   enum AttributeDTD implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "http://javax.xml.XMLConstants/property/accessExternalDTD",
+      "http://javax.xml.XMLConstants/property/accessExternalDTD", NAMED,
       XxeProperty::isSetToEmptyString, SECURED,
       XxeProperty::isSetToNonEmptyString, UNSECURED);
 
@@ -112,10 +119,10 @@ public interface XxeProperty {
   }
 
   enum AttributeSchema implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "http://javax.xml.XMLConstants/property/accessExternalSchema",
+      "http://javax.xml.XMLConstants/property/accessExternalSchema", NAMED,
       XxeProperty::isSetToEmptyString, SECURED,
       XxeProperty::isSetToNonEmptyString, UNSECURED);
 
@@ -131,10 +138,10 @@ public interface XxeProperty {
   }
 
   enum AttributeStyleSheet implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "http://javax.xml.XMLConstants/property/accessExternalStylesheet",
+      "http://javax.xml.XMLConstants/property/accessExternalStylesheet", NAMED,
       XxeProperty::isSetToEmptyString, SECURED,
       XxeProperty::isSetToNonEmptyString, UNSECURED);
 
@@ -150,10 +157,10 @@ public interface XxeProperty {
   }
 
   enum FeatureSupportDtd implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "javax.xml.stream.supportDTD",
+      "javax.xml.stream.supportDTD", NAMED,
       XxeProperty::isSetToFalse, SECURED,
       XxeProperty::isSetToTrue, UNSECURED);
 
@@ -164,10 +171,10 @@ public interface XxeProperty {
   }
 
   enum FeatureIsSupportingExternalEntities implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "javax.xml.stream.isSupportingExternalEntities",
+      "javax.xml.stream.isSupportingExternalEntities", NAMED,
       XxeProperty::isSetToFalse, SECURED,
       XxeProperty::isSetToTrue, UNSECURED);
 
@@ -178,10 +185,10 @@ public interface XxeProperty {
   }
 
   enum FeatureDisallowDoctypeDecl implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "http://apache.org/xml/features/disallow-doctype-decl",
+      "http://apache.org/xml/features/disallow-doctype-decl", NAMED,
       XxeProperty::isSetToTrue, SECURED,
       XxeProperty::isSetToFalse, UNSECURED);
 
@@ -192,10 +199,10 @@ public interface XxeProperty {
   }
 
   enum FeatureLoadExternalDtd implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "http://apache.org/xml/features/nonvalidating/load-external-dtd",
+      "http://apache.org/xml/features/nonvalidating/load-external-dtd", NAMED,
       XxeProperty::isSetToFalse, SECURED,
       XxeProperty::isSetToTrue, UNSECURED);
 
@@ -206,10 +213,10 @@ public interface XxeProperty {
   }
 
   enum FeatureExternalGeneralEntities implements Constraint, XxeProperty {
-    UNSECURED, SECURED;
+    UNSECURED, SECURED, NAMED;
 
     private static final XxePropertyHolder PROPERTIES = new XxePropertyHolder(
-      "http://xml.org/sax/features/external-general-entities",
+      "http://xml.org/sax/features/external-general-entities", NAMED,
       XxeProperty::isSetToFalse, SECURED,
       XxeProperty::isSetToTrue, UNSECURED);
 

--- a/java-frontend/src/test/files/se/XxeProcessingCheck_SchemaFactory_Validator.java
+++ b/java-frontend/src/test/files/se/XxeProcessingCheck_SchemaFactory_Validator.java
@@ -18,6 +18,14 @@ class SchemaFactory_Validator {
     return validator;
   }
 
+  Validator new_schema_with_argument () throws SAXException  {
+    SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI); // Noncompliant
+    StreamSource xsdStreamSource = new StreamSource("xxe.xsd");
+    Schema schema = schemaFactory.newSchema(xsdStreamSource);
+    Validator validator = schema.newValidator();
+    return validator;
+  }
+
   // Securing at validator level
   Validator withAccessExternalDtdAndExternalSchema_validator() throws SAXException  {
     SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI); // Compliant

--- a/java-frontend/src/test/files/se/XxeProcessingCheck_XmlInputFactory.java
+++ b/java-frontend/src/test/files/se/XxeProcessingCheck_XmlInputFactory.java
@@ -40,6 +40,80 @@ class XMLInputFactoryTest {
     return factory;
   }
 
+  XMLInputFactory dtd_from_local_declaration_false() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    String value = XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES;
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_declaration_false() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Noncompliant
+    String value = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_declaration_false() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    boolean b = false;
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, b);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_declaration_false() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    String value = "javax.xml.stream.supportDTD";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_declaration_false_1() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    String value1 = "javax.xml.stream.supportDTD";
+    String value2 = value1;
+    factory.setProperty(value2, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_declaration_false_2() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Noncompliant
+    String value = "other.xml";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_assign_false() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    String value = null;
+    value = "javax.xml.stream.supportDTD";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_assign_false_2() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    String value;
+    value = "javax.xml.stream.supportDTD";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_assign_false_3() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Compliant
+    String value = "something else";
+    value = "javax.xml.stream.supportDTD";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
+  XMLInputFactory dtd_from_local_assign_false_4() {
+    XMLInputFactory factory = XMLInputFactory.newInstance(); // Noncompliant
+    String value = "something else";
+    factory.setProperty(value, false);
+    return factory;
+  }
+
   XMLInputFactory dtd_with_primitive_false2() {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);


### PR DESCRIPTION
S2755 implementation failed to detect two cases:

- When "transferring" method call are used with any number of argument.
- When the property is set from a variable.