### PR TITLE
Fix CheckVerifier when testing multiples files

### DIFF
--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/MultipleFilesJavaCheckVerifierTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/MultipleFilesJavaCheckVerifierTest.java
@@ -50,7 +50,9 @@ class MultipleFilesJavaCheckVerifierTest {
       MultipleFilesJavaCheckVerifier.verify(files, visitor);
       Fail.fail("Should have failed");
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("Unexpected at [4]");
+      // Line 4 of file FILENAME_ISSUES_FIRST, because we added an extra unexpected issue.
+      // All others line of file FILENAME_NO_ISSUE, because no issues were expected.
+      assertThat(e).hasMessage("Unexpected at [1, 3, 4, 4, 7, 8, 8, 10, 11, 12, 14, 17]");
     }
   }
 
@@ -62,14 +64,24 @@ class MultipleFilesJavaCheckVerifierTest {
       MultipleFilesJavaCheckVerifier.verify(files, visitor);
       Fail.fail("Should have failed");
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("Expected at [1], Unexpected at [4]");
+      // We removed issue on line 1, but still have a Noncompliant comment in FILENAME_ISSUES_FIRST.
+      // In Unexpected:
+      // - Line 4 of file FILENAME_ISSUES_FIRST, because we added an extra unexpected issue.
+      // - All others lines of file FILENAME_NO_ISSUE, because no issues were expected.
+      assertThat(e).hasMessage("Expected at [1], Unexpected at [3, 4, 4, 7, 8, 8, 10, 11, 12, 14, 17]");
     }
   }
 
   @Test
   void verify_issues_in_multiple_files() {
-    MultipleFilesJavaCheckVerifier.verify(Arrays.asList(FILENAME_ISSUES_FIRST, FILENAME_ISSUES_SECOND),
-        new JavaCheckVerifierTest.FakeVisitor().withDefaultIssues().withIssue(2, "message B"));
+    IssuableSubscriptionVisitor visitor = new JavaCheckVerifierTest.FakeVisitor().withDefaultIssues().withIssue(2, "message B");
+    List<String> files = Arrays.asList(FILENAME_ISSUES_FIRST, FILENAME_ISSUES_SECOND);
+    try {
+      MultipleFilesJavaCheckVerifier.verify(files, visitor);
+      Fail.fail("Should have failed");
+    } catch (AssertionError e) {
+      assertThat(e).hasMessage("Unexpected at [1, 2, 3, 7, 8, 8, 10, 11, 12, 14, 17]");
+    }
   }
 
   @Test
@@ -80,7 +92,7 @@ class MultipleFilesJavaCheckVerifierTest {
       MultipleFilesJavaCheckVerifier.verifyNoIssueWithoutSemantic(files, visitor);
       Fail.fail("Should have failed");
     } catch (AssertionError e) {
-      assertThat(e.getMessage()).contains("No issues expected but got 10 issue(s):");
+      assertThat(e.getMessage()).contains("No issues expected but got 20 issue(s):"); // 10 per files
     }
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
@@ -45,6 +45,8 @@ public class VisitorsBridgeForTests extends VisitorsBridge {
   private TestJavaFileScannerContext testContext;
   private boolean enableSemantic = true;
 
+  // Stores all issues raised by the different JavaFileScannerContext
+  private final Set<AnalyzerMessage> issues = new LinkedHashSet<>();
 
   @VisibleForTesting
   public VisitorsBridgeForTests(JavaFileScanner visitor, SonarComponents sonarComponents) {
@@ -64,7 +66,7 @@ public class VisitorsBridgeForTests extends VisitorsBridge {
   protected JavaFileScannerContext createScannerContext(CompilationUnitTree tree, Sema semanticModel,
                                                         SonarComponents sonarComponents, boolean failedParsing) {
     Sema model = enableSemantic ? semanticModel : null;
-    testContext = new TestJavaFileScannerContext(tree, currentFile, model, sonarComponents, javaVersion, failedParsing);
+    testContext = new TestJavaFileScannerContext(tree, currentFile, model, sonarComponents, javaVersion, issues, failedParsing);
     return testContext;
   }
 
@@ -72,15 +74,20 @@ public class VisitorsBridgeForTests extends VisitorsBridge {
     return testContext;
   }
 
+  public Set<AnalyzerMessage> getIssues() {
+    return issues;
+  }
+
   public static class TestJavaFileScannerContext extends DefaultJavaFileScannerContext {
 
-    private final Set<AnalyzerMessage> issues = new LinkedHashSet<>();
     private final SonarComponents sonarComponents;
+    private final Set<AnalyzerMessage> issues;
 
     public TestJavaFileScannerContext(CompilationUnitTree tree, InputFile inputFile, Sema semanticModel,
-                                      @Nullable SonarComponents sonarComponents, JavaVersion javaVersion, boolean failedParsing) {
+                                      @Nullable SonarComponents sonarComponents, JavaVersion javaVersion, Set<AnalyzerMessage> issues, boolean failedParsing) {
       super(tree, inputFile, semanticModel, sonarComponents, javaVersion, failedParsing);
       this.sonarComponents = sonarComponents;
+      this.issues = issues;
     }
 
     public Set<AnalyzerMessage> getIssues() {

--- a/java-frontend/src/main/java/org/sonar/java/testing/InternalCheckVerifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/testing/InternalCheckVerifier.java
@@ -215,8 +215,7 @@ public class InternalCheckVerifier implements CheckVerifier {
     astScanner.setVisitorBridge(visitorsBridge);
     astScanner.scan(files);
 
-    VisitorsBridgeForTests.TestJavaFileScannerContext testJavaFileScannerContext = visitorsBridge.lastCreatedTestContext();
-    checkIssues(testJavaFileScannerContext.getIssues());
+    checkIssues(visitorsBridge.getIssues());
   }
 
   private void checkIssues(Set<AnalyzerMessage> issues) {


### PR DESCRIPTION
Only the issues reported by the execution of the rules on the last file were taken into consideration, while we should consider any issue raised during the analysis.