### PR TITLE
SONARJAVA-3579: Fix FP S1170 for final fields having lombok.Builder.Default

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
@@ -75,6 +75,8 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
     RegexPatternsNeedlesslyCheck.class,
     StaticMethodCheck.class);
 
+  private static final String LOMBOK_BUILDER = "lombok.Builder";
+  private static final String LOMBOK_BUILDER_DEFAULT = "lombok.Builder$Default";
   private static final String LOMBOK_VAL = "lombok.val";
   private static final String LOMBOK_VALUE = "lombok.Value";
   private static final String LOMBOK_FIELD_DEFAULTS = "lombok.experimental.FieldDefaults";
@@ -154,6 +156,15 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
         .map(VariableTree.class::cast)
         .filter(v -> !generatesNonFinal(v))
         .forEach(v -> excludeLines(v, ExceptionsShouldBeImmutableCheck.class));
+    }
+
+    // Exclude final fields annotated with @Builder.Default in a @Builder class
+    if (usesAnnotation(tree, Collections.singletonList(LOMBOK_BUILDER))) {
+      tree.members().stream()
+        .filter(t -> t.is(Tree.Kind.VARIABLE))
+        .map(VariableTree.class::cast)
+        .filter(v -> v.symbol().isFinal() && v.symbol().metadata().isAnnotatedWith(LOMBOK_BUILDER_DEFAULT))
+        .forEach(v -> excludeLines(v, ConstantsShouldBeStaticFinalCheck.class));
     }
 
     super.visitClass(tree);

--- a/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/LombokFilter.java
@@ -84,7 +84,7 @@ public class LombokFilter extends BaseTreeVisitorIssueFilter {
   private static final List<String> GENERATE_UNUSED_FIELD_RELATED_METHODS = ImmutableList.<String>builder()
     .add("lombok.Getter")
     .add("lombok.Setter")
-    .add("lombok.Builder")
+    .add(LOMBOK_BUILDER)
     .add("lombok.ToString")
     .add("lombok.AllArgsConstructor")
     .add("lombok.NoArgsConstructor")

--- a/java-checks/src/test/files/filters/LombokFilter.java
+++ b/java-checks/src/test/files/filters/LombokFilter.java
@@ -53,10 +53,16 @@ class Fields {
   @lombok.Builder
   class Builder { // WithIssue
     private int foo; // NoIssue
+
+    @lombok.Builder.Default
+    private final int bar = 1; // NoIssue
   }
 
   class Builder2 { // WithIssue
     private int foo; // WithIssue
+
+    @lombok.Builder.Default
+    private final int bar = 1; // WithIssue
   }
 
   @lombok.ToString

--- a/java-checks/src/test/files/filters/LombokFilter.java
+++ b/java-checks/src/test/files/filters/LombokFilter.java
@@ -53,16 +53,29 @@ class Fields {
   @lombok.Builder
   class Builder { // WithIssue
     private int foo; // NoIssue
-
-    @lombok.Builder.Default
-    private final int bar = 1; // NoIssue
   }
 
   class Builder2 { // WithIssue
     private int foo; // WithIssue
+  }
 
+  // SONARJAVA-3579 No FP for non-static final fields with Builder.Default
+  @lombok.Builder
+  class Builder3 { // NoIssue
     @lombok.Builder.Default
-    private final int bar = 1; // WithIssue
+    public final int bar = 1; // NoIssue
+  }
+
+  // Final fields with Builder.Default that aren't in a Builder class should still complain
+  class Builder4 { // WithIssue
+    @lombok.Builder.Default
+    public final int bar = 1; // WithIssue
+  }
+
+  // Final fields without Builder.Default should still complain
+  @lombok.Builder
+  class Builder5 { // WithIssue
+    public final int foo = 1; // WithIssue
   }
 
   @lombok.ToString


### PR DESCRIPTION
Fixes [false positive](https://sonarcloud.io/project/issues?id=hedera-mirror-node&issues=AXWZiS9Nv5yw_9uAtotR&open=AXWZiS9Nv5yw_9uAtotR) S1170 (e.g. `Make this final field static too.`)  for final fields having `@lombok.Builder.Default`. Previously this class would fail despite being valid Java code with Lombok on the classpath:

```java
@Builder
public class Test {
  @Builder.Default
  private final int foo = 1;
}
```

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
