### PR TITLE
SONARJAVA-3403 FN in S4970: support unrelated Exception

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/checks/UnreachableCatchCheck.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/UnreachableCatchCheck.java
@@ -35,6 +35,15 @@ public class UnreachableCatchCheck {
     }
 
     try {
+      unknown();
+      throwUnknownException();
+    } catch (ExtendsCustomException e) {
+      // ...
+    } catch (CustomException e) { // Compliant
+      // ...
+    }
+
+    try {
       throwExtendsCustomException();
       unknown();
     } catch (ExtendsCustomException e) {

--- a/java-checks-test-sources/src/main/java/checks/UnreachableCatchCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/UnreachableCatchCheck.java
@@ -68,7 +68,7 @@ public class UnreachableCatchCheck {
       // ...
     } catch (IOException e) { // Compliant
       // ...
-    } catch (CustomException e) { // FN, line 67 hide this catch, but we don't support correctly the presence of another type of Exception
+    } catch (CustomException e) { // Noncompliant [[secondary=67]]
       // ...
     }
 
@@ -77,7 +77,7 @@ public class UnreachableCatchCheck {
       throwIOException();
     } catch (ExtendsCustomException | IOException e) {
       // ...
-    } catch (CustomException e) { // FN, we don't support correctly the presence of another type of Exception
+    } catch (CustomException e) { // Noncompliant [[secondary=78]]
       // ...
     }
 
@@ -217,7 +217,7 @@ public class UnreachableCatchCheck {
 
     try {
       throwExtendsCustomException();
-      throwOtherOtherExtendsCustomException();
+      throwOtherExtendsCustomException();
     } catch (ExtendsCustomException e) {
       // ...
     } catch (CustomException e) { // Compliant
@@ -245,7 +245,7 @@ public class UnreachableCatchCheck {
   void throwBoth() throws ExtendsCustomException, OtherExtendsCustomException {
   }
 
-  void throwOtherOtherExtendsCustomException() throws OtherExtendsCustomException {
+  void throwOtherExtendsCustomException() throws OtherExtendsCustomException {
     throw new OtherExtendsCustomException();
   }
 

--- a/java-checks-test-sources/src/main/java/checks/UnreachableCatchCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/UnreachableCatchCheck.java
@@ -13,7 +13,7 @@ public class UnreachableCatchCheck {
       throwExtendsCustomException();
     } catch (ExtendsCustomException e) {
       // ...
-    } catch (CustomException e) { // Noncompliant [[sc=14;ec=29;secondary=14]] {{Remove this type because it is unreachable as hidden by previous catch blocks.}}
+    } catch (CustomException e) { // Noncompliant [[sc=7;ec=12;secondary=14]] {{Remove or refactor this catch clause because it is unreachable as hidden by previous catch blocks.}}
       // ...
     }
 
@@ -21,7 +21,18 @@ public class UnreachableCatchCheck {
       throw new ExtendsCustomException();
     } catch (ExtendsCustomException e) {
       // ...
-    } catch (CustomException|IllegalStateException e) { // Noncompliant [[sc=14;ec=29]]
+    } catch (CustomException|IllegalStateException e) { // Noncompliant [[sc=14;ec=29]] {{Remove this type because it is unreachable as hidden by previous catch blocks.}}
+      // ...
+    }
+
+    try {
+      if (true) throw new ExtendsExtendsCustomException();
+      else throw new ExtendsOtherExtendsCustomException();
+    } catch (ExtendsExtendsCustomException e) {
+      // ...
+    } catch (ExtendsOtherExtendsCustomException e) {
+      // ...
+    } catch (ExtendsCustomException|OtherExtendsCustomException e) { // Noncompliant [[sc=7;ec=12;secondary=31,33]] {{Remove or refactor this catch clause because it is unreachable as hidden by previous catch blocks.}}
       // ...
     }
 
@@ -45,9 +56,9 @@ public class UnreachableCatchCheck {
       throwExtendsExtendsCustomException();
     } catch (ExtendsExtendsCustomException e) {
       // ...
-    } catch (ExtendsCustomException e) { // Noncompliant [[secondary=46]]
+    } catch (ExtendsCustomException e) { // Noncompliant [[secondary=57]]
       // ...
-    } catch (CustomException e) { // Noncompliant [[secondary=46,48]]
+    } catch (CustomException e) { // Noncompliant [[secondary=57,59]]
       // ...
     }
 
@@ -57,7 +68,7 @@ public class UnreachableCatchCheck {
       // ...
     } catch (ExtendsCustomException e) {
       // ...
-    } catch (CustomException e) { // Noncompliant [[secondary=58]]
+    } catch (CustomException e) { // Noncompliant [[secondary=69]]
       // ...
     }
 
@@ -68,7 +79,7 @@ public class UnreachableCatchCheck {
       // ...
     } catch (IOException e) { // Compliant
       // ...
-    } catch (CustomException e) { // Noncompliant [[secondary=67]]
+    } catch (CustomException e) { // Noncompliant [[secondary=78]]
       // ...
     }
 
@@ -77,7 +88,7 @@ public class UnreachableCatchCheck {
       throwIOException();
     } catch (ExtendsCustomException | IOException e) {
       // ...
-    } catch (CustomException e) { // Noncompliant [[secondary=78]]
+    } catch (CustomException e) { // Noncompliant [[secondary=89]]
       // ...
     }
 
@@ -275,6 +286,9 @@ public class UnreachableCatchCheck {
   }
 
   public static class ExtendsExtendsCustomException extends ExtendsCustomException {
+  }
+
+  public static class ExtendsOtherExtendsCustomException extends OtherExtendsCustomException {
   }
 
   class ThrowingExtendsCustomException {

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4970_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4970_java.html
@@ -3,7 +3,8 @@ derived from E.</p>
 <p>These derived exceptions are handled in dedicated <code>catch</code> blocks prior to the <code>catch</code> block of the base exception E. </p>
 <p>The <code>catch</code> block of E is unreachable and should be considered dead code. It should be removed, or the entire try-catch structure should
 be refactored.</p>
-<p> </p>
+<p>It is also possible that a single exception type in a multi-catch block may be hidden while the catch block itself is still reachable. In that case
+it is enough to only remove the hidden exception type or to replace it with another type.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 public class HiddenCatchBlock {


### PR DESCRIPTION
Also fix a bug where try-statements weren't properly skipped when
throwing unknown exceptions. The bug previously didn't have an effect
because unknown exceptions are also unrelated exceptions thus causing
a FN anyway.
