### PR TITLE
SONARJAVA-2154 Remove usages of guava Sets, Iterables and AbstractIterator from java-frontend module

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
@@ -19,19 +19,19 @@
  */
 package org.sonar.java;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.sonar.java.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSortedSet;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.java.classpath.ClasspathForMain;
+import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 
@@ -59,7 +59,7 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator {
   }
 
   private Collection<String> classKeys() {
-    return ImmutableSortedSet.<String>naturalOrder().addAll(resourcesByClass.keySet()).build();
+    return new TreeSet<>(resourcesByClass.keySet());
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/JavaSquid.java
+++ b/java-frontend/src/main/java/org/sonar/java/JavaSquid.java
@@ -85,7 +85,7 @@ public class JavaSquid {
     //AstScanner for main files
     astScanner = new JavaAstScanner(sonarComponents);
     astScanner.setVisitorBridge(createVisitorBridge(codeVisitors, classpath, javaVersion, sonarComponents,
-      SymbolicExecutionMode.getMode(visitors)));
+      SymbolicExecutionMode.getMode(Arrays.asList(visitors))));
 
     //AstScanner for test files
     astScannerForTests = new JavaAstScanner(sonarComponents);

--- a/java-frontend/src/main/java/org/sonar/java/JavaSquid.java
+++ b/java-frontend/src/main/java/org/sonar/java/JavaSquid.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java;
 
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +33,7 @@ import org.sonar.api.utils.log.Profiler;
 import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.ast.visitors.FileLinesVisitor;
 import org.sonar.java.ast.visitors.SyntaxHighlighterVisitor;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.filters.SonarJavaIssueFilter;
 import org.sonar.java.model.VisitorsBridge;
 import org.sonar.java.se.SymbolicExecutionMode;
@@ -59,11 +59,11 @@ public class JavaSquid {
       commonVisitors.add(postAnalysisIssueFilter);
     }
 
-    Iterable<JavaCheck> codeVisitors = Iterables.concat(commonVisitors, Arrays.asList(visitors));
+    Iterable<JavaCheck> codeVisitors = ListUtils.concat(commonVisitors, Arrays.asList(visitors));
     Collection<JavaCheck> testCodeVisitors = new ArrayList<>(commonVisitors);
     if (measurer != null) {
       Iterable<JavaCheck> measurers = Collections.singletonList(measurer);
-      codeVisitors = Iterables.concat(measurers, codeVisitors);
+      codeVisitors = ListUtils.concat(measurers, codeVisitors);
       testCodeVisitors.add(measurer.new TestFileMeasurer());
     }
     List<File> classpath = new ArrayList<>();
@@ -72,7 +72,7 @@ public class JavaSquid {
     List<File> jspClasspath = new ArrayList<>();
     if (sonarComponents != null) {
       if(!sonarComponents.isSonarLintContext()) {
-        codeVisitors = Iterables.concat(codeVisitors, Arrays.asList(new FileLinesVisitor(sonarComponents), new SyntaxHighlighterVisitor(sonarComponents)));
+        codeVisitors = ListUtils.concat(codeVisitors, Arrays.asList(new FileLinesVisitor(sonarComponents), new SyntaxHighlighterVisitor(sonarComponents)));
         testCodeVisitors.add(new SyntaxHighlighterVisitor(sonarComponents));
       }
       classpath = sonarComponents.getJavaClasspath();

--- a/java-frontend/src/main/java/org/sonar/java/ast/parser/ArgumentListTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/ast/parser/ArgumentListTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.ast.parser;
 
-import com.google.common.collect.Iterables;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.Arguments;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -79,7 +79,7 @@ public class ArgumentListTreeImpl extends ListTreeImpl<ExpressionTree> implement
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       openParenToken != null ? Collections.singletonList(openParenToken) : Collections.<Tree>emptyList(),
       super.children(),
       closeParenToken != null ? Collections.singletonList(closeParenToken) : Collections.<Tree>emptyList());

--- a/java-frontend/src/main/java/org/sonar/java/ast/parser/ListTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/ast/parser/ListTreeImpl.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.ast.parser;
 
-import com.google.common.collect.AbstractIterator;
 import java.util.Arrays;
+import org.sonar.java.collections.AbstractIterator;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.ListTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;

--- a/java-frontend/src/main/java/org/sonar/java/ast/parser/TypeParameterListTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/ast/parser/TypeParameterListTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.ast.parser;
 
-import com.google.common.collect.Iterables;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -71,7 +71,7 @@ public class TypeParameterListTreeImpl extends ListTreeImpl<TypeParameterTree> i
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(openBracketToken),
       super.children(),
       Collections.singletonList(closeBracketToken));

--- a/java-frontend/src/main/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitor.java
@@ -19,13 +19,14 @@
  */
 package org.sonar.java.ast.visitors;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.sonar.api.batch.sensor.highlighting.NewHighlighting;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
 import org.sonar.java.SonarComponents;
