### PR TITLE
SONARJAVA-4156 Refactor regex rules using sonar-analyzer-commons

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/regex/AnchorPrecedenceCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/AnchorPrecedenceCheck.java
@@ -19,99 +19,17 @@
  */
 package org.sonar.java.checks.regex;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.sonar.check.Rule;
-import org.sonarsource.analyzer.commons.regex.RegexParseResult;
-import org.sonarsource.analyzer.commons.regex.ast.BoundaryTree;
-import org.sonarsource.analyzer.commons.regex.ast.DisjunctionTree;
-import org.sonarsource.analyzer.commons.regex.ast.NonCapturingGroupTree;
-import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
-import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
-import org.sonarsource.analyzer.commons.regex.ast.SequenceTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonarsource.analyzer.commons.regex.RegexParseResult;
+import org.sonarsource.analyzer.commons.regex.finders.AnchorPrecedenceFinder;
 
 @Rule(key = "S5850")
 public class AnchorPrecedenceCheck extends AbstractRegexCheck {
 
   @Override
   public void checkRegex(RegexParseResult regexForLiterals, ExpressionTree methodInvocationOrAnnotation) {
-    new Visitor().visit(regexForLiterals);
-  }
-
-  private enum Position {
-    BEGINNING, END
-  }
-
-  private class Visitor extends RegexBaseVisitor {
-
-    @Override
-    public void visitDisjunction(DisjunctionTree tree) {
-      List<RegexTree> alternatives = tree.getAlternatives();
-      if ((anchoredAt(alternatives, Position.BEGINNING) || anchoredAt(alternatives, Position.END))
-        && notAnchoredElseWhere(alternatives)) {
-        reportIssue(tree, "Group parts of the regex together to make the intended operator precedence explicit.", null, Collections.emptyList());
-      }
-      super.visitDisjunction(tree);
-    }
-
-    private boolean anchoredAt(List<RegexTree> alternatives, Position position) {
-      int itemIndex = position == Position.BEGINNING ? 0 : (alternatives.size() - 1);
-      RegexTree firstOrLast = alternatives.get(itemIndex);
-      return isAnchored(firstOrLast, position);
-    }
-
-    private boolean notAnchoredElseWhere(List<RegexTree> alternatives) {
-      if (isAnchored(alternatives.get(0), Position.END)
-        || isAnchored(alternatives.get(alternatives.size() - 1), Position.BEGINNING)) {
-        return false;
-      }
-      for (RegexTree alternative : alternatives.subList(1, alternatives.size() - 1)) {
-        if (isAnchored(alternative, Position.BEGINNING) || isAnchored(alternative, Position.END)) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    private boolean isAnchored(RegexTree tree, Position position) {
-      if (!tree.is(RegexTree.Kind.SEQUENCE)) {
-        return false;
-      }
-      SequenceTree sequence = (SequenceTree) tree;
-      List<RegexTree> items = sequence.getItems().stream()
-        .filter(item -> !isFlagSetter(item))
-        .collect(Collectors.toList());
-      if (items.isEmpty()) {
-        return false;
-      }
-      int index = position == Position.BEGINNING ? 0 : (items.size() - 1);
-      RegexTree firstOrLast = items.get(index);
-      return firstOrLast.is(RegexTree.Kind.BOUNDARY) && isAnchor((BoundaryTree) firstOrLast);
-    }
-
-    private boolean isAnchor(BoundaryTree tree) {
-      switch (tree.type()) {
-        case INPUT_START:
-        case LINE_START:
-        case INPUT_END:
-        case INPUT_END_FINAL_TERMINATOR:
-        case LINE_END:
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    /**
-     * Return whether the given regex is a non-capturing group without contents, i.e. one that only sets flags for the
-     * rest of the expression
-     */
-    private boolean isFlagSetter(RegexTree tree) {
-      return tree.is(RegexTree.Kind.NON_CAPTURING_GROUP) && ((NonCapturingGroupTree) tree).getElement() == null;
-    }
-
+    new AnchorPrecedenceFinder(this::reportIssueFromCommons).visit(regexForLiterals);
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/ImpossibleBackReferenceCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/ImpossibleBackReferenceCheck.java
@@ -19,115 +19,17 @@
  */
 package org.sonar.java.checks.regex;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.sonar.check.Rule;
-import org.sonarsource.analyzer.commons.regex.RegexParseResult;
-import org.sonarsource.analyzer.commons.regex.ast.AutomatonState;
-import org.sonarsource.analyzer.commons.regex.ast.BackReferenceTree;
-import org.sonarsource.analyzer.commons.regex.ast.CapturingGroupTree;
-import org.sonarsource.analyzer.commons.regex.ast.DisjunctionTree;
-import org.sonarsource.analyzer.commons.regex.ast.EndOfCapturingGroupState;
-import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
-import org.sonarsource.analyzer.commons.regex.ast.RegexTree;
-import org.sonarsource.analyzer.commons.regex.ast.RepetitionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonarsource.analyzer.commons.regex.RegexParseResult;
+import org.sonarsource.analyzer.commons.regex.finders.ImpossibleBackReferenceFinder;
 
 @Rule(key = "S6001")
 public class ImpossibleBackReferenceCheck extends AbstractRegexCheck {
 
   @Override
   public void checkRegex(RegexParseResult regexForLiterals, ExpressionTree methodInvocationOrAnnotation) {
-    new ImpossibleBackReferenceFinder().visit(regexForLiterals);
-  }
-
-  private class ImpossibleBackReferenceFinder extends RegexBaseVisitor {
-    private Set<BackReferenceTree> impossibleBackReferences = new LinkedHashSet<>();
-    private Map<String, CapturingGroupTree> capturingGroups = new HashMap<>();
-
-    @Override
-    public void visitBackReference(BackReferenceTree tree) {
-      if (!capturingGroups.containsKey(tree.groupName())) {
-        impossibleBackReferences.add(tree);
-      }
-    }
-
-    @Override
-    public void visitCapturingGroup(CapturingGroupTree group) {
-      super.visitCapturingGroup(group);
-      addGroup(group);
-    }
-
-    private void addGroup(CapturingGroupTree group) {
-      capturingGroups.put("" + group.getGroupNumber(), group);
-      group.getName().ifPresent(name -> capturingGroups.put(name, group));
-    }
-
-    @Override
-    public void visitDisjunction(DisjunctionTree tree) {
-      Map<String, CapturingGroupTree> originalCapturingGroups = capturingGroups;
-      Map<String, CapturingGroupTree> allCapturingGroups = new HashMap<>();
-      for (RegexTree alternative : tree.getAlternatives()) {
-        capturingGroups = new HashMap<>(originalCapturingGroups);
-        visit(alternative);
-        allCapturingGroups.putAll(capturingGroups);
-      }
-      capturingGroups = allCapturingGroups;
-    }
-
-    @Override
-    public void visitRepetition(RepetitionTree tree) {
-      Integer maximumRepetitions = tree.getQuantifier().getMaximumRepetitions();
-      if (maximumRepetitions != null && maximumRepetitions < 2) {
-        super.visitRepetition(tree);
-        return;
-      }
-      Set<BackReferenceTree> originalImpossibleBackReferences = impossibleBackReferences;
-      impossibleBackReferences = new LinkedHashSet<>();
-      Map<String, CapturingGroupTree> originalCapturingGroups = new HashMap<>(capturingGroups);
-      super.visitRepetition(tree);
-      if (!impossibleBackReferences.isEmpty()) {
-        capturingGroups = originalCapturingGroups;
-        findReachableGroups(tree.getElement(), tree.continuation(), impossibleBackReferences, new HashSet<>());
-        // Visit the body of the loop a second time, this time with the groups that could be set in the first iteration
-        impossibleBackReferences = originalImpossibleBackReferences;
-        super.visitRepetition(tree);
-      }
-    }
-
-    private void findReachableGroups(AutomatonState start, AutomatonState stop, Set<BackReferenceTree> preliminaryImpossibleReferences, Set<AutomatonState> visited) {
-      if (start == stop || (start instanceof BackReferenceTree && preliminaryImpossibleReferences.contains(start)) || visited.contains(start)) {
-        return;
-      }
-      visited.add(start);
-      if (start instanceof EndOfCapturingGroupState) {
-        addGroup(((EndOfCapturingGroupState) start).group());
-      }
-      for (AutomatonState successor: start.successors()) {
-        findReachableGroups(successor, stop, preliminaryImpossibleReferences, visited);
-      }
-    }
-
-    @Override
-    protected void after(RegexParseResult regexParseResult) {
-      for (BackReferenceTree backReference : impossibleBackReferences) {
-        String message;
-        List<RegexIssueLocation> secondaries = new ArrayList<>();
-        if (capturingGroups.containsKey(backReference.groupName())) {
-          message = "Fix this backreference, so that it refers to a group that can be matched before it.";
-          CapturingGroupTree group = capturingGroups.get(backReference.groupName());
-          secondaries.add(new RegexIssueLocation(group, "This group is used in a backreference before it is defined"));
-        } else {
-          message = "Fix this backreference - it refers to a capturing group that doesn't exist.";
-        }
-        reportIssue(backReference, message, null, secondaries);
-      }
-    }
+    new ImpossibleBackReferenceFinder(this::reportIssueFromCommons).visit(regexForLiterals);
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/SingleCharacterAlternationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/SingleCharacterAlternationCheck.java
@@ -19,32 +19,17 @@
  */
 package org.sonar.java.checks.regex;
 
-import java.util.Collections;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonarsource.analyzer.commons.regex.RegexParseResult;
-import org.sonarsource.analyzer.commons.regex.ast.CharacterClassElementTree;
-import org.sonarsource.analyzer.commons.regex.ast.DisjunctionTree;
-import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
+import org.sonarsource.analyzer.commons.regex.finders.SingleCharacterAlternationFinder;
 
 @Rule(key = "S6035")
 public class SingleCharacterAlternationCheck extends AbstractRegexCheck {
 
   @Override
   public void checkRegex(RegexParseResult regexForLiterals, ExpressionTree methodInvocationOrAnnotation) {
-    new SingleCharacterAlternationFinder().visit(regexForLiterals);
-  }
-
-  class SingleCharacterAlternationFinder extends RegexBaseVisitor {
-
-    @Override
-    public void visitDisjunction(DisjunctionTree tree) {
-      if (tree.getAlternatives().stream().allMatch(CharacterClassElementTree.class::isInstance)) {
-        reportIssue(tree, "Replace this alternation with a character class.", null, Collections.emptyList());
-      }
-      super.visitDisjunction(tree);
-    }
-
+    new SingleCharacterAlternationFinder(this::reportIssueFromCommons).visit(regexForLiterals);
   }
 
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/regex/AnchorPrecedenceCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/regex/AnchorPrecedenceCheckTest.java
@@ -22,14 +22,14 @@ package org.sonar.java.checks.regex;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 
 class AnchorPrecedenceCheckTest {
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/regex/AnchorPrecedenceCheck.java"))
+      .onFile(mainCodeSourcesPath("checks/regex/AnchorPrecedenceCheck.java"))
       .withCheck(new AnchorPrecedenceCheck())
       .verifyIssues();
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/regex/EmptyStringRepetitionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/regex/EmptyStringRepetitionCheckTest.java
@@ -22,14 +22,14 @@ package org.sonar.java.checks.regex;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 
 class EmptyStringRepetitionCheckTest {
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/regex/EmptyStringRepetitionCheck.java"))
+      .onFile(mainCodeSourcesPath("checks/regex/EmptyStringRepetitionCheck.java"))
       .withCheck(new EmptyStringRepetitionCheck())
       .verifyIssues();
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/regex/ImpossibleBackReferenceCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/regex/ImpossibleBackReferenceCheckTest.java
@@ -22,14 +22,14 @@ package org.sonar.java.checks.regex;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 
 class ImpossibleBackReferenceCheckTest {
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/regex/ImpossibleBackReferenceCheck.java"))
+      .onFile(mainCodeSourcesPath("checks/regex/ImpossibleBackReferenceCheck.java"))
       .withCheck(new ImpossibleBackReferenceCheck())
       .verifyIssues();
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/regex/PossessiveQuantifierContinuationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/regex/PossessiveQuantifierContinuationCheckTest.java
@@ -22,14 +22,14 @@ package org.sonar.java.checks.regex;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 
 class PossessiveQuantifierContinuationCheckTest {
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/regex/PossessiveQuantifierContinuationCheck.java"))
+      .onFile(mainCodeSourcesPath("checks/regex/PossessiveQuantifierContinuationCheck.java"))
       .withCheck(new PossessiveQuantifierContinuationCheck())
       .verifyIssues();
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/regex/SingleCharacterAlternationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/regex/SingleCharacterAlternationCheckTest.java
@@ -22,15 +22,15 @@ package org.sonar.java.checks.regex;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
-import static org.sonar.java.checks.verifier.TestUtils.testSourcesPath;
 
 class SingleCharacterAlternationCheckTest {
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(testSourcesPath("checks/regex/SingleCharacterAlternationCheck.java"))
+      .onFile(mainCodeSourcesPath("checks/regex/SingleCharacterAlternationCheck.java"))
       .withCheck(new SingleCharacterAlternationCheck())
       .verifyIssues();
   }


### PR DESCRIPTION
This first PR migrates all the rules that are strictly equivalent (almost token by token) in Analyzer Commons.