### PR TITLE
Fix spelling in rule documentation

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S6104_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S6104_java.html
@@ -8,7 +8,7 @@ entry with a null value. The traditional way should be used instead.</p>
 <p>This rule raises an issue when <code>computeIfAbsent</code> or <code>computeIfPresent</code> is used with a lambda always returning null.</p>
 <h2>Noncompliant Code Example</h2>
 <pre>
-map.computeIfAbsent(key, k -&gt; null); // Noncompliant,  te map will not contain an entry key-&gt;null.
+map.computeIfAbsent(key, k -&gt; null); // Noncompliant,  the map will not contain an entry key-&gt;null.
 map.computeIfPresent(key, (k, oldValue) -&gt; null); // Noncompliant
 </pre>
 <h2>Compliant Solution</h2>


### PR DESCRIPTION
Hi - all this changes is spelling in one of the rule documentation files that clients see - there is no "code" changes in this change.

Thank you very much,
Larry Diamond