### PR TITLE
Fix its expecting default Java version in maven

### DIFF
--- a/its/plugin/projects/java-version-aware-visitor/pom.xml
+++ b/its/plugin/projects/java-version-aware-visitor/pom.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.sonarsource.it.projects</groupId>
-    <artifactId>sample-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
-  </parent>
+  <groupId>org.sonarsource.it.projects</groupId>
   <artifactId>example</artifactId>
   <version>1.0-SNAPSHOT</version>
 

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
@@ -193,7 +193,12 @@ public class JavaTest {
 
     TestUtils.provisionProject(orchestrator, projectKey, "java-version-aware-visitor", "java", "java-version-aware-visitor");
 
-    // no java version specified. maven scanner gets maven default version : java 5.
+    // no java version specified. maven scanner gets maven default version : java 11.
+    orchestrator.executeBuild(build);
+    assertThat(getMeasureAsInteger(projectKey, "violations")).isEqualTo(1);
+
+   // java version is 1.5. Getting no issues..
+    build.setProperty(sonarJavaSource, "1.5");
     orchestrator.executeBuild(build);
     assertThat(getMeasureAsInteger(projectKey, "violations")).isZero();
 

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
@@ -193,12 +193,7 @@ public class JavaTest {
 
     TestUtils.provisionProject(orchestrator, projectKey, "java-version-aware-visitor", "java", "java-version-aware-visitor");
 
-    // no java version specified. maven scanner gets maven default version : java 11.
-    orchestrator.executeBuild(build);
-    assertThat(getMeasureAsInteger(projectKey, "violations")).isEqualTo(1);
-
-   // java version is 1.5. Getting no issues..
-    build.setProperty(sonarJavaSource, "1.5");
+    // no java version specified. maven scanner gets maven default version : java 5.
     orchestrator.executeBuild(build);
     assertThat(getMeasureAsInteger(projectKey, "violations")).isZero();
 


### PR DESCRIPTION
Starting from [this commit](https://github.com/SonarSource/sonar-scanner-maven/commit/0d618b5b8a622aa8c97232bb5acb3fb488387e8a) release version configured in pom.xml will be considered as `sonar.java.source` version.

Our plugin test projects are all configured to run on java 11 using this property in parent's pom.xml. 
To keep testing older versions of java in this test I removed parent section only from this project. So now `sonar.java.source` version won't be overridden and we'll get the right fallback from maven, which is Java 5