### PR TITLE
SONARJAVA-3069 Adapt SE engine to Switch Expressions

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
@@ -746,14 +746,15 @@ public class CFG implements ControlFlowGraph {
     currentBlock = createBlock();
     currentBlock.terminator = terminator;
     Block switchBlock = currentBlock;
-    build(switchExpressionTree.expression());
-    switchExpressionTree.cases()
+    List<ExpressionTree> switchCasesExpressions = switchExpressionTree.cases()
       .stream()
       .map(CaseGroupTree::labels)
       .flatMap(List::stream)
       .map(CaseLabelTree::expressions)
-      .flatMap(List::stream)
-      .forEach(this::build);
+      .flatMap(List::stream).collect(Collectors.toList());
+    Lists.reverse(switchCasesExpressions).forEach(this::build);
+
+    build(switchExpressionTree.expression());
     Block conditionBlock = currentBlock;
     // process body
     currentBlock = createBlock(switchSuccessor);

--- a/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
@@ -737,10 +737,6 @@ public class CFG implements ControlFlowGraph {
   }
 
   private void buildSwitchExpression(SwitchExpressionTree switchExpressionTree, Tree terminator) {
-    if (terminator.is(Tree.Kind.SWITCH_EXPRESSION)) {
-      // force a switch expression in the current block
-      currentBlock.elements.add(terminator);
-    }
     Block switchSuccessor = currentBlock;
     // process condition
     currentBlock = createBlock();
@@ -773,7 +769,7 @@ public class CFG implements ControlFlowGraph {
         currentBlock.setCaseGroup(caseGroupTree);
         switches.getLast().addSuccessor(currentBlock);
         if (!caseGroupTree.equals(firstCase)) {
-          // No block predecessing the first case group.
+          // No block preceding the first case group.
           currentBlock = createBlock(currentBlock);
         }
       }

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -513,12 +513,10 @@ public class ExplodedGraphWalker {
   }
 
   private void handleSwitch(CFG.Block programPosition, List<CaseGroupTree> caseGroups) {
-    ProgramState.Pop poppedSwitchValue = programState.unstackValue(1);
-    ProgramState.SymbolicValueSymbol switchValue = poppedSwitchValue.valuesAndSymbols.get(0);
-    ProgramState state = poppedSwitchValue.state;
+    ProgramState state = programState;
 
     Map<CaseGroupTree, List<ProgramState.SymbolicValueSymbol>> caseValues = new HashMap<>();
-    for (CaseGroupTree caseGroup : caseGroups) {
+    for (CaseGroupTree caseGroup : Lists.reverse(caseGroups)) {
       int numberOfCaseValues = caseGroup.labels()
         .stream()
         .map(CaseLabelTree::expressions)
@@ -529,7 +527,10 @@ public class ExplodedGraphWalker {
       caseValues.put(caseGroup, poppedCaseValues.valuesAndSymbols);
     }
 
-    ProgramState elseState = state;
+    ProgramState.Pop poppedSwitchValue = state.unstackValue(1);
+    ProgramState.SymbolicValueSymbol switchValue = poppedSwitchValue.valuesAndSymbols.get(0);
+
+    ProgramState elseState = poppedSwitchValue.state; // TODO: verify
     // The block that will be taken when all case-conditions are false. This will either be the default-block or, if no
     // default block exists, the block after the switch statement.
     CFG.Block elseBlock = null;

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -530,14 +530,14 @@ public class ExplodedGraphWalker {
     ProgramState.Pop poppedSwitchValue = state.unstackValue(1);
     ProgramState.SymbolicValueSymbol switchValue = poppedSwitchValue.valuesAndSymbols.get(0);
 
-    ProgramState elseState = poppedSwitchValue.state; // TODO: verify
+    ProgramState elseState = poppedSwitchValue.state;
     // The block that will be taken when all case-conditions are false. This will either be the default-block or, if no
     // default block exists, the block after the switch statement.
     CFG.Block elseBlock = null;
     for (CFG.Block successor : programPosition.successors()) {
       CaseGroupTree caseGroup = successor.caseGroup();
       if (caseGroup == null || !caseValues.containsKey(caseGroup)) {
-        assert(elseBlock == null);
+        Preconditions.checkState(elseBlock == null);
         elseBlock = successor;
         continue;
       }
@@ -549,11 +549,11 @@ public class ExplodedGraphWalker {
         elseState = setConstraint(elseState, equality, BooleanConstraint.FALSE);
       }
       if (successor.isDefaultBlock()) {
-        assert(elseBlock == null);
+        Preconditions.checkState(elseBlock == null);
         elseBlock = successor;
       }
     }
-    assert(elseBlock != null);
+    Objects.requireNonNull(elseBlock);
     enqueue(new ProgramPoint(elseBlock), elseState, node.exitPath);
   }
 
@@ -562,7 +562,7 @@ public class ExplodedGraphWalker {
     if (states.isEmpty()) {
       return state;
     }
-    assert(states.size() == 1);
+    Preconditions.checkState(states.size() == 1);
     return states.get(0);
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -76,6 +76,8 @@ import org.sonar.plugins.java.api.tree.ArrayDimensionTree;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.BlockTree;
+import org.sonar.plugins.java.api.tree.CaseGroupTree;
+import org.sonar.plugins.java.api.tree.CaseLabelTree;
 import org.sonar.plugins.java.api.tree.ConditionalExpressionTree;
 import org.sonar.plugins.java.api.tree.DoWhileStatementTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -89,6 +91,8 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.NewArrayTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.ReturnStatementTree;
+import org.sonar.plugins.java.api.tree.SwitchExpressionTree;
+import org.sonar.plugins.java.api.tree.SwitchStatementTree;
 import org.sonar.plugins.java.api.tree.ThrowStatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TypeCastTree;
@@ -409,6 +413,12 @@ public class ExplodedGraphWalker {
           ExpressionTree ifCondition = ((IfStatementTree) terminator).condition();
           handleBranch(block, cleanupCondition(ifCondition), verifyCondition(ifCondition));
           return;
+        case SWITCH_STATEMENT:
+          handleSwitch(block, ((SwitchStatementTree) terminator).cases());
+          return;
+        case SWITCH_EXPRESSION:
+          handleSwitch(block, ((SwitchExpressionTree) terminator).cases());
+          return;
         case CONDITIONAL_OR:
         case CONDITIONAL_AND:
           handleBranch(block, ((BinaryExpressionTree) terminator).leftOperand());
@@ -456,7 +466,7 @@ public class ExplodedGraphWalker {
           // do nothing by default.
       }
     }
-    // unconditional jumps, for-statement, switch-statement, synchronized:
+    // unconditional jumps, for-statement, synchronized:
     if (exitPath) {
       if (block.exitBlock() != null) {
         enqueue(new ProgramPoint(block.exitBlock()), programState, true);
@@ -500,6 +510,59 @@ public class ExplodedGraphWalker {
       cleanedUpCondition = cleanupCondition(((BinaryExpressionTree) cleanedUpCondition).rightOperand());
     }
     return cleanedUpCondition;
+  }
+
+  private void handleSwitch(CFG.Block programPosition, List<CaseGroupTree> caseGroups) {
+    ProgramState.Pop poppedSwitchValue = programState.unstackValue(1);
+    ProgramState.SymbolicValueSymbol switchValue = poppedSwitchValue.valuesAndSymbols.get(0);
+    ProgramState state = poppedSwitchValue.state;
+
+    Map<CaseGroupTree, List<ProgramState.SymbolicValueSymbol>> caseValues = new HashMap<>();
+    for (CaseGroupTree caseGroup : caseGroups) {
+      int numberOfCaseValues = caseGroup.labels()
+        .stream()
+        .map(CaseLabelTree::expressions)
+        .mapToInt(List::size)
+        .sum();
+      ProgramState.Pop poppedCaseValues = state.unstackValue(numberOfCaseValues);
+      state = poppedCaseValues.state;
+      caseValues.put(caseGroup, poppedCaseValues.valuesAndSymbols);
+    }
+
+    ProgramState elseState = state;
+    // The block that will be taken when all case-conditions are false. This will either be the default-block or, if no
+    // default block exists, the block after the switch statement.
+    CFG.Block elseBlock = null;
+    for (CFG.Block successor : programPosition.successors()) {
+      CaseGroupTree caseGroup = successor.caseGroup();
+      if (caseGroup == null || !caseValues.containsKey(caseGroup)) {
+        assert(elseBlock == null);
+        elseBlock = successor;
+        continue;
+      }
+
+      for (ProgramState.SymbolicValueSymbol caseValue : caseValues.get(caseGroup)) {
+        SymbolicValue equality = constraintManager.createEquality(switchValue, caseValue);
+        ProgramState ps = setConstraint(state, equality, BooleanConstraint.TRUE);
+        enqueue(new ProgramPoint(successor), ps, node.exitPath);
+        elseState = setConstraint(elseState, equality, BooleanConstraint.FALSE);
+      }
+      if (successor.isDefaultBlock()) {
+        assert(elseBlock == null);
+        elseBlock = successor;
+      }
+    }
+    assert(elseBlock != null);
+    enqueue(new ProgramPoint(elseBlock), elseState, node.exitPath);
+  }
+
+  private static ProgramState setConstraint(ProgramState state, SymbolicValue condition, BooleanConstraint constraint) {
+    List<ProgramState> states = condition.setConstraint(state, constraint);
+    if (states.isEmpty()) {
+      return state;
+    }
+    assert(states.size() == 1);
+    return states.get(0);
   }
 
   private void handleBranch(CFG.Block programPosition, Tree condition) {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/NullDereferenceCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/NullDereferenceCheck.java
@@ -216,8 +216,11 @@ public class NullDereferenceCheck extends SECheck {
       }
     }
 
-    if (syntaxNode.is(Tree.Kind.THROW_STATEMENT) && context.getConstraintManager().isNull(context.getState(), context.getState().peekValue())) {
-      issue = new NullDereferenceIssue(context.getNode(), context.getState().peekValue(), syntaxNode);
+    if (syntaxNode.is(Tree.Kind.THROW_STATEMENT)) {
+      SymbolicValue peek = context.getState().peekValue();
+      if (peek != null && context.getConstraintManager().isNull(context.getState(), peek)) {
+        issue = new NullDereferenceIssue(context.getNode(), peek, syntaxNode);
+      }
     }
 
     if (issue != null) {

--- a/java-frontend/src/main/java/org/sonar/java/se/constraint/ConstraintManager.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/constraint/ConstraintManager.java
@@ -22,6 +22,7 @@ package org.sonar.java.se.constraint;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.sonar.java.se.ExplodedGraphWalker;
@@ -44,6 +45,10 @@ public class ConstraintManager {
   public void setValueFactory(SymbolicValueFactory valueFactory) {
     Preconditions.checkState(symbolicValueFactory == null, "The symbolic value factory has already been defined by another checker!");
     symbolicValueFactory = valueFactory;
+  }
+
+  public SymbolicValue createEquality(ProgramState.SymbolicValueSymbol lhs, ProgramState.SymbolicValueSymbol rhs) {
+    return createRelationalSymbolicValue(Kind.EQUAL, Arrays.asList(lhs, rhs));
   }
 
   public SymbolicValue createSymbolicValue(Tree syntaxNode) {

--- a/java-frontend/src/test/files/se/DivisionByZeroCheck.java
+++ b/java-frontend/src/test/files/se/DivisionByZeroCheck.java
@@ -361,6 +361,91 @@ class A {
     }
   }
 
+  int ifStatement(int x) {
+    if (x == 0) {
+      return 42/x; // Noncompliant
+    } else if (x == 1) {
+      return 23/x;
+    } else {
+      return 13/x;
+    }
+  }
+
+  int switchStatement1(int x) {
+    switch (x) {
+      case 0:
+        return 42/x; // Noncompliant
+      case 1:
+        return 23/x; // Compliant
+      default:
+        return 13/x; // Compliant
+    }
+  }
+
+  int switchStatement2(int x) {
+    switch (x) {
+      case 0:
+      case 42:
+        return 42/x; // Noncompliant
+      case 1:
+        return 23/x; // Compliant
+      default:
+        return 13/x; // Compliant
+    }
+  }
+
+  int switchStatement3(int x) {
+    switch (x) {
+      case 0:
+        return 42;
+    }
+    return 42/x; // Compliant
+  }
+
+  int switchStatement4(int x) {
+    switch (x) {
+      case 0:
+        break;
+    }
+    return 42/x; // Noncompliant
+  }
+
+  int nestedSwitchStatement(int x, int y) {
+    switch(x) {
+      case 0:
+        switch(y) {
+          case 0:
+            x=1;
+            y=1;
+        }
+      case 42:
+        y = 1;
+        break;
+      default:
+        switch (y) {
+          case 0:
+            y=1;
+        }
+    }
+    return x/y; // Compliant
+  }
+
+  int switchExpression1(int x) {
+    return switch (x) {
+      case 0, 42 -> 42/x; // Noncompliant
+      case 1 -> 23/x; // Compliant
+      default -> 13/x; // Compliant
+    };
+  }
+
+  int switchExpression2(int x) {
+    return 42 / (switch (x) { case 0 -> x; default -> 42;} + 0); // Noncompliant
+  }
+
+  int switchExpression3(int x) {
+    return 42 / (switch (x) { case 0 -> 42; default -> x;} + 0); // Compliant
+  }
+
   void dsdf(int a, int b) {
     int c = 0;
     int d = c + b + (a*c);

--- a/java-frontend/src/test/files/se/UnclosedResourcesCheck.java
+++ b/java-frontend/src/test/files/se/UnclosedResourcesCheck.java
@@ -459,6 +459,22 @@ public class A {
     }
   }
 
+  void switchTest(int x) {
+    MyCloseable a = new MyCloseable(); // Compliant because all paths close a
+    (switch (x) { case 0 -> a; default -> a;}).close();
+  }
+
+  void switchTest2(int x) {
+    MyCloseable a = new MyCloseable(); // Noncompliant
+    MyCloseable b = new MyCloseable(); // Noncompliant
+    (switch (x) { case 0 -> a; default -> b;}).close();
+  }
+
+}
+
+class MyCloseable implements Closeable {
+  @Override
+  void close() {}
 }
 
 class B {

--- a/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -643,9 +643,9 @@ class CFGTest {
         ).hasCaseGroup().successors(0),
       block(
         element(Tree.Kind.VARIABLE, "a"),
-        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.IDENTIFIER, "foo"),
         element(Tree.Kind.INT_LITERAL, 1),
-        element(Tree.Kind.IDENTIFIER, "foo")
+        element(Tree.Kind.INT_LITERAL, 2)
         ).terminator(Tree.Kind.SWITCH_STATEMENT).successors(2, 3, 4));
     cfgChecker.check(cfg);
   }
@@ -687,11 +687,11 @@ class CFGTest {
         element(Tree.Kind.METHOD_INVOCATION)).hasCaseGroup().successors(0),
       block(
         element(Tree.Kind.VARIABLE, "a"),
-        element(Tree.Kind.INT_LITERAL, 4),
-        element(Tree.Kind.INT_LITERAL, 3),
-        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.IDENTIFIER, "foo"),
         element(Tree.Kind.INT_LITERAL, 1),
-        element(Tree.Kind.IDENTIFIER, "foo")).terminator(Tree.Kind.SWITCH_STATEMENT).successors(2, 3, 4));
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 4)).terminator(Tree.Kind.SWITCH_STATEMENT).successors(2, 3, 4));
     cfgChecker.check(cfg);
   }
 
@@ -723,9 +723,9 @@ class CFGTest {
         element(Tree.Kind.METHOD_INVOCATION)).terminator(Tree.Kind.BREAK_STATEMENT).hasCaseGroup().successors(1),
       block(
         element(Tree.Kind.VARIABLE, "a"),
-        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.IDENTIFIER, "foo"),
         element(Tree.Kind.INT_LITERAL, 1),
-        element(Tree.Kind.IDENTIFIER, "foo")).terminator(Tree.Kind.SWITCH_STATEMENT).successors(1, 3, 4),
+        element(Tree.Kind.INT_LITERAL, 2)).terminator(Tree.Kind.SWITCH_STATEMENT).successors(1, 3, 4),
       block(
         element(Tree.Kind.IDENTIFIER, "Integer"),
         element(Tree.Kind.IDENTIFIER, "foo"),
@@ -782,13 +782,13 @@ class CFGTest {
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
         element(VARIABLE, "a"),
-        element(Tree.Kind.INT_LITERAL, 6),
-        element(Tree.Kind.INT_LITERAL, 5),
-        element(Tree.Kind.INT_LITERAL, 4),
-        element(Tree.Kind.INT_LITERAL, 3),
-        element(Tree.Kind.INT_LITERAL, 2),
+        element(IDENTIFIER, "foo"),
         element(Tree.Kind.INT_LITERAL, 1),
-        element(IDENTIFIER, "foo")).terminator(SWITCH_STATEMENT).successors(3, 4, 5, 6, 7),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 5),
+        element(Tree.Kind.INT_LITERAL, 6)).terminator(SWITCH_STATEMENT).successors(3, 4, 5, 6, 7),
       block(
         element(IDENTIFIER, "Integer"),
         element(IDENTIFIER, "foo"),
@@ -832,12 +832,12 @@ class CFGTest {
         element(IDENTIFIER, "def"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
-        element(Tree.Kind.INT_LITERAL, 5),
-        element(Tree.Kind.INT_LITERAL, 4),
-        element(Tree.Kind.INT_LITERAL, 3),
-        element(Tree.Kind.INT_LITERAL, 2),
+        element(IDENTIFIER, "foo"),
         element(Tree.Kind.INT_LITERAL, 1),
-        element(IDENTIFIER, "foo")).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 5)).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6),
       block(
         element(VARIABLE, "a"),
         element(IDENTIFIER, "a")).terminator(RETURN_STATEMENT).successors(0));
