### PR TITLE
SONARJAVA-3415 Fix the secondary message

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/regex/RegexComplexityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/RegexComplexityCheck.java
@@ -193,7 +193,9 @@ public class RegexComplexityCheck extends AbstractRegexCheck {
         firstComponent = syntaxElement;
       }
       String message = "+" + increment;
-      message += " (incl " + (increment - 1) + " for nesting)";
+      if (increment > 1) {
+        message += " (incl " + (increment - 1) + " for nesting)";
+      }
       components.add(new RegexIssueLocation(syntaxElement, message));
     }
 


### PR DESCRIPTION
The message should only contain "incl N for nesting" if N > 0.