### PR TITLE
Refactoring to avoid duplicated code for flags and error handling

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/regex/AnchorPrecedenceCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/AnchorPrecedenceCheck.java
@@ -36,9 +36,7 @@ public class AnchorPrecedenceCheck extends AbstractRegexCheck {
 
   @Override
   public void checkRegex(RegexParseResult regexForLiterals, MethodInvocationTree mit) {
-    if (!regexForLiterals.hasSyntaxErrors()) {
-      new Visitor().visit(regexForLiterals.getResult());
-    }
+    new Visitor().visit(regexForLiterals);
   }
 
   private enum Position {
@@ -46,6 +44,7 @@ public class AnchorPrecedenceCheck extends AbstractRegexCheck {
   }
 
   private class Visitor extends RegexBaseVisitor {
+
     @Override
     public void visitDisjunction(DisjunctionTree tree) {
       List<RegexTree> alternatives = tree.getAlternatives();

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/DuplicatesInCharacterClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/DuplicatesInCharacterClassCheck.java
@@ -42,11 +42,7 @@ public class DuplicatesInCharacterClassCheck extends AbstractRegexCheck {
 
   @Override
   public void checkRegex(RegexParseResult regexForLiterals, MethodInvocationTree mit) {
-    if (!regexForLiterals.hasSyntaxErrors()) {
-      DuplicateFinder duplicateFinder = new DuplicateFinder();
-      duplicateFinder.setActiveFlags(getFlags(mit));
-      duplicateFinder.visit(regexForLiterals.getResult());
-    }
+    new DuplicateFinder().visit(regexForLiterals);
   }
 
   private class DuplicateFinder extends RegexBaseVisitor {

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/RedosCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/RedosCheck.java
@@ -39,17 +39,10 @@ public class RedosCheck extends AbstractRegexCheck {
 
   @Override
   public void checkRegex(RegexParseResult regexForLiterals, MethodInvocationTree mit) {
-    if (!regexForLiterals.hasSyntaxErrors()) {
-      RegexTree regex = regexForLiterals.getResult();
-      NestedRepetitionsFinder visitor = new NestedRepetitionsFinder();
-      visitor.visit(regex);
-      if (!visitor.offendingRepetitions.isEmpty()) {
-        reportIssue(regex, MESSAGE, null, visitor.offendingRepetitions);
-      }
-    }
+    new NestedRepetitionsFinder().visit(regexForLiterals);
   }
 
-  private static class NestedRepetitionsFinder extends RegexBaseVisitor {
+  private class NestedRepetitionsFinder extends RegexBaseVisitor {
 
     private boolean isInsideRepetition = false;
 
@@ -83,6 +76,12 @@ public class RedosCheck extends AbstractRegexCheck {
       isInsideRepetition = oldIsInsideRepetition;
     }
 
+    @Override
+    protected void after(RegexParseResult regexParseResult) {
+      if (!offendingRepetitions.isEmpty()) {
+        reportIssue(regexParseResult.getResult(), MESSAGE, null, offendingRepetitions);
+      }
+    }
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/DefaultJavaFileScannerContext.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/DefaultJavaFileScannerContext.java
@@ -37,6 +37,7 @@ import org.sonar.java.regex.RegexCache;
 import org.sonar.java.regex.RegexCheck;
 import org.sonar.java.regex.RegexParseResult;
 import org.sonar.java.regex.RegexScannerContext;
+import org.sonar.java.regex.ast.FlagSet;
 import org.sonar.java.regex.ast.RegexSyntaxElement;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
@@ -151,8 +152,8 @@ public class DefaultJavaFileScannerContext implements JavaFileScannerContext, Re
   }
 
   @Override
-  public RegexParseResult regexForLiterals(boolean freeSpacingMode, LiteralTree... stringLiterals) {
-    return regexCache.getRegexForLiterals(freeSpacingMode, stringLiterals);
+  public RegexParseResult regexForLiterals(FlagSet initialFlags, LiteralTree... stringLiterals) {
+    return regexCache.getRegexForLiterals(initialFlags, stringLiterals);
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/regex/RegexCache.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/RegexCache.java
@@ -23,15 +23,17 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.sonar.java.regex.ast.FlagSet;
 import org.sonar.java.regex.ast.RegexSource;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 
 public final class RegexCache {
   private final Map<List<LiteralTree>, RegexParseResult> cache = new HashMap<>();
 
-  public RegexParseResult getRegexForLiterals(boolean freeSpacingMode, LiteralTree... stringLiterals) {
+  public RegexParseResult getRegexForLiterals(FlagSet initialFlags, LiteralTree... stringLiterals) {
     return cache.computeIfAbsent(
       Arrays.asList(stringLiterals),
-      k -> new RegexParser(new RegexSource(k), freeSpacingMode).parse());
+      k -> new RegexParser(new RegexSource(k), initialFlags).parse());
   }
+
 }

--- a/java-frontend/src/main/java/org/sonar/java/regex/RegexParseResult.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/RegexParseResult.java
@@ -21,21 +21,29 @@ package org.sonar.java.regex;
 
 import java.util.Collections;
 import java.util.List;
+import org.sonar.java.regex.ast.FlagSet;
 import org.sonar.java.regex.ast.RegexTree;
 
 public class RegexParseResult {
 
   private final RegexTree result;
 
+  private final FlagSet initialFlags;
+
   private final List<SyntaxError> syntaxErrors;
 
-  public RegexParseResult(RegexTree result, List<SyntaxError> syntaxErrors) {
+  public RegexParseResult(RegexTree result, FlagSet initialFlags, List<SyntaxError> syntaxErrors) {
     this.result = result;
+    this.initialFlags = initialFlags;
     this.syntaxErrors = Collections.unmodifiableList(syntaxErrors);
   }
 
   public RegexTree getResult() {
     return result;
+  }
+
+  public FlagSet getInitialFlags() {
+    return initialFlags;
   }
 
   public List<SyntaxError> getSyntaxErrors() {

--- a/java-frontend/src/main/java/org/sonar/java/regex/RegexParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/RegexParser.java
@@ -60,15 +60,17 @@ public class RegexParser {
 
   private final RegexLexer characters;
 
-  private final List<SyntaxError> errors;
+  private final FlagSet initialFlags;
+
+  private final List<SyntaxError> errors = new ArrayList<>();
 
   private int groupNumber = 1;
 
-  public RegexParser(RegexSource source, boolean freeSpacingMode) {
+  public RegexParser(RegexSource source, FlagSet initialFlags) {
     this.source = source;
     this.characters = new RegexLexer(source);
-    this.characters.setFreeSpacingMode(freeSpacingMode);
-    this.errors = new ArrayList<>();
+    this.characters.setFreeSpacingMode(initialFlags.contains(Pattern.COMMENTS));
+    this.initialFlags = initialFlags;
   }
 
   public RegexParseResult parse() {
@@ -82,7 +84,7 @@ public class RegexParser {
       }
     } while (characters.isNotAtEnd());
     RegexTree result = combineTrees(results, (range, elements) -> new SequenceTree(source, range, elements));
-    return new RegexParseResult(result, errors);
+    return new RegexParseResult(result, initialFlags, errors);
   }
 
   private RegexTree parseDisjunction() {

--- a/java-frontend/src/main/java/org/sonar/java/regex/RegexScannerContext.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/RegexScannerContext.java
@@ -21,6 +21,7 @@ package org.sonar.java.regex;
 
 import java.util.List;
 import javax.annotation.Nullable;
+import org.sonar.java.regex.ast.FlagSet;
 import org.sonar.java.regex.ast.RegexSyntaxElement;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 
@@ -28,6 +29,6 @@ public interface RegexScannerContext {
 
   void reportIssue(RegexCheck regexCheck, RegexSyntaxElement regexSyntaxElement, String message, @Nullable Integer cost, List<RegexCheck.RegexIssueLocation> secondaries);
 
-  RegexParseResult regexForLiterals(boolean freeSpacingMode, LiteralTree... stringLiterals);
+  RegexParseResult regexForLiterals(FlagSet initialFlags, LiteralTree... stringLiterals);
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/regex/ast/FlagSet.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/ast/FlagSet.java
@@ -31,13 +31,17 @@ public class FlagSet {
   private final Map<Integer, JavaCharacter> flagCharacters;
 
   public FlagSet() {
-    this.mask = 0;
-    this.flagCharacters = new HashMap<>();
+    this(0);
   }
 
   public FlagSet(FlagSet other) {
     this.mask = other.mask;
     this.flagCharacters = new HashMap<>(other.flagCharacters);
+  }
+
+  public FlagSet(int initialFlags) {
+    this.flagCharacters = new HashMap<>();
+    this.mask = initialFlags;
   }
 
   public boolean contains(int flag) {

--- a/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexBaseVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexBaseVisitor.java
@@ -21,17 +21,12 @@ package org.sonar.java.regex.ast;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
-import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
+import org.sonar.java.regex.RegexParseResult;
 
 public class RegexBaseVisitor implements RegexVisitor {
 
-  private FlagSet activeFlags = new FlagSet();
-
-  @Override
-  public void setActiveFlags(int activeFlags) {
-    this.activeFlags.add(activeFlags);
-  }
+  private FlagSet activeFlags;
 
   @VisibleForTesting
   protected int getActiveFlags() {
@@ -52,8 +47,28 @@ public class RegexBaseVisitor implements RegexVisitor {
     return activeFlags.getJavaCharacterForFlag(flag);
   }
 
+  private void visit(RegexTree tree) {
+    tree.accept(this);
+  }
+
   private void visit(List<RegexTree> trees) {
     trees.forEach(this::visit);
+  }
+
+  @Override
+  public void visit(RegexParseResult regexParseResult) {
+    if (!regexParseResult.hasSyntaxErrors()) {
+      activeFlags = regexParseResult.getInitialFlags();
+      visit(regexParseResult.getResult());
+      after(regexParseResult);
+    }
+  }
+
+  /**
+   * Override to perform an action after the entire regex has been visited.
+   */
+  protected void after(RegexParseResult regexParseResult) {
+    // does nothing unless overridden
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexVisitor.java
@@ -19,17 +19,11 @@
  */
 package org.sonar.java.regex.ast;
 
+import org.sonar.java.regex.RegexParseResult;
+
 public interface RegexVisitor {
 
-  /**
-   * When a regex is constructed using Pattern.compile with the flags argument, this method should be called with the
-   * value of the flags argument (if known) before running the visitor
-   */
-  void setActiveFlags(int flags);
-
-  default void visit(RegexTree tree) {
-    tree.accept(this);
-  }
+  void visit(RegexParseResult regexParseResult);
 
   void visitBackReference(BackReferenceTree tree);
 

--- a/java-frontend/src/test/java/org/sonar/java/regex/RegexCacheTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/regex/RegexCacheTest.java
@@ -22,6 +22,7 @@ package org.sonar.java.regex;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.model.JParserTestUtils;
+import org.sonar.java.regex.ast.FlagSet;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
@@ -33,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RegexCacheTest {
 
   @Test
-  void same_result_if_same_tree_is_provided() throws Exception {
+  void same_result_if_same_tree_is_provided() {
     CompilationUnitTree cut = JParserTestUtils.parse(
       "class A {\n"
         + "  String s0 = \"abc\";\n"
@@ -45,20 +46,20 @@ class RegexCacheTest {
     LiteralTree s1 = (LiteralTree) ((VariableTree) fields.get(1)).initializer();
 
     RegexCache cache = new RegexCache();
-    RegexParseResult resultForS0 = cache.getRegexForLiterals(false, s0);
-    RegexParseResult resultForS1 = cache.getRegexForLiterals(false, s1);
+    RegexParseResult resultForS0 = cache.getRegexForLiterals(new FlagSet(), s0);
+    RegexParseResult resultForS1 = cache.getRegexForLiterals(new FlagSet(), s1);
 
     assertThat(s0.value()).isEqualTo(s1.value());
     assertThat(resultForS0)
       .isNotEqualTo(resultForS1)
       // same input, same result
-      .isSameAs(cache.getRegexForLiterals(false, s0));
+      .isSameAs(cache.getRegexForLiterals(new FlagSet(), s0));
 
-    assertThat(resultForS1).isSameAs(cache.getRegexForLiterals(false, s1));
+    assertThat(resultForS1).isSameAs(cache.getRegexForLiterals(new FlagSet(), s1));
   }
 
   @Test
-  void same_result_if_same_trees_are_provided() throws Exception {
+  void same_result_if_same_trees_are_provided() {
     CompilationUnitTree cut = JParserTestUtils.parse(
       "class A {\n"
         + "  String s0 = \"abc\";\n"
@@ -70,15 +71,15 @@ class RegexCacheTest {
     LiteralTree s1 = (LiteralTree) ((VariableTree) fields.get(1)).initializer();
 
     RegexCache cache = new RegexCache();
-    RegexParseResult resultForS0S1 = cache.getRegexForLiterals(false, s0, s1);
-    RegexParseResult resultForS1S0 = cache.getRegexForLiterals(false, s1, s0);
+    RegexParseResult resultForS0S1 = cache.getRegexForLiterals(new FlagSet(), s0, s1);
+    RegexParseResult resultForS1S0 = cache.getRegexForLiterals(new FlagSet(), s1, s0);
 
     assertThat(s0.value() + s1.value()).isEqualTo(s1.value() + s0.value());
     assertThat(resultForS0S1)
       .isNotEqualTo(resultForS1S0)
       // same order of input, same result
-      .isSameAs(cache.getRegexForLiterals(false, s0, s1));
-    assertThat(resultForS1S0).isSameAs(cache.getRegexForLiterals(false, s1, s0));
+      .isSameAs(cache.getRegexForLiterals(new FlagSet(), s0, s1));
+    assertThat(resultForS1S0).isSameAs(cache.getRegexForLiterals(new FlagSet(), s1, s0));
   }
 
 }

--- a/java-frontend/src/test/java/org/sonar/java/regex/ast/CurlyBraceQuantifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/regex/ast/CurlyBraceQuantifierTest.java
@@ -22,7 +22,6 @@ package org.sonar.java.regex.ast;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.regex.RegexParseResult;
-import org.sonar.java.regex.RegexParser;
 import org.sonar.java.regex.SyntaxError;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +33,7 @@ import static org.sonar.java.regex.RegexParserTestUtils.assertLocation;
 import static org.sonar.java.regex.RegexParserTestUtils.assertPlainCharacter;
 import static org.sonar.java.regex.RegexParserTestUtils.assertSuccessfulParse;
 import static org.sonar.java.regex.RegexParserTestUtils.assertType;
-import static org.sonar.java.regex.RegexParserTestUtils.makeSource;
+import static org.sonar.java.regex.RegexParserTestUtils.parseRegex;
 
 class CurlyBraceQuantifierTest {
 
@@ -106,7 +105,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithNonNumber() {
-    RegexParseResult result = new RegexParser(makeSource("x{a}"), false).parse();
+    RegexParseResult result = parseRegex("x{a}");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Expected integer, but found 'a'", error.getMessage(), "Error should have the right message.");
@@ -118,7 +117,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithJunkAfterNumber() {
-    RegexParseResult result = new RegexParser(makeSource("x{1a}"), false).parse();
+    RegexParseResult result = parseRegex("x{1a}");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Expected ',' or '}', but found 'a'", error.getMessage(), "Error should have the right message.");
@@ -130,7 +129,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithJunkAfterComma() {
-    RegexParseResult result = new RegexParser(makeSource("x{1,a}"), false).parse();
+    RegexParseResult result = parseRegex("x{1,a}");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Expected integer or '}', but found 'a'", error.getMessage(), "Error should have the right message.");
@@ -142,7 +141,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithJunkAfterSecondNumber() {
-    RegexParseResult result = new RegexParser(makeSource("x{1,2a}"), false).parse();
+    RegexParseResult result = parseRegex("x{1,2a}");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Expected '}', but found 'a'", error.getMessage(), "Error should have the right message.");
@@ -154,7 +153,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithMissingClosingBrace() {
-    RegexParseResult result = new RegexParser(makeSource("x{1,2"), false).parse();
+    RegexParseResult result = parseRegex("x{1,2");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Expected '}', but found the end of the regex", error.getMessage(), "Error should have the right message.");
@@ -167,7 +166,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithoutOperand() {
-    RegexParseResult result = new RegexParser(makeSource("{1,2}"), false).parse();
+    RegexParseResult result = parseRegex("{1,2}");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Unexpected quantifier '{1,2}'", error.getMessage(), "Error should have the right message.");
@@ -180,7 +179,7 @@ class CurlyBraceQuantifierTest {
 
   @Test
   void testCurlyBracedQuantifierWithoutOperandInGroup() {
-    RegexParseResult result = new RegexParser(makeSource("({1,2})"), false).parse();
+    RegexParseResult result = parseRegex("({1,2})");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Unexpected quantifier '{1,2}'", error.getMessage(), "Error should have the right message.");

--- a/java-frontend/src/test/java/org/sonar/java/regex/ast/GroupTreesTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/regex/ast/GroupTreesTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.regex.RegexParseResult;
-import org.sonar.java.regex.RegexParser;
 import org.sonar.java.regex.SyntaxError;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,7 +38,7 @@ import static org.sonar.java.regex.RegexParserTestUtils.assertPlainCharacter;
 import static org.sonar.java.regex.RegexParserTestUtils.assertPlainString;
 import static org.sonar.java.regex.RegexParserTestUtils.assertSuccessfulParse;
 import static org.sonar.java.regex.RegexParserTestUtils.assertType;
-import static org.sonar.java.regex.RegexParserTestUtils.makeSource;
+import static org.sonar.java.regex.RegexParserTestUtils.parseRegex;
 
 class GroupTreesTest {
 
@@ -56,7 +55,7 @@ class GroupTreesTest {
 
   @Test
   void testUnfinishedGroup() {
-    RegexParseResult result = new RegexParser(makeSource("(x"), false).parse();
+    RegexParseResult result = parseRegex("(x");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Expected ')', but found the end of the regex", error.getMessage(), "Error should have the right message.");
@@ -68,7 +67,7 @@ class GroupTreesTest {
 
   @Test
   void testExtraParenthesis() {
-    RegexParseResult result = new RegexParser(makeSource("(x))"), false).parse();
+    RegexParseResult result = parseRegex("(x))");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Unexpected ')'", error.getMessage(), "Error should have the right message.");

--- a/java-frontend/src/test/java/org/sonar/java/regex/ast/QuantifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/regex/ast/QuantifierTest.java
@@ -22,7 +22,6 @@ package org.sonar.java.regex.ast;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.regex.RegexParseResult;
-import org.sonar.java.regex.RegexParser;
 import org.sonar.java.regex.SyntaxError;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.sonar.java.regex.RegexParserTestUtils.assertPlainCharacter;
 import static org.sonar.java.regex.RegexParserTestUtils.assertSuccessfulParse;
 import static org.sonar.java.regex.RegexParserTestUtils.assertType;
-import static org.sonar.java.regex.RegexParserTestUtils.makeSource;
+import static org.sonar.java.regex.RegexParserTestUtils.parseRegex;
 
 class QuantifierTest {
 
@@ -97,7 +96,7 @@ class QuantifierTest {
 
   @Test
   void testDoubleQuantifier() {
-    RegexParseResult result = new RegexParser(makeSource("x**"), false).parse();
+    RegexParseResult result = parseRegex("x**");
     assertEquals(1, result.getSyntaxErrors().size(), "Expected exactly one error.");
     SyntaxError error = result.getSyntaxErrors().get(0);
     assertEquals("Unexpected quantifier '*'", error.getMessage(), "Error should have the right message.");


### PR DESCRIPTION
Make the result of parsing a regex contain information about which
flags the regex was created with.

Use this information in the RegexBaseVisitor to set the initial
flags, removing any need to call setFlags, which is now removed.

Also move the logic of checking whether the regex contains syntax
errors before visiting anything into the RegexBaseVisitor and the
methods before and after to it, so now rules should all be
implementable with only a suitable definition of a visitor class
and then `new MyVisitor(possibleArguments).visit(regexForLiterals);`.