### PR TITLE
S2694 false positive on JUnit nested tests

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/InnerStaticClassesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InnerStaticClassesCheck.java
@@ -41,6 +41,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 @Rule(key = "S2694")
 public class InnerStaticClassesCheck extends BaseTreeVisitor implements JavaFileScanner {
 
+  private static final String JUNIT_NESTED_TEST = "org.junit.jupiter.api.Nested";
   private JavaFileScannerContext context;
   private Deque<Symbol> outerClasses = new LinkedList<>();
   private Deque<Boolean> atLeastOneReference = new LinkedList<>();
@@ -86,6 +87,10 @@ public class InnerStaticClassesCheck extends BaseTreeVisitor implements JavaFile
       if (!superClassSymbol.owner().isPackageSymbol() && !superClassSymbol.isStatic()) {
         return false;
       }
+    }
+    if (symbol.metadata().isAnnotatedWith(JUNIT_NESTED_TEST)) {
+      // JUnit nested tests must be non-static https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested
+      return false;
     }
     if (outerClasses.size() == 1) {
       return true;

--- a/java-checks/src/test/files/checks/InnerStaticClassesCheck.java
+++ b/java-checks/src/test/files/checks/InnerStaticClassesCheck.java
@@ -222,3 +222,8 @@ class Other {
   static class Generic<X> {}
 }
 
+class SomeTest {
+  @org.junit.jupiter.api.Nested
+  class NestedTest { // compliant, nested tests must be inner classes
+  }
+}


### PR DESCRIPTION
JUnit nested tests must be inner classes and cannot be converted to
static classes. See
https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested

- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.

I didn't get the integration tests running. Feel free to add and edit.