### PR TITLE
SONARJAVA-2549 Improve S2293 to handle cases where constructor is used in argument

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_java_7.java
+++ b/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_java_7.java
@@ -1,11 +1,12 @@
+package checks;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
-class A {
+class DiamondOperatorCheck_java_7 {
   List<Object> myList1 = new ArrayList<>(); // Compliant
   List<Object> myList2 = new ArrayList<Object>(); // Noncompliant [[sc=39;ec=47]] {{Replace the type specification in this constructor call with the diamond operator ("<>").}}
 
@@ -20,8 +21,8 @@ class A {
     Map<String,List<Integer>> map2 = new HashMap<String,List<Integer>>(); // Noncompliant [[sc=49;ec=71]]
 
     List myOtherList = new ArrayList<Object>(); // Compliant
-    new A().myList1 = new ArrayList<>(); // Compliant
-    new A().myList1 = new ArrayList<Object>(); // Noncompliant [[sc=36;ec=44]]
+    new DiamondOperatorCheck_java_7().myList1 = new ArrayList<>(); // Compliant
+    new DiamondOperatorCheck_java_7().myList1 = new ArrayList<Object>(); // Noncompliant [[sc=62;ec=70]]
 
     List<Object>[] myArrayOfList = new List[10];
     myArrayOfList[0] = new ArrayList<>(); // Compliant
@@ -33,9 +34,9 @@ class A {
     ((List<Object>) new ArrayList<>()).isEmpty(); // Compliant
 
     Iterator<Object> iterator = new Iterator<Object>() { // Compliant - anonymous classes requires to be typed
+      @Override public Object next() { return null; }
+      @Override public boolean hasNext() { return false; }
     };
-
-    MyUnknownVariable = new ArrayList<Object>(); // Compliant
 
     Object data = new List[10];
     ((List[])data)[2] = new ArrayList<String>();
@@ -44,30 +45,12 @@ class A {
   List<Object> qix(boolean test) {
     List<Object> myList = test ?
       new ArrayList<>() : // Compliant
-        new ArrayList<Object>(); // Noncompliant [[sc=22;ec=30]]
-    
+        new ArrayList<Object>(); // Compliant - using diamond operator only works with java 8
+
     myList = new ArrayList<>(test ? new ArrayList<>() : new ArrayList<Object>(5)); // Compliant
     if (test) {
       return new ArrayList<>(); // Compliant
     }
     return new ArrayList<Object>(); // Noncompliant [[sc=25;ec=33]]
   }
-
-  public void assignmentOnMethodInvocation() {
-    this.bar()[0] = new GenericClass<String, Integer, Integer>();
-  }
-
-  public MyInterface[] bar() {
-    return new MyInterface[1];
-  }
-
-  interface MyInterface { }
-  static class GenericClass<X, Y, Z> implements MyInterface { }
-}
-
-enum SonarProblemCase {
-  MY_BUCKET(rp -> { return new ArrayList<Integer>(); }),
-  MY_BUCKET2(rp -> new ArrayList<Integer>());
-
-  SonarProblemCase(Function<Object, Object> bucketer) {}
 }

--- a/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_java_8.java
+++ b/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_java_8.java
@@ -1,12 +1,15 @@
+package checks;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
-class A {
+class DiamondOperatorCheck_java_8 {
   List<Object> myList1 = new ArrayList<>(); // Compliant
-  List<Object> myList2 = new ArrayList<Object>(); // Noncompliant [[sc=39;ec=47]] {{Replace the type specification in this constructor call with the diamond operator ("<>"). (sonar.java.source not set. Assuming 7 or greater.)}}
+  List<Object> myList2 = new ArrayList<Object>(); // Noncompliant [[sc=39;ec=47]] {{Replace the type specification in this constructor call with the diamond operator ("<>").}}
 
   void foo() {
     List<Object> myList;
@@ -19,8 +22,8 @@ class A {
     Map<String,List<Integer>> map2 = new HashMap<String,List<Integer>>(); // Noncompliant [[sc=49;ec=71]]
 
     List myOtherList = new ArrayList<Object>(); // Compliant
-    new A().myList1 = new ArrayList<>(); // Compliant
-    new A().myList1 = new ArrayList<Object>(); // Noncompliant [[sc=36;ec=44]]
+    new DiamondOperatorCheck_java_8().myList1 = new ArrayList<>(); // Compliant
+    new DiamondOperatorCheck_java_8().myList1 = new ArrayList<Object>(); // Noncompliant [[sc=62;ec=70]]
 
     List<Object>[] myArrayOfList = new List[10];
     myArrayOfList[0] = new ArrayList<>(); // Compliant
@@ -32,9 +35,9 @@ class A {
     ((List<Object>) new ArrayList<>()).isEmpty(); // Compliant
 
     Iterator<Object> iterator = new Iterator<Object>() { // Compliant - anonymous classes requires to be typed
+      @Override public Object next() { return null; }
+      @Override public boolean hasNext() { return false; }
     };
-
-    MyUnknownVariable = new ArrayList<Object>(); // Compliant
 
     Object data = new List[10];
     ((List[])data)[2] = new ArrayList<String>();
@@ -44,11 +47,29 @@ class A {
     List<Object> myList = test ?
       new ArrayList<>() : // Compliant
         new ArrayList<Object>(); // Noncompliant [[sc=22;ec=30]]
-    
+
     myList = new ArrayList<>(test ? new ArrayList<>() : new ArrayList<Object>(5)); // Compliant
     if (test) {
       return new ArrayList<>(); // Compliant
     }
     return new ArrayList<Object>(); // Noncompliant [[sc=25;ec=33]]
   }
+
+  public void assignmentOnMethodInvocation() {
+    this.bar()[0] = new GenericClass<String, Integer, Integer>();
+  }
+
+  public MyInterface[] bar() {
+    return new MyInterface[1];
+  }
+
+  interface MyInterface { }
+  static class GenericClass<X, Y, Z> implements MyInterface { }
+}
+
+enum SonarProblemCase {
+  MY_BUCKET(rp -> { return new ArrayList<Integer>(); }),
+  MY_BUCKET2(rp -> new ArrayList<Integer>());
+
+  SonarProblemCase(Function<Object, Object> bucketer) {}
 }

--- a/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_java_8.java
+++ b/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_java_8.java
@@ -1,6 +1,7 @@
 package checks;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -65,6 +66,31 @@ class DiamondOperatorCheck_java_8 {
 
   interface MyInterface { }
   static class GenericClass<X, Y, Z> implements MyInterface { }
+
+  static class A<X> {
+
+    public A(X x) { }
+
+    public void tst() {
+      bar(0, new ArrayList<String>()); // Noncompliant [[sc=27;ec=35]]
+      foo(0, new ArrayList<String>()); // Compliant
+      qix(new ArrayList<String>()); // Compliant
+      gul(new ArrayList<String>()); // Compliant
+
+      A<List<String>> als =
+        new A<List<String>>( // Noncompliant [[sc=14;ec=28]]
+          new ArrayList<String>()); // Noncompliant [[sc=24;ec=32]]
+
+      List<String> values = Arrays.asList("Stop", "pointing", "fingers", "steve");
+      new ArrayList<String>(values); // FN - based on type inference
+      new ArrayList<>(values);
+    }
+
+    static void bar(int i, List<String> strings) {}
+    static void foo(Object... objects) {}
+    static void qix(Object o) {}
+    static <T> void gul(T t) {}
+  }
 }
 
 enum SonarProblemCase {

--- a/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_no_version.java
+++ b/java-checks-test-sources/src/main/java/checks/DiamondOperatorCheck_no_version.java
@@ -1,12 +1,14 @@
+package checks;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-class A {
+class DiamonOperatorCheck_no_version {
   List<Object> myList1 = new ArrayList<>(); // Compliant
-  List<Object> myList2 = new ArrayList<Object>(); // Noncompliant [[sc=39;ec=47]] {{Replace the type specification in this constructor call with the diamond operator ("<>").}}
+  List<Object> myList2 = new ArrayList<Object>(); // Noncompliant [[sc=39;ec=47]] {{Replace the type specification in this constructor call with the diamond operator ("<>"). (sonar.java.source not set. Assuming 7 or greater.)}}
 
   void foo() {
     List<Object> myList;
@@ -19,8 +21,8 @@ class A {
     Map<String,List<Integer>> map2 = new HashMap<String,List<Integer>>(); // Noncompliant [[sc=49;ec=71]]
 
     List myOtherList = new ArrayList<Object>(); // Compliant
-    new A().myList1 = new ArrayList<>(); // Compliant
-    new A().myList1 = new ArrayList<Object>(); // Noncompliant [[sc=36;ec=44]]
+    new DiamonOperatorCheck_no_version().myList1 = new ArrayList<>(); // Compliant
+    new DiamonOperatorCheck_no_version().myList1 = new ArrayList<Object>(); // Noncompliant [[sc=65;ec=73]]
 
     List<Object>[] myArrayOfList = new List[10];
     myArrayOfList[0] = new ArrayList<>(); // Compliant
@@ -32,9 +34,9 @@ class A {
     ((List<Object>) new ArrayList<>()).isEmpty(); // Compliant
 
     Iterator<Object> iterator = new Iterator<Object>() { // Compliant - anonymous classes requires to be typed
+      @Override public Object next() { return null; }
+      @Override public boolean hasNext() { return false; }
     };
-
-    MyUnknownVariable = new ArrayList<Object>(); // Compliant
 
     Object data = new List[10];
     ((List[])data)[2] = new ArrayList<String>();
@@ -43,8 +45,8 @@ class A {
   List<Object> qix(boolean test) {
     List<Object> myList = test ?
       new ArrayList<>() : // Compliant
-        new ArrayList<Object>(); // Compliant - using diamond operator only works with java 8
-    
+        new ArrayList<Object>(); // Noncompliant [[sc=22;ec=30]]
+
     myList = new ArrayList<>(test ? new ArrayList<>() : new ArrayList<Object>(5)); // Compliant
     if (test) {
       return new ArrayList<>(); // Compliant

--- a/java-checks/src/test/java/org/sonar/java/checks/DiamondOperatorCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/DiamondOperatorCheckTest.java
@@ -22,30 +22,32 @@ package org.sonar.java.checks;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
-public class DiamondOperatorCheckTest {
+import static org.sonar.java.CheckTestUtils.testSourcesPath;
+
+class DiamondOperatorCheckTest {
 
   @Test
-  public void test_no_version() {
+  void test_no_version() {
     JavaCheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/DiamondOperatorCheck_no_version.java")
+      .onFile(testSourcesPath("checks/DiamondOperatorCheck_no_version.java"))
       .withCheck(new DiamondOperatorCheck())
       .verifyIssues();
   }
 
   @Test
-  public void test_with_java_7() {
+  void test_with_java_7() {
     JavaCheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/DiamondOperatorCheck_java_7.java")
+      .onFile(testSourcesPath("checks/DiamondOperatorCheck_java_7.java"))
       .withCheck(new DiamondOperatorCheck())
       .withJavaVersion(7)
       .verifyIssues();
   }
 
   @Test
-  public void test_with_java_8() {
+  void test_with_java_8() {
     // take into account ternary operators
     JavaCheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/DiamondOperatorCheck_java_8.java")
+      .onFile(testSourcesPath("checks/DiamondOperatorCheck_java_8.java"))
       .withCheck(new DiamondOperatorCheck())
       .withJavaVersion(8)
       .verifyIssues();


### PR DESCRIPTION
It does not handle all the cases, as it's not triggered when the diamond could be removed thanks to type inferences on provided parameters, but to me it's not really the same ticket. I anyway added a case, flagged as FN.

Please **do not** squash the commits