### PR TITLE
Add test and comment to S3012

### DIFF
--- a/its/ruling/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/ruling/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -265,7 +265,7 @@
   },
   {
     "ruleKey": "S1144",
-    "truePositives": 207,
+    "truePositives": 208,
     "falseNegatives": 1,
     "falsePositives": 0
   },

--- a/java-checks-test-sources/src/main/java/checks/ArrayCopyLoopCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/ArrayCopyLoopCheck.java
@@ -475,13 +475,24 @@ abstract class ArrayCopyLoopCheck implements Collection<Integer> {
 
   public void copy(Collection<Integer> target, int[] source) {
     for (int s : source) {
-      target.add(s); // FP: S3012
+      target.add(s); // FP: S3012. Collection.addAll does not accept int[] as an argument.
     }
   }
 
   private static void copyToSet(long[] array, Set<Long> set) {
     for (long labelId : array) {
       set.add(labelId); // Compliant
+    }
+  }
+
+  private static void copyToNonCollection(int[] array) {
+    class NonCollection {
+      void add(Integer i) {}
+    }
+
+    NonCollection nonCollection = new NonCollection();
+    for (Integer i : array) {
+      nonCollection.add(i); // Compliant
     }
   }
 


### PR DESCRIPTION
I have added a comment and a test to S3012.

The comment is because it took me a while to understand why the test case was a FP.
The test is to make sure that the rule does not get triggered when copying arrays to non collections.