### PR TITLE
SONARJAVA-3332 Upgrade org.eclipse.jdt.core to 3.22.0

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/UseSwitchExpressionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UseSwitchExpressionCheck.java
@@ -58,7 +58,8 @@ public class UseSwitchExpressionCheck extends IssuableSubscriptionVisitor implem
 
   @Override
   public boolean isCompatibleWithJavaVersion(JavaVersion version) {
-    return version.asInt() == 13;
+    // switch-expression is standard since Java 14
+    return version.asInt() >= 14;
   }
 
   @Override

--- a/java-checks/src/test/java/org/sonar/java/checks/UseSwitchExpressionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UseSwitchExpressionCheckTest.java
@@ -31,12 +31,12 @@ class UseSwitchExpressionCheckTest {
     JavaCheckVerifier.newVerifier()
       .onFile("src/test/files/checks/UseSwitchExpressionCheck.java")
       .withCheck(new UseSwitchExpressionCheck())
-      .withJavaVersion(13)
+      .withJavaVersion(14)
       .verifyIssues();
   }
 
   @Test
-  void test_no_issue_below_java_13() {
+  void test_no_issue_below_java_14() {
     JavaCheckVerifier.newVerifier()
       .onFile(testSourcesPath("checks/UseSwitchExpressionCheck_java11.java"))
       .withCheck(new UseSwitchExpressionCheck())
@@ -47,6 +47,11 @@ class UseSwitchExpressionCheckTest {
       .withCheck(new UseSwitchExpressionCheck())
       .withJavaVersion(12)
       .verifyNoIssues();
+    JavaCheckVerifier.newVerifier()
+      .onFile(testSourcesPath("checks/UseSwitchExpressionCheck_java11.java"))
+      .withCheck(new UseSwitchExpressionCheck())
+      .withJavaVersion(13)
+      .verifyNoIssues();
   }
 
   @Test
@@ -54,7 +59,7 @@ class UseSwitchExpressionCheckTest {
     JavaCheckVerifier.newVerifier()
       .onFile("src/test/files/checks/UseSwitchExpressionCheck.java")
       .withCheck(new UseSwitchExpressionCheck())
-      .withJavaVersion(13)
+      .withJavaVersion(14)
       .withoutSemantic()
       .verifyNoIssues();
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/JParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JParser.java
@@ -243,7 +243,7 @@ public class JParser {
 
   private static final Logger LOG = Loggers.get(JParser.class);
 
-  public static final String MAXIMUM_SUPPORTED_JAVA_VERSION = "13";
+  public static final String MAXIMUM_SUPPORTED_JAVA_VERSION = "14";
 
   /**
    * @param unitName see {@link ASTParser#setUnitName(String)}
@@ -255,7 +255,7 @@ public class JParser {
     String source,
     List<File> classpath
   ) {
-    ASTParser astParser = ASTParser.newParser(AST.JLS13);
+    ASTParser astParser = ASTParser.newParser(AST.JLS14);
     Map<String, String> options = new HashMap<>();
     options.put(JavaCore.COMPILER_COMPLIANCE, version);
     options.put(JavaCore.COMPILER_SOURCE, version);
@@ -1697,17 +1697,8 @@ public class JParser {
 
         SwitchCase c = (SwitchCase) o;
 
-        final List expressionsToConvert;
-        if (c.getAST().isPreviewEnabled()) {
-          expressionsToConvert = c.expressions();
-        } else if (c.isDefault()) {
-          expressionsToConvert = Collections.emptyList();
-        } else {
-          expressionsToConvert = Collections.singletonList(c.getExpression());
-        }
-
         List<ExpressionTree> expressions = new ArrayList<>();
-        for (Object oo : expressionsToConvert) {
+        for (Object oo : c.expressions()) {
           expressions.add(
             convertExpression((Expression) oo)
           );
@@ -2156,6 +2147,9 @@ public class JParser {
       }
       case ASTNode.INSTANCEOF_EXPRESSION: {
         InstanceofExpression e = (InstanceofExpression) node;
+        if (e.getAST().isPreviewEnabled() && e.getPatternVariable() != null) {
+          throw new IllegalStateException();
+        }
         return new InstanceOfTreeImpl(
           firstTokenAfter(e.getLeftOperand(), TerminalTokens.TokenNameinstanceof),
           convertType(e.getRightOperand())

--- a/jdt/pom.xml
+++ b/jdt/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.eclipse.jdt</groupId>
         <artifactId>org.eclipse.jdt.core</artifactId>
-        <version>3.20.0</version>
+        <version>3.22.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.platform</groupId>
@@ -39,42 +39,42 @@
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.13.600</version>
+        <version>3.13.700</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.17.0</version>
+        <version>3.18.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.osgi</artifactId>
-        <version>3.15.100</version>
+        <version>3.15.300</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.common</artifactId>
-        <version>3.10.600</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.jobs</artifactId>
-        <version>3.10.600</version>
+        <version>3.10.800</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.preferences</artifactId>
-        <version>3.7.600</version>
+        <version>3.8.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.7.500</version>
+        <version>3.7.700</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.text</artifactId>
-        <version>3.10.0</version>
+        <version>3.10.200</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
* Brings support for Java 14, excluding Preview Features.
* Removes support for Java 13 Preview Features.