### PR TITLE
SONARJAVA-3304 Add test demonstrating fix of false-positive in S2201

### DIFF
--- a/java-checks/src/test/files/checks/IgnoredReturnValueCheckJava14.java
+++ b/java-checks/src/test/files/checks/IgnoredReturnValueCheckJava14.java
@@ -1,0 +1,23 @@
+class SwitchExpression {
+
+  void example(String condition, String s) {
+    s = switch (condition) {
+      case "1" -> s.toString();
+      default -> "";
+    };
+
+    s = switch (condition) {
+      case "1":
+        yield s.toString();
+      default:
+        yield "";
+    };
+
+    switch (condition) {
+      case "1":
+        s.toString(); // Noncompliant {{The return value of "toString" must be used.}}
+        break;
+    }
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/IgnoredReturnValueCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/IgnoredReturnValueCheckTest.java
@@ -35,4 +35,14 @@ class IgnoredReturnValueCheckTest {
       .withCheck(new IgnoredReturnValueCheck())
       .verifyNoIssues();
   }
+
+  @Test
+  void java14_switch_expression() {
+    JavaCheckVerifier.newVerifier()
+      .onFile("src/test/files/checks/IgnoredReturnValueCheckJava14.java")
+      .withJavaVersion(14)
+      .withCheck(new IgnoredReturnValueCheck())
+      .verifyIssues();
+  }
+
 }


### PR DESCRIPTION
False-positive is gone thanks to the addition of AST node for
implicit yield-statement.