### PR TITLE
SONARJAVA-3598 Fix FP in S2973 when symbol is in lowercase

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/EscapedUnicodeCharactersCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/EscapedUnicodeCharactersCheck.java
@@ -33,6 +33,7 @@ class EscapedUnicodeCharactersCheck {
     // Unicode characters with White_Space property
     prefix = "a\u0085" + "a\u00A0" + "a\u1680" + "a\u2000" + "a\u2001" + "a\u2002" + "a\u2003" + "a\u2004" + "a\u2005";
     prefix = "a\u2006" + "a\u2007" + "a\u2008" + "a\u2009" + "a\u200A" + "a\u2028" + "a\u2029" + "a\u202F" + "a\u205F" + "a\u3000";
+    prefix = "a\u00a0" + "a\u200a" + "a\u202f" + "a\u205f";
 
     // Related Unicode characters without White_Space property
     prefix = "a\u180E" + "a\u200B" + "a\u200C" + "a\u200D" + "a\u2060" + "a\uFEFF";

--- a/java-checks/src/main/java/org/sonar/java/checks/EscapedUnicodeCharactersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EscapedUnicodeCharactersCheck.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -73,7 +74,7 @@ public class EscapedUnicodeCharactersCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isPrintableEscapedUnicode(String input) {
-    String hexValue = input.substring(input.length() - 4);
+    String hexValue = input.substring(input.length() - 4).toUpperCase(Locale.ROOT);
     if (UNICODE_WHITESPACES.contains(hexValue)) {
       return false;
     }


### PR DESCRIPTION
Rule S2973 (`EscapedUnicodeCharactersCheck`) allows certain Unicode white space characters to use `\u` notation. However, these exceptions were only allowed if all the hex digits are uppercase. For example, `\u00A0` was allowed but `\u00a0` was not. I changed it to allow lowercase hex digits too.