@@ -891,13 +891,13 @@ class CFGTest {
         element(IDENTIFIER, "def"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
-        element(Tree.Kind.INT_LITERAL, 6),
-        element(Tree.Kind.INT_LITERAL, 5),
-        element(Tree.Kind.INT_LITERAL, 4),
-        element(Tree.Kind.INT_LITERAL, 3),
-        element(Tree.Kind.INT_LITERAL, 2),
+        element(IDENTIFIER, "foo"),
         element(Tree.Kind.INT_LITERAL, 1),
-        element(IDENTIFIER, "foo")).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6, 7),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 5),
+        element(Tree.Kind.INT_LITERAL, 6)).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6, 7),
       block(
         element(VARIABLE, "a"),
         element(IDENTIFIER, "a")).terminator(RETURN_STATEMENT).successors(0));

--- a/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -357,6 +357,7 @@ class CFGTest {
         case LOGICAL_COMPLEMENT:
         case MULTIPLY_ASSIGNMENT:
         case PLUS:
+        case CASE_GROUP:
           break;
         default:
           throw new IllegalArgumentException("Unsupported element kind: " + kind);
@@ -620,20 +621,21 @@ class CFGTest {
       "}");
     CFGChecker cfgChecker = checker(
       block(
-        element(INT_LITERAL, "1"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "bar"),
         element(Tree.Kind.METHOD_INVOCATION)
         ).hasCaseGroup().successors(3),
       block(
-        element(INT_LITERAL, "2"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "qix"),
         element(Tree.Kind.METHOD_INVOCATION)
         ).hasCaseGroup().terminator(Tree.Kind.BREAK_STATEMENT).successors(0),
       block(
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "baz"),
@@ -641,6 +643,8 @@ class CFGTest {
         ).hasCaseGroup().successors(0),
       block(
         element(Tree.Kind.VARIABLE, "a"),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 1),
         element(Tree.Kind.IDENTIFIER, "foo")
         ).terminator(Tree.Kind.SWITCH_STATEMENT).successors(2, 3, 4));
     cfgChecker.check(cfg);
