### PR TITLE
SONARJAVA-3602 Add test at verifier level

### DIFF
--- a/java-frontend/src/test/files/testing/MultipleIssuesSameLine.java
+++ b/java-frontend/src/test/files/testing/MultipleIssuesSameLine.java
@@ -1,0 +1,8 @@
+class A {
+  // Noncompliant@+2 {{msg 1}}
+  // Noncompliant@+1 {{msg 2}}
+  Object foo;
+  // Noncompliant@+2 {{msg 1}}
+  // Noncompliant@+1 {{msg 2}}
+  Object bar;
+}

--- a/java-frontend/src/test/java/org/sonar/java/testing/ExpectationsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/testing/ExpectationsTest.java
@@ -19,19 +19,19 @@
  */
 package org.sonar.java.testing;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.Test;
-import org.sonar.java.testing.Expectations.Parser;
+import org.sonar.java.collections.MapBuilder;
 
 import static org.sonar.java.testing.Expectations.IssueAttribute.END_COLUMN;
 import static org.sonar.java.testing.Expectations.IssueAttribute.END_LINE;
 import static org.sonar.java.testing.Expectations.IssueAttribute.FLOWS;
+import static org.sonar.java.testing.Expectations.IssueAttribute.LINE;
 import static org.sonar.java.testing.Expectations.IssueAttribute.MESSAGE;
 import static org.sonar.java.testing.Expectations.IssueAttribute.SECONDARY_LOCATIONS;
 import static org.sonar.java.testing.Expectations.IssueAttribute.START_COLUMN;
