### PR TITLE
SONARJAVA-3822: S6073 should not report on method invocation arguments that actually return an argument matcher

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -1,0 +1,100 @@
+package checks.tests;
+
+
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import static org.mockito.AdditionalMatchers.gt;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.AdditionalMatchers.or;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.intThat;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MockitoArgumentMatchersUsedOnAllParameters {
+
+  @Test
+  public void nonCompliant() {
+    verify(foo).bar(
+      returnRawValue(), // Noncompliant [[sc=7;ec=23]] {{Add an "eq()" argument matcher on this parameter.}}
+      any(), any()
+    );
+    verify(foo).bar(
+      returnRawValueThroughLayers(), // Noncompliant [[sc=7;ec=36]] {{Add an "eq()" argument matcher on this parameter.}}
+      any(), any()
+    );
+  }
+
+  @Test
+  public void compliant() {
+    Foo foo = mock(Foo.class);
+    given(foo.bar(
+      unresolvableMethod(), // Compliant, in case of incomplete semantic, we consider that the method invocation eventually returns an argument matcher
+      any(),
+      any()))
+      .willReturn(null);
+
+    given(foo.bar(
+      wrapUnresolvableMethod(), // Compliant, in case of incomplete semantic, we consider that the method invocation eventually returns an argument matcher
+      any(),
+      any()))
+      .willReturn(null);
+
+    given(foo.bar(
+      wrapThroughLayers(), // Compliant, in case of incomplete semantic, we consider that the method invocation eventually returns an argument matcher
+      any(),
+      any()))
+      .willReturn(null);
+  }
+
+  private int returnRawValue() {
+    return 42;
+  }
+
+  private int returnRawValueThroughLayers() {
+    return returnRawValue();
+  }
+
+  private wrapUnresolvableMethod() {
+    return unresolvableMethod();
+  }
+
+  private wrapUnresolvableMethodThroughLayers() {
+    return wrapThroughLayers();
+  }
+
+  private int wrapThroughLayers(int value) {
+    return wrapArgThat(value);
+  }
+
+
+  static class Foo {
+    Object bar(int a, Object b, Object c) {
+      return null;
+    }
+
+    String baz(Object a, Object b) {
+      return "hi";
+    }
+
+    boolean bop() {
+      return false;
+    }
+
+    void quux(int a, int b) {
+    }
+  }
+}

--- a/java-checks-test-sources/src/main/files/non-compiling/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -32,10 +32,6 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
       returnRawValue(), // Noncompliant [[sc=7;ec=23]] {{Add an "eq()" argument matcher on this parameter.}}
       any(), any()
     );
-    verify(foo).bar(
-      returnRawValueThroughLayers(), // Noncompliant [[sc=7;ec=36]] {{Add an "eq()" argument matcher on this parameter.}}
-      any(), any()
-    );
   }
 
   @Test
@@ -58,6 +54,11 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
       any(),
       any()))
       .willReturn(null);
+
+    verify(foo).bar(
+      returnRawValueThroughLayers(),  // Compliant FN, if the method invoked calls another method, we don't go deeper and consider it eventually returns an argument matcher
+      any(), any()
+    );
   }
 
   private int returnRawValue() {

--- a/java-checks-test-sources/src/main/files/non-compiling/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -7,6 +7,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import not.a.real.SomeHelper;
+
 import static org.mockito.AdditionalMatchers.gt;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.AdditionalMatchers.or;
@@ -23,6 +25,9 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import static not.a.real.thing.unresolvableMethod;
+import static not.a.real.Helper.wrapArgThat;
 
 public class MockitoArgumentMatchersUsedOnAllParameters {
 
@@ -57,6 +62,16 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
 
     verify(foo).bar(
       returnRawValueThroughLayers(),  // Compliant FN, if the method invoked calls another method, we don't go deeper and consider it eventually returns an argument matcher
+      any(), any()
+    );
+
+    verify(foo).bar(
+      wrapArgThat(), // Compliant
+      any(), any()
+    );
+
+    verify(foo).bar(
+      SomeHelper.wrapArgThat(), // Compliant
       any(), any()
     );
   }

--- a/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.intThat;
 import static org.mockito.ArgumentMatchers.notNull;
@@ -49,10 +50,15 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
       i1.toString(), // Noncompliant [[sc=7;ec=20]] {{Add an "eq()" argument matcher on this parameter.}}
       any());
 
