### PR TITLE
SONARJAVA-3679 Report issue with AnalyzerMessage

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/security/ExcessiveContentRequestCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/ExcessiveContentRequestCheck.java
@@ -126,11 +126,11 @@ public class ExcessiveContentRequestCheck extends IssuableSubscriptionVisitor im
 
   @Override
   public void visitNode(Tree tree) {
+    DefaultJavaFileScannerContext defaultContext = (DefaultJavaFileScannerContext) context;
     if (tree.is(Tree.Kind.NEW_CLASS)) {
       NewClassTree newClassTree = (NewClassTree) tree;
       if (MULTIPART_CONSTRUCTOR.matches(newClassTree)) {
         // Create an issue that we will report only at the end of the analysis if the maximum size was never set.
-        DefaultJavaFileScannerContext defaultContext = (DefaultJavaFileScannerContext) context;
         AnalyzerMessage analyzerMessage = defaultContext.createAnalyzerMessage(this, newClassTree, MESSAGE_SIZE_NOT_SET);
         multipartConstructorIssues.add(analyzerMessage);
       }
@@ -138,9 +138,10 @@ public class ExcessiveContentRequestCheck extends IssuableSubscriptionVisitor im
       MethodInvocationTree mit = (MethodInvocationTree) tree;
       if (METHODS_SETTING_MAX_SIZE.matches(mit)) {
         sizeSetSomewhere = true;
-        getIfExceedSize(mit.arguments().get(0)).ifPresent(bytesExceeding ->
-          reportIssue(mit, String.format(MESSAGE_EXCEED_SIZE, bytesExceeding, fileUploadSizeLimit))
-        );
+        getIfExceedSize(mit.arguments().get(0))
+          .map(bytesExceeding ->
+            defaultContext.createAnalyzerMessage(this, mit, String.format(MESSAGE_EXCEED_SIZE, bytesExceeding, fileUploadSizeLimit)))
+          .ifPresent(defaultContext::reportIssue);
       }
     }
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/DefaultJavaFileScannerContext.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/DefaultJavaFileScannerContext.java
@@ -258,7 +258,7 @@ public class DefaultJavaFileScannerContext implements JavaFileScannerContext, Re
     return complexityVisitor.getNodes(tree);
   }
 
-  private static void throwIfEndOfAnalysisCheck(JavaCheck javaCheck) {
+  protected static void throwIfEndOfAnalysisCheck(JavaCheck javaCheck) {
     if (javaCheck instanceof EndOfAnalysisCheck) {
       throw new UnsupportedOperationException("EndOfAnalysisCheck must only call reportIssue with AnalyzerMessage and must never pass a Tree reference.");
     }

--- a/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/VisitorsBridgeForTests.java
@@ -99,22 +99,26 @@ public class VisitorsBridgeForTests extends VisitorsBridge {
 
     @Override
     public void reportIssue(JavaCheck javaCheck, Tree syntaxNode, String message, List<Location> secondary, @Nullable Integer cost) {
+      throwIfEndOfAnalysisCheck(javaCheck);
       List<List<Location>> flows = secondary.stream().map(Collections::singletonList).collect(Collectors.toList());
       issues.add(createAnalyzerMessage(getInputFile(), javaCheck, syntaxNode, null, message, flows, cost));
     }
 
     @Override
     public void reportIssue(JavaCheck javaCheck, Tree startTree, Tree endTree, String message) {
+      throwIfEndOfAnalysisCheck(javaCheck);
       issues.add(createAnalyzerMessage(javaCheck, startTree, endTree, message, Collections.emptyList(), null));
     }
 
     @Override
     public void reportIssue(JavaCheck javaCheck, Tree startTree, Tree endTree, String message, List<Location> secondary, @Nullable Integer cost) {
+      throwIfEndOfAnalysisCheck(javaCheck);
       issues.add(createAnalyzerMessage(javaCheck, startTree, endTree, message, secondary, cost));
     }
 
     @Override
     public void reportIssueWithFlow(JavaCheck javaCheck, Tree syntaxNode, String message, Iterable<List<Location>> flows, @Nullable Integer cost) {
+      throwIfEndOfAnalysisCheck(javaCheck);
       issues.add(createAnalyzerMessage(getInputFile(), javaCheck, syntaxNode, null, message, flows, cost));
     }
 


### PR DESCRIPTION
See [DefaultJavaFileScannerContext.java#L263](https://github.com/SonarSource/sonar-java/blob/master/java-frontend/src/main/java/org/sonar/java/model/DefaultJavaFileScannerContext.java#L263).

I believe this is a protection, to not store references to trees across different files analysis.
In this case, I don't think it was relevant: the issue was directly reported during the analysis of the file (and not at the end of the analysis), but we can report with AnalyzerMessage anyway since it does not change anything at the end.