### PR TITLE
Update dependencies of sonar-checks-test-sources

### DIFF
--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.6.28</version>
+      <version>3.9.0</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -360,7 +360,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.16.1</version>
+      <version>3.19.0</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -400,7 +400,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
+      <version>3.0.2</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -435,7 +435,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
+      <version>3.12.0</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
@@ -592,25 +592,25 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.21</version>
+      <version>1.7.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-ext</artifactId>
-      <version>1.7.21</version>
+      <version>1.7.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.7.0</version>
+      <version>5.7.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.7.0</version>
+      <version>5.7.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -694,13 +694,13 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.10</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.10</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -730,7 +730,7 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
-      <version>7.7</version>
+      <version>8.9.0.43852</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -778,7 +778,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.7.7</version>
+      <version>3.9.0</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/java-checks-test-sources/src/main/java/checks/AssertionTypesCheck_AssertJ.java
+++ b/java-checks-test-sources/src/main/java/checks/AssertionTypesCheck_AssertJ.java
@@ -130,8 +130,8 @@ public class AssertionTypesCheck_AssertJ {
       .isNotEqualTo(42); // Compliant
 
     int[][] arrayOfArray = new int[0][];
-    assertThat(arrayOfArray).contains(arrayOfArray);       // false-negative
-    assertThat(arrayOfArray).doesNotContain(arrayOfArray); // false-negative
+    // assertThat(arrayOfArray).contains(arrayOfArray); // false-negative - removed in latest versions of assertj
+    // assertThat(arrayOfArray).doesNotContain(arrayOfArray); // false-negative - removed in latest versions of assertj
     assertThat(arrayOfArray).isIn(arrayOfArray);           // false-negative
   }
 


### PR DESCRIPTION
All the changes only impact the `java-checks-test-sources` module, which only contains test code, nothing being shipped with the analyzer.

* Updated dependencies to match versions used by sonar-java parent pom.
* Updated logback version to not use one being vulnerable and get rid of the warning (even if we do strictly nothing with this library)