### PR TITLE
Fix RestAssured 2.x support

### DIFF
--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -497,6 +497,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.jayway.restassured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>2.9.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <version>3.0.2</version>

--- a/java-checks-test-sources/src/main/java/checks/tests/AssertionsInTestsCheck/RestAssured2.java
+++ b/java-checks-test-sources/src/main/java/checks/tests/AssertionsInTestsCheck/RestAssured2.java
@@ -1,0 +1,133 @@
+package checks.tests.AssertionsInTestsCheck;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.builder.ResponseSpecBuilder;
+import com.jayway.restassured.response.ValidatableResponse;
+import com.jayway.restassured.specification.ResponseSpecification;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+
+class RestAssured2Test {
+
+  @Test
+  public void incomplete() { // Noncompliant
+    // do nothing
+  }
+
+  @Test
+  public void test_body() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .body("[0].userId", equalTo(5));
+  }
+
+  @Test
+  public void test_content() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .content(is("body"));
+  }
+
+  @Test
+  public void test_contentType() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .contentType("application/json");
+  }
+
+  @Test
+  public void test_cookie() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .cookie("Cookie1");
+  }
+
+  @Test
+  public void test_cookies() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .cookies("Cookie1", "Cookie");
+  }
+
+  @Test
+  public void test_header() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .header("Header1", "Test");
+  }
+
+  @Test
+  public void test_headers() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .headers("a", "a");
+  }
+
+  @Test
+  public void test_spec() { // Compliant
+    ResponseSpecification spec = new ResponseSpecBuilder().expectStatusCode(200).expectBody("content", equalTo("Hello, Johan!")).build();
+
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .spec(spec);
+  }
+
+  @Test
+  public void test_specification() { // Compliant
+
+    ResponseSpecification spec = new ResponseSpecBuilder().expectStatusCode(200).expectBody("content", equalTo("Hello, Johan!")).build();
+
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .specification(spec);
+  }
+
+  @Test
+  public void test_statuscode() { // Compliant
+    ValidatableResponse validatableResponse = RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .statusCode(200);
+  }
+
+  @Test
+  public void test_statusline() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .statusLine("statusline");
+  }
+
+  @Test
+  public void test_time() { // Compliant
+    RestAssured
+      .given()
+      .get("http://url.com")
+      .then()
+      .time(lessThan(2L), SECONDS);
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -44,8 +44,11 @@ public final class UnitTestUtils {
   public static final MethodMatchers ASSERTION_INVOCATION_MATCHERS = MethodMatchers.or(
     // fest 1.x / 2.X
     MethodMatchers.create().ofSubTypes("org.fest.assertions.GenericAssert", "org.fest.assertions.api.AbstractAssert").anyName().withAnyParameters().build(),
-    // rest assured 2.0
-    MethodMatchers.create().ofTypes("io.restassured.response.ValidatableResponseOptions")
+    // rest assured 2.x, 3.x, 4.x
+    MethodMatchers.create().ofTypes(
+      "com.jayway.restassured.response.ValidatableResponseOptions", //restassured 2.x
+      "io.restassured.response.ValidatableResponseOptions" //restassured 3.x and 4.x
+    )
       .name(name -> name.equals("body") ||
         name.equals("time") ||
         name.startsWith("time") ||

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2699_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S2699_java.html
@@ -12,7 +12,7 @@ code under test.</p>
   <li> JMockit </li>
   <li> JUnit </li>
   <li> Mockito </li>
-  <li> Rest-assured 2.0 </li>
+  <li> Rest-assured 2.x, 3.x and 4.x</li>
   <li> RxJava 1.x and 2.x </li>
   <li> Selenide </li>
   <li> Spring's <code>org.springframework.test.web.servlet.ResultActions.andExpect()</code> </li>

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/AssertionsInTestsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/AssertionsInTestsCheckTest.java
@@ -59,6 +59,7 @@ class AssertionsInTestsCheckTest {
     "ReactiveX1",
     "ReactiveX2",
     "RestAssured",
+    "RestAssured2",
     "Mockito",
     "JMock",
     "WireMock",


### PR DESCRIPTION
Documentation stated that RestAssured 2.x was support when it was in fact only 3.x and 4.x

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