@@ -40,25 +40,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ExpectationsTest {
 
-  private static final int LINE = 42;
+  private static final int TEST_LINE = 42;
 
   @Test
   void issue_without_details() {
-    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant", LINE).issue;
-    assertThat(issue).containsEntry(Expectations.IssueAttribute.LINE, LINE);
+    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant", TEST_LINE).issue;
+    assertThat(issue).containsEntry(LINE, TEST_LINE);
   }
 
   @Test
   void issue_with_message() {
-    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant {{message}}", LINE).issue;
+    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant {{message}}", TEST_LINE).issue;
     assertThat(issue).containsEntry(MESSAGE, "message");
   }
 
   @Test
   void issue_with_attributes() {
-    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant [[flows=f1,f2,f3;sc=3;ec=7;el=4;secondary=5]]", LINE).issue;
+    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant [[flows=f1,f2,f3;sc=3;ec=7;el=4;secondary=5]]", TEST_LINE).issue;
     assertThat(issue)
-      .containsEntry(FLOWS, ImmutableList.of("f1", "f2", "f3"))
+      .containsEntry(FLOWS, Arrays.asList("f1", "f2", "f3"))
       .containsEntry(START_COLUMN, 3)
       .containsEntry(END_COLUMN, 7)
       .containsEntry(END_LINE, Expectations.Parser.LineRef.fromString("4"))
@@ -68,15 +68,15 @@ class ExpectationsTest {
 
   @Test
   void relative_end_line_attribute() {
-    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant [[el=+1]]", LINE).issue;
-    assertThat(issue).containsEntry(END_LINE, Expectations.Parser.LineRef.fromString(String.valueOf(LINE + 1)));
+    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant [[el=+1]]", TEST_LINE).issue;
+    assertThat(issue).containsEntry(END_LINE, Expectations.Parser.LineRef.fromString(String.valueOf(TEST_LINE + 1)));
   }
 
   @Test
   void invalid_attribute_name() {
-    Parser parser = new Expectations().parser();
+    Expectations.Parser parser = new Expectations().parser();
     try {
-      parser.parseIssue("// Noncompliant [[invalid]]", LINE);
+      parser.parseIssue("// Noncompliant [[invalid]]", TEST_LINE);
       Fail.fail("exception expected");
     } catch (AssertionError e) {
       assertThat(e).hasMessage("// Noncompliant attributes not valid: 'invalid'");
@@ -85,7 +85,7 @@ class ExpectationsTest {
 
   @Test
   void issue_with_attributes_and_comment() {
-    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant [[sc=1;ec=6]] {{message}}", LINE).issue;
+    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant [[sc=1;ec=6]] {{message}}", TEST_LINE).issue;
     assertThat(issue)
       .containsEntry(MESSAGE, "message")
       .containsEntry(START_COLUMN, 1)
@@ -94,7 +94,7 @@ class ExpectationsTest {
 
   @Test
   void issue_with_attributes_and_comment_switched() {
-    Expectations.Issue issue = new Expectations().parser().parseIssue("// Noncompliant {{message}} [[sc=1;ec=6]]", LINE).issue;
+    Expectations.Issue issue = new Expectations().parser().parseIssue("// Noncompliant {{message}} [[sc=1;ec=6]]", TEST_LINE).issue;
     assertThat(issue.get(MESSAGE)).isEqualTo("message");
     assertThat(issue.get(START_COLUMN)).isEqualTo(1);
     assertThat(issue.get(END_COLUMN)).isEqualTo(6);
@@ -102,7 +102,7 @@ class ExpectationsTest {
 
   @Test
   void end_line_attribute() {
-    Parser parser = new Expectations().parser();
+    Expectations.Parser parser = new Expectations().parser();
     try {
       parser.parseIssue("// Noncompliant [[endLine=-1]] {{message}}", 0);
       Fail.fail("exception expected");
@@ -113,7 +113,7 @@ class ExpectationsTest {
 
   @Test
   void line_shifting() {
-    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant@-1", LINE).issue;
+    Map<Expectations.IssueAttribute, Object> issue = new Expectations().parser().parseIssue("// Noncompliant@-1", TEST_LINE).issue;
     assertThat(issue).containsEntry(Expectations.IssueAttribute.LINE, 41);
   }
 
@@ -125,30 +125,30 @@ class ExpectationsTest {
 
   @Test
   void flow_without_details() {
-    List<Expectations.FlowComment> flows = Expectations.Parser.parseFlows("// flow@npe1", LINE);
+    List<Expectations.FlowComment> flows = Expectations.Parser.parseFlows("// flow@npe1", TEST_LINE);
     assertThat(flows).hasSize(1);
     Expectations.FlowComment flow = flows.iterator().next();
     assertThat(flow.id).isEqualTo("npe1");
-    assertThat(flow.line).isEqualTo(LINE);
+    assertThat(flow.line).isEqualTo(TEST_LINE);
   }
 
   @Test
   void flow_with_message() throws Exception {
-    List<Expectations.FlowComment> flows = Expectations.Parser.parseFlows("// flow@npe1 {{message}}", LINE);
+    List<Expectations.FlowComment> flows = Expectations.Parser.parseFlows("// flow@npe1 {{message}}", TEST_LINE);
     assertThat(flows).hasSize(1);
     Expectations.FlowComment flow = flows.iterator().next();
     assertThat(flow.id).isEqualTo("npe1");
-    assertThat(flow.line).isEqualTo(LINE);
+    assertThat(flow.line).isEqualTo(TEST_LINE);
     assertThat(flow.attributes).containsEntry(MESSAGE, "message");
   }
 
   @Test
   void flow_with_attributes_and_message() throws Exception {
-    List<Expectations.FlowComment> flows = Expectations.Parser.parseFlows("// flow@npe1 [[sc=1;ec=6]] {{message}}", LINE);
+    List<Expectations.FlowComment> flows = Expectations.Parser.parseFlows("// flow@npe1 [[sc=1;ec=6]] {{message}}", TEST_LINE);
     assertThat(flows).hasSize(1);
     Expectations.FlowComment flow = flows.iterator().next();
     assertThat(flow.id).isEqualTo("npe1");
-    assertThat(flow.line).isEqualTo(LINE);
+    assertThat(flow.line).isEqualTo(TEST_LINE);
     assertThat(flow.attributes)
       .containsEntry(START_COLUMN, 1)
       .containsEntry(END_COLUMN, 6)
@@ -157,19 +157,19 @@ class ExpectationsTest {
 
   @Test
   void issue_and_flow_on_the_same_line() {
-    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant [[flows=id]] flow@id", LINE);
-    assertThat(iaf.issue.get(Expectations.IssueAttribute.LINE)).isEqualTo(LINE);
+    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant [[flows=id]] flow@id", TEST_LINE);
+    assertThat(iaf.issue.get(Expectations.IssueAttribute.LINE)).isEqualTo(TEST_LINE);
     assertThat((List) iaf.issue.get(FLOWS)).contains("id");
     assertThat(iaf.flows).hasSize(1);
     Expectations.FlowComment flow = iaf.flows.iterator().next();
     assertThat(flow.id).isEqualTo("id");
-    assertThat(flow.line).isEqualTo(LINE);
+    assertThat(flow.line).isEqualTo(TEST_LINE);
   }
 
   @Test
   void issue_and_flow_message() {
-    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant {{issue msg}} flow@id {{flow msg}}", LINE);
-    assertThat(iaf.issue.get(Expectations.IssueAttribute.MESSAGE)).isEqualTo("issue msg");
+    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant {{issue msg}} flow@id {{flow msg}}", TEST_LINE);
+    assertThat(iaf.issue.get(MESSAGE)).isEqualTo("issue msg");
     assertThat(iaf.flows).hasSize(1);
     Expectations.FlowComment flow = iaf.flows.iterator().next();
     assertThat(flow.attributes).containsEntry(MESSAGE, "flow msg");
@@ -177,8 +177,8 @@ class ExpectationsTest {
 
   @Test
   void issue_and_flow_message2() {
-    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant flow@id {{flow msg}}", LINE);
-    assertThat(iaf.issue.get(Expectations.IssueAttribute.MESSAGE)).isNull();
+    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant flow@id {{flow msg}}", TEST_LINE);
+    assertThat(iaf.issue.get(MESSAGE)).isNull();
     assertThat(iaf.flows).hasSize(1);
     Expectations.FlowComment flow = iaf.flows.iterator().next();
     assertThat(flow.attributes).containsEntry(MESSAGE, "flow msg");
@@ -186,9 +186,9 @@ class ExpectationsTest {
 
   @Test
   void issue_and_flow_attr() {
-    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant [[sc=1;ec=2]] bla bla flow@id [[sc=3;ec=4]] bla bla", LINE);
-    assertThat(iaf.issue.get(Expectations.IssueAttribute.START_COLUMN)).isEqualTo(1);
-    assertThat(iaf.issue.get(Expectations.IssueAttribute.END_COLUMN)).isEqualTo(2);
+    Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant [[sc=1;ec=2]] bla bla flow@id [[sc=3;ec=4]] bla bla", TEST_LINE);
+    assertThat(iaf.issue.get(START_COLUMN)).isEqualTo(1);
+    assertThat(iaf.issue.get(END_COLUMN)).isEqualTo(2);
     assertThat(iaf.flows).hasSize(1);
     Expectations.FlowComment flow = iaf.flows.iterator().next();
     assertThat(flow.attributes)
@@ -199,37 +199,36 @@ class ExpectationsTest {
   @Test
   void issue_and_flow_all_options() {
     Expectations.Parser.ParsedComment iaf = new Expectations().parser()
-      .parseIssue("// Noncompliant [[flows;sc=1;ec=2]] bla {{issue msg}} bla flow@id [[sc=3;ec=4]] bla {{flow msg}} bla", LINE);
-    assertThat(iaf.issue).isEqualTo(ImmutableMap.of(
-      Expectations.IssueAttribute.LINE, 42,
-      MESSAGE, "issue msg",
-      START_COLUMN, 1,
-      END_COLUMN, 2,
-      FLOWS, Collections.emptyList()
-    ));
+      .parseIssue("// Noncompliant [[flows;sc=1;ec=2]] bla {{issue msg}} bla flow@id [[sc=3;ec=4]] bla {{flow msg}} bla", TEST_LINE);
+    assertThat(iaf.issue).isEqualTo(MapBuilder.<Expectations.IssueAttribute, Object>newMap()
+      .put(LINE, 42)
+      .put(MESSAGE, "issue msg")
+      .put(START_COLUMN, 1)
+      .put(END_COLUMN, 2)
+      .put(FLOWS, Collections.emptyList()).build());
     assertThat(iaf.flows).hasSize(1);
     Expectations.FlowComment flow = iaf.flows.iterator().next();
-    assertThat(flow.line).isEqualTo(LINE);
-    assertThat(flow.attributes).isEqualTo(ImmutableMap.of(
-      MESSAGE, "flow msg",
-      START_COLUMN, 3,
-      END_COLUMN, 4
-    ));
+    assertThat(flow.line).isEqualTo(TEST_LINE);
+    assertThat(flow.attributes).isEqualTo(MapBuilder.<Expectations.IssueAttribute, Object>newMap()
+      .put(MESSAGE, "flow msg")
+      .put(START_COLUMN, 3)
+      .put(END_COLUMN, 4)
+      .build());
   }
 
   @Test
   void issue_and_multiple_flows_on_the_same_line() {
     Expectations.Parser.ParsedComment iaf = new Expectations().parser().parseIssue("// Noncompliant [[flows=id]] {{issue msg}} flow@id1,id2 {{flow msg12}} flow@id3 {{flow msg3}}",
-      LINE);
-    assertThat(iaf.issue.get(Expectations.IssueAttribute.MESSAGE)).isEqualTo("issue msg");
+      TEST_LINE);
+    assertThat(iaf.issue.get(MESSAGE)).isEqualTo("issue msg");
     assertThat(iaf.flows).hasSize(3);
     List<Integer> lines = iaf.flows.stream().map(f -> f.line).collect(Collectors.toList());
-    assertThat(lines).isEqualTo(ImmutableList.of(LINE, LINE, LINE));
+    assertThat(lines).isEqualTo(Arrays.asList(TEST_LINE, TEST_LINE, TEST_LINE));
     Map<String, Object> idMsgMap = iaf.flows.stream().collect(Collectors.toMap(f -> f.id, f -> MESSAGE.get(f.attributes)));
-    assertThat(idMsgMap).isEqualTo(ImmutableMap.of(
-      "id1", "flow msg12",
-      "id2", "flow msg12",
-      "id3", "flow msg3"
-    ));
+    assertThat(idMsgMap).isEqualTo(MapBuilder.<String, Object>newMap()
+      .put("id1", "flow msg12")
+      .put("id2", "flow msg12")
+      .put("id3", "flow msg3")
+      .build());
   }
 }


### PR DESCRIPTION
The actual fix has been done by @sebastian-hungerecker-sonarsource and @alban-auzeill while working on another ticket, and it is already part of Master: https://github.com/SonarSource/sonar-java/commit/2b50830337bf844e443898834ecce4b92084e3b6

This PR only add more tests for consistency and remove the need of Guava in the verifier module