### PR TITLE
Update max supported version to Java 17, used only in internal sanity test

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/JavaVersionImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JavaVersionImpl.java
@@ -37,7 +37,8 @@ public class JavaVersionImpl implements JavaVersion {
   private static final int JAVA_14 = 14;
   private static final int JAVA_15 = 15;
   private static final int JAVA_16 = 16;
-  public static final int MAX_SUPPORTED = JAVA_16;
+  private static final int JAVA_17 = 17;
+  public static final int MAX_SUPPORTED = JAVA_17;
 
   private final int javaVersion;
 


### PR DESCRIPTION
@quentin-jaquier-sonarsource this is the only place where mention to Java 17 can be added, just to avoid forgetting in the future when implementing rules specific to Java 17. I didn't create a ticket for it as it doesn't have any functional change.