### PR TITLE
Extend S1181 to be fully appliable to ERR08-J

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CatchOfThrowableOrErrorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CatchOfThrowableOrErrorCheck.java
@@ -69,7 +69,7 @@ public class CatchOfThrowableOrErrorCheck extends IssuableSubscriptionVisitor {
 
   private void checkType(TypeTree typeTree, CatchTree catchTree) {
     Type type = typeTree.symbolType();
-    if (type.is("java.lang.Error")) {
+    if (type.is("java.lang.Error") || type.is("java.lang.Exception") || type.is("java.lang.RuntimeException")) {
       insertIssue(typeTree, type);
     } else if (type.is(JAVA_LANG_THROWABLE)) {
       GuavaCloserRethrowVisitor visitor = new GuavaCloserRethrowVisitor(catchTree.parameter().symbol());
@@ -81,7 +81,7 @@ public class CatchOfThrowableOrErrorCheck extends IssuableSubscriptionVisitor {
   }
 
   private void insertIssue(TypeTree typeTree, Type type) {
-    reportIssue(typeTree, "Catch Exception instead of " + type.name() + ".");
+    reportIssue(typeTree, "Catch the proper exception instead of " + type.name() + ".");
   }
 
   private static class GuavaCloserRethrowVisitor extends BaseTreeVisitor {

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1181_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1181_java.html
@@ -17,7 +17,7 @@ try { /* ... */ } catch (MyException e) { /* ... */ }
 <h2>See</h2>
 <ul>
   <li> <a href="http://cwe.mitre.org/data/definitions/396.html">MITRE, CWE-396</a> - Declaration of Catch for Generic Exception </li>
-  <li> <a href="https://www.securecoding.cert.org/confluence/x/BIB3AQ">CERT, ERR08-J.</a> - Do not catch NullPointerException or any of its ancestors
+  <li> <a href="https://wiki.sei.cmu.edu/confluence/x/_TdGBQ">CERT, ERR08-J.</a> - Do not catch NullPointerException or any of its ancestors
   </li>
 </ul>
 

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1181_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1181_java.html
@@ -2,14 +2,16 @@
 meant to be caught by applications.</p>
 <p>Catching either <code>Throwable</code> or <code>Error</code> will also catch <code>OutOfMemoryError</code> and <code>InternalError</code>, from
 which an application should not attempt to recover.</p>
+<p>Programs must not catch the <code>NullPointerException</code>, so it is suggested to not catch any of its ancestor.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 try { /* ... */ } catch (Throwable t) { /* ... */ }
 try { /* ... */ } catch (Error e) { /* ... */ }
+try { /* ... */ } catch (Exception e) { /* ... */ }
+try { /* ... */ } catch (RuntimeException e) { /* ... */ }
 </pre>
 <h2>Compliant Solution</h2>
 <pre>
-try { /* ... */ } catch (RuntimeException e) { /* ... */ }
 try { /* ... */ } catch (MyException e) { /* ... */ }
 </pre>
 <h2>See</h2>

--- a/java-checks/src/test/files/checks/CatchOfThrowableOrErrorCheck.java
+++ b/java-checks/src/test/files/checks/CatchOfThrowableOrErrorCheck.java
@@ -4,34 +4,45 @@ class A extends Exception {
   private void f() {
     Closer closer = Closer.create();
     try {
-    } catch (RuntimeException e) {    // Compliant
-    } catch (Throwable e) {           // Noncompliant [[sc=14;ec=23]] {{Catch Exception instead of Throwable.}}
-    } catch (Error e) {               // Noncompliant {{Catch Exception instead of Error.}}
+    } catch (RuntimeException e) {    // Noncompliant {{Catch the proper exception instead of RuntimeException.}}
+    } catch (Throwable e) {           // Noncompliant [[sc=14;ec=23]] {{Catch the proper exception instead of Throwable.}}
+    } catch (Error e) {               // Noncompliant {{Catch the proper exception instead of Error.}}
     } catch (StackOverflowError e) {  // Compliant
     } catch (Foo |
-      Error |                       // Noncompliant {{Catch Exception instead of Error.}}
-      RuntimeException e) {
+      Error |                         // Noncompliant {{Catch the proper exception instead of Error.}}
+      RuntimeException |              // Noncompliant {{Catch the proper exception instead of RuntimeException.}}
+      Exception |                     // Noncompliant {{Catch the proper exception instead of Exception.}}
+      Throwable                       // Noncompliant {{Catch the proper exception instead of Throwable.}}
+      e) {
       try {
-      } catch (Error e) {             // Noncompliant {{Catch Exception instead of Error.}}
+      } catch (Error e) {             // Noncompliant {{Catch the proper exception instead of Error.}}
       }
-    } catch (java.lang.Throwable e) { // Noncompliant {{Catch Exception instead of Throwable.}}
-    } catch (java.lang.Error e) {     // Noncompliant {{Catch Exception instead of Error.}}
+    } catch (java.lang.Throwable e) { // Noncompliant {{Catch the proper exception instead of Throwable.}}
+    } catch (java.lang.Error e) {     // Noncompliant {{Catch the proper exception instead of Error.}}
+    } catch (java.lang.Exception e) { // Noncompliant {{Catch the proper exception instead of Exception.}}
+    } catch (java.lang.RuntimeException e) {     // Noncompliant {{Catch the proper exception instead of RuntimeException.}}
+    } catch (Exception e) {           // Noncompliant {{Catch the proper exception instead of Exception.}}
+    } catch (IOException ex) {        //Compliant
     } catch (foo.Throwable e) {       // Compliant
     } catch (java.foo.Throwable e) {  // Compliant
     } catch (foo.lang.Throwable e) {  // Compliant
+    } catch (java.foo.RuntimeException e) {  // Compliant
+    } catch (foo.lang.RuntimeException e) {  // Compliant
+    } catch (java.foo.Exception e) {  // Compliant
+    } catch (foo.lang.Exception e) {  // Compliant
     } catch (java.lang.foo e) {       // Compliant
     } catch (foo.java.lang.Throwable e) { // Compliant
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Noncompliant {{Catch the proper exception instead of Throwable.}}
       throw e;
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Noncompliant {{Catch the proper exception instead of Throwable.}}
       throw new Exception(e).getCause();
     } catch (Throwable e) {           // Compliant
       throw closer.rethrow(e);
     } catch (java.lang.Throwable e) { // Compliant
       throw closer.rethrow(e);
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Noncompliant {{Catch the proper exception instead of Throwable.}}
       throw closer.rethrow(new Exception(e));
-    } catch (Throwable e) {           // Noncompliant {{Catch Exception instead of Throwable.}}
+    } catch (Throwable e) {           // Noncompliant {{Catch the proper exception instead of Throwable.}}
       Throwable myThrowable = new Throwable(e);
       throw closer.rethrow(myThrowable);
     } catch (Throwable e) {           // Compliant


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.

Actually it fails the JspTest, but at my side it fails without my modifications so I hope it doesn't count.
![image](https://user-images.githubusercontent.com/31959880/100517192-4bfbb600-3189-11eb-84a5-a1f3efc731a3.png)

- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)

I'm trying to implement rules from [this page](https://wiki.sei.cmu.edu/confluence/display/java/SEI+CERT+Oracle+Coding+Standard+for+Java), as I expanded your partially working rule [S1181](https://rules.sonarsource.com/java/RSPEC-1181) to be fully appliable to [ERR08-J. Do not catch NullPointerException or any of its ancestors](https://wiki.sei.cmu.edu/confluence/display/java/ERR08-J.+Do+not+catch+NullPointerException+or+any+of+its+ancestors) with [S1696](https://rules.sonarsource.com/java/RSPEC-1696). If you want I can merge these two rules into one.