### PR TITLE
S5838 misses some length()/size() > 0 assertions

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/AssertJChainSimplificationCheckTest.java
+++ b/java-checks-test-sources/src/main/java/checks/AssertJChainSimplificationCheckTest.java
@@ -196,6 +196,7 @@ public class AssertJChainSimplificationCheckTest {
 
     assertThat(getString().length()).isLessThanOrEqualTo(0); // Noncompliant {{Use isNotPositive() instead.}}
     assertThat(getString().length()).isLessThan(1); // Noncompliant {{Use isNotPositive() instead.}}
+    assertThat(getString().length()).isPositive(); // Noncompliant {{Use assertThat(actual).isNotEmpty() instead.}}
     assertThat(getString().length()).isNotPositive(); // Noncompliant {{Use assertThat(actual).isEmpty() instead.}}
     assertThat(getString().length()).isZero(); // Noncompliant {{Use assertThat(actual).isEmpty() instead.}}
     assertThat(getString().length()).isNotZero(); // Noncompliant {{Use assertThat(actual).isNotEmpty() instead.}}
@@ -249,6 +250,7 @@ public class AssertJChainSimplificationCheckTest {
     assertThat(getCollection().size()).isLessThan(length); // Noncompliant {{Use assertThat(actual).hasSizeLessThan(expected) instead.}}
     assertThat(getCollection().size()).isGreaterThan(length); // Noncompliant {{Use assertThat(actual).hasSizeGreaterThan(expected) instead.}}
     assertThat(getCollection().size()).isGreaterThanOrEqualTo(length); // Noncompliant {{Use assertThat(actual).hasSizeGreaterThanOrEqualTo(expected) instead.}}
+    assertThat(getCollection().size()).isPositive(); // Noncompliant {{Use assertThat(actual).isNotEmpty() instead.}}
 
     assertThat(getCollection().contains(something)).isTrue(); // Noncompliant {{Use assertThat(actual).contains(expected) instead.}}
     assertThat(getCollection().contains(something)).isFalse(); // Noncompliant {{Use assertThat(actual).doesNotContain(expected) instead.}}
@@ -274,6 +276,7 @@ public class AssertJChainSimplificationCheckTest {
     assertThat(getMap().size()).isGreaterThan(42); // Noncompliant {{Use assertThat(actual).hasSizeGreaterThan(expected) instead.}}
     assertThat(getMap().size()).isGreaterThanOrEqualTo(42); // Noncompliant {{Use assertThat(actual).hasSizeGreaterThanOrEqualTo(expected) instead.}}
     assertThat(getMap().size()).isLessThan(0); // Noncompliant {{Use isNegative() instead.}}
+    assertThat(getMap().size()).isPositive(); // Noncompliant {{Use assertThat(actual).isNotEmpty() instead.}}
 
     assertThat(getMap().containsKey(key)).isTrue(); // Noncompliant {{Use assertThat(actual).containsKey(expected) instead.}}
     assertThat(getMap().containsValue(value)).isTrue(); // Noncompliant {{Use assertThat(actual).containsValue(expected) instead.}}
@@ -299,6 +302,7 @@ public class AssertJChainSimplificationCheckTest {
     assertThat(getFile().length()).isNotZero(); // Noncompliant {{Use assertThat(actual).isNotEmpty() instead.}}
     assertThat(getFile().length()).isNotEqualTo(0);	// Noncompliant {{Use isNotZero() instead.}}
     assertThat(getFile().length()).isEqualTo(size); // Noncompliant {{Use assertThat(actual).hasSize(expected) instead.}}
+    assertThat(getFile().length()).isPositive(); // Noncompliant {{Use assertThat(actual).isNotEmpty() instead.}}
 
     assertThat(getFile().canRead()).isTrue(); // Noncompliant {{Use assertThat(actual).canRead() instead.}}
     assertThat(getFile().canWrite()).isTrue(); // Noncompliant {{Use assertThat(actual).canWrite() instead.}}

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/AssertJChainSimplificationIndex.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/AssertJChainSimplificationIndex.java
@@ -221,6 +221,8 @@ public class AssertJChainSimplificationIndex {
       arrayLengthSimplifier(msgWithActual(IS_NOT_EMPTY))))
     .put(IS_POSITIVE, Arrays.asList(
       compareToSimplifier(msgWithActualExpected(IS_GREATER_THAN)),
+      methodCallInSubject(MethodMatchers.or(Matchers.STRING_LENGTH, Matchers.COLLECTION_SIZE), msgWithActual(IS_NOT_EMPTY)),
+      methodCallInSubject(Matchers.FILE_LENGTH, msgWithActual(IS_NOT_EMPTY)),
       arrayLengthSimplifier(msgWithActual(IS_NOT_EMPTY))))
     .put(IS_SAME_AS, Collections.singletonList(
       methodCallInSubject(Matchers.GET, msgWithActualExpected("containsSame"))))


### PR DESCRIPTION
assertThat(file.length() > 0).isTrue() and similar comparisons of
length/size greater zero should be mapped to isNotEmpty().

This was missing for file, collection and string. The existing optimizations would only lead to size().isPositive().

Please ensure your pull request adheres to the following guidelines: 

- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [X] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
