### PR TITLE
SONARJAVA-3745 Simplify implementation and fix FPs

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/CollectorsToList.java
+++ b/java-checks-test-sources/src/main/java/checks/CollectorsToList.java
@@ -1,6 +1,7 @@
 package checks;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -53,6 +54,11 @@ public class CollectorsToList {
 
     list2.add("X");
 
+    List<String> list3 = Stream.of("A", "B", "C")
+      .collect(Collectors.toList()); // Compliant, list3 needs to be mutable
+
+    list3.retainAll(Arrays.asList("C", "D"));
+
     memberList = Stream.of("A", "B", "C")
       .collect(Collectors.toList()); // Compliant, memberList needs to be mutable as its modified in addX
 
@@ -63,7 +69,7 @@ public class CollectorsToList {
 
     listWrapper2.strings = Stream.of("A", "B", "C").collect(Collectors.toList()); // Compliant, list is modified in addX
 
-    List<String> list3 = Stream.of("A", "B", "C")
+    List<String> list4 = Stream.of("A", "B", "C")
       .collect(Collectors.toCollection(ArrayList::new)); // Compliant because it's creating a specific list type instead of using toList
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/CollectorsToListCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CollectorsToListCheck.java
@@ -19,11 +19,6 @@
  */
 package org.sonar.java.checks;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import javax.annotation.CheckForNull;
 import org.sonar.check.Rule;
 import org.sonar.java.JavaVersionAwareVisitor;
@@ -31,6 +26,7 @@ import org.sonar.java.checks.methods.AbstractMethodDetection;
 import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
@@ -41,24 +37,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S6204")
 public class CollectorsToListCheck extends AbstractMethodDetection implements JavaVersionAwareVisitor {
-  private static class Issue {
-    private static final String MESSAGE = "Replace this usage of 'Stream.collect(Collectors.%s())' with 'Stream.toList()'";
-
-    Tree tree;
-    boolean isMutable;
-    @CheckForNull
-    Symbol assignedVariable;
-
-    Issue(Tree tree, boolean isMutable, @CheckForNull Symbol assignedVariable) {
-      this.tree = tree;
-      this.isMutable = isMutable;
-      this.assignedVariable = assignedVariable;
-    }
-
-    String message() {
-      return String.format(MESSAGE, isMutable ? "toList" : "toUnmodifiableList");
-    }
-  }
+  private static final String MESSAGE = "Replace this usage of 'Stream.collect(Collectors.%s())' with 'Stream.toList()'";
 
   private static final MethodMatchers COLLECT = MethodMatchers.create()
     .ofSubTypes("java.util.stream.Stream")
@@ -84,9 +63,6 @@ public class CollectorsToListCheck extends AbstractMethodDetection implements Ja
     .withAnyParameters()
     .build();
 
-  private final Set<Symbol> mutableLists = new HashSet<>();
-  private final List<Issue> issues = new ArrayList<>();
-
   @Override
   public boolean isCompatibleWithJavaVersion(JavaVersion version) {
     return version.isJava16Compatible();
@@ -94,69 +70,61 @@ public class CollectorsToListCheck extends AbstractMethodDetection implements Ja
 
   @Override
   protected MethodMatchers getMethodInvocationMatchers() {
-    return MethodMatchers.or(COLLECT, LIST_MODIFICATION_METHODS);
-  }
-
-  @Override
-  public List<Tree.Kind> nodesToVisit() {
-    return Arrays.asList(Tree.Kind.COMPILATION_UNIT, Tree.Kind.METHOD_INVOCATION);
-  }
-
-  @Override
-  public void visitNode(Tree tree) {
-    if (tree.is(Tree.Kind.COMPILATION_UNIT)) {
-      mutableLists.clear();
-      issues.clear();
-    }
-    super.visitNode(tree);
-  }
-
-  @Override
-  public void leaveNode(Tree tree) {
-    if (tree.is(Tree.Kind.COMPILATION_UNIT)) {
-      for (Issue issue : issues) {
-        if (!issue.isMutable || issue.assignedVariable == null || !mutableLists.contains(issue.assignedVariable)) {
-          reportIssue(issue.tree, issue.message());
-        }
-      }
-    }
-    super.leaveNode(tree);
+    return MethodMatchers.or(COLLECT);
   }
 
   @Override
   protected void onMethodInvocationFound(MethodInvocationTree mit) {
-    if (COLLECT.matches(mit)) {
-      boolean mutable;
-      if (!mit.arguments().get(0).is(Tree.Kind.METHOD_INVOCATION)) return;
-      MethodInvocationTree collector = (MethodInvocationTree) mit.arguments().get(0);
-      if (COLLECTORS_TO_LIST.matches(collector)) {
-        mutable = true;
-      } else if (COLLECTORS_TO_UNMODIFIABLE_LIST.matches(collector)) {
-        mutable = false;
-      } else {
-        return;
-      }
-      Symbol assignedVariable = findAssignedVariable(mit);
-      issues.add(new Issue(collector, mutable, assignedVariable));
-    } else if (mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
-      MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) mit.methodSelect();
-      if (memberSelect.expression().is(Tree.Kind.IDENTIFIER)) {
-        mutableLists.add(((IdentifierTree) memberSelect.expression()).symbol());
-      }
+    boolean mutable;
+    if (!mit.arguments().get(0).is(Tree.Kind.METHOD_INVOCATION)) return;
+    MethodInvocationTree collector = (MethodInvocationTree) mit.arguments().get(0);
+    if (COLLECTORS_TO_LIST.matches(collector)) {
+      mutable = true;
+    } else if (COLLECTORS_TO_UNMODIFIABLE_LIST.matches(collector)) {
+      mutable = false;
+    } else {
+      return;
+    }
+    Symbol assignedVariable = findAssignedVariable(mit.parent());
+    if (!mutable || assignedVariable == null
+      || assignedVariable.usages().stream().noneMatch(CollectorsToListCheck::isListBeingModified)) {
+      reportIssue(collector, mutable);
     }
   }
 
-  @CheckForNull
-  private static Symbol findAssignedVariable(MethodInvocationTree mit) {
-    if (mit.parent().is(Tree.Kind.ASSIGNMENT)) {
-      ExpressionTree variable = ((AssignmentExpressionTree) mit.parent()).variable();
-      if (variable.is(Tree.Kind.IDENTIFIER)) {
-        return ((IdentifierTree) variable).symbol();
+  private void reportIssue(MethodInvocationTree collector, boolean mutable) {
+    String message = String.format(MESSAGE, mutable ? "toList" : "toUnmodifiableList");
+    reportIssue(collector, message);
+  }
+
+  private static boolean isListBeingModified(Tree list) {
+    while (list.parent().is(Tree.Kind.ARRAY_ACCESS_EXPRESSION, Tree.Kind.MEMBER_SELECT)) {
+      Tree possibleMethodInvocation = list.parent().parent();
+      if (possibleMethodInvocation.is(Tree.Kind.METHOD_INVOCATION)) {
+        MethodInvocationTree mit = (MethodInvocationTree) possibleMethodInvocation;
+        ExpressionTree receiver = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
+        return receiver == list && LIST_MODIFICATION_METHODS.matches(mit);
       }
+      list = list.parent();
     }
-    if (mit.parent().is(Tree.Kind.VARIABLE)) {
-      return ((VariableTree) mit.parent()).symbol();
+    return false;
+  }
+
+  @CheckForNull
+  private static Symbol findAssignedVariable(Tree tree) {
+    switch (tree.kind()) {
+      case ASSIGNMENT:
+        return findAssignedVariable(((AssignmentExpressionTree) tree).variable());
+      case VARIABLE:
+        return ((VariableTree) tree).symbol();
+      case IDENTIFIER:
+        return ((IdentifierTree) tree).symbol();
+      case MEMBER_SELECT:
+        return ((MemberSelectExpressionTree) tree).identifier().symbol();
+      case ARRAY_ACCESS_EXPRESSION:
+        return findAssignedVariable(((ArrayAccessExpressionTree) tree).expression());
+      default:
+        return null;
     }
-    return null;
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/CollectorsToListCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CollectorsToListCheck.java
@@ -42,7 +42,7 @@ public class CollectorsToListCheck extends AbstractMethodDetection implements Ja
   private static final MethodMatchers COLLECT = MethodMatchers.create()
     .ofSubTypes("java.util.stream.Stream")
     .names("collect")
-    .withAnyParameters()
+    .addParametersMatcher("java.util.stream.Collector")
     .build();
 
   private static final MethodMatchers COLLECTORS_TO_LIST = MethodMatchers.create()
@@ -59,7 +59,7 @@ public class CollectorsToListCheck extends AbstractMethodDetection implements Ja
 
   private static final MethodMatchers LIST_MODIFICATION_METHODS = MethodMatchers.create()
     .ofSubTypes("java.util.List")
-    .names("add", "addAll", "remove", "removeAll", "replaceAll", "set", "sort", "clear")
+    .names("add", "addAll", "remove", "removeAll", "retainAll", "replaceAll", "set", "sort", "clear")
     .withAnyParameters()
     .build();
 
@@ -70,7 +70,7 @@ public class CollectorsToListCheck extends AbstractMethodDetection implements Ja
 
   @Override
   protected MethodMatchers getMethodInvocationMatchers() {
-    return MethodMatchers.or(COLLECT);
+    return COLLECT;
   }
 
   @Override


### PR DESCRIPTION
Use semantics to find the usages of a variable to simplify the
implementation and fix FPs where lists were assigned to fields or
array slots.
