### PR TITLE
SONARJAVA-2944 S4970: don't report issue for Exception

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/UnreachableCatchCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/UnreachableCatchCheck.java
@@ -34,7 +34,7 @@ public class UnreachableCatchCheck {
       throwIOException();
     } catch (IOException e) {
       // ...
-    } catch (Exception e) { // Noncompliant
+    } catch (Exception e) { // Compliant, also catch runtime exception
       // ...
     }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/UnreachableCatchCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UnreachableCatchCheck.java
@@ -122,6 +122,7 @@ public class UnreachableCatchCheck extends IssuableSubscriptionVisitor {
   private static boolean isChecked(Type type) {
     return !type.isSubtypeOf("java.lang.RuntimeException")
       && !type.isSubtypeOf("java.lang.Error")
+      && !type.is("java.lang.Exception")
       && !type.is("java.lang.Throwable");
   }
 


### PR DESCRIPTION
Exception can also be a runtime exception, we should not report an issue for them.