### PR TITLE
Update rule S3751 - accept protected and package scope modifiers

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/spring/RequestMappingMethodPublicCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/RequestMappingMethodPublicCheck.java
@@ -57,8 +57,8 @@ public class RequestMappingMethodPublicCheck extends IssuableSubscriptionVisitor
 
     if (isClassController(methodSymbol)
       && isRequestMappingAnnotated(methodSymbol)
-      && !methodSymbol.isPublic()) {
-      reportIssue(methodTree.simpleName(), "Make this method \"public\".");
+      && methodSymbol.isPrivate()) {
+      reportIssue(methodTree.simpleName(), "Make this method non \"private\".");
     }
   }
 

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S3751_java.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S3751_java.html
@@ -4,7 +4,7 @@ even if the method is <code>private</code>, because Spring invokes such methods 
 <p>So marking a sensitive method <code>private</code> may seem like a good way to control how such code is called. Unfortunately, not all Spring
 frameworks ignore visibility in this way. For instance, if you’ve tried to control web access to your sensitive, <code>private</code>,
 <code>@RequestMapping</code> method by marking it <code>@Secured</code> …​ it will still be called, whether or not the user is authorized to access
-it. That’s because AOP proxies are not applied to non-public methods.</p>
+it. That’s because AOP proxies are not applied to private methods.</p>
 <p>In addition to <code>@RequestMapping</code>, this rule also considers the annotations introduced in Spring Framework 4.3: <code>@GetMapping</code>,
 <code>@PostMapping</code>, <code>@PutMapping</code>, <code>@DeleteMapping</code>, <code>@PatchMapping</code>.</p>
 <h2>Noncompliant Code Example</h2>

--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S3751_java.json
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S3751_java.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"@RequestMapping\" methods should be \"public\"",
+  "title": "\"@RequestMapping\" methods should not be \"private\"",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/java-checks/src/test/files/checks/spring/RequestMappingMethodPublicCheck.java
+++ b/java-checks/src/test/files/checks/spring/RequestMappingMethodPublicCheck.java
@@ -15,7 +15,7 @@ public class HelloWorld {
   }
 
   @RequestMapping(value = "/greet", method = GET)
-  private String greet(String greetee) { // Noncompliant [[sc=18;ec=23]] {{Make this method "public".}}
+  private String greet(String greetee) { // Noncompliant [[sc=18;ec=23]] {{Make this method non "private".}}
   }
 
   @GetMapping
@@ -63,7 +63,7 @@ class Foo {
   }
 
   @RequestMapping(value = "/greet", method = GET)
-  private String greet(String greetee) { // Noncompliant [[sc=18;ec=23]] {{Make this method "public".}}
+  private String greet(String greetee) { // Noncompliant [[sc=18;ec=23]] {{Make this method non "private".}}
   }
 
   @GetMapping public String a() { }


### PR DESCRIPTION
Updating rule to raise violation only if the private modifier is used.
Motivation: From a long time ago Spring AOP has support for protected and
package-private access modifiers. This rule is obsolete and hinders
proper encapsulation.

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
