### PR TITLE
SONARJAVA-3899 SONARJAVA-3842 Test correct behavior of "newDocumentBuilder" usage

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java
@@ -1,0 +1,17 @@
+package symbolicexecution.checks;
+
+import java.io.File;
+import java.io.IOException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.xml.sax.SAXException;
+
+class DocumentBuilderFactoryTest {
+  private DocumentBuilder foo() throws ParserConfigurationException, IOException, SAXException {
+    DocumentBuilderFactory dbf = unknown();
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    db.parse(new File(""));
+    return db;
+  }
+}

--- a/java-checks-test-sources/src/main/java/symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java
+++ b/java-checks-test-sources/src/main/java/symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java
@@ -177,3 +177,25 @@ class DocumentBuilderFactoryTest {
     }
   }
 }
+
+class DocumentBuilderFactoryTest_InStaticBlock {
+  private static final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+
+  static {
+    documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+  }
+
+  public static DocumentBuilder noIssue() throws Exception {
+    // No issue here, the code is equivalent to the one in the other method.
+    // We only report an issue on the declaration of "DocumentBuilderFactory", exactly to avoid such cases where the DocumentBuilder is created somewhere else.
+    return documentBuilderFactory.newDocumentBuilder();
+  }
+
+  public static DocumentBuilder equivalent() throws Exception {
+    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+    documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return documentBuilderFactory.newDocumentBuilder();
+  }
+}

--- a/java-checks-test-sources/src/main/java/symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java
+++ b/java-checks-test-sources/src/main/java/symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java
@@ -187,7 +187,7 @@ class DocumentBuilderFactoryTest_InStaticBlock {
   }
 
   public static DocumentBuilder noIssue() throws Exception {
-    // No issue here, the code is equivalent to the one in the other method.
+    // No issue here, the code is equivalent to the one in the next method.
     // We only report an issue on the declaration of "DocumentBuilderFactory", exactly to avoid such cases where the DocumentBuilder is created somewhere else.
     return documentBuilderFactory.newDocumentBuilder();
   }

--- a/java-symbolic-execution/src/test/java/org/sonar/java/se/checks/XxeProcessingCheckTest.java
+++ b/java-symbolic-execution/src/test/java/org/sonar/java/se/checks/XxeProcessingCheckTest.java
@@ -118,4 +118,13 @@ class XxeProcessingCheckTest {
       .verifyIssues();
   }
 
+  @Test
+  void non_compiling_code() {
+    SECheckVerifier.newVerifier()
+      .onFile(TestUtils.nonCompilingTestSourcesPath("symbolicexecution/checks/S2755_XxeProcessingCheck_DocumentBuilderFactory.java"))
+      .withCheck(new XxeProcessingCheck())
+      .withClassPath(SETestUtils.CLASS_PATH)
+      .verifyNoIssues();
+  }
+
 }


### PR DESCRIPTION
The problems of both SONARJAVA-3899 and SONARJAVA-3842 were solved in https://github.com/SonarSource/sonar-java/pull/3926, more specifically in https://github.com/SonarSource/sonar-java/pull/3926/commits/496c487c251791a3935595c500f6c2ceb6429b7f.

This PR aims to test the correct behavior of this change with regard to the two tickets.