### PR TITLE
SONARJAVA-4329 Fix FNs in S1612 when replacement reference is ambiguous

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -12,6 +12,9 @@ import java.util.stream.Stream;
 
 class LambdaA {
   void fun() {
+    String strings = "test";
+    Runnable run = () -> System.out.println(strings);
+    run.run();
     IntStream.range(1, 5)
         .map((x) -> x * x)
         .map(x -> square(x)) // Noncompliant [[sc=16;ec=18]] {{Replace this lambda with method reference 'this::square'.}}

--- a/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -390,10 +390,12 @@ class CastCheck {
     // fix@qf_method_override {{Replace with "Nested::doSomething"}}
     // edit@qf_method_override [[sc=43;ec=63]] {{Nested::doSomething}}
 
-    Stream.of(new NestedExtendOverrideTakeInt()).forEach(x -> x.doSomething()); // Compliant, shorter
+    Stream.of(new NestedExtendOverrideTakeInt()).forEach(x -> x.doSomething()); // Noncompliant [[sc=60;ec=62;quickfixes=qf_method_override3]]
+    // fix@qf_method_override3 {{Replace with "Nested::doSomething"}}
+    // edit@qf_method_override3 [[sc=58;ec=78]] {{Nested::doSomething}}
     Stream.of(new NestedExtendOverrideTakeInt()).forEach(parameterWithLongName -> parameterWithLongName.doSomething()); // Noncompliant [[sc=80;ec=82;quickfixes=qf_method_override2]]
-    // fix@qf_method_override2 {{Replace with "NestedExtendOverrideTakeInt::doSomething"}}
-    // edit@qf_method_override2 [[sc=58;ec=118]] {{NestedExtendOverrideTakeInt::doSomething}}
+    // fix@qf_method_override2 {{Replace with "Nested::doSomething"}}
+    // edit@qf_method_override2 [[sc=58;ec=118]] {{Nested::doSomething}}
   }
 
   class NestedExtend extends Nested {
@@ -430,13 +432,17 @@ class LambdaB {
     Collection<Integer> idList = List.of(1, 2);
     System.out.println(idList
       .stream()
-      .map(integer -> integer.toString()) // Noncompliant, can use 'Object::toString'
+      .map(integer -> integer.toString()) // Noncompliant [[sc=20;ec=22;quickfixes=qf_int_to_str1]]
+      // fix@qf_int_to_str1 {{Replace with "Object::toString"}}
+      // edit@qf_int_to_str1 [[sc=12;ec=41]] {{Object::toString}}
       .distinct());
     System.out.println(idList
       .stream()
       .map(integer -> Integer.toString(integer)) // Compliant (the static ambiguous method can't be referenced using a superclass, like for its non-static counterpart)
       .distinct());
-    apply((i, r) -> Integer.toString(i, r)); // Noncompliant, equivalent method reference is not ambiguous
+    apply((i, r) -> Integer.toString(i, r)); // Noncompliant [[sc=18;ec=20;quickfixes=qf_int_to_str2]]
+    // fix@qf_int_to_str2 {{Replace with "Integer::toString"}}
+    // edit@qf_int_to_str2 [[sc=11;ec=43]] {{Integer::toString}}
   }
 
   String apply(BiFunction<Integer, Integer, String> f) {
@@ -464,6 +470,10 @@ class TestObject {
   static int spam(TestObject to) {
     return to.hashCode();
   }
+
+  int eggs() throws Exception {
+    throw new UnsupportedOperationException();
+  }
 }
 
 class TestNumber extends TestObject {
@@ -475,7 +485,9 @@ class TestNumber extends TestObject {
   }
 
   void test() {
-    Optional.of(new TestNumber()).map(testNumber -> testNumber.foo()); // Noncompliant, method reference 'TestObject::foo' works
+    Optional.of(new TestNumber()).map(testNumber -> testNumber.foo()); // Noncompliant [[sc=50;ec=52;quickfixes=qf_supertype]]
+    // fix@qf_supertype {{Replace with "TestObject::foo"}}
+    // edit@qf_supertype [[sc=39;ec=69]] {{TestObject::foo}}
   }
 }
 class TestInteger extends TestNumber {
@@ -483,11 +495,22 @@ class TestInteger extends TestNumber {
     return "Integer here";
   }
 
+  int eggs() {
+    return 42;
+  }
+
+  static int eggs(TestInteger ti) {
+    return ti.hashCode();
+  }
+
   void test() {
-    Optional.of(new TestInteger()).map(testInteger -> testInteger.foo()); // Noncompliant, method reference 'TestObject::foo' works
+    Optional.of(new TestInteger()).map(testInteger -> testInteger.foo()); // Noncompliant [[sc=52;ec=54;quickfixes=qf_supertype2]]
+    // fix@qf_supertype2 {{Replace with "TestObject::foo"}}
+    // edit@qf_supertype2 [[sc=40;ec=72]] {{TestObject::foo}}
     Optional.of(new TestInteger()).map(testInteger -> TestNumber.foo(testInteger)); // Compliant, method reference is ambiguous
     Optional.of(new TestInteger()).map(testInteger -> testInteger.spam()); // Compliant, method reference is ambiguous
     Optional.of(new TestInteger()).map(testInteger -> (foo().length() % 23 == 0 ? testInteger : null).spam(testInteger)); // Compliant, method reference is ambiguous
+    Optional.of(new TestInteger()).map(testInteger -> testInteger.eggs()); // Compliant, method reference is ambiguous
   }
 }
 

--- a/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -429,17 +429,6 @@ class CastCheck {
 
 class LambdaB {
   void intToString() {
-    Collection<Integer> idList = List.of(1, 2);
-    System.out.println(idList
-      .stream()
-      .map(integer -> integer.toString()) // Noncompliant [[sc=20;ec=22;quickfixes=qf_int_to_str1]]
-      // fix@qf_int_to_str1 {{Replace with "Object::toString"}}
-      // edit@qf_int_to_str1 [[sc=12;ec=41]] {{Object::toString}}
-      .distinct());
-    System.out.println(idList
-      .stream()
-      .map(integer -> Integer.toString(integer)) // Compliant (the static ambiguous method can't be referenced using a superclass, like for its non-static counterpart)
-      .distinct());
     apply((i, r) -> Integer.toString(i, r)); // Noncompliant [[sc=18;ec=20;quickfixes=qf_int_to_str2]]
     // fix@qf_int_to_str2 {{Replace with "Integer::toString"}}
     // edit@qf_int_to_str2 [[sc=11;ec=43]] {{Integer::toString}}
@@ -527,5 +516,19 @@ class TestInteger extends TestNumber {
     // fix@qf_2args {{Replace with "TestInteger::bar"}}
     // edit@qf_2args [[sc=17;ec=55]] {{TestInteger::bar}}
     consumeBoth((testInteger, s) -> testInteger.bar("test")); // Compliant
+  }
+}
+
+class UnambiguousDueToParameterType {
+  static int foo(String s) {
+    return 1;
+  }
+
+  int foo() {
+    return 2;
+  }
+
+  void test() {
+    Optional.of(this).map(x -> x.foo());
   }
 }

--- a/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -503,6 +503,18 @@ class TestInteger extends TestNumber {
     return ti.hashCode();
   }
 
+  String bar(String s) {
+    return s;
+  }
+
+  static String bar(TestInteger i, String s, String t) {
+    return eggs(i) == 0 ? s : t;
+  }
+
+  static void consumeBoth(BiConsumer<TestInteger, String> bc) {
+    bc.accept(null, null);
+  }
+
   void test() {
     Optional.of(new TestInteger()).map(testInteger -> testInteger.foo()); // Noncompliant [[sc=52;ec=54;quickfixes=qf_supertype2]]
     // fix@qf_supertype2 {{Replace with "TestObject::foo"}}
@@ -511,7 +523,9 @@ class TestInteger extends TestNumber {
     Optional.of(new TestInteger()).map(testInteger -> testInteger.spam()); // Compliant, method reference is ambiguous
     Optional.of(new TestInteger()).map(testInteger -> (foo().length() % 23 == 0 ? testInteger : null).spam(testInteger)); // Compliant, method reference is ambiguous
     Optional.of(new TestInteger()).map(testInteger -> testInteger.eggs()); // Compliant, method reference is ambiguous
+    consumeBoth((testInteger, s) -> testInteger.bar(s)); // Noncompliant [[sc=34;ec=36;quickfixes=qf_2args]]
+    // fix@qf_2args {{Replace with "TestInteger::bar"}}
+    // edit@qf_2args [[sc=17;ec=55]] {{TestInteger::bar}}
+    consumeBoth((testInteger, s) -> testInteger.bar("test")); // Compliant
   }
 }
-
-

--- a/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -382,7 +382,7 @@ public class ReplaceLambdaByMethodRefCheck extends IssuableSubscriptionVisitor {
    * Example: (a, b, c) -> a.foo(b, c)
    */
   private static boolean isMethodCalledOnFirstParam(MethodInvocationTree mit, List<VariableTree> parameters) {
-    if (mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
+    if (!parameters.isEmpty() && mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
       ExpressionTree expression = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
       Symbol parameterSymbol = parameters.get(0).symbol();
       return expression.is(Tree.Kind.IDENTIFIER) &&

--- a/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -240,7 +240,7 @@ public class ReplaceLambdaByMethodRefCheck extends IssuableSubscriptionVisitor {
         return getNewClass(((NewClassTree) tree), parameters);
       } else if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
         MethodInvocationTree mit = (MethodInvocationTree) tree;
-        if (hasMethodInvocationInMethodSelect(mit) || hasNonFinalFieldInMethodSelect(mit)) {
+        if (mit.methodSymbol().isUnknown() || hasMethodInvocationInMethodSelect(mit) || hasNonFinalFieldInMethodSelect(mit)) {
           return Optional.empty();
         }
         Arguments arguments = mit.arguments();

--- a/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -22,6 +22,7 @@ package org.sonar.java.checks;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import javax.annotation.CheckForNull;
@@ -86,11 +87,8 @@ public class ReplaceLambdaByMethodRefCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isReplacementMoreConcise(LambdaExpressionTree tree, String replacement) {
-    SyntaxToken first = tree.firstToken();
-    SyntaxToken last = tree.lastToken();
-    if (first == null || last == null) {
-      return true;
-    }
+    SyntaxToken first = Objects.requireNonNull(tree.firstToken());
+    SyntaxToken last = Objects.requireNonNull(tree.lastToken());
     boolean multiline = first.range().start().line() != last.range().end().line();
     boolean shorter = replacement.length() <= last.range().end().column() - first.range().start().column();
     return multiline || shorter;

--- a/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReplaceLambdaByMethodRefCheck.java
@@ -257,7 +257,7 @@ public class ReplaceLambdaByMethodRefCheck extends IssuableSubscriptionVisitor {
   }
 
   private static Optional<String> getUnambiguousReference(MethodInvocationTree mit) {
-    Symbol.MethodSymbol ms = ((Symbol.MethodSymbol) mit.symbol());
+    Symbol.MethodSymbol ms = mit.methodSymbol();
     ArrayList<Symbol.MethodSymbol> methodSymbols = new ArrayList<>(ms.overriddenSymbols());
     Collections.reverse(methodSymbols);
     methodSymbols.add(ms);
@@ -298,8 +298,8 @@ public class ReplaceLambdaByMethodRefCheck extends IssuableSubscriptionVisitor {
 
   private static Optional<String> getReplacementForMethodInvocation(MethodInvocationTree mit) {
     ExpressionTree methodSelect = mit.methodSelect();
+    Symbol.MethodSymbol symbol = mit.methodSymbol();
     if (methodSelect.is(Tree.Kind.IDENTIFIER)) {
-      Symbol symbol = mit.symbol();
       if (symbol.isStatic()) {
         return getUnambiguousReference(mit);
       }
@@ -312,7 +312,7 @@ public class ReplaceLambdaByMethodRefCheck extends IssuableSubscriptionVisitor {
         }
       }
       return Optional.of(symbolOwner.name() + ".this::" + symbol.name());
-    } else if (methodSelect.is(Tree.Kind.MEMBER_SELECT) && mit.symbol().isStatic()) {
+    } else if (methodSelect.is(Tree.Kind.MEMBER_SELECT) && symbol.isStatic()) {
       return getUnambiguousReference(mit);
     }
     MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) methodSelect;

--- a/java-frontend/src/main/java/org/sonar/java/model/JUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JUtils.java
@@ -22,6 +22,7 @@ package org.sonar.java.model;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -66,6 +67,11 @@ public final class JUtils {
 
   public static boolean isPrimitiveWrapper(Type type) {
     return type.isClass() && WRAPPER_TO_PRIMITIVE.containsKey(type.fullyQualifiedName());
+  }
+
+  public static Type wrapTypeIfPrimitive(Type type) {
+    Type wrapped = primitiveWrapperType(type);
+    return Objects.requireNonNullElse(wrapped, type);
   }
 
   @Nullable

--- a/java-frontend/src/test/java/org/sonar/java/model/JUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JUtilsTest.java
@@ -105,6 +105,35 @@ class JUtilsTest {
   }
 
   @Nested
+  class WrapTypeIfPrimitiveTest {
+    @Test
+    void prim_to_wrapped() {
+      Type primitiveType = SEMA.type(SEMA.resolveType("byte"));
+      Type wrappedType = JUtils.wrapTypeIfPrimitive(primitiveType);
+      assertThat(wrappedType).isNotNull();
+      assertThat(wrappedType.isPrimitive()).isFalse();
+      assertThat(wrappedType.fullyQualifiedName()).isEqualTo("java.lang.Byte");
+    }
+
+    @Test
+    void already_wrapped() {
+      Type boxedType = SEMA.type(SEMA.resolveType("java.lang.Byte"));
+      Type wrappedType = JUtils.wrapTypeIfPrimitive(boxedType);
+      assertThat(wrappedType).isNotNull();
+      assertThat(wrappedType.isPrimitive()).isFalse();
+      assertThat(wrappedType.fullyQualifiedName()).isEqualTo("java.lang.Byte");
+    }
+
+    @Test
+    void unrelated() {
+      Type otherType = SEMA.type(SEMA.resolveType("java.lang.Object"));
+      Type wrappedType = JUtils.wrapTypeIfPrimitive(otherType);
+      assertThat(wrappedType).isNotNull();
+      assertThat(wrappedType.isPrimitive()).isFalse();
+      assertThat(wrappedType.fullyQualifiedName()).isEqualTo("java.lang.Object");
+    }
+  }
+  @Nested
   class IsNullType {
     private final JavaTree.CompilationUnitTreeImpl cu = test("class C { Object m1() { return null; } Unknown m2() { return null; } }");
     private final ClassTreeImpl c = firstClass(cu);


### PR DESCRIPTION
This PR changes the following:
- Ambiguous method references, like `Integer::toString` for lambda `x -> x.toString()` and `x -> Integer.toString(x)`, are not suggested anymore. This also works for lambdas with multiple arguments
- If there exist an unambiguous reference in a supertype, this will be suggested instead. For example `x -> x.toString()` where `x` is an `Integer` can be unambiguously referred by `Object::toString`. The replacement only happens if thrown exceptions are the same in the supertype method. Annotations are not checked.