### PR TITLE
SONARJAVA-3787 Children of Switch Statement should not be a Switch Expression

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/statement/SwitchStatementTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/statement/SwitchStatementTreeImpl.java
@@ -19,8 +19,10 @@
  */
 package org.sonar.java.model.statement;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.sonar.java.collections.ListUtils;
 import org.sonar.java.model.JavaTree;
 import org.sonar.plugins.java.api.tree.CaseGroupTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -90,7 +92,11 @@ public class SwitchStatementTreeImpl extends JavaTree implements SwitchStatement
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(switchExpression);
+    return ListUtils.concat(
+      Arrays.asList(switchExpression.switchKeyword(), switchExpression.openParenToken(),
+        switchExpression.expression(), switchExpression.closeParenToken(), switchExpression.openBraceToken()),
+      switchExpression.cases(),
+      Collections.singletonList(switchExpression.closeBraceToken()));
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/BaseTreeVisitor.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/BaseTreeVisitor.java
@@ -116,7 +116,8 @@ public class BaseTreeVisitor implements TreeVisitor {
 
   @Override
   public void visitSwitchStatement(SwitchStatementTree tree) {
-    scan(tree.asSwitchExpression());
+    scan(tree.expression());
+    scan(tree.cases());
   }
 
   @Override

--- a/java-frontend/src/test/java/org/sonar/java/model/JavaTreeModelTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JavaTreeModelTest.java
@@ -1675,7 +1675,7 @@ class JavaTreeModelTest {
       SwitchStatementTree tree = (SwitchStatementTree) firstMethodFirstStatement("class T { void m() { switch (e) { default: } } }");
       assertThat(tree.cases()).hasSize(1);
       assertThat(tree.cases().get(0).body()).isEmpty();
-      assertThat(tree).hasChildrenSize(1);
+      assertThat(tree).hasChildrenSize(7);
     }
   }
 


### PR DESCRIPTION
Internally, we represent Switch Statement thanks to a Switch Expression. It makes sense since both share the same structure.

However, this is only an internal detail, when we call "getChildren" on a Switch Statement, it should not contain the Switch Expression, but the actual children of the node. Similarly, when we visit a SwitchStatement, we should not scan the SwitchExpression, but directly visit the children, as we would do for a SwitchExpression.

This result in strange behavior in the `SubscriptionVisitor`:
If you register only on `SWITCH_EXPRESSION` but the code contains a `SWITCH_STATEMENT`, the nested expression will actually be visited. Similarly when using a BaseTreeVisitor, `visitSwitchExpression` will be called when your code only contains a Switch Statement.

Currently, we are never using `SWITCH_EXPRESSION` or overriding `visitSwitchExpression`, so this problem does not have any impact. However, it becomes a problem when we want to explicitly support Switch Expression in rules. The risk is that when registering on Switch Expression, the logic will actually be called two times for every Switch Statement (once for the Statement, and once for the nested Expression). In addition, if we want a rule supporting only Switch Expression, it is currently not possible.