### PR TITLE
SONARJAVA-3501 only ignore usued imports on lombok.val and lombok.var

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
@@ -118,7 +118,7 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
   public void visitImport(ImportTree tree) {
     String fullyQualifiedName = ExpressionsHelper.concatenate((ExpressionTree) tree.qualifiedIdentifier());
 
-    excludeLinesIfTrue(fullyQualifiedName.startsWith("lombok."), tree, UselessImportCheck.class);
+    excludeLinesIfTrue("lombok.var".equals(fullyQualifiedName) || LOMBOK_VAL.equals(fullyQualifiedName), tree, UselessImportCheck.class);
 
     super.visitImport(tree);
   }

--- a/java-checks/src/test/files/filters/LombokFilter.java
+++ b/java-checks/src/test/files/filters/LombokFilter.java
@@ -1,13 +1,17 @@
-import lombok.val;
+/* unused */ import java.util.List; // WithIssue
+import java.util.regex.Pattern;
+
+import lombok.val; // NoIssue
 import lombok.var; // NoIssue
-import java.util.List; // WithIssue
-import static lombok.AccessLevel.PRIVATE;
-import static lombok.AccessLevel.PROTECTED;
-import static lombok.AccessLevel.PUBLIC;
+/* unused */ import lombok.SneakyThrows; // WithIssue
+
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
 import org.springframework.stereotype.Repository;
-import java.util.regex.Pattern;
+
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+import static lombok.AccessLevel.PUBLIC;
 
 class Fields {
   @lombok.Getter

--- a/java-checks/src/test/java/org/sonar/java/filters/FilterVerifier.java
+++ b/java-checks/src/test/java/org/sonar/java/filters/FilterVerifier.java
@@ -52,8 +52,6 @@ import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class FilterVerifier {
 
@@ -78,13 +76,13 @@ public class FilterVerifier {
     VisitorsBridgeForTests.TestJavaFileScannerContext testJavaFileScannerContext = visitorsBridge.lastCreatedTestContext();
 
     Multimap<Integer, String> issuesByLines = HashMultimap.create();
-    for (AnalyzerMessage analyzerMessage : testJavaFileScannerContext.getIssues()) {
+    Set<AnalyzerMessage> issues = testJavaFileScannerContext.getIssues();
+    for (AnalyzerMessage analyzerMessage : issues) {
       Integer issueLine = analyzerMessage.getLine();
       String ruleKeyName = AnnotationUtils.getAnnotation(analyzerMessage.getCheck().getClass(), Rule.class).key();
       RuleKey ruleKey = RuleKey.of("java", ruleKeyName);
 
       if (issueCollector.rejectedIssuesLines.contains(issueLine)) {
-
         assertThat(filter.accept(ruleKey, analyzerMessage))
           .overridingErrorMessage("Line #" + issueLine + " has been marked with 'NoIssue' but issue of rule '" + ruleKey + "' has been accepted!")
           .isFalse();


### PR DESCRIPTION
.