### PR TITLE
SONARJAVA-3986 FP in S2583 with Java 16 pattern matching

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/symbolicexecution/checks/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/symbolicexecution/checks/ConditionAlwaysTrueOrFalseCheck.java
@@ -250,6 +250,14 @@ class Class extends SuperClass {
     }
   }
 
+  public void instanceOfPatternMathing() {
+    Object object = new Object();
+    // Java 16 pattern matching instance of
+    if (object instanceof String s) { // Compliant
+    } else if (object instanceof Integer i) { // Compliant
+    }
+  }
+
   public void literals() {
     // literals
     if (!true) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}

--- a/java-checks-test-sources/src/main/files/non-compiling/symbolicexecution/checks/ConditionAlwaysTrueOrFalseCheck.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/symbolicexecution/checks/ConditionAlwaysTrueOrFalseCheck.java
@@ -256,6 +256,13 @@ class Class extends SuperClass {
     if (object instanceof String s) { // Compliant
     } else if (object instanceof Integer i) { // Compliant
     }
+
+    if (object instanceof String str) {
+      // str inherits the contraints from objects
+      if (str == null) { // Noncompliant {{Change this condition so that it does not always evaluate to "false"}}
+
+      }
+    }
   }
 
   public void literals() {

--- a/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
@@ -1106,6 +1106,7 @@ public class CFG implements ControlFlowGraph {
 
   private void buildInstanceOf(PatternInstanceOfTree instanceOfTree) {
     currentBlock.elements.add(instanceOfTree);
+    build(instanceOfTree.variable());
     build(instanceOfTree.expression());
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/cfg/CFGTest.java
@@ -1794,6 +1794,7 @@ class CFGTest {
     final CFGChecker cfgChecker = checker(
       block(
         element(Tree.Kind.IDENTIFIER, "a"),
+        element(Kind.VARIABLE, "str"),
         element(Tree.Kind.PATTERN_INSTANCE_OF)
         ).terminator(Tree.Kind.IF_STATEMENT).successors(0, 1),
       block(

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -706,6 +706,7 @@ public class ExplodedGraphWalker {
       case BITWISE_COMPLEMENT:
       case LOGICAL_COMPLEMENT:
       case INSTANCE_OF:
+      case PATTERN_INSTANCE_OF:
         executeUnaryExpression(tree);
         break;
       case IDENTIFIER:

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/constraint/ConstraintManager.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/constraint/ConstraintManager.java
@@ -63,6 +63,7 @@ public class ConstraintManager {
         result = new SymbolicValue.NotSymbolicValue();
         break;
       case INSTANCE_OF:
+      case PATTERN_INSTANCE_OF:
         result = new SymbolicValue.InstanceOfSymbolicValue();
         break;
       case MEMBER_SELECT:


### PR DESCRIPTION
For:
```
if (x instanceof String) {}
```
The basic block of the CFG looks like this:

- IDENTIFIER (x)
- INSTANCE_OF
- IF_STATEMENT

When the ExplodedGraphWalker reaches "INSTANCE_OF", the symbolic value of "x" will be on top of the stack. We will wrap it into a "InstanceOfSymbolicValue". (This new symbolic value is not doing much, as we currently do not track the types constraints.) This new symbolic value will replace the top of the stack. "IF_STATEMENT" will then consume this symbolic value.

For:
```
if (x instanceof String str) {} else if (x instanceof Integer i) {}
```
the corresponding cfg is:
- IDENTIFIER (x)
- PATTERN_INSTANCE_OF
- IF_STATEMENT
- IDENTIFIER (x)
- PATTERN_INSTANCE_OF
- IF_STATEMENT

The problem is that we are doing nothing when PATTERN_INSTANCE_OF is reached. It means that the first "IF_STATEMENT" will consume the symbolic value of "x", and assign the constraint `false` in the false branch. When the second "IF_STATEMENT" is reached, "x" has the constraint "false", generating a false positive.

The first commit solves this problem (and the problem of the ticket) by treating "PATTERN_INSTANCE_OF" exactly as "INSTANCE_OF". It makes sense because the two trees has the same impact on "x". Note that it does nothing special for the new variable "str".

The second commit is an improvement suggestion, to remove false negatives in the same rule (and potentially in others): it will set the symbolic value of "str" to the one from "x".