### PR TITLE
SONARJAVA-4010 Make sure primitive type symbols have an owner

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -172,6 +172,9 @@ abstract class JSymbol implements Symbol {
   }
 
   private Symbol typeOwner(ITypeBinding typeBinding) {
+    if (typeBinding.isPrimitive()) {
+      return Symbols.rootPackage;
+    }
     IMethodBinding declaringMethod = typeBinding.getDeclaringMethod();
     if (declaringMethod != null) {
       // local type

--- a/java-frontend/src/test/java/org/sonar/java/model/JSymbolTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JSymbolTest.java
@@ -92,11 +92,26 @@ class JSymbolTest {
       .as("of method parameter")
       .hasOwner(cu.sema.methodSymbol(m.methodBinding));
 
+    assertThat(cu.sema.typeSymbol(p.variableBinding.getType()))
+      .as("of type int")
+      .hasOwner(Symbols.rootPackage)
+      .hasSameHashCodeAs(p.type().symbolType().symbol().hashCode());
+
     JType uType = cu.sema.type(u.variableBinding.getType());
     Symbol.TypeSymbol uTypeSymbol = uType.symbol();
     assertThat(uType.isUnknown()).isTrue();
     assertThat(uTypeSymbol.isUnknown()).isTrue();
     assertThat(uTypeSymbol.owner().isUnknown()).isTrue();
+  }
+
+  @Test
+  void primitive_type_hash_code() {
+    JavaTree.CompilationUnitTreeImpl cu = test("class C { int u; int v; }");
+    ClassTreeImpl c = (ClassTreeImpl) cu.types().get(0);
+    VariableTreeImpl uField = (VariableTreeImpl) c.members().get(0);
+    VariableTreeImpl vField = (VariableTreeImpl) c.members().get(1);
+    assertThat(cu.sema.typeSymbol(uField.variableBinding.getType()))
+      .hasSameHashCodeAs(cu.sema.typeSymbol(vField.variableBinding.getType()));
   }
 
   @Test


### PR DESCRIPTION
Relates to #3884.

I decided to get rid of the `null` approach in order to avoid any future NPE, and assigned ownership of primitive type symbols to the root package.