### PR TITLE
SONARJAVA-4363 Update S2272: Check if methods called by `next()` can throw NoSuchElementException

### DIFF
--- a/its/ruling/src/test/resources/guava/java-S2272.json
+++ b/its/ruling/src/test/resources/guava/java-S2272.json
@@ -6,11 +6,6 @@
 'com.google.guava:guava:src/com/google/common/collect/Iterators.java':[
 1123,
 ],
-'com.google.guava:guava:src/com/google/common/collect/LinkedListMultimap.java':[
-352,
-428,
-498,
-],
 'com.google.guava:guava:src/com/google/common/collect/TreeTraverser.java':[
 209,
 ],

--- a/java-checks-test-sources/src/main/files/non-compiling/checks/IteratorNextExceptionCheck.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/IteratorNextExceptionCheck.java
@@ -87,3 +87,19 @@ class IteratorNextExceptionCheckE implements Iterator<String> {
     return false;
   }
 }
+
+class IteratorNextExceptionCheckF implements Iterator<String> {
+
+  public String next() { // Compliant
+    foo();
+  }
+
+  private String foo() throws UnknownException {
+
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+}

--- a/java-checks-test-sources/src/main/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/IteratorNextExceptionCheck.java
@@ -181,3 +181,64 @@ class IteratorNextExceptionCheckN implements Iterator<Double> {
     return a.hasNext();
   }
 }
