### PR TITLE
S1948: handle a org.apache.wicket.spring.injection.annot.SpringBean annotated field as transient or serializable

### DIFF
--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -700,6 +700,12 @@
       <version>4.0.10</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-spring</artifactId>
+      <version>9.1.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/java-checks-test-sources/src/main/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
@@ -1,5 +1,8 @@
 package checks.serialization;
 
+import org.apache.wicket.markup.html.panel.GenericPanel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.springframework.stereotype.Component;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -362,4 +365,18 @@ class SerializableImpl implements NonSerializableInterface, java.io.Serializable
 
 interface NonSerializableInterface {
   void doSomething();
+}
+
+@Component
+class MyBean {
+}
+
+class WicketComponentWithSpringBean extends GenericPanel<String> {
+
+  @SpringBean
+  private MyBean myBean; // Compliant
+
+  public WicketComponentWithSpringBean(String id) {
+    super(id);
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
@@ -136,6 +136,7 @@ public class SerializableFieldInSerializableClassCheck extends IssuableSubscript
     SymbolMetadata metadata = member.symbol().metadata();
     return metadata.isAnnotatedWith("javax.inject.Inject")
       || metadata.isAnnotatedWith("javax.ejb.EJB")
+      || metadata.isAnnotatedWith("org.apache.wicket.spring.injection.annot.SpringBean")
       || metadata.annotations().stream().anyMatch(annotation -> annotation.symbol().isUnknown());
   }
 


### PR DESCRIPTION
Apache Wicket will inject a serializable Proxy in @SpringBean annotated fields, which delegates to the corresponding Spring Bean. 
This change will eliminate a false-positive on `S1948` when using Apache Wicket with @SpringBean.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
  - some ITs (Plugin Test) are failing, but I get the same errors/failures on master. Maybe this is a ENV issue on my machine, but my changes should not influnece the Plugin Test at all. So lets see what the CI/CD results say :zany_face: 
  - all other ITs are running fine :smiley: 
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
  - no Jira issue available
