### PR TITLE
Cleanup top-level dependencies

### DIFF
--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -873,6 +873,12 @@
     <version>3.7.2</version>
     <scope>provided</scope>
 	</dependency>
+    <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>6.4.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -270,12 +270,7 @@
         <version>2.8.9</version>
         <scope>compile</scope>
       </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.woodstox</groupId>
-        <artifactId>woodstox-core</artifactId>
-        <version>6.2.6</version>
-      </dependency>
+      <!-- staxmate is used by java-surefire -->
       <dependency>
         <groupId>com.fasterxml.staxmate</groupId>
         <artifactId>staxmate</artifactId>


### PR DESCRIPTION
- Move woodstox-core to java-checks-test-sources
- Document staxmate as java-surefire dependency