### PR TITLE
SONARJAVA-3633 Move test files to compiled module for S4032

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/package-info.java
+++ b/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/package-info.java
@@ -1,0 +1,1 @@
+package checks.UselessPackageInfoCheck;

--- a/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/packageWithNoOtherFiles/package-info.java
+++ b/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/packageWithNoOtherFiles/package-info.java
@@ -1,0 +1,1 @@
+package checks.UselessPackageInfoCheck.packageWithNoOtherFiles;

--- a/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/HelloWorld.java
+++ b/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/HelloWorld.java
@@ -1,0 +1,4 @@
+package checks.UselessPackageInfoCheck.packageWithNoOtherFilesButNotPackageInfo;
+
+class HelloWorld {
+}

--- a/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/package-info.java
+++ b/java-checks-test-sources/src/main/java/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/package-info.java
@@ -1,0 +1,1 @@
+package checks.UselessPackageInfoCheck.packageWithNoOtherFilesButNotPackageInfo;

--- a/java-checks/src/test/files/checks/UselessPackageInfoCheck/package-info.java
+++ b/java-checks/src/test/files/checks/UselessPackageInfoCheck/package-info.java
@@ -1,1 +1,0 @@
-package packageInfo;

--- a/java-checks/src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFiles/package-info.java
+++ b/java-checks/src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFiles/package-info.java
@@ -1,1 +1,0 @@
-package packageInfo;

--- a/java-checks/src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/HelloWorld.java
+++ b/java-checks/src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/HelloWorld.java
@@ -1,4 +1,0 @@
-package packageInfo;
-
-class HelloWorld {
-}

--- a/java-checks/src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/package-info.java
+++ b/java-checks/src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/package-info.java
@@ -1,1 +1,0 @@
-package packageInfo;

--- a/java-checks/src/test/java/org/sonar/java/checks/UselessPackageInfoCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UselessPackageInfoCheckTest.java
@@ -22,12 +22,14 @@ package org.sonar.java.checks;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
+import static org.sonar.java.CheckTestUtils.testSourcesPath;
+
 class UselessPackageInfoCheckTest {
 
   @Test
   void withNoOtherFile() {
     JavaCheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFiles/package-info.java")
+      .onFile(testSourcesPath("checks/UselessPackageInfoCheck/packageWithNoOtherFiles/package-info.java"))
       .withCheck(new UselessPackageInfoCheck())
       .verifyIssueOnFile("Remove this package.");
   }
@@ -35,7 +37,7 @@ class UselessPackageInfoCheckTest {
   @Test
   void withOtherFile() {
     JavaCheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/UselessPackageInfoCheck/package-info.java")
+      .onFile(testSourcesPath("checks/UselessPackageInfoCheck/package-info.java"))
       .withCheck(new UselessPackageInfoCheck())
       .verifyNoIssues();
   }
@@ -43,7 +45,7 @@ class UselessPackageInfoCheckTest {
   @Test
   void notAPackageInfo() {
     JavaCheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/HelloWorld.java")
+      .onFile(testSourcesPath("checks/UselessPackageInfoCheck/packageWithNoOtherFilesButNotPackageInfo/HelloWorld.java"))
       .withCheck(new UselessPackageInfoCheck())
       .verifyNoIssues();
   }


### PR DESCRIPTION
Due to a bug in the JavaCheckVerifier (see [SONARJAVA-3643](https://jira.sonarsource.com/browse/SONARJAVA-3643)), I have to postpone the implementation of the fix of SONARJAVA-3633.

Since I already made the effort to move the test files to the compiled module, it makes sense to still merge this code.