### PR TITLE
SONARJAVA-4100 Abstract classes should be excluded from S5790

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/JunitNestedAnnotationCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/JunitNestedAnnotationCheck.java
@@ -79,4 +79,12 @@ public class JunitNestedAnnotationCheck { // Compliant, this class has some test
     }
   }
 
+  abstract class AbstractInner { // Compliant abstract classes do no not need to be annottated
+    protected abstract String abstractMethod();
+
+    @Test
+    void test() {
+    }
+  }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JunitNestedAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JunitNestedAnnotationCheck.java
@@ -65,7 +65,8 @@ public class JunitNestedAnnotationCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isNestedClass(Symbol.TypeSymbol classSymbol) {
-    return Optional.ofNullable(classSymbol.owner())
+    return !classSymbol.isAbstract() &&
+      Optional.ofNullable(classSymbol.owner())
       .map(Symbol::isTypeSymbol)
       .orElse(false);
   }


### PR DESCRIPTION
Inner classes that are abstract but contain test code should not be
reported by S5790.