@@ -50,20 +51,20 @@ public class SyntaxHighlighterVisitor extends SubscriptionVisitor {
 
   public SyntaxHighlighterVisitor(SonarComponents sonarComponents) {
     this.sonarComponents = sonarComponents;
+    
+    keywords = Collections.unmodifiableSet(Arrays.stream(JavaKeyword.keywordValues()).collect(Collectors.toSet()));
+    restrictedKeywords = Collections.unmodifiableSet(Arrays.stream(JavaRestrictedKeyword.restrictedKeywordValues()).collect(Collectors.toSet()));
 
-    keywords = ImmutableSet.copyOf(JavaKeyword.keywordValues());
-    restrictedKeywords = ImmutableSet.copyOf(JavaRestrictedKeyword.restrictedKeywordValues());
-
-    ImmutableMap.Builder<Tree.Kind, TypeOfText> typesByKindBuilder = ImmutableMap.builder();
-    typesByKindBuilder.put(Tree.Kind.STRING_LITERAL, TypeOfText.STRING);
-    typesByKindBuilder.put(Tree.Kind.CHAR_LITERAL, TypeOfText.STRING);
-    typesByKindBuilder.put(Tree.Kind.FLOAT_LITERAL, TypeOfText.CONSTANT);
-    typesByKindBuilder.put(Tree.Kind.DOUBLE_LITERAL, TypeOfText.CONSTANT);
-    typesByKindBuilder.put(Tree.Kind.LONG_LITERAL, TypeOfText.CONSTANT);
-    typesByKindBuilder.put(Tree.Kind.INT_LITERAL, TypeOfText.CONSTANT);
-    typesByKindBuilder.put(Tree.Kind.ANNOTATION, TypeOfText.ANNOTATION);
-    typesByKindBuilder.put(Tree.Kind.VAR_TYPE, TypeOfText.KEYWORD);
-    typesByKind = typesByKindBuilder.build();
+    Map<Tree.Kind, TypeOfText> typesByKindMap = new EnumMap<>(Tree.Kind.class);
+    typesByKindMap.put(Tree.Kind.STRING_LITERAL, TypeOfText.STRING);
+    typesByKindMap.put(Tree.Kind.CHAR_LITERAL, TypeOfText.STRING);
+    typesByKindMap.put(Tree.Kind.FLOAT_LITERAL, TypeOfText.CONSTANT);
+    typesByKindMap.put(Tree.Kind.DOUBLE_LITERAL, TypeOfText.CONSTANT);
+    typesByKindMap.put(Tree.Kind.LONG_LITERAL, TypeOfText.CONSTANT);
+    typesByKindMap.put(Tree.Kind.INT_LITERAL, TypeOfText.CONSTANT);
+    typesByKindMap.put(Tree.Kind.ANNOTATION, TypeOfText.ANNOTATION);
+    typesByKindMap.put(Tree.Kind.VAR_TYPE, TypeOfText.KEYWORD);
+    this.typesByKind = Collections.unmodifiableMap(typesByKindMap);
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/cfg/LiveVariables.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/LiveVariables.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.cfg;
 
-import com.google.common.collect.Sets;
 import org.sonar.java.collections.ListUtils;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -115,7 +115,7 @@ public class LiveVariables {
       block.exceptions().stream().map(in::get).filter(Objects::nonNull).forEach(blockOut::addAll);
       // in = gen and (out - kill)
       Set<Symbol> newIn = new HashSet<>(gen.get(block));
-      newIn.addAll(Sets.difference(blockOut, kill.get(block)));
+      newIn.addAll(SetUtils.difference(blockOut, kill.get(block)));
 
       if (newIn.equals(in.get(block))) {
         continue;

--- a/java-frontend/src/main/java/org/sonar/java/cfg/LiveVariables.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/LiveVariables.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.cfg;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.sonar.java.collections.ListUtils;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -99,7 +98,7 @@ public class LiveVariables {
 
     // Make things immutable.
     for (Map.Entry<CFG.Block, Set<Symbol>> blockSetEntry : liveVariables.out.entrySet()) {
-      blockSetEntry.setValue(ImmutableSet.copyOf(blockSetEntry.getValue()));
+      blockSetEntry.setValue(Collections.unmodifiableSet(blockSetEntry.getValue()));
     }
 
     return liveVariables;

--- a/java-frontend/src/main/java/org/sonar/java/classpath/AbstractClasspath.java
+++ b/java-frontend/src/main/java/org/sonar/java/classpath/AbstractClasspath.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.classpath;
 
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -47,6 +46,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+import org.sonar.java.collections.CollectionUtils;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @ScannerSide
@@ -105,7 +105,7 @@ public abstract class AbstractClasspath {
   }
 
   protected boolean hasMoreThanOneJavaFile() {
-    return Iterables.size(fs.inputFiles(fs.predicates().and(fs.predicates().hasLanguage("java"), fs.predicates().hasType(fileType)))) > 1;
+    return CollectionUtils.size(fs.inputFiles(fs.predicates().and(fs.predicates().hasLanguage("java"), fs.predicates().hasType(fileType)))) > 1;
   }
 
   private Set<File> getFilesForPattern(Path baseDir, String pathPattern, boolean libraryProperty) {

--- a/java-frontend/src/main/java/org/sonar/java/collections/AbstractIterator.java
+++ b/java-frontend/src/main/java/org/sonar/java/collections/AbstractIterator.java
@@ -1,0 +1,98 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.collections;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import javax.annotation.Nullable;
+import org.sonar.java.Preconditions;
+
+public abstract class AbstractIterator<T> implements Iterator<T> {
+  private State state;
+  
+  private T next;
+
+  protected AbstractIterator() {
+    this.state = State.NOT_READY;
+  }
+
+  @Nullable
+  protected abstract T computeNext();
+
+  @Nullable
+  protected final T endOfData() {
+    this.state = State.DONE;
+    return null;
+  }
+
+  public final boolean hasNext() {
+    Preconditions.checkState(this.state != State.FAILED);
+    switch(this.state) {
+      case DONE:
+        return false;
+      case READY:
+        return true;
+      default:
+        return this.tryToComputeNext();
+    }
+  }
+
+  private boolean tryToComputeNext() {
+    this.state = State.FAILED;
+    this.next = this.computeNext();
+    if (this.state != State.DONE) {
+      this.state = State.READY;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Nullable
+  public final T next() {
+    if (!this.hasNext()) {
+      throw new NoSuchElementException();
+    } else {
+      this.state = State.NOT_READY;
+      T result = this.next;
+      this.next = null;
+      return result;
+    }
+  }
+
+  @Nullable
+  public final T peek() {
+    if (!this.hasNext()) {
+      throw new NoSuchElementException();
+    } else {
+      return this.next;
+    }
+  }
+
+  private enum State {
+    READY,
+    NOT_READY,
+    DONE,
+    FAILED;
+
+    State() {
+    }
+  }
+}

--- a/java-frontend/src/main/java/org/sonar/java/collections/CollectionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/collections/CollectionUtils.java
@@ -1,0 +1,50 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.collections;
+
+import java.util.Collection;
+import java.util.Iterator;
+import javax.annotation.Nullable;
+
+public final class CollectionUtils {
+
+  private CollectionUtils() {
+  }
+  
+  @Nullable
+  public static <T> T getFirst(Iterable<T> iterable, @Nullable T defaultValue) {
+    Iterator<T> iterator = iterable.iterator();
+    return iterator.hasNext() ? iterator.next() : defaultValue;
+  }
+
+  public static int size(Iterable<?> iterable) {
+    return iterable instanceof Collection ? ((Collection<?>)iterable).size() : size(iterable.iterator());
+  }
+
+  private static int size(Iterator<?> iterator) {
+    int count;
+    for(count = 0; iterator.hasNext(); ++count) {
+      iterator.next();
+    }
+
+    return count;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/collections/ListUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/collections/ListUtils.java
@@ -20,8 +20,11 @@
 package org.sonar.java.collections;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class ListUtils {
 
@@ -44,5 +47,18 @@ public final class ListUtils {
     Collections.reverse(reversed);
     return reversed;
   }
-  
+
+  @SafeVarargs
+  public static <T> List<T> concat(List<? extends T>... lists) {
+    return Arrays.stream(lists)
+      .flatMap(List::stream)
+      .collect(Collectors.toList());
+  }
+
+  @SafeVarargs
+  public static <T> List<T> concat(Iterable<? extends T>... iterables) {
+    return Arrays.stream(iterables)
+      .flatMap(it -> StreamSupport.stream(it.spliterator(), false))
+      .collect(Collectors.toList());
+  }
 }

--- a/java-frontend/src/main/java/org/sonar/java/collections/SetUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/collections/SetUtils.java
@@ -53,4 +53,12 @@ public final class SetUtils {
       .filter(elem -> !set2.contains(elem))
       .collect(Collectors.toSet());
   }
+
+  public static <T> T getOnlyElement(Set<T> set) {
+    if (set.size() == 1) {
+      return set.iterator().next();
+    }
+    throw new IllegalArgumentException(String.format("Expected list of size 1, but was list of size %d.", set.size()));
+  }
+
 }

--- a/java-frontend/src/main/java/org/sonar/java/collections/SetUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/collections/SetUtils.java
@@ -49,16 +49,16 @@ public final class SetUtils {
   }
 
   public static <T> Set<T> difference(Set<T> set1, Set<T> set2) {
-    return set1.stream()
-      .filter(elem -> !set2.contains(elem))
-      .collect(Collectors.toSet());
+    Set<T> newSet1 = new HashSet<>(set1);
+    newSet1.removeAll(set2);
+    return newSet1;
   }
 
   public static <T> T getOnlyElement(Set<T> set) {
     if (set.size() == 1) {
       return set.iterator().next();
     }
-    throw new IllegalArgumentException(String.format("Expected list of size 1, but was list of size %d.", set.size()));
+    throw new IllegalArgumentException(String.format("Expected set of size 1, but was set of size %d.", set.size()));
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/collections/SetUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/collections/SetUtils.java
@@ -47,4 +47,10 @@ public final class SetUtils {
       .flatMap(Set::stream)
       .collect(Collectors.toSet());
   }
+
+  public static <T> Set<T> difference(Set<T> set1, Set<T> set2) {
+    return set1.stream()
+      .filter(elem -> !set2.contains(elem))
+      .collect(Collectors.toSet());
+  }
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/JUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JUtils.java
@@ -19,11 +19,12 @@
  */
 package org.sonar.java.model;
 
-import com.google.common.collect.ImmutableBiMap;
+import java.util.Map;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.sonar.java.collections.MapBuilder;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.semantic.Type;
@@ -43,28 +44,35 @@ public final class JUtils {
   private JUtils() {
   }
 
-  private static final ImmutableBiMap<String, String> WRAPPER_TO_PRIMITIVE;
-
-  static {
-    WRAPPER_TO_PRIMITIVE = ImmutableBiMap.<String, String>builder()
-      .put("java.lang.Byte", "byte")
-      .put("java.lang.Character", "char")
-      .put("java.lang.Short", "short")
-      .put("java.lang.Integer", "int")
-      .put("java.lang.Long", "long")
-      .put("java.lang.Float", "float")
-      .put("java.lang.Double", "double")
-      .put("java.lang.Boolean", "boolean")
-      .build();
-  }
-
+  private static final Map<String, String> WRAPPER_TO_PRIMITIVE = MapBuilder.<String, String>newMap()
+    .put("java.lang.Byte", "byte")
+    .put("java.lang.Character", "char")
+    .put("java.lang.Short", "short")
+    .put("java.lang.Integer", "int")
+    .put("java.lang.Long", "long")
+    .put("java.lang.Float", "float")
+    .put("java.lang.Double", "double")
+    .put("java.lang.Boolean", "boolean")
+    .build();
+  
+  private static final Map<String, String> PRIMITIVE_TO_WRAPPER = MapBuilder.<String, String>newMap()
+    .put("byte", "java.lang.Byte")
+    .put("char", "java.lang.Character")
+    .put("short", "java.lang.Short")
+    .put("int", "java.lang.Integer")
+    .put("long","java.lang.Long")
+    .put("float", "java.lang.Float")
+    .put("double", "java.lang.Double")
+    .put("boolean", "java.lang.Boolean")
+    .build();
+    
   public static boolean isPrimitiveWrapper(Type type) {
     return type.isClass() && WRAPPER_TO_PRIMITIVE.containsKey(type.fullyQualifiedName());
   }
 
   @Nullable
   public static Type primitiveWrapperType(Type type) {
-    String name = WRAPPER_TO_PRIMITIVE.inverse().get(type.fullyQualifiedName());
+    String name = PRIMITIVE_TO_WRAPPER.get(type.fullyQualifiedName());
     if (name == null) {
       return null;
     }

--- a/java-frontend/src/main/java/org/sonar/java/model/JavaTree.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JavaTree.java
@@ -21,7 +21,6 @@ package org.sonar.java.model;
 
 import java.util.Arrays;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
@@ -34,6 +33,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.sonar.java.ast.parser.TypeUnionListTreeImpl;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.declaration.AnnotationTreeImpl;
 import org.sonar.java.model.expression.AssessableExpressionTree;
 import org.sonar.java.model.expression.TypeArgumentListTreeImpl;
@@ -192,7 +192,7 @@ public abstract class JavaTree implements Tree {
     public Iterable<Tree> children() {
       Iterable<Tree> packageIterator = packageDeclaration == null ? Collections.emptyList() : Collections.singletonList(packageDeclaration);
       Iterable<Tree> moduleIterator = moduleDeclaration == null ? Collections.emptyList() : Collections.singletonList(moduleDeclaration);
-      return Iterables.concat(
+      return ListUtils.concat(
         packageIterator,
         imports,
         types,
@@ -265,7 +265,7 @@ public abstract class JavaTree implements Tree {
 
     @Override
     public Iterable<Tree> children() {
-      return Iterables.concat(
+      return ListUtils.concat(
         annotations,
         Arrays.asList(packageKeyword, packageName, semicolonToken)
         );
@@ -368,7 +368,7 @@ public abstract class JavaTree implements Tree {
     @Override
     public Iterable<Tree> children() {
 
-      return Iterables.concat(
+      return ListUtils.concat(
         Collections.singletonList(importToken),
         isStatic ? Collections.singletonList(staticToken) : Collections.<Tree>emptyList(),
         Arrays.asList(qualifiedIdentifier, semicolonToken));
@@ -547,7 +547,7 @@ public abstract class JavaTree implements Tree {
 
     @Override
     public Iterable<Tree> children() {
-      return Iterables.concat(annotations, Collections.singletonList(token));
+      return ListUtils.concat(annotations, Collections.singletonList(token));
     }
 
     @Override
@@ -600,7 +600,7 @@ public abstract class JavaTree implements Tree {
 
     @Override
     public Iterable<Tree> children() {
-      return Iterables.concat(annotations, Arrays.asList(type, typeArguments));
+      return ListUtils.concat(annotations, Arrays.asList(type, typeArguments));
     }
   }
 
@@ -657,7 +657,7 @@ public abstract class JavaTree implements Tree {
     @Override
     public Iterable<Tree> children() {
       boolean hasBrackets = ellipsisToken == null;
-      return Iterables.concat(
+      return ListUtils.concat(
         Collections.singletonList(type),
         annotations,
         hasBrackets ? Arrays.asList(openBracketToken, closeBracketToken) : Collections.singletonList(ellipsisToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.java.model;
 
-import org.sonar.java.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,10 +27,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.java.AnalyzerMessage;
 import org.sonar.java.SonarComponents;
+import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.java.se.SymbolicExecutionMode;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaFileScanner;
@@ -58,7 +58,8 @@ public class VisitorsBridgeForTests extends VisitorsBridge {
   }
 
   public VisitorsBridgeForTests(Iterable<? extends JavaCheck> visitors, List<File> projectClasspath, @Nullable SonarComponents sonarComponents) {
-    super(visitors, projectClasspath, sonarComponents, SymbolicExecutionMode.getMode(Iterables.toArray(visitors, JavaCheck.class)));
+    super(visitors, projectClasspath, sonarComponents, SymbolicExecutionMode.getMode(
+      StreamSupport.stream(visitors.spliterator(), false).toArray(JavaCheck[]::new)));
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.java.AnalyzerMessage;
@@ -58,8 +57,7 @@ public class VisitorsBridgeForTests extends VisitorsBridge {
   }
 
   public VisitorsBridgeForTests(Iterable<? extends JavaCheck> visitors, List<File> projectClasspath, @Nullable SonarComponents sonarComponents) {
-    super(visitors, projectClasspath, sonarComponents, SymbolicExecutionMode.getMode(
-      StreamSupport.stream(visitors.spliterator(), false).toArray(JavaCheck[]::new)));
+    super(visitors, projectClasspath, sonarComponents, SymbolicExecutionMode.getMode(visitors));
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/model/declaration/ClassTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/declaration/ClassTreeImpl.java
@@ -20,10 +20,10 @@
 package org.sonar.java.model.declaration;
 
 import org.sonar.java.Preconditions;
-import com.google.common.collect.Iterables;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.sonar.java.ast.parser.QualifiedIdentifierListTreeImpl;
 import org.sonar.java.ast.parser.TypeParameterListTreeImpl;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.java.model.Symbols;
@@ -224,7 +224,7 @@ public class ClassTreeImpl extends JavaTree implements ClassTree {
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(modifiers),
       addIfNotNull(atToken),
       addIfNotNull(declarationKeyword),

--- a/java-frontend/src/main/java/org/sonar/java/model/declaration/VariableTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/declaration/VariableTreeImpl.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.java.model.declaration;
 
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.java.model.Symbols;
@@ -150,7 +150,7 @@ public class VariableTreeImpl extends JavaTree implements VariableTree {
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Arrays.asList(modifiers, type, simpleName),
       initializer != null ? Arrays.asList(equalToken, initializer) : Collections.<Tree>emptyList(),
       endToken != null ? Collections.singletonList(endToken) : Collections.<Tree>emptyList()

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/IdentifierTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/IdentifierTreeImpl.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.model.expression;
 
-import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -29,6 +28,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.IPackageBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JLabelSymbol;
 import org.sonar.java.model.JavaTree;
@@ -105,7 +105,7 @@ public class IdentifierTreeImpl extends AssessableExpressionTree implements Iden
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(annotations, Collections.singletonList(nameToken));
+    return ListUtils.concat(annotations, Collections.singletonList(nameToken));
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/LambdaExpressionTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/LambdaExpressionTreeImpl.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.model.expression;
 
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
@@ -91,7 +91,7 @@ public class LambdaExpressionTreeImpl extends AssessableExpressionTree implement
   @Override
   public Iterable<Tree> children() {
     boolean hasParentheses = openParenToken != null;
-    return Iterables.concat(
+    return ListUtils.concat(
       hasParentheses ? Collections.singletonList(openParenToken) : Collections.<Tree>emptyList(),
       parameters,
       hasParentheses ? Collections.singletonList(closeParenToken) : Collections.<Tree>emptyList(),

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/MemberSelectExpressionTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/MemberSelectExpressionTreeImpl.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.java.model.expression;
 
-import com.google.common.collect.Iterables;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
@@ -87,7 +86,7 @@ public class MemberSelectExpressionTreeImpl extends AssessableExpressionTree imp
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       annotations,
       Arrays.asList(
         expression,

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/MethodInvocationTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/MethodInvocationTreeImpl.java
@@ -19,10 +19,10 @@
  */
 package org.sonar.java.model.expression;
 
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.sonar.java.ast.parser.ArgumentListTreeImpl;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.Symbols;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.Arguments;
@@ -101,7 +101,7 @@ public class MethodInvocationTreeImpl extends AssessableExpressionTree implement
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       typeArguments != null ? Collections.singletonList(typeArguments) : Collections.<Tree>emptyList(),
       Arrays.asList(methodSelect, arguments));
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/MethodReferenceTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/MethodReferenceTreeImpl.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.model.expression;
 
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MethodReferenceTree;
@@ -61,7 +61,7 @@ public class MethodReferenceTreeImpl extends AssessableExpressionTree implements
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       typeArgument != null ? Collections.singletonList(typeArgument) : Collections.<Tree>emptyList(),
       Arrays.asList(expression, doubleColon, method));
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/TypeArgumentListTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/TypeArgumentListTreeImpl.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.model.expression;
 
-import com.google.common.collect.Iterables;
 import org.sonar.java.ast.parser.ListTreeImpl;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -59,7 +59,7 @@ public class TypeArgumentListTreeImpl extends ListTreeImpl<Tree> implements Type
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(openBracketToken),
       super.children(),
       Collections.singletonList(closeBracketToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/TypeCastExpressionTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/TypeCastExpressionTreeImpl.java
@@ -21,8 +21,8 @@ package org.sonar.java.model.expression;
 
 import java.util.Arrays;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.Iterables;
 import org.sonar.java.ast.parser.BoundListTreeImpl;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.ListTree;
@@ -112,7 +112,7 @@ public class TypeCastExpressionTreeImpl extends AssessableExpressionTree impleme
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Arrays.asList(openParenToken, type),
       andToken == null ? Collections.<Tree>emptyList() : Collections.singletonList(andToken()),
       Arrays.asList(bounds, closeParenToken, expression)

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/AssertStatementTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/AssertStatementTreeImpl.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.AssertStatementTree;
@@ -103,7 +103,7 @@ public class AssertStatementTreeImpl extends JavaTree implements AssertStatement
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Arrays.asList(assertToken, condition),
       colonToken != null ? Arrays.asList(colonToken, detail) : Collections.<Tree>emptyList(),
       Collections.singletonList(semicolonToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/BlockTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/BlockTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.BlockTree;
@@ -77,7 +77,7 @@ public class BlockTreeImpl extends JavaTree implements BlockTree {
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(openBraceToken),
       body,
       Collections.singletonList(closeBraceToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/BreakStatementTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/BreakStatementTreeImpl.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
 import java.util.Collections;
 import javax.annotation.Nullable;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.BreakStatementTree;
@@ -77,7 +77,7 @@ public class BreakStatementTreeImpl extends JavaTree implements BreakStatementTr
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(breakToken),
       labelOrValue != null ? Collections.singletonList(labelOrValue) : Collections.<Tree>emptyList(),
       Collections.<Tree>singletonList(semicolonToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/CaseGroupTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/CaseGroupTreeImpl.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
 import java.util.Collections;
 import org.sonar.java.ast.parser.BlockStatementListTreeImpl;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.CaseGroupTree;
 import org.sonar.plugins.java.api.tree.CaseLabelTree;
@@ -63,7 +63,7 @@ public class CaseGroupTreeImpl extends JavaTree implements CaseGroupTree {
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       labels,
       body);
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/CaseLabelTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/CaseLabelTreeImpl.java
@@ -19,11 +19,11 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.sonar.java.ast.api.JavaPunctuator;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.CaseLabelTree;
@@ -88,7 +88,7 @@ public class CaseLabelTreeImpl extends JavaTree implements CaseLabelTree {
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(caseOrDefaultKeyword),
       expressions,
       Collections.singletonList(colonOrArrowToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/ContinueStatementTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/ContinueStatementTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.java.model.expression.IdentifierTreeImpl;
@@ -73,7 +73,7 @@ public class ContinueStatementTreeImpl extends JavaTree implements ContinueState
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(continueKeyword),
       label != null ? Collections.singletonList(label) : Collections.<Tree>emptyList(),
       Collections.singletonList(semicolonToken));

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/ExpressionStatementTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/ExpressionStatementTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
@@ -65,7 +65,7 @@ public class ExpressionStatementTreeImpl extends JavaTree implements ExpressionS
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Collections.singletonList(expression),
       semicolonToken != null ? Collections.singletonList(semicolonToken) : Collections.<Tree>emptyList());
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/IfStatementTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/IfStatementTreeImpl.java
@@ -21,7 +21,7 @@ package org.sonar.java.model.statement;
 
 import java.util.Arrays;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.Iterables;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -124,7 +124,7 @@ public class IfStatementTreeImpl extends JavaTree implements IfStatementTree {
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Arrays.asList(ifKeyword, openParenToken, condition, closeParenToken, thenStatement),
       elseKeyword != null ? Arrays.asList(elseKeyword, elseStatement) : Collections.<Tree>emptyList());
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/StaticInitializerTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/StaticInitializerTreeImpl.java
@@ -19,15 +19,13 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
+import java.util.ArrayList;
+import java.util.List;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.StaticInitializerTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
-
-import java.util.Collections;
-import java.util.List;
 
 public class StaticInitializerTreeImpl extends BlockTreeImpl implements StaticInitializerTree {
 
@@ -45,9 +43,10 @@ public class StaticInitializerTreeImpl extends BlockTreeImpl implements StaticIn
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
-      Collections.singletonList(staticKeyword),
-      super.children());
+    List<Tree> list = new ArrayList<>();
+    list.add(staticKeyword);
+    super.children().forEach(list::add);
+    return list;
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/statement/SwitchExpressionTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/SwitchExpressionTreeImpl.java
@@ -19,11 +19,11 @@
  */
 package org.sonar.java.model.statement;
 
-import com.google.common.collect.Iterables;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.expression.AssessableExpressionTree;
 import org.sonar.plugins.java.api.tree.CaseGroupTree;
@@ -101,7 +101,7 @@ public class SwitchExpressionTreeImpl extends AssessableExpressionTree implement
 
   @Override
   public Iterable<Tree> children() {
-    return Iterables.concat(
+    return ListUtils.concat(
       Arrays.asList(switchKeyword, openParenToken, expression, closeParenToken, openBraceToken),
       cases,
       Collections.singletonList(closeBraceToken));

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraph.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraph.java
@@ -19,9 +19,10 @@
  */
 package org.sonar.java.se;
 
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
 
 import org.sonar.java.se.xproc.MethodYield;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -38,7 +39,7 @@ import java.util.Set;
 public class ExplodedGraph {
 
   private final Map<Node, Node> nodes = new HashMap<>();
-  private final Multimap<ProgramPoint, Node> nodesByProgramPoint = LinkedListMultimap.create();
+  private final Map<ProgramPoint, List<Node>> nodesByProgramPoint = new HashMap<>();
 
   /**
    * Returns node associated with given (programPoint,programState) pair. If no node for this pair exists, it is created.
@@ -52,7 +53,7 @@ public class ExplodedGraph {
     }
     result.isNew = true;
     nodes.put(result, result);
-    nodesByProgramPoint.put(programPoint, result);
+    nodesByProgramPoint.computeIfAbsent(programPoint, k -> new LinkedList<>()).add(result);
     return result;
   }
 
@@ -93,7 +94,7 @@ public class ExplodedGraph {
     }
 
     public Collection<Node> siblings() {
-      Collection<Node> collection = explodedGraph.nodesByProgramPoint.get(programPoint);
+      Collection<Node> collection = explodedGraph.nodesByProgramPoint.getOrDefault(programPoint, Collections.emptyList());
       collection.remove(this);
       return collection;
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -21,7 +21,6 @@ package org.sonar.java.se;
 
 import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +41,7 @@ import javax.annotation.Nullable;
 import org.sonar.java.cfg.CFG;
 import org.sonar.java.cfg.LiveVariables;
 import org.sonar.java.collections.ListUtils;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.Sema;
 import org.sonar.java.se.checks.DivisionByZeroCheck;
@@ -108,7 +108,7 @@ public class ExplodedGraphWalker {
   public static final int MAX_NESTED_BOOLEAN_STATES = 10_000;
   // would correspond to 10 parameters annotated with @Nullable
   private static final int MAX_STARTING_STATES = 1_024;
-  private static final Set<String> THIS_SUPER = ImmutableSet.of("this", "super");
+  private static final Set<String> THIS_SUPER = SetUtils.immutableSetOf("this", "super");
 
   @VisibleForTesting
   static final int MAX_EXEC_PROGRAM_POINT = 2;

--- a/java-frontend/src/main/java/org/sonar/java/se/FlowComputation.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/FlowComputation.java
@@ -20,7 +20,6 @@
 package org.sonar.java.se;
 
 import org.sonar.java.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
@@ -566,15 +565,15 @@ public class FlowComputation {
 
     Set<LearnedConstraint> learnedConstraints(ExplodedGraph.Edge edge) {
       Set<LearnedConstraint> learnedConstraints = edge.learnedConstraints();
-      ImmutableSet.Builder<LearnedConstraint> lcByDomainBuilder = ImmutableSet.builder();
+      Set<LearnedConstraint> lcByDomain = new HashSet<>();
       // guarantee that we will keep the same domain order when reporting
       for (Class<? extends Constraint> domain : domains) {
         learnedConstraints.stream()
           .filter(lc -> symbolicValues.contains(lc.symbolicValue()) && hasConstraintForDomain(lc, domain))
-          .forEach(lcByDomainBuilder::add);
+          .forEach(lcByDomain::add);
       }
 
-      return lcByDomainBuilder.build();
+      return Collections.unmodifiableSet(lcByDomain);
     }
 
     private boolean hasConstraintForDomain(LearnedConstraint lc, Class<? extends Constraint> domain) {

--- a/java-frontend/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
@@ -89,7 +89,8 @@ public final class NullableAnnotationUtils {
 
   private static final Set<String> NULLABLE_ANNOTATIONS = Collections.unmodifiableSet(
     Stream.of(STRONG_NULLABLE_ANNOTATIONS, WEAK_NULLABLE_ANNOTATIONS)
-    .flatMap(Set::stream).collect(Collectors.toSet()));
+      .flatMap(Set::stream)
+      .collect(Collectors.toSet()));
 
   private static final Set<String> NONNULL_ANNOTATIONS = SetUtils.immutableSetOf(
     "android.annotation.NonNull",

--- a/java-frontend/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
@@ -19,17 +19,19 @@
  */
 package org.sonar.java.se;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.model.JUtils;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
@@ -56,7 +58,7 @@ public final class NullableAnnotationUtils {
    * Nullable annotations can be "strong", when one must check for nullness, or "weak", when it
    * can be null, but it may be fine to not check it.
    */
-  private static final Set<String> STRONG_NULLABLE_ANNOTATIONS = ImmutableSet.of(
+  private static final Set<String> STRONG_NULLABLE_ANNOTATIONS = SetUtils.immutableSetOf(
     "javax.annotation.CheckForNull",
     "edu.umd.cs.findbugs.annotations.CheckForNull",
     "org.netbeans.api.annotations.common.CheckForNull",
@@ -65,28 +67,31 @@ public final class NullableAnnotationUtils {
     "org.springframework.lang.Nullable",
     "reactor.util.annotation.Nullable");
 
-  private static final Set<String> NULLABLE_ANNOTATIONS = new ImmutableSet.Builder<String>()
-    .add("android.annotation.Nullable")
-    .add("android.support.annotation.Nullable")
-    .add("androidx.annotation.Nullable")
-    .add("com.sun.istack.internal.Nullable")
-    .add("edu.umd.cs.findbugs.annotations.Nullable")
-    .add("io.reactivex.annotations.Nullable")
-    .add("io.reactivex.rxjava3.annotations.Nullable")
-    .add("javax.annotation.Nullable")
-    .add("org.checkerframework.checker.nullness.compatqual.NullableDecl")
-    .add("org.checkerframework.checker.nullness.compatqual.NullableType")
-    .add("org.checkerframework.checker.nullness.qual.Nullable")
-    .add("org.eclipse.jdt.annotation.Nullable")
-    .add("org.eclipse.jgit.annotations.Nullable")
-    .add("org.jetbrains.annotations.Nullable")
-    .add("org.jmlspecs.annotation.Nullable")
-    .add("org.netbeans.api.annotations.common.NullAllowed")
-    .add("org.netbeans.api.annotations.common.NullUnknown")
-    .addAll(STRONG_NULLABLE_ANNOTATIONS)
-    .build();
 
-  private static final Set<String> NONNULL_ANNOTATIONS = ImmutableSet.of(
+  private static final Set<String> WEAK_NULLABLE_ANNOTATIONS = SetUtils.immutableSetOf(
+    "android.annotation.Nullable",
+    "android.support.annotation.Nullable",
+    "androidx.annotation.Nullable",
+    "com.sun.istack.internal.Nullable",
+    "edu.umd.cs.findbugs.annotations.Nullable",
+    "io.reactivex.annotations.Nullable",
+    "io.reactivex.rxjava3.annotations.Nullable",
+    "javax.annotation.Nullable",
+    "org.checkerframework.checker.nullness.compatqual.NullableDecl",
+    "org.checkerframework.checker.nullness.compatqual.NullableType",
+    "org.checkerframework.checker.nullness.qual.Nullable",
+    "org.eclipse.jdt.annotation.Nullable",
+    "org.eclipse.jgit.annotations.Nullable",
+    "org.jetbrains.annotations.Nullable",
+    "org.jmlspecs.annotation.Nullable",
+    "org.netbeans.api.annotations.common.NullAllowed",
+    "org.netbeans.api.annotations.common.NullUnknown");
+
+  private static final Set<String> NULLABLE_ANNOTATIONS = Collections.unmodifiableSet(
+    Stream.of(STRONG_NULLABLE_ANNOTATIONS, WEAK_NULLABLE_ANNOTATIONS)
+    .flatMap(Set::stream).collect(Collectors.toSet()));
+
+  private static final Set<String> NONNULL_ANNOTATIONS = SetUtils.immutableSetOf(
     "android.annotation.NonNull",
     "android.support.annotation.NonNull",
     "android.support.annotation.NonNull",

--- a/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/ProgramState.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.java.se;
 
+import java.util.HashSet;
 import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import org.sonar.java.collections.PCollections;
 import org.sonar.java.collections.PMap;
 import org.sonar.java.collections.PStack;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.se.checks.CustomUnclosedResourcesCheck;
 import org.sonar.java.se.checks.LocksNotUnlockedCheck;
 import org.sonar.java.se.checks.StreamConsumedCheck;
@@ -52,7 +53,7 @@ import org.sonar.plugins.java.api.semantic.Type;
 
 public class ProgramState {
 
-  private static final Set<Class<? extends Constraint>> NON_DISPOSABLE_CONSTRAINTS = ImmutableSet.of(UnclosedResourcesCheck.ResourceConstraint.class,
+  private static final Set<Class<? extends Constraint>> NON_DISPOSABLE_CONSTRAINTS = SetUtils.immutableSetOf(UnclosedResourcesCheck.ResourceConstraint.class,
     CustomUnclosedResourcesCheck.CustomResourceConstraint.class, LocksNotUnlockedCheck.LockConstraint.class, StreamConsumedCheck.StreamPipelineConstraint.class);
   private Set<RelationalSymbolicValue> knownRelations;
 
@@ -533,22 +534,22 @@ public class ProgramState {
   }
 
   Set<LearnedConstraint> learnedConstraints(ProgramState parent) {
-    ImmutableSet.Builder<LearnedConstraint> result = ImmutableSet.builder();
+    Set<LearnedConstraint> result = new HashSet<>();
     constraints.forEach((sv, pmap) -> pmap.forEach((domain, c) -> {
       if (!c.equals(parent.getConstraint(sv, domain))) {
         result.add(new LearnedConstraint(sv, c));
       }
     }));
-    return result.build();
+    return Collections.unmodifiableSet(result);
   }
 
   Set<LearnedAssociation> learnedAssociations(ProgramState parent) {
-    ImmutableSet.Builder<LearnedAssociation> result = ImmutableSet.builder();
+    Set<LearnedAssociation> result = new HashSet<>();
     values.forEach((s, sv) -> {
       if (parent.getValue(s) != sv) {
         result.add(new LearnedAssociation(sv, s));
       }
     });
-    return result.build();
+    return Collections.unmodifiableSet(result);
   }
 }

--- a/java-frontend/src/main/java/org/sonar/java/se/SymbolicExecutionMode.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/SymbolicExecutionMode.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.se;
 
-import java.util.Arrays;
+import java.util.stream.StreamSupport;
 import org.sonar.java.se.checks.SECheck;
 import org.sonar.plugins.java.api.JavaCheck;
 
@@ -27,15 +27,16 @@ public enum SymbolicExecutionMode {
   DISABLED,
   ENABLED;
 
-  public static SymbolicExecutionMode getMode(JavaCheck[] visitors) {
+  public static SymbolicExecutionMode getMode(Iterable<? extends JavaCheck> visitors) {
     if (hasASymbolicExecutionCheck(visitors)) {
       return SymbolicExecutionMode.ENABLED;
     }
     return SymbolicExecutionMode.DISABLED;
   }
 
-  private static boolean hasASymbolicExecutionCheck(JavaCheck[] visitors) {
-    return Arrays.stream(visitors).anyMatch(v -> v instanceof SECheck);
+  private static boolean hasASymbolicExecutionCheck(Iterable<? extends JavaCheck> visitors) {
+    return StreamSupport.stream(visitors.spliterator() ,false)
+      .anyMatch(v -> v instanceof SECheck);
   }
 
   public boolean isEnabled() {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/ExceptionalYieldChecker.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/ExceptionalYieldChecker.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.java.se.checks;
 
-import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
 
 import org.sonar.java.collections.ListUtils;
 import org.sonar.java.se.ExplodedGraph;
@@ -85,7 +85,7 @@ public class ExceptionalYieldChecker {
     Set<Flow> argumentsFlows = flowsForMethodArguments(node, mit, parameterCausingExceptionIndex, FlowComputation.MAX_REPORTED_FLOWS);
     Set<Flow> exceptionFlows = yield.exceptionFlows(FlowComputation.MAX_REPORTED_FLOWS);
 
-    ImmutableSet.Builder<Flow> flows = ImmutableSet.builder();
+    Set<Flow> flows = new HashSet<>();
     for (Flow argumentFlow : argumentsFlows) {
       for (Flow exceptionFlow : exceptionFlows) {
         flows.add(Flow.builder()
@@ -97,7 +97,7 @@ public class ExceptionalYieldChecker {
       }
     }
 
-    check.reportIssue(reportTree, String.format(message, methodName), flows.build());
+    check.reportIssue(reportTree, String.format(message, methodName), Collections.unmodifiableSet(flows));
   }
 
   private static Set<Flow> flowsForMethodArguments(ExplodedGraph.Node node, MethodInvocationTree mit, int parameterCausingExceptionIndex, int maxReturnedFlows) {

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/RedundantAssignmentsCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/RedundantAssignmentsCheck.java
@@ -20,12 +20,12 @@
 package org.sonar.java.se.checks;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 
 import org.sonar.check.Rule;
 import org.sonar.java.cfg.CFG;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.se.CheckerContext;
 import org.sonar.java.se.ExplodedGraph;
 import org.sonar.java.se.Flow;
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 @Rule(key = "S4165")
 public class RedundantAssignmentsCheck extends SECheck {
 
-  private static final Set<String> STREAM_TYPES = ImmutableSet.of(
+  private static final Set<String> STREAM_TYPES = SetUtils.immutableSetOf(
     "java.util.stream.Stream",
     "java.util.stream.IntStream",
     "java.util.stream.LongStream",

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/RedundantAssignmentsCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/RedundantAssignmentsCheck.java
@@ -19,13 +19,20 @@
  */
 package org.sonar.java.se.checks;
 
-import com.google.common.collect.Iterables;
-
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.java.cfg.CFG;
+import org.sonar.java.collections.CollectionUtils;
 import org.sonar.java.collections.SetUtils;
 import org.sonar.java.se.CheckerContext;
 import org.sonar.java.se.ExplodedGraph;
@@ -39,16 +46,6 @@ import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
-
-import javax.annotation.Nullable;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Rule(key = "S4165")
 public class RedundantAssignmentsCheck extends SECheck {
@@ -110,7 +107,7 @@ public class RedundantAssignmentsCheck extends SECheck {
         Set<Flow> flows = allAssignments.stream().map(AssignmentDataHolder::flows).flatMap(Set::stream).collect(Collectors.toSet());
         reportIssue(assignmentForTree.getKey(),
           String.format("Remove this useless assignment; \"%s\" already holds the assigned value along all execution paths.",
-            Iterables.getFirst(allAssignments, null).assignedSymbol.name()),
+            CollectionUtils.getFirst(allAssignments, null).assignedSymbol.name()),
           flows);
       }
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/StreamConsumedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/StreamConsumedCheck.java
@@ -19,11 +19,11 @@
  */
 package org.sonar.java.se.checks;
 
-import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonar.check.Rule;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.collections.SetUtils;
 import org.sonar.java.se.CheckerContext;
 import org.sonar.java.se.ExplodedGraph;
@@ -116,10 +116,10 @@ public class StreamConsumedCheck extends SECheck {
     if (isIntermediateOperation(mit)) {
       // intermediate operations return same stream pipeline, so we reuse SV
       context.getConstraintManager().setValueFactory(() -> invocationTarget);
-      return Iterables.getOnlyElement(invocationTarget.setConstraint(programState, StreamPipelineConstraint.NOT_CONSUMED));
+      return ListUtils.getOnlyElement(invocationTarget.setConstraint(programState, StreamPipelineConstraint.NOT_CONSUMED));
     }
     if (isTerminalOperation(mit)) {
-      return Iterables.getOnlyElement(invocationTarget.setConstraint(programState, StreamPipelineConstraint.CONSUMED));
+      return ListUtils.getOnlyElement(invocationTarget.setConstraint(programState, StreamPipelineConstraint.CONSUMED));
     }
     if (mit.symbol().isUnknown()) {
       // lambdas used in pipelines are sometimes not resolved properly, this is to shutdown the noise
@@ -141,7 +141,7 @@ public class StreamConsumedCheck extends SECheck {
           reportIssue(mrt, "Refactor this code so that this consumed stream pipeline is not reused.", flow(ownerSV, context.getNode()));
           return null;
         } else {
-          return Iterables.getOnlyElement(ownerSV.setConstraint(programState, StreamPipelineConstraint.CONSUMED));
+          return ListUtils.getOnlyElement(ownerSV.setConstraint(programState, StreamPipelineConstraint.CONSUMED));
         }
       }
     }

--- a/java-frontend/src/main/java/org/sonar/java/se/checks/StreamConsumedCheck.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/checks/StreamConsumedCheck.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.java.se.checks;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonar.check.Rule;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.se.CheckerContext;
 import org.sonar.java.se.ExplodedGraph;
 import org.sonar.java.se.Flow;
@@ -55,7 +55,7 @@ public class StreamConsumedCheck extends SECheck {
     CONSUMED, NOT_CONSUMED
   }
 
-  private static final Set<String> STREAM_TYPES = ImmutableSet.of("java.util.stream.Stream", "java.util.stream.IntStream", "java.util.stream.LongStream",
+  private static final Set<String> STREAM_TYPES = SetUtils.immutableSetOf("java.util.stream.Stream", "java.util.stream.IntStream", "java.util.stream.LongStream",
     "java.util.stream.DoubleStream");
   private static final MethodMatchers TERMINAL_OPERATIONS = MethodMatchers.or(
     MethodMatchers.create()

--- a/java-frontend/src/main/java/org/sonar/java/se/xproc/MethodYield.java
+++ b/java-frontend/src/main/java/org/sonar/java/se/xproc/MethodYield.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.se.xproc;
 
+import java.util.HashSet;
 import org.sonar.java.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -205,7 +205,7 @@ public abstract class MethodYield {
   }
 
   private Set<SymbolicValue> getSymbolicValues(List<Integer> parameterIndices) {
-    ImmutableSet.Builder<SymbolicValue> parameterSVs = ImmutableSet.builder();
+    Set<SymbolicValue> parameterSVs = new HashSet<>();
     parameterIndices.stream()
       // Ignore last parameter(s) of a variadic method
       .filter(i -> !behavior.isMethodVarArgs() || i < behavior.methodArity() -1)
@@ -216,6 +216,6 @@ public abstract class MethodYield {
         parameterSVs.add(behavior.parameters().get(parameterIndex));
       }
     });
-    return parameterSVs.build();
+    return Collections.unmodifiableSet(parameterSVs);
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/collections/AVLTreeTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/AVLTreeTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.collections;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -127,7 +126,10 @@ class AVLTreeTest {
     HashMap<Object, Object> biConsumer = new HashMap<>();
     t.forEach((k, v) -> assertThat(biConsumer.put(k, v)).as("unique key-value").isNull());
     assertThat(biConsumer)
-      .isEqualTo(ImmutableMap.of(k1, "v1", k2, "v2"));
+      .isEqualTo(MapBuilder.newMap()
+        .put(k1, "v1")
+        .put(k2, "v2")
+        .build());
 
     HashSet<Object> consumer = new HashSet<>();
     t.forEach(k -> assertThat(consumer.add(k)).as("unique key").isTrue());

--- a/java-frontend/src/test/java/org/sonar/java/collections/AbstractIteratorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/AbstractIteratorTest.java
@@ -1,0 +1,83 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.collections;
+
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractIteratorTest {
+  
+  @Test
+  void test_iterator() { 
+    AbstractIterator<Integer> iterator = new IteratorImpl();
+    int test = 10;
+    while (iterator.hasNext()) {
+      assertThat(iterator.next()).isEqualTo(test);
+      test--;
+    }
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test
+  void test_has_no_next() {
+    AbstractIterator<Integer> iterator = new IteratorImpl();
+    assertThat(iterator.hasNext()).isTrue();
+    exhaustIterator(iterator);
+    assertThat(iterator.hasNext()).isFalse();
+    Assertions.assertThrows(NoSuchElementException.class, iterator::peek);
+  }
+
+  @Test
+  void test_failed_next() {
+    AbstractIterator<Integer> iterator = new IteratorImpl();
+    exhaustIterator(iterator);
+    Assertions.assertThrows(NoSuchElementException.class, iterator::next);
+  }
+
+  private void exhaustIterator(AbstractIterator<Integer> iterator) {
+    for (int i = 0; i < 10; i++) {
+      iterator.next();
+    }
+  }
+
+
+  @Test
+  void test_peek() {
+    AbstractIterator<Integer> iterator = new IteratorImpl();
+    assertThat(iterator.peek()).isEqualTo(10);
+  }
+  
+
+  private static class IteratorImpl extends AbstractIterator<Integer> {
+      private int counter = 10;
+
+    @Override
+    protected Integer computeNext() {
+      if (counter > 0) {
+        return counter--;
+      }
+      return endOfData();
+    }
+  }
+}
+

--- a/java-frontend/src/test/java/org/sonar/java/collections/CollectionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/CollectionUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2020 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.java.collections;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class CollectionUtilsTest {
+  
+  @Test
+  void test_get_first_String() {
+    List<String> list = Arrays.asList("A", "B", "Z");
+    assertThat(CollectionUtils.getFirst(list, null)).isEqualTo("A");
+  }
+
+  @Test
+  void test_get_first_default_value() {
+    assertThat(CollectionUtils.getFirst(Collections.emptySet(), "ABC")).isEqualTo("ABC");
+  }
+
+  @Test
+  void test_get_collection_size() {
+    assertThat(CollectionUtils.size(Arrays.asList("a", "b", "c"))).isEqualTo(3);
+  }
+  
+  @Test
+  void test_get_iterable_size() {
+    assertThat(CollectionUtils.size(new SomeIterable<String>())).isEqualTo(3);
+  }
+  
+  private static class SomeIterable<T> implements Iterable<T> {
+    
+    @Override
+    public Iterator<T> iterator() {
+      return new Iterator<T>() {
+        private int count = 3;
+        @Override
+        public boolean hasNext() {
+          return count > 0;
+        }
+
+        @Override
+        @Nullable
+        public T next() {
+          count--;
+          return null;
+        }
+      };
+    }
+  }
+}

--- a/java-frontend/src/test/java/org/sonar/java/collections/ListUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/ListUtilsTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +64,62 @@ final class ListUtilsTest {
     Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> ListUtils.getOnlyElement(list));
     assertThat(exception).hasMessage("Expected list of size 1, but was list of size 2.");
   }
+
+
+  @Test
+  void test_concat_any_list() {
+    List<SomeType> set1 = Arrays.asList(new SomeType("value1"), new SomeType("value2"));
+    List<SomeType> set2 = Arrays.asList(new SomeType("value3"), new SomeType("value4"));
+
+    assertThat(ListUtils.concat(set1, set2))
+      .containsExactly(new SomeType("value1"), new SomeType("value2"), new SomeType("value3"), new SomeType("value4"));
+  }
+
+  @Test
+  void test_concat_many_lists() {
+    List<SomeType> set1 = Arrays.asList(new SomeType("value1"), new SomeType("value2"));
+    List<SomeType> set2 = Arrays.asList(new SomeType("value3"), new SomeType("value4"));
+    List<SomeType> set3 = Arrays.asList(new SomeType("value5"), new SomeType("value6"));
+    List<SomeType> set4 = Arrays.asList(new SomeType("value7"), new SomeType("value8"));
+    List<SomeType> set5 = Arrays.asList(new SomeType("value9"), new SomeType("value10"));
+    List<SomeType> set6 = Arrays.asList(new SomeType("value11"), new SomeType("value12"));
+    List<SomeType> set7 = Arrays.asList(new SomeType("value13"), new SomeType("value14"));
+
+    assertThat(ListUtils.concat(set1, set2, set3, set4, set5, set6, set7))
+      .containsExactly(
+        new SomeType("value1"), new SomeType("value2"),
+        new SomeType("value3"), new SomeType("value4"),
+        new SomeType("value5"), new SomeType("value6"),
+        new SomeType("value7"), new SomeType("value8"),
+        new SomeType("value9"), new SomeType("value10"),
+        new SomeType("value11"), new SomeType("value12"),
+        new SomeType("value13"), new SomeType("value14")
+      );
+  }
+
+
+  @Test
+  void test_concat_many_iterables() {
+    List<SomeType> set1 = Arrays.asList(new SomeType("value1"), new SomeType("value2"));
+    Set<SomeType> set2 = SetUtils.immutableSetOf(new SomeType("value3"), new SomeType("value4"));
+    List<SomeType> set3 = Arrays.asList(new SomeType("value5"), new SomeType("value6"));
+    Set<SomeType> set4 = SetUtils.immutableSetOf(new SomeType("value7"), new SomeType("value8"));
+    List<SomeType> set5 = Arrays.asList(new SomeType("value9"), new SomeType("value10"));
+    Set<SomeType> set6 = SetUtils.immutableSetOf(new SomeType("value11"), new SomeType("value12"));
+    List<SomeType> set7 = Arrays.asList(new SomeType("value13"), new SomeType("value14"));
+
+    assertThat(ListUtils.concat(set1, set2, set3, set4, set5, set6, set7))
+      .containsExactlyInAnyOrder(
+        new SomeType("value1"), new SomeType("value2"),
+        new SomeType("value3"), new SomeType("value4"),
+        new SomeType("value5"), new SomeType("value6"),
+        new SomeType("value7"), new SomeType("value8"),
+        new SomeType("value9"), new SomeType("value10"),
+        new SomeType("value11"), new SomeType("value12"),
+        new SomeType("value13"), new SomeType("value14")
+      );
+  }
+
 
   private static class SomeType {
     final String value;

--- a/java-frontend/src/test/java/org/sonar/java/collections/SetUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/SetUtilsTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.java.collections;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
@@ -78,6 +79,33 @@ final class SetUtilsTest {
         new SomeType("value11"), new SomeType("value12"),
         new SomeType("value13"), new SomeType("value14")
       );
+  }
+  
+  @Test
+  void test_no_difference() {
+    Set<String> set1 = SetUtils.immutableSetOf("A", "B", "C");
+    Set<String> set2 = SetUtils.immutableSetOf("A", "B", "C");
+    
+    assertThat(SetUtils.difference(set1, set2))
+      .isEqualTo(Collections.emptySet());
+  }
+  
+  @Test
+  void test_no_difference_on_left() {
+    Set<String> set1 = SetUtils.immutableSetOf("A", "B", "C");
+    Set<String> set2 = SetUtils.immutableSetOf("A", "B", "C", "D", "E");
+    
+    assertThat(SetUtils.difference(set1, set2))
+      .isEqualTo(Collections.emptySet());
+  }
+  
+  @Test
+  void test_difference() {
+    Set<String> set1 = SetUtils.immutableSetOf("A", "B", "C");
+    Set<String> set2 = SetUtils.immutableSetOf("A", "B", "C", "D", "E");
+    
+    assertThat(SetUtils.difference(set2, set1))
+      .containsExactlyInAnyOrder("D", "E");
   }
   
   private static class SomeType {

--- a/java-frontend/src/test/java/org/sonar/java/collections/SetUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/SetUtilsTest.java
@@ -107,7 +107,28 @@ final class SetUtilsTest {
     assertThat(SetUtils.difference(set2, set1))
       .containsExactlyInAnyOrder("D", "E");
   }
-  
+
+  @Test
+  void test_get_the_only_element() {
+    Set<String> list = Collections.singleton("A");
+    assertThat(SetUtils.getOnlyElement(list)).isEqualTo("A");
+  }
+
+  @Test
+  void test_get_the_only_element_with_empty_list() {
+    Set<String> list = Collections.emptySet();
+    Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> SetUtils.getOnlyElement(list));
+    assertThat(exception).hasMessage("Expected list of size 1, but was list of size 0.");
+  }
+
+  @Test
+  void test_get_the_only_element_with_too_big_list() {
+    Set<String> list = SetUtils.immutableSetOf("A", "B");
+    Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> SetUtils.getOnlyElement(list));
+    assertThat(exception).hasMessage("Expected list of size 1, but was list of size 2.");
+  }
+
+
   private static class SomeType {
     final String value;
 

--- a/java-frontend/src/test/java/org/sonar/java/collections/SetUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/collections/SetUtilsTest.java
@@ -115,17 +115,17 @@ final class SetUtilsTest {
   }
 
   @Test
-  void test_get_the_only_element_with_empty_list() {
+  void test_get_the_only_element_with_empty_set() {
     Set<String> list = Collections.emptySet();
     Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> SetUtils.getOnlyElement(list));
-    assertThat(exception).hasMessage("Expected list of size 1, but was list of size 0.");
+    assertThat(exception).hasMessage("Expected set of size 1, but was set of size 0.");
   }
 
   @Test
-  void test_get_the_only_element_with_too_big_list() {
+  void test_get_the_only_element_with_too_big_set() {
     Set<String> list = SetUtils.immutableSetOf("A", "B");
     Exception exception = Assertions.assertThrows(IllegalArgumentException.class, () -> SetUtils.getOnlyElement(list));
-    assertThat(exception).hasMessage("Expected list of size 1, but was list of size 2.");
+    assertThat(exception).hasMessage("Expected set of size 1, but was set of size 2.");
   }
 
 

--- a/java-frontend/src/test/java/org/sonar/java/model/DefaultJavaFileScannerContextWithSensorContextTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/DefaultJavaFileScannerContextWithSensorContextTest.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.java.model;
 
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +40,7 @@ import org.sonar.api.platform.Server;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.classpath.ClasspathForMain;
 import org.sonar.java.classpath.ClasspathForTest;
 import org.sonar.java.se.checks.SECheck;
@@ -106,7 +107,7 @@ class DefaultJavaFileScannerContextWithSensorContextTest {
   void test_report_issue_with_flow() throws Exception {
     List<JavaFileScannerContext.Location> flow1 = Collections.singletonList(new JavaFileScannerContext.Location("flow1", tree));
     List<JavaFileScannerContext.Location> flow2 = Collections.singletonList(new JavaFileScannerContext.Location("flow2", tree));
-    ImmutableSet<List<JavaFileScannerContext.Location>> flows = ImmutableSet.of(flow1, flow2);
+    Set<List<JavaFileScannerContext.Location>> flows = SetUtils.immutableSetOf(flow1, flow2);
     scannerContext.reportIssueWithFlow(check, tree, "msg", flows, null);
     Issue issue = sensorContext.allIssues().iterator().next();
     assertThat(issue.flows()).hasSize(2);
@@ -116,7 +117,7 @@ class DefaultJavaFileScannerContextWithSensorContextTest {
   void test_report_se_issue_with_flow() throws Exception {
     List<JavaFileScannerContext.Location> flow1 = Collections.singletonList(new JavaFileScannerContext.Location("SE flow1", tree));
     List<JavaFileScannerContext.Location> flow2 = Collections.singletonList(new JavaFileScannerContext.Location("SE flow2", tree));
-    ImmutableSet<List<JavaFileScannerContext.Location>> flows = ImmutableSet.of(flow1, flow2);
+    Set<List<JavaFileScannerContext.Location>> flows = SetUtils.immutableSetOf(flow1, flow2);
 
     scannerContext.reportIssueWithFlow(seCheck, tree, "msg", flows, null);
     Issue issue = sensorContext.allIssues().iterator().next();

--- a/java-frontend/src/test/java/org/sonar/java/model/TreeTokenCompletenessTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/TreeTokenCompletenessTest.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.java.model;
 
-import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +66,7 @@ class TreeTokenCompletenessTest {
   }
 
   private static Map<Integer, String> getDifferences(List<String> basedOnSyntaxTree, List<String> basedOnFileLine) {
-    Map<Integer, String> differences = Maps.newHashMap();
+    Map<Integer, String> differences = new HashMap<>();
     for (int i = 0; i < basedOnSyntaxTree.size(); i++) {
       String lineFromSyntaxTree = basedOnSyntaxTree.get(i);
       String lineFromFile = basedOnFileLine.get(i);

--- a/java-frontend/src/test/java/org/sonar/java/se/ProgramStateTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ProgramStateTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.se;
 
-import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
@@ -144,7 +143,7 @@ class ProgramStateTest {
     ProgramState child = ProgramState.EMPTY_STATE.addConstraint(relation, BooleanConstraint.TRUE);
     Set<LearnedConstraint> learnedConstraints = child.learnedConstraints(parent);
     assertThat(learnedConstraints).hasSize(1);
-    Constraint relationConstraint = Iterables.getOnlyElement(learnedConstraints).constraint();
+    Constraint relationConstraint = SetUtils.getOnlyElement(learnedConstraints).constraint();
     assertThat(relationConstraint).isEqualTo(BooleanConstraint.TRUE);
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/se/ProgramStateTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/ProgramStateTest.java
@@ -19,12 +19,12 @@
  */
 package org.sonar.java.se;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.se.ProgramState.Pop;
 import org.sonar.java.se.checks.UnclosedResourcesCheck;
 import org.sonar.java.se.constraint.BooleanConstraint;
@@ -226,7 +226,7 @@ class ProgramStateTest {
     ps1 = ps1.stackValue(sv);
     ps2 = ps2.stackValue(sv, symbol);
     assertThat(ps1).isEqualTo(ps2);
-    assertThat(ImmutableSet.of(ps1, ps2)).hasSize(1);
+    assertThat(SetUtils.immutableSetOf(ps1, ps2)).hasSize(1);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/se/checks/DivisionByZeroCheckTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/checks/DivisionByZeroCheckTest.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.java.se.checks;
 
-import com.google.common.collect.Iterables;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.se.ProgramState;
 import org.sonar.java.se.SETestUtils;
 import org.sonar.java.se.constraint.BooleanConstraint;
@@ -76,10 +76,10 @@ class DivisionByZeroCheckTest {
 
   private DivisionByZeroCheck.ZeroConstraint copyConstraint(SymbolicValue a, SymbolicValue b, RelationalSymbolicValue.Kind relation,
     @Nullable DivisionByZeroCheck.ZeroConstraint expected) {
-    ProgramState ps = Iterables.getOnlyElement(a.setConstraint(ProgramState.EMPTY_STATE, ZERO));
+    ProgramState ps = ListUtils.getOnlyElement(a.setConstraint(ProgramState.EMPTY_STATE, ZERO));
     RelationalSymbolicValue rel = new RelationalSymbolicValue(relation);
     SymbolicValueTestUtil.computedFrom(rel, b, a);
-    ps = Iterables.getOnlyElement(rel.setConstraint(ps, BooleanConstraint.TRUE));
+    ps = ListUtils.getOnlyElement(rel.setConstraint(ps, BooleanConstraint.TRUE));
     return ps.getConstraint(b, DivisionByZeroCheck.ZeroConstraint.class);
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/se/symbolicvalues/RelationalSymbolicValueTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/symbolicvalues/RelationalSymbolicValueTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.se.symbolicvalues;
 
-import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.collections.SetUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.expression.BinaryExpressionTreeImpl;
@@ -174,7 +174,7 @@ class RelationalSymbolicValueTest {
   private ProgramState stateWithRelations(RelationalSymbolicValue... known) {
     ProgramState ps = ProgramState.EMPTY_STATE;
     for (RelationalSymbolicValue rel : known) {
-      ps = Iterables.getOnlyElement(rel.setConstraint(ps, TRUE));
+      ps = ListUtils.getOnlyElement(rel.setConstraint(ps, TRUE));
     }
     return ps;
   }
@@ -184,7 +184,7 @@ class RelationalSymbolicValueTest {
     RelationalSymbolicValue aLEb = relationalSV(Tree.Kind.LESS_THAN_OR_EQUAL_TO, a, b);
     RelationalSymbolicValue bLEa = relationalSV(Tree.Kind.LESS_THAN_OR_EQUAL_TO, b, a);
     RelationalSymbolicValue aEb = relationalSV(Tree.Kind.EQUAL_TO, a, b);
-    ProgramState state = Iterables.getOnlyElement(aEb.setConstraint(stateWithRelations(aLEb, bLEa), TRUE));
+    ProgramState state = ListUtils.getOnlyElement(aEb.setConstraint(stateWithRelations(aLEb, bLEa), TRUE));
     assertThat(state.getConstraint(aEb, BooleanConstraint.class)).isEqualTo(TRUE);
   }
 
@@ -220,7 +220,7 @@ class RelationalSymbolicValueTest {
       given[i - 1] = relationalSV(Tree.Kind.LESS_THAN, sv[i - 1], sv[i]);
     }
     RelationalSymbolicValue firstLessThanLast = relationalSV(Tree.Kind.LESS_THAN, sv[0], sv[chainLength - 1]);
-    ProgramState programState = Iterables.getOnlyElement(firstLessThanLast.setConstraint(stateWithRelations(given), TRUE));
+    ProgramState programState = ListUtils.getOnlyElement(firstLessThanLast.setConstraint(stateWithRelations(given), TRUE));
     assertThat(programState.getConstraint(firstLessThanLast, BooleanConstraint.class)).isEqualTo(TRUE);
   }
 
@@ -238,9 +238,9 @@ class RelationalSymbolicValueTest {
     SymbolicValue bNEc = relationalSV(Tree.Kind.NOT_EQUAL_TO, c, b);
     ProgramState programState = ProgramState.EMPTY_STATE;
     List<ProgramState> programStates = aNEb.setConstraint(programState, TRUE);
-    programState = Iterables.getOnlyElement(programStates);
+    programState = ListUtils.getOnlyElement(programStates);
     programStates = bNEc.setConstraint(programState, TRUE);
-    programState = Iterables.getOnlyElement(programStates);
+    programState = ListUtils.getOnlyElement(programStates);
 
     SymbolicValue aNEc = relationalSV(Tree.Kind.NOT_EQUAL_TO, c, a);
     programStates = aNEc.setConstraint(programState, FALSE);
@@ -296,11 +296,11 @@ class RelationalSymbolicValueTest {
     SymbolicValue a = new SymbolicValue();
     SymbolicValue b = new SymbolicValue();
     List<ProgramState> newProgramStates = a.setConstraint(ps, ZERO);
-    ps = Iterables.getOnlyElement(newProgramStates);
+    ps = ListUtils.getOnlyElement(newProgramStates);
     // 0 >= b
     SymbolicValue aGEb = relationalSV(Tree.Kind.GREATER_THAN_OR_EQUAL_TO, b, a);
     newProgramStates = aGEb.setConstraint(ps, TRUE);
-    ps = Iterables.getOnlyElement(newProgramStates);
+    ps = ListUtils.getOnlyElement(newProgramStates);
 
     // Zero constraint should stay when Zero is >= to SV without any constraint
     assertThat(ps.getConstraint(a, DivisionByZeroCheck.ZeroConstraint.class)).isEqualTo(ZERO);
@@ -362,7 +362,7 @@ class RelationalSymbolicValueTest {
   @Test
   void test_constraints_are_copied_over_transitive_relations() throws Exception {
     ProgramState ps = ProgramState.EMPTY_STATE;
-    ps = Iterables.getOnlyElement(a.setConstraint(ps, ObjectConstraint.NULL));
+    ps = ListUtils.getOnlyElement(a.setConstraint(ps, ObjectConstraint.NULL));
     RelationalSymbolicValue ab = relationalSV(Tree.Kind.EQUAL_TO, a, b);
     ps = setTrue(ps, ab);
     assertNullConstraint(ps, b);
@@ -408,7 +408,7 @@ class RelationalSymbolicValueTest {
   }
 
   private ProgramState setTrue(ProgramState ps, RelationalSymbolicValue ab) {
-    return Iterables.getOnlyElement(ab.setConstraint(ps, TRUE));
+    return ListUtils.getOnlyElement(ab.setConstraint(ps, TRUE));
   }
 
   private String relationToString(Tree.Kind kind, SymbolicValue leftOp, SymbolicValue rightOp) {
@@ -470,7 +470,7 @@ class RelationalSymbolicValueTest {
   void test_constraint_copy_of_sv_with_no_constraints_is_symmetric() throws Exception {
     ProgramState ps = ProgramState.EMPTY_STATE;
     SymbolicValue svZero = new SymbolicValue();
-    ps = Iterables.getOnlyElement(svZero.setConstraint(ps, ZERO));
+    ps = ListUtils.getOnlyElement(svZero.setConstraint(ps, ZERO));
     SymbolicValue sv = new SymbolicValue();
     RelationalSymbolicValue neq = new RelationalSymbolicValue(NOT_EQUAL, svZero, sv);
     ProgramState psWithNeq = setTrue(ps, neq);
@@ -485,7 +485,7 @@ class RelationalSymbolicValueTest {
   void test_constraint_copy_of_not_null_constraint() throws Exception {
     ProgramState ps = ProgramState.EMPTY_STATE;
     SymbolicValue svNotNull = new SymbolicValue();
-    ps = Iterables.getOnlyElement(svNotNull.setConstraint(ps, ObjectConstraint.NOT_NULL));
+    ps = ListUtils.getOnlyElement(svNotNull.setConstraint(ps, ObjectConstraint.NOT_NULL));
     SymbolicValue sv = new SymbolicValue();
     // sv != NOT_NULL
     RelationalSymbolicValue neq = new RelationalSymbolicValue(NOT_EQUAL, svNotNull, sv);

--- a/java-frontend/src/test/java/org/sonar/java/se/symbolicvalues/RelationalSymbolicValueTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/se/symbolicvalues/RelationalSymbolicValueTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.se.symbolicvalues;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.java.collections.SetUtils;
 import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.expression.BinaryExpressionTreeImpl;
 import org.sonar.java.se.ProgramState;
@@ -355,7 +355,7 @@ class RelationalSymbolicValueTest {
     RelationalSymbolicValue ab = relationalSV(Tree.Kind.EQUAL_TO, a, b);
     RelationalSymbolicValue bc = relationalSV(Tree.Kind.EQUAL_TO, b, c);
     RelationalSymbolicValue cd = relationalSV(Tree.Kind.EQUAL_TO, c, d);
-    Set<RelationalSymbolicValue> transitive = ab.transitiveRelations(ImmutableSet.of(ab, bc, cd));
+    Set<RelationalSymbolicValue> transitive = ab.transitiveRelations(SetUtils.immutableSetOf(ab, bc, cd));
     assertThat(transitive).containsOnly(relationalSV(Tree.Kind.EQUAL_TO, a, c), relationalSV(Tree.Kind.EQUAL_TO, b, d), relationalSV(Tree.Kind.EQUAL_TO, a, d));
   }
 


### PR DESCRIPTION
Depends on this [pr](https://github.com/SonarSource/sonar-java/pull/3342). Should be rebased