@@ -664,26 +668,29 @@ class CFGTest {
       "  }");
     final CFGChecker cfgChecker = checker(
       block(
-        element(INT_LITERAL, "1"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "bar"),
         element(Tree.Kind.METHOD_INVOCATION)).hasCaseGroup().successors(3),
       block(
-        element(INT_LITERAL, "2"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "qix"),
         element(Tree.Kind.METHOD_INVOCATION)).terminator(Tree.Kind.BREAK_STATEMENT).hasCaseGroup().successors(0),
       block(
-        element(INT_LITERAL, "3"),
-        element(INT_LITERAL, "4"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "baz"),
         element(Tree.Kind.METHOD_INVOCATION)).hasCaseGroup().successors(0),
       block(
         element(Tree.Kind.VARIABLE, "a"),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 1),
         element(Tree.Kind.IDENTIFIER, "foo")).terminator(Tree.Kind.SWITCH_STATEMENT).successors(2, 3, 4));
     cfgChecker.check(cfg);
   }
@@ -703,19 +710,21 @@ class CFGTest {
       "  }");
     final CFGChecker cfgChecker = checker(
       block(
-        element(INT_LITERAL, "1"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "bar"),
         element(Tree.Kind.METHOD_INVOCATION)).hasCaseGroup().successors(3),
       block(
-        element(INT_LITERAL, "2"),
+        element(Tree.Kind.CASE_GROUP),
         element(Tree.Kind.IDENTIFIER, "System"),
         element(Tree.Kind.MEMBER_SELECT),
         element(Tree.Kind.IDENTIFIER, "qix"),
         element(Tree.Kind.METHOD_INVOCATION)).terminator(Tree.Kind.BREAK_STATEMENT).hasCaseGroup().successors(1),
       block(
         element(Tree.Kind.VARIABLE, "a"),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 1),
         element(Tree.Kind.IDENTIFIER, "foo")).terminator(Tree.Kind.SWITCH_STATEMENT).successors(1, 3, 4),
       block(
         element(Tree.Kind.IDENTIFIER, "Integer"),
@@ -745,7 +754,7 @@ class CFGTest {
       "  }");
     final CFGChecker cfgChecker = checker(
       block(
-        element(INT_LITERAL, "1"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "bar1"),
         element(METHOD_INVOCATION),
@@ -753,27 +762,32 @@ class CFGTest {
         element(IDENTIFIER, "bar2"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
-        element(INT_LITERAL, "2"),
-        element(INT_LITERAL, "3"),
-        element(INT_LITERAL, "4"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "qix"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
-        element(INT_LITERAL, "5"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "gul"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
-        element(INT_LITERAL, "6"),
+        element(Tree.Kind.CASE_GROUP),
         element(STRING_LITERAL, "boom"),
         element(NEW_CLASS)).hasCaseGroup().terminator(THROW_STATEMENT).successors(0),
       block(
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "def"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
         element(VARIABLE, "a"),
+        element(Tree.Kind.INT_LITERAL, 6),
+        element(Tree.Kind.INT_LITERAL, 5),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 1),
         element(IDENTIFIER, "foo")).terminator(SWITCH_STATEMENT).successors(3, 4, 5, 6, 7),
       block(
         element(IDENTIFIER, "Integer"),
@@ -795,7 +809,7 @@ class CFGTest {
       "  }");
     final CFGChecker cfgChecker = checker(
       block(
-        element(INT_LITERAL, "1"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "bar1"),
         element(METHOD_INVOCATION),
@@ -804,21 +818,25 @@ class CFGTest {
         element(METHOD_INVOCATION),
         element(PLUS)).hasCaseGroup().successors(1),
       block(
-        element(INT_LITERAL, "2"),
-        element(INT_LITERAL, "3"),
-        element(INT_LITERAL, "4"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "qix"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
-        element(INT_LITERAL, "5"),
+        element(Tree.Kind.CASE_GROUP),
         element(STRING_LITERAL, "boom"),
         element(NEW_CLASS)).hasCaseGroup().terminator(THROW_STATEMENT).successors(0),
       block(
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "def"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
+        element(Tree.Kind.INT_LITERAL, 5),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 1),
         element(IDENTIFIER, "foo")).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6),
       block(
         element(VARIABLE, "a"),
@@ -847,14 +865,12 @@ class CFGTest {
       "  }");
     final CFGChecker cfgChecker = checker(
       block(
-        element(INT_LITERAL, "1"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "bar"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(6),
       block(
-        element(INT_LITERAL, "2"),
-        element(INT_LITERAL, "3"),
-        element(INT_LITERAL, "4"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "bar1"),
         element(METHOD_INVOCATION),
@@ -863,17 +879,24 @@ class CFGTest {
         element(METHOD_INVOCATION),
         element(PLUS)).hasCaseGroup().terminator(YIELD_STATEMENT).successors(1),
       block(
-        element(INT_LITERAL, "5"),
+        element(Tree.Kind.CASE_GROUP),
         element(STRING_LITERAL, "boom"),
         element(NEW_CLASS)).hasCaseGroup().terminator(THROW_STATEMENT).successors(0),
       block(
-        element(INT_LITERAL, "6"),
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "foo")).hasCaseGroup().successors(1),
       block(
+        element(Tree.Kind.CASE_GROUP),
         element(IDENTIFIER, "fun"),
         element(IDENTIFIER, "def"),
         element(METHOD_INVOCATION)).hasCaseGroup().successors(1),
       block(
+        element(Tree.Kind.INT_LITERAL, 6),
+        element(Tree.Kind.INT_LITERAL, 5),
+        element(Tree.Kind.INT_LITERAL, 4),
+        element(Tree.Kind.INT_LITERAL, 3),
+        element(Tree.Kind.INT_LITERAL, 2),
+        element(Tree.Kind.INT_LITERAL, 1),
         element(IDENTIFIER, "foo")).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6, 7),
       block(
         element(VARIABLE, "a"),

--- a/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -821,7 +821,6 @@ class CFGTest {
       block(
         element(IDENTIFIER, "foo")).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6),
       block(
-        element(SWITCH_EXPRESSION),
         element(VARIABLE, "a"),
         element(IDENTIFIER, "a")).terminator(RETURN_STATEMENT).successors(0));
     cfgChecker.check(cfg);
@@ -877,7 +876,6 @@ class CFGTest {
       block(
         element(IDENTIFIER, "foo")).terminator(SWITCH_EXPRESSION).successors(3, 4, 5, 6, 7),
       block(
-        element(SWITCH_EXPRESSION),
         element(VARIABLE, "a"),
         element(IDENTIFIER, "a")).terminator(RETURN_STATEMENT).successors(0));
     cfgChecker.check(cfg);


### PR DESCRIPTION
Fix CFG generation for switch expressions.

The generated CFG for switch expressions previously included the
switch expression twice, once as a terminator (as it should be) and
once as an expression in the block that used the result of the switch
expression. This would make the switch expression the top of the stack
instead of the result and once the user popped the switch expression,
the result of the switch expression would be left on the stack when
the stack should either be empty or contain the results of other
subexpressions.

With the CFG fixed, switch expressions should now be handled properly
with no need to change the symbolic execution engine itself.