-    // FP Wrapped argument matcher is masked by behind a method call
     verify(foo).bar(
-      wrapArgumentMatcher(42), // Noncompliant [[sc=7;ec=30]] {{Add an "eq()" argument matcher on this parameter.}}
-      any(), any());
+      returnRawValue(), // Noncompliant [[sc=7;ec=23]] {{Add an "eq()" argument matcher on this parameter.}}
+      any(), any()
+    );
+
+    verify(foo).bar(
+      returnRawValueThroughLayers(), // Noncompliant [[sc=7;ec=36]] {{Add an "eq()" argument matcher on this parameter.}}
+      any(), any()
+    );
   }
 
   @Test
@@ -88,10 +94,40 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
     eq(42);
     anySet();
     anyList();
+
+    // Cases where the method called returns an ArgumentMatcher
+    verify(foo).bar(
+      wrapArgumentMatcher(42), // Compliant
+      any(), any());
+
+    verify(foo).bar(
+      wrapArgThat(1), // Compliant
+      any(), any());
+
+    verify(foo).bar(
+      wrapThroughLayers(1), // Compliant
+      any(), any());
+  }
+
+
+  private int returnRawValue() {
+    return 42;
+  }
+
+  private int returnRawValueThroughLayers() {
+    return returnRawValue();
   }
 
   private int wrapArgumentMatcher(int value) {
     return eq(value);
+  }
+
+  private int wrapArgThat(int lowerBound) {
+    return argThat(number -> lowerBound < number);
+  }
+
+  private int wrapThroughLayers(int value) {
+    return wrapArgThat(value);
   }
 
   static class Foo {

--- a/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -1,6 +1,7 @@
 package checks.tests;
 
 
+import java.util.Random;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -59,6 +60,14 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
       returnRawValueThroughLayers(), // Noncompliant [[sc=7;ec=36]] {{Add an "eq()" argument matcher on this parameter.}}
       any(), any()
     );
+
+    verify(foo).bar(
+      recursiveCall(), // Noncompliant , If one the branches of the method invoked returns something else than an argument matcher it is considered non-compliant
+      any(), any());
+
+    verify(foo).bar(
+      new Integer("42"), // Noncompliant
+      any(), any());
   }
 
   @Test
@@ -128,6 +137,14 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
 
   private int wrapThroughLayers(int value) {
     return wrapArgThat(value);
+  }
+
+  private int recursiveCall() {
+    Random random = new Random();
+    if ((random.nextInt() % 2) == 0) {
+      return argThat(number -> number >= 0);
+    }
+    return recursiveCall();
   }
 
   static class Foo {

--- a/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -57,15 +57,6 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
     );
 
     verify(foo).bar(
-      returnRawValueThroughLayers(), // Noncompliant [[sc=7;ec=36]] {{Add an "eq()" argument matcher on this parameter.}}
-      any(), any()
-    );
-
-    verify(foo).bar(
-      recursiveCall(), // Noncompliant , If one the branches of the method invoked returns something else than an argument matcher it is considered non-compliant
-      any(), any());
-
-    verify(foo).bar(
       new Integer("42"), // Noncompliant
       any(), any());
   }
@@ -115,6 +106,19 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
 
     verify(foo).bar(
       wrapThroughLayers(1), // Compliant
+      any(), any());
+
+    verify(foo).bar(
+      wrapThroughLayers(42), // Compliant
+      any(), any());
+
+    verify(foo).bar(
+      returnRawValueThroughLayers(), // Compliant FN, if the method invoked calls another method, we don't go deeper and consider it eventually returns an argument matcher
+      any(), any()
+    );
+
+    verify(foo).bar(
+      recursiveCall(), // Compliant, if the method invoked calls another method, we don't go deeper and consider it eventually returns an argument matcher
       any(), any());
   }
 