+
+class IteratorNextExceptionCheckO implements Iterator<String> {
+  private int count = 10;
+
+  public String next() { // Compliant
+    return getNext();
+  }
+
+  private String getNext() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return "hello";
+  }
+
+  public static void justThrow() {
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public boolean hasNext() {
+    count--;
+    return count > 0;
+  }
+
+}
+
+class IteratorNextExceptionCheckP implements Iterator<T> {
+  private T elem;
+
+  public T next() { // Compliant
+    if (!hasNext()) {
+      IteratorNextExceptionCheckO.justThrow();
+    }
+    return elem;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+
+}
+
+class IteratorNextExceptionCheckQ implements Iterator<T> {
+  private T elem;
+
+  public T next() { // Compliant
+    if (!hasNext()) {
+      class Foo extends NoSuchElementException {}
+      throw new Foo();
+    }
+    return elem;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/ArrayForVarArgCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ArrayForVarArgCheck.java
@@ -48,7 +48,7 @@ public class ArrayForVarArgCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
-    Symbol sym;
+    Symbol.MethodSymbol sym;
     Arguments args;
     if (tree.is(Tree.Kind.NEW_CLASS)) {
       NewClassTree nct = (NewClassTree) tree;
@@ -61,10 +61,9 @@ public class ArrayForVarArgCheck extends IssuableSubscriptionVisitor {
     }
 
     if (sym.isMethodSymbol()) {
-      Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) sym;
-      if (isLastArgumentVarargs(methodSymbol, args)) {
+      if (isLastArgumentVarargs(sym, args)) {
         ExpressionTree lastArg = args.get(args.size() - 1);
-        checkInvokedMethod(methodSymbol, lastArg);
+        checkInvokedMethod(sym, lastArg);
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/ArrayForVarArgCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ArrayForVarArgCheck.java
@@ -60,11 +60,9 @@ public class ArrayForVarArgCheck extends IssuableSubscriptionVisitor {
       args = mit.arguments();
     }
 
-    if (sym.isMethodSymbol()) {
-      if (isLastArgumentVarargs(sym, args)) {
-        ExpressionTree lastArg = args.get(args.size() - 1);
-        checkInvokedMethod(sym, lastArg);
-      }
+    if (!sym.isUnknown() && isLastArgumentVarargs(sym, args)) {
+      ExpressionTree lastArg = args.get(args.size() - 1);
+      checkInvokedMethod(sym, lastArg);
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/CallOuterPrivateMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CallOuterPrivateMethodCheck.java
@@ -78,10 +78,10 @@ public class CallOuterPrivateMethodCheck extends IssuableSubscriptionVisitor {
   }
 
   private class MethodInvocationVisitor extends BaseTreeVisitor {
-    private final Map<Symbol.TypeSymbol, Map<Symbol, Integer>> usagesByInnerClass = new HashMap<>();
+    private final Map<Symbol.TypeSymbol, Map<Symbol.MethodSymbol, Integer>> usagesByInnerClass = new HashMap<>();
     private final Map<String, Set<MethodInvocationTree>> unknownInvocations = new HashMap<>();
     private Symbol.TypeSymbol classSymbol;
-    private Map<Symbol, Integer> usages;
+    private Map<Symbol.MethodSymbol, Integer> usages;
 
     public void setClassSymbol(Symbol.TypeSymbol classSymbol) {
       this.classSymbol = classSymbol;
@@ -91,14 +91,14 @@ public class CallOuterPrivateMethodCheck extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitMethodInvocation(MethodInvocationTree tree) {
-      Symbol symbol = tree.symbol();
+      Symbol.MethodSymbol symbol = tree.symbol();
       if (symbol.isUnknown()) {
         String name = ExpressionUtils.methodName(tree).name();
         unknownInvocations.computeIfAbsent(name, k -> new HashSet<>()).add(tree);
       } else if (isPrivateMethodOfOuterClass(symbol) && isInvocationOnCurrentInstance(tree)) {
-        if (JUtils.isParametrizedMethod((Symbol.MethodSymbol) symbol) && symbol.declaration() != null) {
+        if (JUtils.isParametrizedMethod(symbol) && symbol.declaration() != null) {
           // generic methods requires to use their declaration symbol rather than the parameterized one
-          symbol = ((Symbol.MethodSymbol) symbol).declaration().symbol();
+          symbol = symbol.declaration().symbol();
         }
         usages.compute(symbol, (k, v) -> v == null ? 1 : (v + 1));
       }
@@ -126,11 +126,11 @@ public class CallOuterPrivateMethodCheck extends IssuableSubscriptionVisitor {
       usagesByInnerClass.forEach((symbol, innerClassUsages) -> innerClassUsages.forEach((methodUsed, count) -> {
         boolean matchArity = unknownInvocations.getOrDefault(methodUsed.name(), new HashSet<>())
           .stream()
-          .anyMatch(mit -> hasSameArity((Symbol.MethodSymbol) methodUsed, mit));
+          .anyMatch(mit -> hasSameArity(methodUsed, mit));
 
         // if an unknown method has same name and same arity, do not report, likely a FP.
         if (!matchArity && methodUsed.usages().size() == count) {
-          reportIssueOnMethod((MethodTree) methodUsed.declaration(), symbol);
+          reportIssueOnMethod(methodUsed.declaration(), symbol);
         }
       }));
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/CastArithmeticOperandCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CastArithmeticOperandCheck.java
@@ -118,9 +118,9 @@ public class CastArithmeticOperandCheck extends BaseTreeVisitor implements JavaF
     }
   }
 
-  private void checkMethodInvocationArgument(Arguments arguments, Symbol symbol) {
-    if (symbol.isMethodSymbol()) {
-      List<Type> parametersTypes = ((Symbol.MethodSymbol) symbol).parameterTypes();
+  private void checkMethodInvocationArgument(Arguments arguments, Symbol.MethodSymbol symbol) {
+    if (!symbol.isUnknown()) {
+      List<Type> parametersTypes = symbol.parameterTypes();
       if (arguments.size() == parametersTypes.size()) {
         int i = 0;
         for (Type argType : parametersTypes) {

--- a/java-checks/src/main/java/org/sonar/java/checks/CatchExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CatchExceptionCheck.java
@@ -117,8 +117,8 @@ public class CatchExceptionCheck extends IssuableSubscriptionVisitor {
       super.visitNewClass(tree);
     }
 
-    private boolean isThrowingJavaLangException(Symbol symbol) {
-      containsExplicitThrowsException |= symbol.isUnknown() || ((Symbol.MethodSymbol) symbol).thrownTypes().stream().anyMatch(CatchExceptionCheck::isJavaLangException);
+    private boolean isThrowingJavaLangException(Symbol.MethodSymbol symbol) {
+      containsExplicitThrowsException |= symbol.isUnknown() || symbol.thrownTypes().stream().anyMatch(CatchExceptionCheck::isJavaLangException);
       return containsExplicitThrowsException;
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/CatchOfThrowableOrErrorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CatchOfThrowableOrErrorCheck.java
@@ -140,7 +140,7 @@ public class CatchOfThrowableOrErrorCheck extends IssuableSubscriptionVisitor {
       super.visitNewClass(tree);
     }
 
-    private void checkIfThrowThrowable(Symbol symbol) {
+    private void checkIfThrowThrowable(Symbol.MethodSymbol symbol) {
       if (containsExplicitThrowable || containsUnresolvableCall) {
         return;
       }
@@ -148,12 +148,10 @@ public class CatchOfThrowableOrErrorCheck extends IssuableSubscriptionVisitor {
         containsUnresolvableCall = true;
         return;
       }
-      if (symbol.isMethodSymbol()) {
-        for (Type type : ((Symbol.MethodSymbol) symbol).thrownTypes()) {
-          if (type.is(JAVA_LANG_THROWABLE)) {
-            containsExplicitThrowable = true;
-            return;
-          }
+      for (Type type : symbol.thrownTypes()) {
+        if (type.is(JAVA_LANG_THROWABLE)) {
+          containsExplicitThrowable = true;
+          return;
         }
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/CollectionInappropriateCallsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CollectionInappropriateCallsCheck.java
@@ -128,7 +128,7 @@ public class CollectionInappropriateCallsCheck extends IssuableSubscriptionVisit
 
   private static boolean isCallToParametrizedOrUnknownMethod(ExpressionTree expressionTree) {
     if (expressionTree.is(Tree.Kind.METHOD_INVOCATION)) {
-      Symbol.MethodSymbol symbol = (Symbol.MethodSymbol) ((MethodInvocationTree) expressionTree).symbol();
+      Symbol.MethodSymbol symbol = ((MethodInvocationTree) expressionTree).symbol();
       return symbol.isUnknown() || JUtils.isParametrizedMethod(symbol);
     }
     return false;

--- a/java-checks/src/main/java/org/sonar/java/checks/ConfusingVarargCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ConfusingVarargCheck.java
@@ -67,7 +67,7 @@ public class ConfusingVarargCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
-    Symbol symbol;
+    Symbol.MethodSymbol symbol;
     Arguments arguments;
     if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
       MethodInvocationTree mit = (MethodInvocationTree) tree;
@@ -78,8 +78,8 @@ public class ConfusingVarargCheck extends IssuableSubscriptionVisitor {
       symbol = nct.constructorSymbol();
       arguments = nct.arguments();
     }
-    if (symbol.isMethodSymbol() && !ALLOWED_VARARG_METHODS.matches(symbol)) {
-      checkConfusingVararg((Symbol.MethodSymbol) symbol, arguments);
+    if (!symbol.isUnknown() && !ALLOWED_VARARG_METHODS.matches(symbol)) {
+      checkConfusingVararg(symbol, arguments);
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/DefaultEncodingUsageCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DefaultEncodingUsageCheck.java
@@ -226,10 +226,9 @@ public class DefaultEncodingUsageCheck extends AbstractMethodDetection implement
 
   @Override
   protected void onConstructorFound(NewClassTree newClassTree) {
-    Symbol symbol = newClassTree.constructorSymbol();
-    if (symbol.isMethodSymbol()) {
-      Symbol.MethodSymbol constructor = (Symbol.MethodSymbol) symbol;
-      String signature = constructor.owner().name() + "(" + constructor.parameterTypes().stream().map(Type::toString).collect(Collectors.joining(",")) + ")";
+    Symbol.MethodSymbol symbol = newClassTree.constructorSymbol();
+    if (!symbol.isUnknown()) {
+      String signature = symbol.owner().name() + "(" + symbol.parameterTypes().stream().map(Type::toString).collect(Collectors.joining(",")) + ")";
       reportIssue(newClassTree.identifier(), "Remove this use of constructor \"" + signature + "\".");
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/DiamondOperatorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DiamondOperatorCheck.java
@@ -111,7 +111,7 @@ public class DiamondOperatorCheck extends SubscriptionVisitor implements JavaVer
     }
 
     Tree invocation = parent.parent();
-    Symbol symbol = null;
+    Symbol.MethodSymbol symbol = null;
     // arguments are only used in METHOD_INVOCATION, NEW_CLASS_TREE and ANNOTATION
     // however annotations values can not store parameterized types
     if (invocation.is(Tree.Kind.METHOD_INVOCATION)) {
@@ -120,12 +120,12 @@ public class DiamondOperatorCheck extends SubscriptionVisitor implements JavaVer
       symbol = ((NewClassTree) invocation).constructorSymbol();
     }
 
-    if (!symbol.isMethodSymbol()) {
+    if (symbol.isUnknown()) {
       // unresolved invocation
       return false;
     }
 
-    Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) symbol;
+    Symbol.MethodSymbol methodSymbol = symbol;
     int index = getArgIndex(newClassTree, (Arguments) parent);
     if (index >= methodSymbol.parameterTypes().size()) {
       // killing the noise - varargs

--- a/java-checks/src/main/java/org/sonar/java/checks/ImmediateReverseBoxingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ImmediateReverseBoxingCheck.java
@@ -109,9 +109,9 @@ public class ImmediateReverseBoxingCheck extends IssuableSubscriptionVisitor {
         checkForBoxing(((MemberSelectExpressionTree) methodSelect).expression(), mit);
       }
     } else {
-      Symbol symbol = mit.symbol();
-      if (symbol.isMethodSymbol()) {
-        checkMethodInvocationArguments(mit, ((Symbol.MethodSymbol) symbol).parameterTypes());
+      Symbol.MethodSymbol symbol = mit.symbol();
+      if (!symbol.isUnknown()) {
+        checkMethodInvocationArguments(mit, symbol.parameterTypes());
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/InterruptedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InterruptedExceptionCheck.java
@@ -141,10 +141,9 @@ public class InterruptedExceptionCheck extends IssuableSubscriptionVisitor {
     return blockVisitor.threadInterrupted;
   }
 
-  private static boolean throwInterruptedException(Symbol symbol) {
-    return symbol.isMethodSymbol()
-      && ((Symbol.MethodSymbol) symbol).thrownTypes().stream()
-      .anyMatch(t -> t.is("java.lang.InterruptedException"));
+  private static boolean throwInterruptedException(Symbol.MethodSymbol symbol) {
+    return !symbol.isUnknown()
+      && symbol.thrownTypes().stream().anyMatch(t -> t.is("java.lang.InterruptedException"));
   }
 
   private static class BlockVisitor extends BaseTreeVisitor {

--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -95,8 +95,8 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
     public void visitMethodInvocation(MethodInvocationTree methodInvocation) {
       if (NEXT_INVOCATION_MATCHER.matches(methodInvocation) || throwsNoSuchElementException(methodInvocation)) {
         expectedExceptionIsThrown = true;
-      } else if (methodInvocation.symbol().isMethodSymbol()) {
-        Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) methodInvocation.symbol();
+      } else {
+        Symbol.MethodSymbol methodSymbol = methodInvocation.symbol();
         MethodTree methodTree = methodSymbol.declaration();
         if (methodTree != null && canVisit(methodTree)) {
           methodsVisited.add(methodTree);
@@ -111,15 +111,12 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
     }
 
     private static boolean throwsNoSuchElementException(MethodInvocationTree methodInvocationTree) {
-      Symbol symbol = methodInvocationTree.symbol();
+      Symbol.MethodSymbol symbol = methodInvocationTree.symbol();
       if (symbol.isUnknown()) {
         // Consider that it could throw an Exception to avoid FP.
         return true;
       }
-      if (!symbol.isMethodSymbol()) {
-        return false;
-      }
-      return throwsNoSuchElementException(((Symbol.MethodSymbol) symbol).thrownTypes());
+      return throwsNoSuchElementException(symbol.thrownTypes());
     }
 
     private static boolean throwsNoSuchElementException(List<? extends Type> thrownTypes) {

--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -39,7 +39,6 @@ import org.sonar.plugins.java.api.tree.Tree.Kind;
 
 @Rule(key = "S2272")
 public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
-  private static final int MAX_METHOD_VISITS = 50;
 
   private static final MethodMatchers NEXT_INVOCATION_MATCHER = MethodMatchers.create()
       .ofSubTypes("java.util.Iterator")
@@ -98,16 +97,12 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
       } else {
         Symbol.MethodSymbol methodSymbol = methodInvocation.symbol();
         MethodTree methodTree = methodSymbol.declaration();
-        if (methodTree != null && canVisit(methodTree)) {
-          methodsVisited.add(methodTree);
+        boolean canVisit = methodTree != null && methodsVisited.add(methodTree);
+        if (canVisit) {
           scan(methodTree);
         }
       }
       super.visitMethodInvocation(methodInvocation);
-    }
-
-    private boolean canVisit(MethodTree methodTree) {
-      return !methodsVisited.contains(methodTree) && methodsVisited.size() < MAX_METHOD_VISITS;
     }
 
     private static boolean throwsNoSuchElementException(MethodInvocationTree methodInvocationTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/RawExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RawExceptionCheck.java
@@ -109,9 +109,9 @@ public class RawExceptionCheck extends BaseTreeVisitor implements JavaFileScanne
     super.visitNewClass(nct);
   }
 
-  private void collectThrownTypes(Symbol symbol) {
-    if (symbol.isMethodSymbol()) {
-      exceptionsThrownByMethodInvocations.addAll(((Symbol.MethodSymbol) symbol).thrownTypes());
+  private void collectThrownTypes(Symbol.MethodSymbol symbol) {
+    if (!symbol.isUnknown()) {
+      exceptionsThrownByMethodInvocations.addAll(symbol.thrownTypes());
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/RedundantThrowsDeclarationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RedundantThrowsDeclarationCheck.java
@@ -260,12 +260,12 @@ public class RedundantThrowsDeclarationCheck extends IssuableSubscriptionVisitor
       super.visitNewClass(tree);
     }
 
-    private void addThrownTypes(Symbol methodSymbol) {
+    private void addThrownTypes(Symbol.MethodSymbol methodSymbol) {
       if (!visitedUnknown) {
-        if (methodSymbol.isUnknown() || !methodSymbol.isMethodSymbol()) {
+        if (methodSymbol.isUnknown()) {
           visitedUnknown = true;
         } else {
-          thrownExceptions.addAll(((Symbol.MethodSymbol) methodSymbol).thrownTypes());
+          thrownExceptions.addAll(methodSymbol.thrownTypes());
         }
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/ServletMethodsExceptionsThrownCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ServletMethodsExceptionsThrownCheck.java
@@ -93,9 +93,9 @@ public class ServletMethodsExceptionsThrownCheck extends IssuableSubscriptionVis
   }
 
   private void checkMethodInvocation(MethodInvocationTree node) {
-    Symbol symbol = node.symbol();
-    if (symbol.isMethodSymbol()) {
-      List<Type> types = ((Symbol.MethodSymbol) symbol).thrownTypes();
+    Symbol.MethodSymbol symbol = node.symbol();
+    if (!symbol.isUnknown()) {
+      List<Type> types = symbol.thrownTypes();
       if (!types.isEmpty()) {
         addIssueIfNotCaught(types, ExpressionUtils.methodName(node), symbol.name());
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StandardCharsetsConstantsCheck.java
@@ -257,7 +257,7 @@ public class StandardCharsetsConstantsCheck extends AbstractMethodDetection impl
     checkCall(newClassTree, newClassTree.constructorSymbol(), newClassTree.arguments());
   }
 
-  private void checkCall(ExpressionTree callExpression, Symbol symbol, Arguments arguments) {
+  private void checkCall(ExpressionTree callExpression, Symbol.MethodSymbol symbol, Arguments arguments) {
     getCharsetNameArgument(symbol, arguments)
       .ifPresent(charsetNameArgument -> getConstantName(charsetNameArgument)
         .ifPresent(constantName -> {

--- a/java-checks/src/main/java/org/sonar/java/checks/StringMethodsWithLocaleCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringMethodsWithLocaleCheck.java
@@ -58,7 +58,7 @@ public class StringMethodsWithLocaleCheck extends AbstractMethodDetection {
   }
 
   private static boolean isLocaleVariant(MethodInvocationTree mit) {
-    return ((Symbol.MethodSymbol) mit.symbol()).parameterTypes().get(0).is("java.util.Locale");
+    return mit.symbol().parameterTypes().get(0).is("java.util.Locale");
   }
 
   private static boolean usesLocaleDependentFormatteer(ExpressionTree firstArg) {

--- a/java-checks/src/main/java/org/sonar/java/checks/SynchronizedClassUsageCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SynchronizedClassUsageCheck.java
@@ -98,7 +98,7 @@ public class SynchronizedClassUsageCheck extends IssuableSubscriptionVisitor {
       if (tree.symbol().isMethodSymbol() && tree.symbol().declaration() == null) {
         String fqn = tree.symbol().owner().type().fullyQualifiedName();
         if (isMethodFromJavaPackage(fqn)) {
-          Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) tree.symbol();
+          Symbol.MethodSymbol methodSymbol = tree.symbol();
           List<Type> types = new ArrayList<>(methodSymbol.parameterTypes());
           Symbol.TypeSymbol returnType = methodSymbol.returnType();
           if (returnType != null) {

--- a/java-checks/src/main/java/org/sonar/java/checks/ThreadAsRunnableArgumentCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ThreadAsRunnableArgumentCheck.java
@@ -44,7 +44,7 @@ public class ThreadAsRunnableArgumentCheck extends IssuableSubscriptionVisitor {
   @Override
   public void visitNode(Tree tree) {
     List<ExpressionTree> arguments;
-    Symbol methodSymbol;
+    Symbol.MethodSymbol methodSymbol;
     if (tree.is(Tree.Kind.NEW_CLASS)) {
       NewClassTree nct = (NewClassTree) tree;
       methodSymbol = nct.constructorSymbol();
@@ -54,8 +54,8 @@ public class ThreadAsRunnableArgumentCheck extends IssuableSubscriptionVisitor {
       methodSymbol = mit.symbol();
       arguments = mit.arguments();
     }
-    if (!arguments.isEmpty() && methodSymbol.isMethodSymbol()) {
-      checkArgumentsTypes(arguments, (Symbol.MethodSymbol) methodSymbol);
+    if (!arguments.isEmpty() && !methodSymbol.isUnknown()) {
+      checkArgumentsTypes(arguments, methodSymbol);
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/VarCanBeUsedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/VarCanBeUsedCheck.java
@@ -101,8 +101,8 @@ public class VarCanBeUsedCheck extends IssuableSubscriptionVisitor implements Ja
 
   private static boolean isExcludedInitializer(ExpressionTree initializer) {
     if (initializer.is(Tree.Kind.METHOD_INVOCATION)) {
-      Symbol symbol = ((MethodInvocationTree) initializer).symbol();
-      return symbol.isMethodSymbol() && JUtils.isParametrizedMethod((Symbol.MethodSymbol) symbol);
+      Symbol.MethodSymbol symbol = ((MethodInvocationTree) initializer).symbol();
+      return !symbol.isUnknown() && JUtils.isParametrizedMethod(symbol);
     }
     return initializer.is(Tree.Kind.CONDITIONAL_EXPRESSION, Tree.Kind.METHOD_REFERENCE, Tree.Kind.LAMBDA_EXPRESSION);
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/MethodTreeUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/MethodTreeUtils.java
@@ -140,9 +140,9 @@ public final class MethodTreeUtils {
 
   public static class MethodInvocationCollector extends BaseTreeVisitor {
     private final List<Tree> invocationTree = new ArrayList<>();
-    private final Predicate<Symbol> collectPredicate;
+    private final Predicate<Symbol.MethodSymbol> collectPredicate;
 
-    public MethodInvocationCollector(Predicate<Symbol> collectPredicate) {
+    public MethodInvocationCollector(Predicate<Symbol.MethodSymbol> collectPredicate) {
       this.collectPredicate = collectPredicate;
     }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/security/ServerCertificatesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/ServerCertificatesCheck.java
@@ -100,9 +100,9 @@ public class ServerCertificatesCheck extends IssuableSubscriptionVisitor {
       visitMethodSymbol(tree.symbol());
     }
 
-    private void visitMethodSymbol(Symbol symbol) {
-      if (symbol.isMethodSymbol()) {
-        throwsException |= !((Symbol.MethodSymbol) symbol).thrownTypes().isEmpty();
+    private void visitMethodSymbol(Symbol.MethodSymbol symbol) {
+      if (!symbol.isUnknown()) {
+        throwsException |= !symbol.thrownTypes().isEmpty();
       } else {
         // JavaSymbolNotFound, to avoid FP, assumes it throws exceptions
         throwsException = true;

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/AssertionArgumentOrderCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/AssertionArgumentOrderCheck.java
@@ -199,7 +199,7 @@ public class AssertionArgumentOrderCheck extends AbstractMethodDetection {
     int arity = mit.arguments().size();
     ExpressionTree arg = mit.arguments().get(arity - 1);
     // Check for assert equals method with delta
-    if (arity > 2 && (arity == 4 || ((Symbol.MethodSymbol) mit.symbol()).parameterTypes().stream().allMatch(AssertionArgumentOrderCheck::isDoubleOrFloat))) {
+    if (arity > 2 && (arity == 4 || mit.symbol().parameterTypes().stream().allMatch(AssertionArgumentOrderCheck::isDoubleOrFloat))) {
       // last arg is actually delta, take the previous last to get the actual arg.
       arg = mit.arguments().get(arity - 2);
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/AssertionTypesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/AssertionTypesCheck.java
@@ -357,10 +357,10 @@ public class AssertionTypesCheck extends IssuableSubscriptionVisitor {
     }
 
     static Type expectedArgumentType(MethodInvocationTree mit, int argumentIndex) {
-      if (!mit.symbol().isMethodSymbol()) {
+      if (mit.symbol().isUnknown()) {
         return Symbols.unknownType;
       }
-      List<Type> parameterTypes = ((Symbol.MethodSymbol) mit.symbol()).parameterTypes();
+      List<Type> parameterTypes = mit.symbol().parameterTypes();
       if (argumentIndex >= parameterTypes.size()) {
         return Symbols.unknownType;
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoArgumentMatchersUsedOnAllParametersCheck.java
@@ -124,7 +124,7 @@ public class MockitoArgumentMatchersUsedOnAllParametersCheck extends AbstractMoc
    */
   private static boolean returnsAnArgumentMatcher(MethodInvocationTree invocation) {
     ExpressionTree methodSelect = invocation.methodSelect();
-    IdentifierTree identifier = null;
+    IdentifierTree identifier;
     if (methodSelect.is(Tree.Kind.MEMBER_SELECT)) {
       identifier = ((MemberSelectExpressionTree) methodSelect).identifier();
     } else {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/OneExpectedCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/OneExpectedCheckedExceptionCheck.java
@@ -51,10 +51,9 @@ public class OneExpectedCheckedExceptionCheck extends AbstractOneExpectedExcepti
     }
   }
 
-  private static boolean throwExpectedException(Symbol symbol, List<Type> checkedTypes) {
-    return symbol.isMethodSymbol()
-      && ((Symbol.MethodSymbol) symbol).thrownTypes().stream()
-      .anyMatch(t -> checkedTypes.stream().anyMatch(t::isSubtypeOf));
+  private static boolean throwExpectedException(Symbol.MethodSymbol symbol, List<Type> checkedTypes) {
+    return !symbol.isUnknown()
+      && symbol.thrownTypes().stream().anyMatch(t -> checkedTypes.stream().anyMatch(t::isSubtypeOf));
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
+++ b/java-frontend/src/main/java/org/sonar/java/cfg/CFG.java
@@ -1075,7 +1075,7 @@ public class CFG implements ControlFlowGraph {
     }
   }
 
-  private void handleExceptionalPaths(Symbol symbol) {
+  private void handleExceptionalPaths(Symbol.MethodSymbol symbol) {
     TryStatement pop = enclosingTry.pop();
     TryStatement tryStatement;
     Block exceptionPredecessor = currentBlock;
@@ -1092,8 +1092,8 @@ public class CFG implements ControlFlowGraph {
         exceptionPredecessor = currentBlock;
       }
     }
-    if (symbol.isMethodSymbol()) {
-      List<Type> thrownTypes = ((Symbol.MethodSymbol) symbol).thrownTypes();
+    if (!symbol.isUnknown()) {
+      List<Type> thrownTypes = symbol.thrownTypes();
       thrownTypes.forEach(thrownType -> {
         for (Type caughtType : tryStatement.catches.keySet()) {
           if (thrownType.isSubtypeOf(caughtType) ||

--- a/java-frontend/src/main/java/org/sonar/java/model/SyntacticEquivalence.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/SyntacticEquivalence.java
@@ -159,16 +159,16 @@ public final class SyntacticEquivalence {
       return false;
     }
 
-    Symbol leftSymbol = ((MethodInvocationTree) leftNode).symbol();
-    Symbol rightSymbol = ((MethodInvocationTree) rightNode).symbol();
+    Symbol.MethodSymbol leftSymbol = ((MethodInvocationTree) leftNode).symbol();
+    Symbol.MethodSymbol rightSymbol = ((MethodInvocationTree) rightNode).symbol();
 
-    if (!leftSymbol.isMethodSymbol() || !rightSymbol.isMethodSymbol()) {
+    if (leftSymbol.isUnknown() || rightSymbol.isUnknown()) {
       // This can happen when the symbol is unknown. If it is the case, we consider them as not the same to avoid FP.
       return true;
     }
 
-    List<Type> leftArguments = ((Symbol.MethodSymbol) leftSymbol).parameterTypes();
-    List<Type> rightArguments = ((Symbol.MethodSymbol) rightSymbol).parameterTypes();
+    List<Type> leftArguments = leftSymbol.parameterTypes();
+    List<Type> rightArguments = rightSymbol.parameterTypes();
 
     int leftArgumentsSize = leftArguments.size();
     if (leftArgumentsSize == rightArguments.size()) {

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/MethodInvocationTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/MethodInvocationTreeImpl.java
@@ -89,7 +89,7 @@ public class MethodInvocationTreeImpl extends AssessableExpressionTree implement
   }
 
   @Override
-  public Symbol symbol() {
+  public Symbol.MethodSymbol symbol() {
     return methodBinding != null
       ? root.sema.methodSymbol(methodBinding)
       : Symbols.unknownMethodSymbol;

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/NewClassTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/NewClassTreeImpl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.Symbols;
 import org.sonar.java.model.declaration.ClassTreeImpl;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.Arguments;
@@ -161,8 +162,11 @@ public class NewClassTreeImpl extends AssessableExpressionTree implements NewCla
   }
 
   @Override
-  public Symbol constructorSymbol() {
-    return this.getConstructorIdentifier().symbol();
+  public Symbol.MethodSymbol constructorSymbol() {
+    Symbol constructorSymbol = this.getConstructorIdentifier().symbol();
+    return constructorSymbol.isMethodSymbol() ?
+      (Symbol.MethodSymbol) constructorSymbol :
+      Symbols.unknownMethodSymbol;
   }
 
   private static void addIfNotNull(List<Tree> list, Tree... trees) {

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/MethodInvocationTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/MethodInvocationTree.java
@@ -49,6 +49,6 @@ public interface MethodInvocationTree extends ExpressionTree {
 
   Arguments arguments();
 
-  Symbol symbol();
+  Symbol.MethodSymbol symbol();
 
 }

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/NewClassTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/NewClassTree.java
@@ -69,6 +69,6 @@ public interface NewClassTree extends ExpressionTree {
   @Nullable
   ClassTree classBody();
 
-  Symbol constructorSymbol();
+  Symbol.MethodSymbol constructorSymbol();
 
 }

--- a/java-frontend/src/test/java/org/sonar/java/model/JMethodSymbolTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JMethodSymbolTest.java
@@ -83,7 +83,7 @@ class JMethodSymbolTest {
       .containsExactly(declarationParameterSymbol);
 
     MethodInvocationTree invocationWithString = (MethodInvocationTree) ((ExpressionStatementTree) m.block().body().get(0)).expression();
-    Symbol.MethodSymbol invocationSymbol = (Symbol.MethodSymbol) invocationWithString.symbol();
+    Symbol.MethodSymbol invocationSymbol = invocationWithString.symbol();
     // Parameter types are not always the same as the one from the declaration: it can be the actual type and not the generic (Integer instead of T).
     Type invocationArgument = invocationSymbol.parameterTypes().get(0);
     assertThat(invocationArgument)
@@ -109,8 +109,8 @@ class JMethodSymbolTest {
     MethodInvocationTree startWith1 = (MethodInvocationTree) ((ExpressionStatementTree) body.get(0)).expression();
     MethodInvocationTree startWith2 = (MethodInvocationTree) ((ExpressionStatementTree) body.get(1)).expression();
 
-    Symbol.MethodSymbol symbol1 = (Symbol.MethodSymbol) startWith1.symbol();
-    Symbol.MethodSymbol symbol2 = (Symbol.MethodSymbol) startWith2.symbol();
+    Symbol.MethodSymbol symbol1 = startWith1.symbol();
+    Symbol.MethodSymbol symbol2 = startWith2.symbol();
 
     assertThat(symbol1.parameterTypes().get(0).name()).isEqualTo("String");
     assertThat(symbol2.parameterTypes().get(0).name()).isEqualTo("String");
@@ -166,12 +166,12 @@ class JMethodSymbolTest {
             // Dependency#m(@Nullable Object param)
             // GenericDependency#m(@Nullable T param)
             MethodInvocationTree dependencyInvocation = (MethodInvocationTree) ((ExpressionStatementTree) body.get(0)).expression();
-            Symbol dependencyParamDeclaration = ((Symbol.MethodSymbol) dependencyInvocation.symbol()).declarationParameters().get(0);
+            Symbol dependencyParamDeclaration = dependencyInvocation.symbol().declarationParameters().get(0);
             assertThat(dependencyParamDeclaration.owner().owner().name()).isEqualTo("Dependency");
             assertThat(dependencyParamDeclaration.metadata().isAnnotatedWith("semantic.Nullable")).isTrue();
 
             MethodInvocationTree genericDependencyInvocation = (MethodInvocationTree) ((ExpressionStatementTree) body.get(1)).expression();
-            Symbol genericDependencyParamDeclaration = ((Symbol.MethodSymbol) genericDependencyInvocation.symbol()).declarationParameters().get(0);
+            Symbol genericDependencyParamDeclaration = genericDependencyInvocation.symbol().declarationParameters().get(0);
             assertThat(genericDependencyParamDeclaration.owner().owner().name()).isEqualTo("GenericDependency");
             assertThat(genericDependencyParamDeclaration.metadata().isAnnotatedWith("semantic.Nullable")).isTrue();
           } catch (Exception e) {

--- a/java-frontend/src/test/java/org/sonar/java/model/JSymbolMetadataTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JSymbolMetadataTest.java
@@ -107,7 +107,7 @@ class JSymbolMetadataTest {
     MethodTreeImpl m = (MethodTreeImpl) c.members().get(0);
     ExpressionStatementTreeImpl es = (ExpressionStatementTreeImpl) m.block().body().get(0);
     MethodInvocationTreeImpl mit = (MethodInvocationTreeImpl) es.expression();
-    Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) mit.symbol();
+    Symbol.MethodSymbol methodSymbol = mit.symbol();
     Symbol symbol = methodSymbol.declarationParameters().get(0);
 
     SymbolMetadata.NullabilityData nullabilityData = symbol.metadata().nullabilityData();
@@ -217,9 +217,9 @@ class JSymbolMetadataTest {
     MethodInvocationTree invocationWithString = (MethodInvocationTree) ((ExpressionStatementTree) callDeclaration.block().body().get(0)).expression();
     MethodInvocationTree invocationWithInteger = (MethodInvocationTree) ((ExpressionStatementTree) callDeclaration.block().body().get(1)).expression();
 
-    SymbolMetadata.NullabilityData invocation1ParamData = ((Symbol.MethodSymbol) invocationWithString.symbol())
+    SymbolMetadata.NullabilityData invocation1ParamData = invocationWithString.symbol()
       .declarationParameters().get(0).metadata().nullabilityData();
-    SymbolMetadata.NullabilityData invocation2ParamData = ((Symbol.MethodSymbol) invocationWithInteger.symbol())
+    SymbolMetadata.NullabilityData invocation2ParamData = invocationWithInteger.symbol()
       .declarationParameters().get(0).metadata().nullabilityData();
 
     assertThat(declarationData)

--- a/java-frontend/src/test/java/org/sonar/java/model/JUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JUtilsTest.java
@@ -244,7 +244,7 @@ class JUtilsTest {
     MethodTreeImpl m = firstMethod(a);
     ExpressionStatementTreeImpl es = (ExpressionStatementTreeImpl) m.block().body().get(0);
     MethodInvocationTreeImpl mit = (MethodInvocationTreeImpl) es.expression();
-    Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) mit.symbol();
+    Symbol.MethodSymbol methodSymbol = mit.symbol();
     Symbol symbol = methodSymbol.declarationParameters().get(0);
     assertThat(symbol.isVariableSymbol()).isTrue();
     assertThat(JUtils.isEffectivelyFinal((Symbol.VariableSymbol) symbol)).isFalse();
@@ -333,7 +333,7 @@ class JUtilsTest {
     void placeholder_symbols_are_parameters() {
       ExpressionStatementTreeImpl es = (ExpressionStatementTreeImpl) m.block().body().get(2);
       MethodInvocationTreeImpl mit = (MethodInvocationTreeImpl) es.expression();
-      Symbol.MethodSymbol symbol = (Symbol.MethodSymbol) mit.symbol();
+      Symbol.MethodSymbol symbol = mit.symbol();
       assertThat(JUtils.isParameter(symbol.declarationParameters().get(0))).isTrue();
     }
   }
@@ -364,7 +364,7 @@ class JUtilsTest {
     void placeholders_can_not_be_evaluated() {
       ExpressionStatementTreeImpl es = (ExpressionStatementTreeImpl) m.block().body().get(1);
       MethodInvocationTreeImpl mit = (MethodInvocationTreeImpl) es.expression();
-      Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) mit.symbol();
+      Symbol.MethodSymbol methodSymbol = mit.symbol();
       Symbol symbol = methodSymbol.declarationParameters().get(0);
       assertThat(symbol.isVariableSymbol()).isTrue();
       assertThat(JUtils.constantValue((Symbol.VariableSymbol) symbol)).isEmpty();
@@ -707,7 +707,7 @@ class JUtilsTest {
         .isEqualTo(m.methodBinding.isGenericMethod())
         .isTrue();
       assertThat(JUtils.isParametrizedMethod(cu.sema.methodSymbol(methodInvocation.methodBinding)))
-        .isEqualTo(JUtils.isParametrizedMethod((Symbol.MethodSymbol) methodInvocation.symbol()))
+        .isEqualTo(JUtils.isParametrizedMethod(methodInvocation.symbol()))
         .isEqualTo(methodInvocation.methodBinding.isParameterizedMethod())
         .isTrue();
     }

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -784,9 +784,9 @@ public class ExplodedGraphWalker {
 
     // get method behavior for method with known declaration (ie: within the same file)
     MethodBehavior methodInvokedBehavior = null;
-    Symbol methodSymbol = mit.symbol();
-    if(methodSymbol.isMethodSymbol()) {
-      methodInvokedBehavior = behaviorCache.get((Symbol.MethodSymbol) methodSymbol);
+    Symbol.MethodSymbol methodSymbol = mit.symbol();
+    if(!methodSymbol.isUnknown()) {
+      methodInvokedBehavior = behaviorCache.get(methodSymbol);
     }
 
     // Enqueue additional exceptional paths corresponding to unchecked exceptions, for instance OutOfMemoryError

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java
@@ -844,13 +844,13 @@ public class ExplodedGraphWalker {
     return ps;
   }
 
-  private void enqueueThrownExceptionalPaths(Symbol symbol) {
-    if (!symbol.isMethodSymbol()) {
+  private void enqueueThrownExceptionalPaths(Symbol.MethodSymbol symbol) {
+    if (symbol.isUnknown()) {
       // do nothing for unknown methods
       return;
     }
     ProgramState ps = programState.clearStack();
-    ((Symbol.MethodSymbol) symbol).thrownTypes().stream()
+    symbol.thrownTypes().stream()
       .map(constraintManager::createExceptionalSymbolicValue)
       .map(ps::stackValue)
       .forEach(ps1 -> enqueueExceptionalPaths(ps1, symbol));
@@ -1057,7 +1057,7 @@ public class ExplodedGraphWalker {
   private void executeNewClass(NewClassTree newClassTree) {
     programState = programState.unstackValue(newClassTree.arguments().size()).state;
     // Enqueue exceptional paths
-    Symbol symbol = newClassTree.constructorSymbol();
+    Symbol.MethodSymbol symbol = newClassTree.constructorSymbol();
     if (((CFG.Block) node.programPoint.block).exceptions().stream().anyMatch(CFG.Block.IS_CATCH_BLOCK)) {
       // To avoid noise, we only add unchecked exceptional paths (includingUnknownException) when we are in a try-catch block.
       enqueueUncheckedExceptionalPaths(symbol);

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/FlowComputation.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/FlowComputation.java
@@ -783,7 +783,7 @@ public class FlowComputation {
 
   public static Flow flowsForArgumentsChangingName(List<Integer> argumentIndices, MethodInvocationTree mit) {
 
-    Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) mit.symbol();
+    Symbol.MethodSymbol methodSymbol = mit.symbol();
     MethodTree declaration = methodSymbol.declaration();
     if (declaration == null) {
       return Flow.empty();

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/MapComputeIfAbsentOrPresentCheck.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/MapComputeIfAbsentOrPresentCheck.java
@@ -155,12 +155,12 @@ public class MapComputeIfAbsentOrPresentCheck extends SECheck implements JavaVer
     if (!expr.is(Tree.Kind.METHOD_INVOCATION)) {
       return false;
     }
-    Symbol symbol = ((MethodInvocationTree) expr).symbol();
-    if (!symbol.isMethodSymbol()) {
+    Symbol.MethodSymbol symbol = ((MethodInvocationTree) expr).symbol();
+    if (symbol.isUnknown()) {
       // assume a checked exception could be returned
       return true;
     }
-    return ((Symbol.MethodSymbol) symbol).thrownTypes().stream().anyMatch(t -> !t.isSubtypeOf("java.lang.RuntimeException"));
+    return symbol.thrownTypes().stream().anyMatch(t -> !t.isSubtypeOf("java.lang.RuntimeException"));
   }
 
   private boolean isInsideIfStatementWithNullCheckWithoutElse(MethodInvocationTree mit) {

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/NonNullSetToNullCheck.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/NonNullSetToNullCheck.java
@@ -211,11 +211,11 @@ public class NonNullSetToNullCheck extends SECheck {
 
     @Override
     public void visitNewClass(NewClassTree syntaxTree) {
-      Symbol symbol = syntaxTree.constructorSymbol();
-      if (symbol.isMethodSymbol()) {
+      Symbol.MethodSymbol symbol = syntaxTree.constructorSymbol();
+      if (!symbol.isUnknown()) {
         int peekSize = syntaxTree.arguments().size();
         List<SymbolicValue> argumentValues = ListUtils.reverse(programState.peekValues(peekSize));
-        checkNullArguments(syntaxTree, (Symbol.MethodSymbol) symbol, argumentValues);
+        checkNullArguments(syntaxTree, symbol, argumentValues);
       }
     }
 

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/NonNullSetToNullCheck.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/NonNullSetToNullCheck.java
@@ -221,8 +221,8 @@ public class NonNullSetToNullCheck extends SECheck {
 
     @Override
     public void visitMethodInvocation(MethodInvocationTree syntaxTree) {
-      Symbol symbol = syntaxTree.symbol();
-      if (symbol.isMethodSymbol()) {
+      Symbol.MethodSymbol symbol = syntaxTree.symbol();
+      if (!symbol.isUnknown()) {
         Arguments arguments = syntaxTree.arguments();
         int peekSize = arguments.size() + 1;
         List<SymbolicValue> argumentValues = ListUtils.reverse(programState.peekValues(peekSize).subList(0, peekSize - 1));
@@ -230,7 +230,7 @@ public class NonNullSetToNullCheck extends SECheck {
         if (reportTree.is(Tree.Kind.MEMBER_SELECT)) {
           reportTree = ((MemberSelectExpressionTree) reportTree).identifier();
         }
-        checkNullArguments(reportTree, (Symbol.MethodSymbol) symbol, argumentValues);
+        checkNullArguments(reportTree, symbol, argumentValues);
       }
     }
 

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/ParameterNullnessCheck.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/ParameterNullnessCheck.java
@@ -67,22 +67,21 @@ public class ParameterNullnessCheck extends SECheck {
     return state;
   }
 
-  private void checkParameters(Tree syntaxNode, Symbol symbol, Arguments arguments, ProgramState state) {
+  private void checkParameters(Tree syntaxNode, Symbol.MethodSymbol symbol, Arguments arguments, ProgramState state) {
     if (!symbol.isMethodSymbol() || arguments.isEmpty()) {
       return;
     }
     if (AUTHORIZED_METHODS.matches(symbol)) {
       return;
     }
-    Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) symbol;
     int nbArguments = arguments.size();
     List<SymbolicValue> argumentSVs = getArgumentSVs(state, syntaxNode, nbArguments);
-    int nbArgumentToCheck = Math.min(nbArguments, methodSymbol.parameterTypes().size() - (JUtils.isVarArgsMethod(methodSymbol) ? 1 : 0));
-    List<Symbol> parameterSymbols = methodSymbol.declarationParameters();
+    int nbArgumentToCheck = Math.min(nbArguments, symbol.parameterTypes().size() - (JUtils.isVarArgsMethod(symbol) ? 1 : 0));
+    List<Symbol> parameterSymbols = symbol.declarationParameters();
     for (int i = 0; i < nbArgumentToCheck; i++) {
       ObjectConstraint constraint = state.getConstraint(argumentSVs.get(i), ObjectConstraint.class);
       if (constraint != null && constraint.isNull() && parameterIsNonNullIndirectly(parameterSymbols.get(i))) {
-        reportIssue(syntaxNode, arguments.get(i), methodSymbol);
+        reportIssue(syntaxNode, arguments.get(i), symbol);
       }
     }
   }

--- a/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/StreamConsumedCheck.java
+++ b/java-symbolic-execution/src/main/java/org/sonar/java/se/checks/StreamConsumedCheck.java
@@ -163,11 +163,11 @@ public class StreamConsumedCheck extends SECheck {
     if (BASE_STREAM_INTERMEDIATE_OPERATIONS.matches(mit)) {
       return true;
     }
-    Symbol method = mit.symbol();
-    return method.isMethodSymbol()
+    Symbol.MethodSymbol method = mit.symbol();
+    return !method.isUnknown()
       && !method.isStatic()
       && STREAM_TYPES.contains(method.owner().type().fullyQualifiedName())
-      && STREAM_TYPES.contains(((Symbol.MethodSymbol) method).returnType().type().fullyQualifiedName());
+      && STREAM_TYPES.contains(method.returnType().type().fullyQualifiedName());
   }
 
   private static boolean isPipelineConsumed(ProgramState programState, SymbolicValue symbolicValue) {

--- a/java-symbolic-execution/src/test/java/org/sonar/java/se/xproc/BehaviorCacheTest.java
+++ b/java-symbolic-execution/src/test/java/org/sonar/java/se/xproc/BehaviorCacheTest.java
@@ -295,7 +295,7 @@ class BehaviorCacheTest {
       @Override
       public ProgramState checkPreStatement(CheckerContext context, Tree syntaxNode) {
         if (syntaxNode.is(Tree.Kind.METHOD_INVOCATION)) {
-          Symbol.MethodSymbol symbol = (Symbol.MethodSymbol) ((MethodInvocationTree) syntaxNode).symbol();
+          Symbol.MethodSymbol symbol = ((MethodInvocationTree) syntaxNode).symbol();
           MethodBehavior peekMethodBehavior = ((CheckerDispatcher) context).peekMethodBehavior(symbol);
           if ("isBlank".equals(symbol.name())) {
             assertThat(peekMethodBehavior).isNotNull();
@@ -310,7 +310,7 @@ class BehaviorCacheTest {
       @Override
       public ProgramState checkPostStatement(CheckerContext context, Tree syntaxNode) {
         if (syntaxNode.is(Tree.Kind.METHOD_INVOCATION)) {
-          Symbol.MethodSymbol symbol = (Symbol.MethodSymbol) ((MethodInvocationTree) syntaxNode).symbol();
+          Symbol.MethodSymbol symbol = ((MethodInvocationTree) syntaxNode).symbol();
           String methodName = symbol.name();
           MethodBehavior peekMethodBehavior = ((CheckerDispatcher) context).peekMethodBehavior(symbol);
           if ("foo".equals(methodName) || "isBlank".equals(methodName)) {


### PR DESCRIPTION
With this change, method bodies are recursively visited to find a throw statement for `NoSuchElementException`. We make sure not to visit the same method twice and to limit to the total number of method visited.

Additionally, exceptions that are subtypes of `NoSuchElementException` are now also taken into account.
