### PR TITLE
expose ClasspathForMain.getBinaryDirs() via JavaResourceLocator API

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
@@ -80,12 +80,12 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator {
 
   @Override
   public Collection<File> classpath() {
-    return javaClasspath.getElements();
+    return Collections.unmodifiableList(javaClasspath.getElements());
   }
 
   @Override
   public Collection<File> binaryDirs() {
-    return javaClasspath.getBinaryDirs();
+    return Collections.unmodifiableList(javaClasspath.getBinaryDirs());
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
@@ -84,6 +84,11 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator {
   }
 
   @Override
+  public Collection<File> binaryDirs() {
+    return javaClasspath.getBinaryDirs();
+  }
+
+  @Override
   public void scanFile(JavaFileScannerContext context) {
     InputFile inputFile = context.getInputFile();
     JavaFilesCache javaFilesCache = new JavaFilesCache();

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
@@ -51,6 +51,12 @@ public interface JavaResourceLocator extends JavaFileScanner {
   Collection<File> classFilesToAnalyze();
 
   /**
+   * The folders containing the binary .class files.
+   * @return a list of folders.
+   */
+  Collection<File> binaryDirs();
+
+  /**
    * Classpath configured for the project.
    * This classpath method is used by the findbugs plugin to configure the analysis.
    * @return the list of jar and class files constituting the classpath of the analyzed project.

--- a/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
@@ -30,6 +30,7 @@ import org.sonar.java.classpath.ClasspathForMain;
 import org.sonar.java.model.VisitorsBridge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -71,12 +72,22 @@ class DefaultJavaResourceLocatorTest {
 
   @Test
   void classpath() throws Exception {
-    assertThat(javaResourceLocator.classpath()).hasSize(1);
+    var classpath = javaResourceLocator.classpath();
+    assertThat(classpath).hasSize(1);
+
+    var file = new File("");
+    assertThatThrownBy(() -> classpath.add(file))
+      .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void binaryDirs() {
-    assertThat(javaResourceLocator.binaryDirs()).containsExactly(new File(BINARY_DIRS));
+    var binaryDirs = javaResourceLocator.binaryDirs();
+    assertThat(binaryDirs).containsExactly(new File(BINARY_DIRS));
+
+    var file = new File("");
+    assertThatThrownBy(() -> binaryDirs.add(file))
+      .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
@@ -73,6 +73,11 @@ class DefaultJavaResourceLocatorTest {
   }
 
   @Test
+  void binaryDirs() throws Exception {
+    assertThat(javaResourceLocator.binaryDirs()).hasSize(1);
+  }
+
+  @Test
   void classFilesToAnalyze() throws Exception {
     assertThat(javaResourceLocator.classFilesToAnalyze()).hasSize(5);
   }

--- a/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
@@ -37,11 +37,13 @@ class DefaultJavaResourceLocatorTest {
 
   private static DefaultJavaResourceLocator javaResourceLocator;
 
+  private static final String BINARY_DIRS = "target/test-classes";
+
   @BeforeAll
   public static void setup() {
     ClasspathForMain javaClasspath = mock(ClasspathForMain.class);
-    when(javaClasspath.getBinaryDirs()).thenReturn(Collections.singletonList(new File("target/test-classes")));
-    when(javaClasspath.getElements()).thenReturn(Collections.singletonList(new File("target/test-classes")));
+    when(javaClasspath.getBinaryDirs()).thenReturn(Collections.singletonList(new File(BINARY_DIRS)));
+    when(javaClasspath.getElements()).thenReturn(Collections.singletonList(new File(BINARY_DIRS)));
     InputFile inputFile = TestUtils.inputFile("src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java");
     DefaultJavaResourceLocator jrl = new DefaultJavaResourceLocator(javaClasspath);
     JavaAstScanner.scanSingleFileForTests(inputFile, new VisitorsBridge(jrl));
@@ -73,8 +75,8 @@ class DefaultJavaResourceLocatorTest {
   }
 
   @Test
-  void binaryDirs() throws Exception {
-    assertThat(javaResourceLocator.binaryDirs()).hasSize(1);
+  void binaryDirs() {
+    assertThat(javaResourceLocator.binaryDirs()).containsExactly(new File(BINARY_DIRS));
   }
 
   @Test


### PR DESCRIPTION
Follow-up to the discussion: https://community.sonarsource.com/t/locating-compiled-class-files/69145

This illustrates how the plugin API could expose the contents of `sonar.java.binaries`