--- a/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
+++ b/java-checks-test-sources/src/main/java/checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java
@@ -120,6 +120,21 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
     verify(foo).bar(
       recursiveCall(), // Compliant, if the method invoked calls another method, we don't go deeper and consider it eventually returns an argument matcher
       any(), any());
+
+
+    verify(foo).bar(
+      staticallyWrapArgThat(41), // Compliant, if the method invoked calls another method, we don't go deeper and consider it eventually returns an argument matcher
+      any(), any());
+
+    MockitoArgumentMatchersUsedOnAllParameters obj = new MockitoArgumentMatchersUsedOnAllParameters();
+
+    verify(foo).bar(
+      obj.wrapArgThat(41), // Compliant
+      any(), any());
+
+    verify(foo).bar(
+      obj.staticallyWrapArgThat(41), // Compliant
+      any(), any());
   }
 
 
@@ -149,6 +164,10 @@ public class MockitoArgumentMatchersUsedOnAllParameters {
       return argThat(number -> number >= 0);
     }
     return recursiveCall();
+  }
+
+  private static int staticallyWrapArgThat(int lowerBound) {
+    return argThat(number -> lowerBound < number);
   }
 
   static class Foo {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheck.java
@@ -107,6 +107,9 @@ public class MockitoArgumentMatchersUsedOnAllParametersCheck extends AbstractMoc
       }
       Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) symbol;
       MethodTree declaration = methodSymbol.declaration();
+      if (declaration == null) {
+        return false;
+      }
       MethodVisitor methodVisitor = new MethodVisitor();
       declaration.accept(methodVisitor);
       return methodVisitor.returnsAnArgumentMatcher;
@@ -139,16 +142,16 @@ public class MockitoArgumentMatchersUsedOnAllParametersCheck extends AbstractMoc
         return;
       }
       cachedResults.put(tree, Boolean.FALSE);
-      List<ExpressionTree> expressionsReturned = tree.block().body().stream()
+      List<ExpressionTree> terminalMethodInvocations = tree.block().body().stream()
         .filter(statement -> statement.is(Tree.Kind.RETURN_STATEMENT))
         .map(ReturnStatementTree.class::cast)
         .map(ReturnStatementTree::expression)
         .filter(expression -> expression.is(Tree.Kind.METHOD_INVOCATION))
         .collect(Collectors.toList());
-      if (expressionsReturned.isEmpty()) {
+      if (terminalMethodInvocations.isEmpty()) {
         return;
       }
-      returnsAnArgumentMatcher = expressionsReturned.stream()
+      returnsAnArgumentMatcher = terminalMethodInvocations.stream()
         .allMatch(MockitoArgumentMatchersUsedOnAllParametersCheck::isArgumentMatcherLike);
       cachedResults.put(tree, returnsAnArgumentMatcher);
     }

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheckTest.java
@@ -37,7 +37,7 @@ class MockitoArgumentMatchersUsedOnAllParametersCheckTest {
 
   @Test
   void test_non_compiling() {
-    JavaCheckVerifier.newVerifier()
+    CheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java"))
       .withCheck(new MockitoArgumentMatchersUsedOnAllParametersCheck())
       .verifyIssues();

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheckTest.java
@@ -22,6 +22,7 @@ package org.sonar.java.checks.tests;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
 
 class MockitoArgumentMatchersUsedOnAllParametersCheckTest {
@@ -30,6 +31,14 @@ class MockitoArgumentMatchersUsedOnAllParametersCheckTest {
   void test() {
     CheckVerifier.newVerifier()
       .onFile(testSourcesPath("checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java"))
+      .withCheck(new MockitoArgumentMatchersUsedOnAllParametersCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_non_compiling() {
+    JavaCheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/tests/MockitoArgumentMatchersUsedOnAllParameters.java"))
       .withCheck(new MockitoArgumentMatchersUsedOnAllParametersCheck())
       .verifyIssues();
   }


### PR DESCRIPTION
This pull request adds the capability to the check to look into methods that might return an argument matcher.
If the method cannot be resolved or its code explored, then it is assumed that the method might return an argument matcher and thus no issue is reported.