### PR TITLE
SONARJAVA-2154 Remove remaining usages of guava from sonar-java main sources

### DIFF
--- a/its/plugin/plugins/java-extension-plugin/pom.xml
+++ b/its/plugin/plugins/java-extension-plugin/pom.xml
@@ -34,11 +34,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>26.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>java-checks-testkit</artifactId>
       <version>${project.version}</version>

--- a/its/plugin/plugins/java-extension-plugin/src/main/java/org/sonar/samples/java/JavaExtensionPlugin.java
+++ b/its/plugin/plugins/java-extension-plugin/src/main/java/org/sonar/samples/java/JavaExtensionPlugin.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.samples.java;
 
-import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
 import java.util.List;
 import org.sonar.api.SonarPlugin;
 
@@ -27,7 +27,7 @@ public class JavaExtensionPlugin extends SonarPlugin {
 
   @Override
   public List getExtensions() {
-    return ImmutableList.of(
+    return Arrays.asList(
       JavaExtensionRulesDefinition.class,
       JavaExtensionsCheckRegistrar.class,
       StartableExtension.class);

--- a/java-checks-testkit/pom.xml
+++ b/java-checks-testkit/pom.xml
@@ -40,10 +40,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/JavaCheckVerifier.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/JavaCheckVerifier.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.java.checks.verifier;
 
-import com.google.common.annotations.Beta;
 import java.io.File;
 import java.util.Collection;
+import org.sonar.java.annotations.Beta;
 import org.sonar.java.testing.CheckVerifier;
 import org.sonar.java.testing.FilesUtils;
 import org.sonar.plugins.java.api.JavaFileScanner;

--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/MultipleFilesJavaCheckVerifier.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/MultipleFilesJavaCheckVerifier.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.java.checks.verifier;
 
-import com.google.common.annotations.Beta;
 import java.util.List;
+import org.sonar.java.annotations.Beta;
 import org.sonar.plugins.java.api.JavaFileScanner;
 
 /**

--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -83,6 +83,11 @@
       <artifactId>test-sonar-xml-parsing</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/java-surefire/src/main/java/org/sonar/plugins/surefire/SurefireExtensions.java
+++ b/java-surefire/src/main/java/org/sonar/plugins/surefire/SurefireExtensions.java
@@ -19,8 +19,7 @@
  */
 package org.sonar.plugins.surefire;
 
-import com.google.common.collect.ImmutableList;
-
+import java.util.Arrays;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.java.JavaConstants;
@@ -35,22 +34,22 @@ public final class SurefireExtensions {
 
   @SuppressWarnings("rawtypes")
   public static List getExtensions() {
-    return ImmutableList.of(
-        /**
-         * @since 4.11
-         */
-        PropertyDefinition.builder(SurefireUtils.SUREFIRE_REPORT_PATHS_PROPERTY)
-            .name("JUnit Report Paths")
-            .description("Comma-separated paths to the various directories containing the *.xml JUnit report files. "
-              + "Each path may be absolute or relative to the project base directory.")
-            .onQualifiers(Qualifiers.PROJECT)
-            .multiValues(true)
-            .category(JavaConstants.JAVA_CATEGORY)
-            .subCategory("JUnit")
-            .build(),
+    return Arrays.asList(
+      /**
+       * @since 4.11
+       */
+      PropertyDefinition.builder(SurefireUtils.SUREFIRE_REPORT_PATHS_PROPERTY)
+        .name("JUnit Report Paths")
+        .description("Comma-separated paths to the various directories containing the *.xml JUnit report files. "
+          + "Each path may be absolute or relative to the project base directory.")
+        .onQualifiers(Qualifiers.PROJECT)
+        .multiValues(true)
+        .category(JavaConstants.JAVA_CATEGORY)
+        .subCategory("JUnit")
+        .build(),
 
-        SurefireSensor.class,
-        SurefireJavaParser.class);
+      SurefireSensor.class,
+      SurefireJavaParser.class);
   }
 
 }

--- a/java-surefire/src/main/java/org/sonar/plugins/surefire/data/UnitTestIndex.java
+++ b/java-surefire/src/main/java/org/sonar/plugins/surefire/data/UnitTestIndex.java
@@ -19,9 +19,8 @@
  */
 package org.sonar.plugins.surefire.data;
 
-import com.google.common.collect.Sets;
-
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,7 +44,7 @@ public class UnitTestIndex {
   }
 
   public Set<String> getClassnames() {
-    return Sets.newHashSet(indexByClassname.keySet());
+    return new HashSet<>(indexByClassname.keySet());
   }
 
   public Map<String, UnitTestClassReport> getIndexByClassname() {

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -128,8 +128,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>19000000</maxsize>
-                  <minsize>18000000</minsize>
+                  <maxsize>17500000</maxsize>
+                  <minsize>17000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
Depends on this [pr](https://github.com/SonarSource/sonar-java/pull/3343) Only the last commit is relevant