### PR TITLE
Fix the locations of escape sequences

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/regex/DuplicatesInCharacterClassCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/regex/DuplicatesInCharacterClassCheck.java
@@ -16,6 +16,7 @@ public class DuplicatesInCharacterClassCheck {
     str.matches("(?iu)[äÄ]"); // Noncompliant [[sc=25;ec=26]]
     str.matches("(?iU)[äÄ]"); // Noncompliant [[sc=25;ec=26]]
     str.matches("(?iu)[xX]"); // Noncompliant [[sc=25;ec=26]]
+    str.matches("[\\\"\\\".]"); // Noncompliant [[sc=23;ec=27]]
   }
 
   void compliant() {

--- a/java-frontend/src/main/java/org/sonar/java/regex/JavaCharacterParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/JavaCharacterParser.java
@@ -118,12 +118,13 @@ public class JavaCharacterParser {
             javaCharacter = unicodeProcessedCharacters.getCurrent();
           }
           ch = (char) Integer.parseInt(codeUnit.toString(), 8);
-          return new JavaCharacter(source, backslash.getRange().extendTo(unicodeProcessedCharacters.getCurrentStartIndex()), ch);
+          int endIndex = javaCharacter == null ? source.length() : javaCharacter.getRange().getBeginningOffset();
+          return new JavaCharacter(source, backslash.getRange().extendTo(endIndex), ch);
         }
         break;
     }
     unicodeProcessedCharacters.moveNext();
-    return new JavaCharacter(source, backslash.getRange().extendTo(unicodeProcessedCharacters.getCurrentStartIndex()), ch);
+    return new JavaCharacter(source, backslash.getRange().merge(javaCharacter.getRange()), ch);
   }
 
   private static boolean isOctalDigit(int c) {

--- a/java-frontend/src/main/java/org/sonar/java/regex/JavaUnicodeEscapeParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/JavaUnicodeEscapeParser.java
@@ -55,10 +55,6 @@ public class JavaUnicodeEscapeParser {
     return current;
   }
 
-  public int getCurrentStartIndex() {
-    return index;
-  }
-
   public void moveNext() {
     if (index >= sourceText.length()) {
       current = null;


### PR DESCRIPTION
Some escape sequences had locations which included one character too
many and/or did not include the leading backslash.