### PR TITLE
Add another Noncompliant example to S3655_java.html

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S3655_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S3655_java.html
@@ -12,6 +12,12 @@ Optional&lt;String&gt; value = this.getOptionalValue();
 
 String stringValue = value.get(); // Noncompliant
 </pre>
+<h2>Noncompliant Code Example<h2>
+<pre>
+if (data.getOptionalValue().isPresent()) { ...
+    data.getOptionalValue().get(); // Also Noncompliant because of indirect access
+}
+</pre>
 <h2>Compliant Solution</h2>
 <pre>
 Optional&lt;String&gt; value = this.getOptionalValue();


### PR DESCRIPTION
Add another example to S3655_java.html that makes clear that the isPresent() check is not compliant when used indirectly. In my experience this aspect is not obvious to some developers.

Please ensure your pull request adheres to the following guidelines: 

- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
