### PR TITLE
S1948: a searializable collection with serializable generic-type doesn't have to be private or transient (false-positive)

### DIFF
--- a/its/ruling/src/test/resources/commons-beanutils/java-S1948.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S1948.json
@@ -5,7 +5,6 @@
 ],
 'commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BasicDynaClass.java':[
 114,
-141,
 ],
 'commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanComparator.java':[
 52,

--- a/its/ruling/src/test/resources/guava/java-S1948.json
+++ b/its/ruling/src/test/resources/guava/java-S1948.json
@@ -128,9 +128,6 @@
 'com.google.guava:guava:src/com/google/common/collect/ImmutableEnumMap.java':[
 107,
 ],
-'com.google.guava:guava:src/com/google/common/collect/ImmutableEnumSet.java':[
-132,
-],
 'com.google.guava:guava:src/com/google/common/collect/ImmutableList.java':[
 588,
 ],

--- a/java-checks-test-sources/src/main/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
@@ -1,5 +1,6 @@
 package checks.serialization;
 
+import com.google.common.collect.*;
 import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.springframework.stereotype.Component;
@@ -379,4 +380,18 @@ class WicketComponentWithSpringBean extends GenericPanel<String> {
   public WicketComponentWithSpringBean(String id) {
     super(id);
   }
+}
+
+class GuavaImmutable implements Serializable {
+  ImmutableList<String> immutableList; // Compliant
+  ImmutableSet<String> immutableSet; // Compliant
+  ImmutableCollection<String> immutableCollection; // Compliant
+  ImmutableMap<String, String> immutableMap; // Compliant
+  ImmutableBiMap<String, String> immutableBiMap; // Compliant
+  ImmutableMultiset<String> immutableMultiset; // Compliant
+
+  ImmutableRangeMap<String, String> immutableRangeMap; // Compliant
+  ImmutableRangeSet<String> immutableRangeSet; // Compliant
+  ImmutableTable<String, String, String> immutableTable; // Compliant
+  ImmutableMultimap<String, String> immutableMultimap; // Compliant
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/serialization/SerializableFieldInSerializableClassCheck.java
@@ -66,7 +66,8 @@ public class SerializableFieldInSerializableClassCheck extends IssuableSubscript
     if (!isExcluded(variableTree)) {
       IdentifierTree simpleName = variableTree.simpleName();
       if (isCollectionOfSerializable(variableTree.type())) {
-        if (!ModifiersUtils.hasModifier(variableTree.modifiers(), Modifier.PRIVATE)) {
+        if (!ModifiersUtils.hasModifier(variableTree.modifiers(), Modifier.PRIVATE)
+          && !implementsSerializable(variableTree.type().symbolType())) {
           reportIssue(simpleName, "Make \"" + simpleName.name() + "\" private or transient.");
         } else if (isUnserializableCollection(variableTree.type().symbolType())
           || isUnserializableCollection(variableTree.initializer())) {


### PR DESCRIPTION
In my optinion rule `S1948` produces false-positives on searializable collections with serializable generic-types, e.g. 
```
class MyClass implements Serializable {
  ArrayList<String> arrayList; // Compliant
}
```
The argument `because they could be assigned non-Serializable values externally` is not true:
* I can't assign an non-Serializable `List` to the above `arrayList`
* OK, I can assign a `ArrayList<Object>` when I ignore all compiler warnings and IDE warnings, but in this case a ClassCast error is much more likely/serious then a serialization issue! And even if the field is private I could also assign this with a getter.


- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
  - no Jira issue exists
