### PR TITLE
SONARJAVA-3608 Report on the methodSelect instead of only name

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/tests/MockitoEqSimplificationCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/tests/MockitoEqSimplificationCheck.java
@@ -5,6 +5,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.mockito.Matchers;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
@@ -31,8 +32,10 @@ public class MockitoEqSimplificationCheck {
     Object v4 = new Object();
     Object v5 = new Object();
 
-    given(foo.bar(eq(v1), eq(v2), eq(v3))).willReturn(null); // Noncompliant [[sc=19;ec=21;secondary=34,34]] {{Remove this and every subsequent useless "eq(...)" invocation; pass the values directly.}}
-    when(foo.baz(eq(v4), eq(v5))).thenReturn("foo"); // Noncompliant [[sc=18;ec=20;secondary=35]] {{Remove this and every subsequent useless "eq(...)" invocation; pass the values directly.}}
+    given(foo.bar(eq(v1), eq(v2), eq(v3))).willReturn(null); // Noncompliant [[sc=19;ec=21;secondary=35,35]] {{Remove this and every subsequent useless "eq(...)" invocation; pass the values directly.}}
+    when(foo.baz(eq(v4), eq(v5))).thenReturn("foo"); // Noncompliant [[sc=18;ec=20;secondary=36]] {{Remove this and every subsequent useless "eq(...)" invocation; pass the values directly.}}
+    when(foo.baz(Matchers.eq(v4),  // Noncompliant [[sc=18;ec=29;secondary=38]] 
+      eq(v5))).thenReturn("foo");
     doThrow(new RuntimeException()).when(foo).quux(eq(42)); // Noncompliant [[sc=52;ec=54]] {{Remove this useless "eq(...)" invocation; pass the values directly.}}
     doCallRealMethod().when(foo).baz(eq(v4), eq(v5)); // Noncompliant
     verify(foo).bar(eq(v1), eq(v2), eq(v3));   // Noncompliant

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoEqSimplificationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoEqSimplificationCheck.java
@@ -89,11 +89,11 @@ public class MockitoEqSimplificationCheck extends IssuableSubscriptionVisitor {
     }
 
     if (!eqs.isEmpty()) {
-      reportIssue(ExpressionUtils.methodName(eqs.get(0)), String.format(
+      reportIssue(eqs.get(0).methodSelect(), String.format(
         "Remove this%s useless \"eq(...)\" invocation; pass the values directly.", eqs.size() == 1 ? "" : " and every subsequent"),
         eqs.stream()
           .skip(1)
-          .map(eq -> new JavaFileScannerContext.Location("", ExpressionUtils.methodName(eq)))
+          .map(eq -> new JavaFileScannerContext.Location("", eq.methodSelect()))
           .collect(Collectors.toList()),
         null);
     }


### PR DESCRIPTION
Mockito's Matchers.eq() method is a static method, so there is no risk of
highlighting too much when raising on the 'methodSelect()' part of the
method invocations. Such calls can not be chained.