### PR TITLE
Export test classpath and binaries via java resource locator

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/java/DefaultJavaResourceLocator.java
@@ -31,6 +31,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.java.classpath.ClasspathForMain;
+import org.sonar.java.classpath.ClasspathForTest;
 import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.JavaResourceLocator;
@@ -40,11 +41,13 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator {
   private static final Logger LOG = Loggers.get(DefaultJavaResourceLocator.class);
 
   private final ClasspathForMain javaClasspath;
+  private final ClasspathForTest javaTestClasspath;
   @VisibleForTesting
   Map<String, InputFile> resourcesByClass;
 
-  public DefaultJavaResourceLocator(ClasspathForMain javaClasspath) {
+  public DefaultJavaResourceLocator(ClasspathForMain javaClasspath, ClasspathForTest javaTestClasspath) {
     this.javaClasspath = javaClasspath;
+    this.javaTestClasspath = javaTestClasspath;
     resourcesByClass = new HashMap<>();
   }
 
@@ -84,8 +87,18 @@ public class DefaultJavaResourceLocator implements JavaResourceLocator {
   }
 
   @Override
+  public Collection<File> testClasspath() {
+    return Collections.unmodifiableList(javaTestClasspath.getElements());
+  }
+
+  @Override
   public Collection<File> binaryDirs() {
     return Collections.unmodifiableList(javaClasspath.getBinaryDirs());
+  }
+
+  @Override
+  public Collection<File> testBinaryDirs() {
+    return Collections.unmodifiableList(javaTestClasspath.getBinaryDirs());
   }
 
   @Override

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
@@ -53,29 +53,27 @@ public interface JavaResourceLocator extends JavaFileScanner {
   /**
    * The folders containing the binary .class files.
    * @return a list of folders.
-   * @since 9.7
+   * @since SonarQube 9.8
    */
   Collection<File> binaryDirs();
 
   /**
    * The folders containing the binary .class files corresponding to the tests.
    * @return a list of folders.
-   * @since 9.7
+   * @since SonarQube 9.8
    */
   Collection<File> testBinaryDirs();
 
   /**
    * Classpath configured for the project.
-   * This classpath method is used by the findbugs plugin to configure the analysis.
    * @return the list of jar and class files constituting the classpath of the analyzed project.
    */
   Collection<File> classpath();
 
   /**
    * Classpath configured for the project tests.
-   * This classpath method is used by the findbugs plugin to configure the analysis.
    * @return the list of jar and class files constituting the classpath of the analyzed project.
-   * @since 9.7
+   * @since SonarQube 9.8
    */
   Collection<File> testClasspath();
 }

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaResourceLocator.java
@@ -53,8 +53,16 @@ public interface JavaResourceLocator extends JavaFileScanner {
   /**
    * The folders containing the binary .class files.
    * @return a list of folders.
+   * @since 9.7
    */
   Collection<File> binaryDirs();
+
+  /**
+   * The folders containing the binary .class files corresponding to the tests.
+   * @return a list of folders.
+   * @since 9.7
+   */
+  Collection<File> testBinaryDirs();
 
   /**
    * Classpath configured for the project.
@@ -63,4 +71,11 @@ public interface JavaResourceLocator extends JavaFileScanner {
    */
   Collection<File> classpath();
 
+  /**
+   * Classpath configured for the project tests.
+   * This classpath method is used by the findbugs plugin to configure the analysis.
+   * @return the list of jar and class files constituting the classpath of the analyzed project.
+   * @since 9.7
+   */
+  Collection<File> testClasspath();
 }

--- a/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/DefaultJavaResourceLocatorTest.java
@@ -40,7 +40,7 @@ class DefaultJavaResourceLocatorTest {
   private static DefaultJavaResourceLocator javaResourceLocator;
 
   private static final String BINARY_DIRS = "target/test-classes";
-  private static final String TEST_BINARY_DIRS = "target/test-classes";
+  private static final String TEST_BINARY_DIRS = "target/test/test-classes";
 
   @BeforeAll
   public static void setup() {

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
@@ -128,7 +128,7 @@ class JavaSensorTest {
     DefaultFileSystem fs = context.fileSystem();
     fs.setWorkDir(tmp.newFolder().toPath());
     SonarComponents sonarComponents = createSonarComponentsMock(context);
-    DefaultJavaResourceLocator javaResourceLocator = new DefaultJavaResourceLocator(new ClasspathForMain(settings.asConfig(), fs));
+    DefaultJavaResourceLocator javaResourceLocator = createDefaultJavaResourceLocator(settings, fs);
     JavaSensor jss = new JavaSensor(sonarComponents, fs, javaResourceLocator, settings.asConfig(), noSonarFilter, null);
 
     jss.execute(context);
@@ -172,6 +172,13 @@ class JavaSensorTest {
     BadMethodNameCheck check = new BadMethodNameCheck();
     when(sonarComponents.mainChecks()).thenReturn(Collections.singletonList(check));
     return sonarComponents;
+  }
+
+  private static DefaultJavaResourceLocator createDefaultJavaResourceLocator(MapSettings settings, DefaultFileSystem fs) {
+    ClasspathForMain classpathForMain = new ClasspathForMain(settings.asConfig(), fs);
+    ClasspathForTest classpathForTest = new ClasspathForTest(settings.asConfig(), fs);
+
+    return new DefaultJavaResourceLocator(classpathForMain, classpathForTest);
   }
 
   @Test
@@ -406,7 +413,7 @@ class JavaSensorTest {
     when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
     ClasspathForTest javaTestClasspath = new ClasspathForTest(context.config(), fs);
     ClasspathForMain javaClasspath = new ClasspathForMain(context.config(), fs);
-    DefaultJavaResourceLocator resourceLocator = new DefaultJavaResourceLocator(new ClasspathForMain(context.config(), fs));
+    DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(settings, fs);
 
     CheckRegistrar[] checkRegistrars = new CheckRegistrar[] {new CustomRegistrar()};
 
@@ -439,7 +446,7 @@ class JavaSensorTest {
     DefaultFileSystem fs = context.fileSystem();
     fs.setWorkDir(workDir);
     SonarComponents components = createSonarComponentsMock(context);
-    DefaultJavaResourceLocator resourceLocator = new DefaultJavaResourceLocator(new ClasspathForMain(configuration, fs));
+    DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(settings, fs);
     JavaSensor jss = new JavaSensor(components, fs, resourceLocator, configuration, mock(NoSonarFilter.class), null);
     jss.execute(context);
   }

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
@@ -128,7 +128,7 @@ class JavaSensorTest {
     DefaultFileSystem fs = context.fileSystem();
     fs.setWorkDir(tmp.newFolder().toPath());
     SonarComponents sonarComponents = createSonarComponentsMock(context);
-    DefaultJavaResourceLocator javaResourceLocator = createDefaultJavaResourceLocator(settings, fs);
+    DefaultJavaResourceLocator javaResourceLocator = createDefaultJavaResourceLocator(settings.asConfig(), fs);
     JavaSensor jss = new JavaSensor(sonarComponents, fs, javaResourceLocator, settings.asConfig(), noSonarFilter, null);
 
     jss.execute(context);
@@ -174,9 +174,9 @@ class JavaSensorTest {
     return sonarComponents;
   }
 
-  private static DefaultJavaResourceLocator createDefaultJavaResourceLocator(MapSettings settings, DefaultFileSystem fs) {
-    ClasspathForMain classpathForMain = new ClasspathForMain(settings.asConfig(), fs);
-    ClasspathForTest classpathForTest = new ClasspathForTest(settings.asConfig(), fs);
+  private static DefaultJavaResourceLocator createDefaultJavaResourceLocator(Configuration settings, DefaultFileSystem fs) {
+    ClasspathForMain classpathForMain = new ClasspathForMain(settings, fs);
+    ClasspathForTest classpathForTest = new ClasspathForTest(settings, fs);
 
     return new DefaultJavaResourceLocator(classpathForMain, classpathForTest);
   }
@@ -413,7 +413,7 @@ class JavaSensorTest {
     when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
     ClasspathForTest javaTestClasspath = new ClasspathForTest(context.config(), fs);
     ClasspathForMain javaClasspath = new ClasspathForMain(context.config(), fs);
-    DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(settings, fs);
+    DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(context.config(), fs);
 
     CheckRegistrar[] checkRegistrars = new CheckRegistrar[] {new CustomRegistrar()};
 
@@ -446,7 +446,7 @@ class JavaSensorTest {
     DefaultFileSystem fs = context.fileSystem();
     fs.setWorkDir(workDir);
     SonarComponents components = createSonarComponentsMock(context);
-    DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(settings, fs);
+    DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(context.config(), fs);
     JavaSensor jss = new JavaSensor(components, fs, resourceLocator, configuration, mock(NoSonarFilter.class), null);
     jss.execute(context);
   }


### PR DESCRIPTION
Hello @johann-beleites-sonarsource  ,
This is a follow up to the discussion: https://community.sonarsource.com/t/locating-compiled-class-files/69145/1

Exposing the test classpath and binaries of the project under analysis would help implementing https://github.com/spotbugs/sonar-findbugs/issues/18

Thanks in advance for looking into it!