### PR TITLE
Deprecate S4784 and change type of S2039 and S2386 to Code Smell

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2039_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2039_java.json
@@ -1,6 +1,6 @@
 {
   "title": "Member variable visibility should be specified",
-  "type": "VULNERABILITY",
+  "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2386_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2386_java.json
@@ -1,6 +1,6 @@
 {
   "title": "Mutable fields should not be \"public static\"",
-  "type": "VULNERABILITY",
+  "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4784_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4784_java.html
@@ -79,4 +79,6 @@ expression. These methods are used most of the time to split on simple regular e
   </li>
   <li> OWASP Regular expression Denial of Service - ReDoS </li>
 </ul>
+<h2>Deprecated</h2>
+<p>This rule is deprecated; use {rule:squid:S5852} instead.</p>
 

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4784_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4784_java.json
@@ -1,7 +1,7 @@
 {
   "title": "Using regular expressions is security-sensitive",
   "type": "SECURITY_HOTSPOT",
-  "status": "ready",
+  "status": "deprecated",
   "tags": [
     
   ],


### PR DESCRIPTION
Please rebase the two commits.