### PR TITLE
Update tests for S3252 and S1942

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/checks/StaticMemberAccess.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/StaticMemberAccess.java
@@ -1,0 +1,21 @@
+package checks;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+
+class StaticMemberAccessParent {
+  public static int counter;
+}
+
+class StaticMemberAccessChild extends StaticMemberAccessParent {
+  public StaticMemberAccessChild() {
+    StaticMemberAccessChild.counter++;  // Noncompliant {{Use static access with "checks.StaticMemberAccessParent" for "counter".}}
+    StaticMemberAccessParent.counter++; // Compliant
+
+    StaticMemberAccessChild.unknown++;  // Compliant
+    StaticMemberAccessParent.unknown++; // Compliant
+
+    StaticMemberAccessChild.unknown(); // Compliant
+    StaticMemberAccessParent.unknown(); // Compliant
+  }
+}

--- a/java-checks-test-sources/src/main/java/checks/SimpleClassNameCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/SimpleClassNameCheck.java
@@ -9,23 +9,29 @@ import java.util.List;
 class SimpleClass {
  
   void notWildcardImport() {
-    ImmutableList list;      // Noncompliant
-    ImmutableList.Builder<Object> builder =  // Noncompliant [[startColumn=5;endColumn=44]]
-      ImmutableList.builder(); // Noncompliant {{Replace this fully qualified name with "ImmutableList"}}
-    System.out.println(ImmutableList.class); // Noncompliant [[startColumn=24;endColumn=63]]
+    com.google.common.collect.ImmutableList list;      // Noncompliant
+    com.google.common.collect.ImmutableList.Builder<Object> builder =  // Noncompliant [[startColumn=5;endColumn=44]]
+      com.google.common.collect.ImmutableList.builder(); // Noncompliant {{Replace this fully qualified name with "ImmutableList"}}
+    System.out.println(com.google.common.collect.ImmutableList.class); // Noncompliant [[startColumn=24;endColumn=63]]
 
     ImmutableList.builder();
     ImmutableList anotherList;
   }
 
   void wildcardImport() {
-    List<String> myList =      // Noncompliant {{Replace this fully qualified name with "List"}}
-      new ArrayList<String>(); // Noncompliant [[startColumn=11;endColumn=30]]
+    java.util.List<String> myList =      // Noncompliant {{Replace this fully qualified name with "List"}}
+      new java.util.ArrayList<String>(); // Noncompliant [[startColumn=11;endColumn=30]]
 
-    ImmutableMap map; // Noncompliant
+    List<String> myList2 =      // Compliant
+      new ArrayList<String>();
+
+    com.google.common.collect.ImmutableMap map; // Noncompliant
+
+    ImmutableMap.builder();
 
     java.awt.image.ImageProducer x; // OK
-    Charset.defaultCharset().name(); // Noncompliant
+    java.nio.charset.Charset.defaultCharset().name(); // Noncompliant
+    Charset.defaultCharset().name(); // Compliant
   }
 }
 ;

--- a/java-checks-test-sources/src/main/java/checks/StaticMemberAccess.java
+++ b/java-checks-test-sources/src/main/java/checks/StaticMemberAccess.java
@@ -3,18 +3,22 @@ package checks;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
-class CoolParent {
+class StaticMemberAccessParent {
   public static int counter;
 
   static void foo() {
-    CoolParent.counter++;
+    StaticMemberAccessParent.counter++;
     counter++;
   }
 }
 
-class Child extends CoolParent {
-  public Child() {
-    CoolParent.counter++;  // Noncompliant {{Use static access with "test.Parent" for "counter".}}
+class StaticMemberAccessChild extends StaticMemberAccessParent {
+  public StaticMemberAccessChild() {
+    StaticMemberAccessChild.counter++;  // Noncompliant {{Use static access with "checks.StaticMemberAccessParent" for "counter".}}
+    StaticMemberAccessParent.counter++; // Compliant
+
+    StaticMemberAccessChild.foo(); // Noncompliant
+    StaticMemberAccessParent.foo(); // Compliant
   }
 }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/SimpleClassNameCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/SimpleClassNameCheckTest.java
@@ -32,8 +32,11 @@ class SimpleClassNameCheckTest {
     JavaCheckVerifier.newVerifier()
       .onFile(testSourcesPath("checks/SimpleClassNameCheck.java"))
       .withCheck(new SimpleClassNameCheck())
-      .verifyNoIssues();
+      .verifyIssues();
+  }
 
+  @Test
+  void test_non_compiling() {
     JavaCheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/SimpleClassNameCheck.java"))
       .withCheck(new SimpleClassNameCheck())

--- a/java-checks/src/test/java/org/sonar/java/checks/StaticMemberAccessCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StaticMemberAccessCheckTest.java
@@ -27,29 +27,31 @@ import static org.sonar.java.CheckTestUtils.testSourcesPath;
 
 class StaticMemberAccessCheckTest {
 
+  private static final String FILE_NAME = "checks/StaticMemberAccess.java";;
+
   @Test
   void test() {
     JavaCheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/StaticMemberAccess.java"))
+      .onFile(testSourcesPath(FILE_NAME))
       .withCheck(new StaticMemberAccessCheck())
-      .verifyNoIssues();
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
     JavaCheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/StaticMemberAccess.java"))
+      .onFile(testSourcesPath(FILE_NAME))
       .withCheck(new StaticMemberAccessCheck())
       .withoutSemantic()
       .verifyNoIssues();
   }
 
-  void testNonCompiling() {
+  @Test
+  void test_non_compiling() {
     JavaCheckVerifier.newVerifier()
-      .onFile(nonCompilingTestSourcesPath("checks/StaticMemberAccess.java"))
+      .onFile(nonCompilingTestSourcesPath(FILE_NAME))
       .withCheck(new StaticMemberAccessCheck())
       .verifyIssues();
-    JavaCheckVerifier.newVerifier()
-      .onFile(nonCompilingTestSourcesPath("checks/StaticMemberAccess.java"))
-      .withCheck(new StaticMemberAccessCheck())
-      .withoutSemantic()
-      .verifyNoIssues();
   }
 
 }


### PR DESCRIPTION
During the Guava removal, 2 tests ended up not testing anything, since they `verifyNoIssues` despite the fact that the rule should still raise issues.

Only the tests are affected, the behavior of the rules are correct and unchanged.