### PR TITLE
Fix typo in S2232_java.html

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2232_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2232_java.html
@@ -12,7 +12,7 @@ while (! rs.isLast()) { // Noncompliant
 <h2>Compliant Solution</h2>
 <pre>
 ResultSet rs = stmt.executeQuery("SELECT name, address FROM PERSON");
-while (! rs.next()) {
+while (rs.next()) {
   // process row
 }
 </pre>


### PR DESCRIPTION
Compliant solution in documentation of S2232 is using wrong invariant for while-loop as condition-negation was apparently carried over unchanged from the non-compliant example.
