### PR TITLE
SONARJAVA-4363 Fix FNs on S2272 when NoSuchElementException is thrown indirectly

### DIFF
--- a/its/ruling/src/test/resources/guava/java-S2272.json
+++ b/its/ruling/src/test/resources/guava/java-S2272.json
@@ -6,11 +6,6 @@
 'com.google.guava:guava:src/com/google/common/collect/Iterators.java':[
 1123,
 ],
-'com.google.guava:guava:src/com/google/common/collect/LinkedListMultimap.java':[
-352,
-428,
-498,
-],
 'com.google.guava:guava:src/com/google/common/collect/TreeTraverser.java':[
 209,
 ],

--- a/java-checks-test-sources/src/main/files/non-compiling/checks/IteratorNextExceptionCheck.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/IteratorNextExceptionCheck.java
@@ -87,3 +87,19 @@ class IteratorNextExceptionCheckE implements Iterator<String> {
     return false;
   }
 }
+
+class IteratorNextExceptionCheckF implements Iterator<String> {
+
+  public String next() { // Compliant
+    foo();
+  }
+
+  private String foo() throws UnknownException {
+
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+}

--- a/java-checks-test-sources/src/main/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/IteratorNextExceptionCheck.java
@@ -181,3 +181,64 @@ class IteratorNextExceptionCheckN implements Iterator<Double> {
     return a.hasNext();
   }
 }
