### PR TITLE
SONARJAVA-3736 Test support of Text Block in rules relying on String literals from expressions

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/checks/StrongCipherAlgorithmCheck.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/StrongCipherAlgorithmCheck.java
@@ -1,0 +1,19 @@
+package checks;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import java.security.NoSuchAlgorithmException;
+
+class StrongCipherAlgorithmCheck {
+  private static final String DES_STRING = "DES";
+  private static final String DES_TEXT_BLOCK = """
+    DES""";
+
+  void foo() throws NoSuchAlgorithmException, NoSuchPaddingException {
+    Cipher.getInstance(DES_STRING); // Noncompliant
+    Cipher.getInstance(DES_TEXT_BLOCK); // Noncompliant
+    // Noncompliant@+1
+    Cipher.getInstance("""
+      DES""");
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/StrongCipherAlgorithmCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StrongCipherAlgorithmCheckTest.java
@@ -22,6 +22,7 @@ package org.sonar.java.checks;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
 
 class StrongCipherAlgorithmCheckTest {
@@ -31,6 +32,15 @@ class StrongCipherAlgorithmCheckTest {
     JavaCheckVerifier.newVerifier()
       .onFile(testSourcesPath("checks/StrongCipherAlgorithmCheck.java"))
       .withCheck(new StrongCipherAlgorithmCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_java_15() {
+    JavaCheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/StrongCipherAlgorithmCheck.java"))
+      .withCheck(new StrongCipherAlgorithmCheck())
+      .withJavaVersion(15)
       .verifyIssues();
   }
 


### PR DESCRIPTION
In fact, the important change ([supporting text block in `asConstant`](https://github.com/SonarSource/sonar-java/pull/3504/files#diff-e09d8d74fec9f3de313b998a998a1118aa3b9f58eabc6d5fb76f525aa402b337R214)) was already done in #3504, so this PR contains only one test to make sure this feature is supported in the different rules.