### PR TITLE
Include Eclipse annotation on nonNullFields check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dependency-reduced-pom.xml
 .project
 .settings
 
+# --- VSCode
+.factorypath
+.vscode/
+
 # ---- Sonar Scanners
 .scannerwork
 .sonar

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
@@ -213,7 +213,7 @@ public final class NullableAnnotationUtils {
         return ORG_SPRINGFRAMEWORK_LANG_NON_NULL_FIELDS;
       }
 
-      if (isGloballyAnnotatedWithEclipseNonNullByDefault((Symbol.MethodSymbol) symbol, "FIELD")) {
+      if (isGloballyAnnotatedWithEclipseNonNullByDefault(symbol, "FIELD")) {
         return ORG_ECLIPSE_JDT_ANNOTATION_NON_NULL_BY_DEFAULT;
       }
     }
@@ -298,7 +298,7 @@ public final class NullableAnnotationUtils {
       .orElse(null);
   }
 
-  private static boolean isGloballyAnnotatedWithEclipseNonNullByDefault(Symbol.MethodSymbol symbol, String parameter) {
+  private static boolean isGloballyAnnotatedWithEclipseNonNullByDefault(Symbol symbol, String parameter) {
     List<SymbolMetadata.AnnotationValue> valuesForGlobalAnnotation = valuesForGlobalAnnotation(symbol, ORG_ECLIPSE_JDT_ANNOTATION_NON_NULL_BY_DEFAULT);
     if (valuesForGlobalAnnotation == null) {
       return false;

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/NullableAnnotationUtils.java
@@ -208,9 +208,14 @@ public final class NullableAnnotationUtils {
 
   @CheckForNull
   private static String nonNullFieldAnnotation(Symbol symbol) {
-    if (symbol.isVariableSymbol() && symbol.owner().isTypeSymbol() && !isUsingNullable(symbol.metadata())
-      && valuesForGlobalAnnotation(symbol, ORG_SPRINGFRAMEWORK_LANG_NON_NULL_FIELDS) != null) {
-      return ORG_SPRINGFRAMEWORK_LANG_NON_NULL_FIELDS;
+    if (symbol.isVariableSymbol() && symbol.owner().isTypeSymbol() && !isUsingNullable(symbol.metadata())) {
+      if (valuesForGlobalAnnotation(symbol, ORG_SPRINGFRAMEWORK_LANG_NON_NULL_FIELDS) != null) {
+        return ORG_SPRINGFRAMEWORK_LANG_NON_NULL_FIELDS;
+      }
+
+      if (isGloballyAnnotatedWithEclipseNonNullByDefault((Symbol.MethodSymbol) symbol, "FIELD")) {
+        return ORG_ECLIPSE_JDT_ANNOTATION_NON_NULL_BY_DEFAULT;
+      }
     }
     return null;
   }

--- a/java-symbolic-execution/src/test/files/se/annotations/NullableAnnotationUtils_global.java
+++ b/java-symbolic-execution/src/test/files/se/annotations/NullableAnnotationUtils_global.java
@@ -17,7 +17,7 @@ interface Javax2 {
 abstract class Spring {
   Object nonNullField;
   abstract void nonNull(Object p1);
-  Object returnType();
+  abstract Object returnType();
 }
 
 @com.mongodb.lang.NonNullApi
@@ -36,14 +36,21 @@ interface Eclipse2 {
   Object returnType();
 }
 
-@org.eclipse.jdt.annotation.NonNullByDefault({DefaultLocation.RETURN_TYPE, DefaultLocation.PARAMETER})
-interface Eclipse3 {
-  void nonNull(Object p1);
-  Object returnType();
+@org.eclipse.jdt.annotation.NonNullByDefault(DefaultLocation.FIELD)
+abstract class Eclipse3 {
+  Object nonNullField;
+}
+
+@org.eclipse.jdt.annotation.NonNullByDefault({DefaultLocation.RETURN_TYPE, DefaultLocation.PARAMETER, DefaultLocation.FIELD})
+abstract class Eclipse4 {
+  Object nonNullField;
+  abstract void nonNull(Object p1);
+  abstract Object returnType();
 }
 
 @org.eclipse.jdt.annotation.NonNullByDefault
-interface Eclipse4 {
-  void nonNull(Object p1);
-  Object returnType();
+abstract class Eclipse5 {
+  Object nonNullField;
+  abstract void nonNull(Object p1);
+  abstract Object returnType();
 }

--- a/java-symbolic-execution/src/test/java/org/sonar/java/se/NullableAnnotationUtilsTest.java
+++ b/java-symbolic-execution/src/test/java/org/sonar/java/se/NullableAnnotationUtilsTest.java
@@ -85,7 +85,7 @@ class NullableAnnotationUtilsTest {
 
     List<Symbol> nonNullFields = Collector.variablesWithName("nonNull", cut);
     assertThat(nonNullFields)
-      .hasSize(1)
+      .hasSize(4)
       .allMatch(NullableAnnotationUtils::isAnnotatedNonNull);
     assertThat(nonNullFields.stream().map(Symbol::metadata))
       .noneMatch(NullableAnnotationUtils::isAnnotatedNullable);


### PR DESCRIPTION
Hi,

I opened this small PR to add `FIELD` to the checks of Eclipse's `@NonNullByDefault` annotation. Following the contribution guidelines, I also opened a topic in Sonar Source Community which can be found in the link below:
https://community.sonarsource.com/t/eclipses-nonnullbydefault-annotation-should-also-check-fields/39288?u=joselion

I hope this could be useful and I'm looking forward to any feedback!

Cheers 🙂 

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
