### PR TITLE
correcting à false positive on rule S3438

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/xml/spring/SingleConnectionFactoryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/xml/spring/SingleConnectionFactoryCheck.java
@@ -39,21 +39,10 @@ public class SingleConnectionFactoryCheck extends SimpleXPathBasedCheck {
   @Override
   public void scanFile(XmlFile file) {
     evaluateAsList(singleConnectionFactoryBeansExpression, file.getNamespaceUnawareDocument()).forEach(bean -> {
-      if (!hasReconnectOnExceptionPropertyEnabled(bean)) {
+      if (!hasAttributeValue(bean, "p:reconnectOnException") && !hasPropertyAsChild(bean, reconnectOnExceptionPropertyExpression)) {
         reportIssue(bean, "Add a \"reconnectOnException\" property, set to \"true\"");
       }
     });
-  }
-
-  private boolean hasReconnectOnExceptionPropertyEnabled(Node bean) {
-    return hasPropertyAsAttribute(bean) ||
-      hasAttributeValue(bean, "reconnectOnException") ||
-      hasPropertyAsChild(bean, reconnectOnExceptionPropertyExpression);
-  }
-
-  private static boolean hasPropertyAsAttribute(Node bean) {
-    Node attribute = XmlFile.nodeAttribute(bean, "p:reconnectOnException");
-    return attribute != null && "true".equals(attribute.getNodeValue());
   }
 
   private static boolean hasAttributeValue(Node bean, String attributeName) {

--- a/java-checks/src/test/resources/checks/SingleConnectionFactoryCheck/beans.xml
+++ b/java-checks/src/test/resources/checks/SingleConnectionFactoryCheck/beans.xml
@@ -37,4 +37,12 @@
     </property>
   </bean>
 
+  <bean id="scf8" class="org.springframework.jms.connection.SingleConnectionFactory"> <!-- Compliant -->
+    <property name="reconnectOnException" value="true"/>
+  </bean>
+
+  <bean id="scf9" class="org.springframework.jms.connection.SingleConnectionFactory"> <!-- Noncompliant {{Add a "reconnectOnException" property, set to "true"}} -->
+    <property name="reconnectOnException" value="false" />
+  </bean>
+
 </beans>

--- a/java-checks/src/test/resources/checks/SingleConnectionFactoryCheck/beans.xml
+++ b/java-checks/src/test/resources/checks/SingleConnectionFactoryCheck/beans.xml
@@ -26,4 +26,15 @@
 
   <bean id="scf5" class="org.springframework.jms.connection.SingleConnectionFactory" p:reconnectOnException="false"> <!-- Noncompliant {{Add a "reconnectOnException" property, set to "true"}} -->
   </bean>
+
+  <bean id="scf6" class="org.springframework.jms.connection.SingleConnectionFactory"> <!-- Compliant -->
+    <property name="reconnectOnException" value="true">
+    </property>
+  </bean>
+
+  <bean id="scf7" class="org.springframework.jms.connection.SingleConnectionFactory"> <!-- Noncompliant {{Add a "reconnectOnException" property, set to "true"}} -->
+    <property name="reconnectOnException" value="false">
+    </property>
+  </bean>
+
 </beans>


### PR DESCRIPTION
The java analyzer detect the sample
`<property name="reconnectOnException" value="true">`
as offending rule S3438.

Please ensure your pull request adheres to the following guidelines: 

- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
