### PR TITLE
SONARJAVA-3865: Deprecate S4604

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4604_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4604_java.html
@@ -55,4 +55,6 @@ public class MyApplication {
 ...
 }
 </pre>
+<h2>Deprecated</h2>
+<p>This rule is deprecated, and will eventually be removed.</p>
 

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4604_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S4604_java.json
@@ -1,15 +1,12 @@
 {
   "title": "\"@EnableAutoConfiguration\" should be fine-tuned",
   "type": "CODE_SMELL",
-  "status": "ready",
+  "status": "deprecated",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "30min"
   },
-  "tags": [
-    "spring",
-    "performance"
-  ],
+  "tags": [],
   "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-4604",
   "sqKey": "S4604",


### PR DESCRIPTION
Following the [deprecation of S4604](https://github.com/SonarSource/rspec/pull/131), this change updates the documentation of rule S4604 in the java analyzer.