### PR TITLE
Return all overrides, not just the first one

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/Symbols.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/Symbols.java
@@ -22,7 +22,6 @@ package org.sonar.java.model;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import javax.annotation.CheckForNull;
 
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -256,6 +255,11 @@ public class Symbols {
     @Override
     public Symbol.MethodSymbol overriddenSymbol() {
       return null;
+    }
+
+    @Override
+    public List<Symbol.MethodSymbol> overriddenSymbols() {
+      return Collections.emptyList();
     }
 
     @Override

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/semantic/Symbol.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/semantic/Symbol.java
@@ -187,9 +187,19 @@ public interface Symbol {
      * Note that if the method returns null, the method is not overriding any method for sure.
      *
      * @return the overridden symbol, null if the method is not overriding any method or overriding can not be determined (incomplete semantic)
+     * @deprecated This method only returns the first symbol that has been overridden, rather than all symbols that are being overridden. Use {@link #overriddenSymbols()} to get a list of all symbols
      */
     @Nullable
+    @Deprecated
     Symbol.MethodSymbol overriddenSymbol();
+
+    /**
+     * Retrieve the overridden symbols, which may may not be able to be determined (returning 'unknown' symbol).
+     * Note that if the method returns an empty ist, the method is not overriding any method for sure.
+     *
+     * @return the overridden symbols, or an empty list if the method is not overriding any method or overriding can not be determined (incomplete semantics)
+     */
+    List<Symbol.MethodSymbol> overriddenSymbols();
 
     @Nullable
     @Override


### PR DESCRIPTION
The `overriddenSymbol` method currently returns a single method that the current method overrides - checking through the parent interfaces, then super classes, and finally `Object` for the first matching method - even where the method is overridden from multiple sources, such as both an interface and parent class, or implemented from multiple interfaces. Where a rule needs to check all overridden methods for certain information - such as annotations being replicated onto classes from all parent interfaces - this incomplete list prevents these rules from performing a full check.

This change introduces an `overriddenSymbols` method that returns a list of methods that are being overridden across all parent interfaces and super classes, and updates the `overriddenSymbol` method to delegate to the new method and return the first matched method to retain backwards compatibility. As use of the existing `overriddenSymbol` method could potentially lead to misleading results, this method has been marked as deprecated in favour of the new method, although the usage in the existing rules have not been migrated since their usages do not seem to be directly impacted.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