+
+class IteratorNextExceptionCheckO implements Iterator<String> {
+  private int count = 10;
+
+  public String next() { // Compliant
+    return getNext();
+  }
+
+  private String getNext() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return "hello";
+  }
+
+  public static void justThrow() {
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public boolean hasNext() {
+    count--;
+    return count > 0;
+  }
+
+}
+
+class IteratorNextExceptionCheckP implements Iterator<T> {
+  private T elem;
+
+  public T next() { // Compliant
+    if (!hasNext()) {
+      IteratorNextExceptionCheckO.justThrow();
+    }
+    return elem;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+
+}
+
+class IteratorNextExceptionCheckQ implements Iterator<T> {
+  private T elem;
+
+  public T next() { // Compliant
+    if (!hasNext()) {
+      class Foo extends NoSuchElementException {}
+      throw new Foo();
+    }
+    return elem;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return false;
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -94,8 +94,8 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
     public void visitMethodInvocation(MethodInvocationTree methodInvocation) {
       if (NEXT_INVOCATION_MATCHER.matches(methodInvocation) || throwsNoSuchElementException(methodInvocation)) {
         expectedExceptionIsThrown = true;
-      } else if (methodInvocation.symbol().isMethodSymbol()) {
-        Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) methodInvocation.symbol();
+      } else {
+        Symbol.MethodSymbol methodSymbol = methodInvocation.methodSymbol();
         MethodTree methodTree = methodSymbol.declaration();
         boolean canVisit = methodTree != null && methodsVisited.add(methodTree);
         if (canVisit) {

--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -39,7 +39,6 @@ import org.sonar.plugins.java.api.tree.Tree.Kind;
 
 @Rule(key = "S2272")
 public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
-  private static final int MAX_METHOD_VISITS = 50;
 
   private static final MethodMatchers NEXT_INVOCATION_MATCHER = MethodMatchers.create()
       .ofSubTypes("java.util.Iterator")
@@ -98,16 +97,12 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
       } else if (methodInvocation.symbol().isMethodSymbol()) {
         Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) methodInvocation.symbol();
         MethodTree methodTree = methodSymbol.declaration();
-        if (methodTree != null && canVisit(methodTree)) {
-          methodsVisited.add(methodTree);
+        boolean canVisit = methodTree != null && methodsVisited.add(methodTree);
+        if (canVisit) {
           scan(methodTree);
         }
       }
       super.visitMethodInvocation(methodInvocation);
-    }
-
-    private boolean canVisit(MethodTree methodTree) {
-      return !methodsVisited.contains(methodTree) && methodsVisited.size() < MAX_METHOD_VISITS;
     }
 
     private static boolean throwsNoSuchElementException(MethodInvocationTree methodInvocationTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IteratorNextExceptionCheck.java
@@ -20,7 +20,9 @@
 package org.sonar.java.checks;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
@@ -37,6 +39,7 @@ import org.sonar.plugins.java.api.tree.Tree.Kind;
 
 @Rule(key = "S2272")
 public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
+  private static final int MAX_METHOD_VISITS = 50;
 
   private static final MethodMatchers NEXT_INVOCATION_MATCHER = MethodMatchers.create()
       .ofSubTypes("java.util.Iterator")
@@ -54,8 +57,9 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
     MethodTree methodTree = (MethodTree) tree;
     if (isIteratorNextMethod(methodTree.symbol()) && methodTree.block() != null) {
       NextMethodBodyVisitor visitor = new NextMethodBodyVisitor();
+      visitor.methodsVisited.add(methodTree);
       tree.accept(visitor);
-      if (!visitor.foundThrow) {
+      if (!visitor.expectedExceptionIsThrown) {
         reportIssue(methodTree.simpleName(), "Add a \"NoSuchElementException\" for iteration beyond the end of the collection.");
       }
     }
@@ -70,8 +74,8 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
   }
 
   private static class NextMethodBodyVisitor extends BaseTreeVisitor {
-
-    private boolean foundThrow = false;
+    private boolean expectedExceptionIsThrown = false;
+    private final Set<MethodTree> methodsVisited = new HashSet<>();
 
     @Override
     public void visitThrowStatement(ThrowStatementTree throwStatementTree) {
@@ -79,9 +83,9 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
       if (expression.is(Tree.Kind.NEW_CLASS)) {
         NewClassTree newClassTree = (NewClassTree) expression;
         Type symbolType = newClassTree.symbolType();
-        if (symbolType.is("java.util.NoSuchElementException") || symbolType.isUnknown()) {
+        if (symbolType.isSubtypeOf("java.util.NoSuchElementException") || symbolType.isUnknown()) {
           // Consider any unknown Exception as NoSuchElementException to avoid FP.
-          foundThrow = true;
+          expectedExceptionIsThrown = true;
         }
       }
       super.visitThrowStatement(throwStatementTree);
@@ -90,9 +94,20 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
     @Override
     public void visitMethodInvocation(MethodInvocationTree methodInvocation) {
       if (NEXT_INVOCATION_MATCHER.matches(methodInvocation) || throwsNoSuchElementException(methodInvocation)) {
-        foundThrow = true;
+        expectedExceptionIsThrown = true;
+      } else if (methodInvocation.symbol().isMethodSymbol()) {
+        Symbol.MethodSymbol methodSymbol = (Symbol.MethodSymbol) methodInvocation.symbol();
+        MethodTree methodTree = methodSymbol.declaration();
+        if (methodTree != null && canVisit(methodTree)) {
+          methodsVisited.add(methodTree);
+          scan(methodTree);
+        }
       }
       super.visitMethodInvocation(methodInvocation);
+    }
+
+    private boolean canVisit(MethodTree methodTree) {
+      return !methodsVisited.contains(methodTree) && methodsVisited.size() < MAX_METHOD_VISITS;
     }
 
     private static boolean throwsNoSuchElementException(MethodInvocationTree methodInvocationTree) {
@@ -105,7 +120,7 @@ public class IteratorNextExceptionCheck extends IssuableSubscriptionVisitor {
     }
 
     private static boolean throwsNoSuchElementException(List<? extends Type> thrownTypes) {
-      return thrownTypes.stream().anyMatch(t -> t.is("java.util.NoSuchElementException"));
+      return thrownTypes.stream().anyMatch(t -> t.isSubtypeOf("java.util.NoSuchElementException") || t.isUnknown());
     }
 
   }


### PR DESCRIPTION
Method calls are visited recursively to check if they might throw NoSuchElementException.
Methods outside the current file and try-catch statement are not handled.