### PR TITLE
Document the correct usage of Visitor.visit vs. RegexTree.accept

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexBaseVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexBaseVisitor.java
@@ -66,7 +66,7 @@ public class RegexBaseVisitor implements RegexVisitor {
   }
 
   /**
-   * Override to perform an action before the entire regex has been visited.
+   * Override to perform an action before any part of the regex is visited.
    */
   protected void before(RegexParseResult regexParseResult) {
     // does nothing unless overridden

--- a/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexTree.java
+++ b/java-frontend/src/main/java/org/sonar/java/regex/ast/RegexTree.java
@@ -44,6 +44,10 @@ public abstract class RegexTree extends RegexSyntaxElement {
     super(source, range);
   }
 
+  /**
+   * This method should only be called by RegexBaseVisitor (or other implementations of the RegexVisitor interface).
+   * Do not call this method to invoke a visitor, use visitor.visit(tree) instead.
+   */
   public abstract void accept(RegexVisitor visitor);
 
   public abstract Kind kind();


### PR DESCRIPTION
Also change some misleading wording in the documentation of
RegexBaseVisitor.before.
