### PR TITLE
SONARJAVA-4415 Add parameter to ignore particular annotations in S1068

### DIFF
--- a/java-checks-test-sources/src/main/files/non-compiling/checks/unused/UnusedPrivateFieldCheckWithIgnoredAnnotation.java
+++ b/java-checks-test-sources/src/main/files/non-compiling/checks/unused/UnusedPrivateFieldCheckWithIgnoredAnnotation.java
@@ -1,0 +1,10 @@
+package checks.unused;
+
+import javax.inject.Inject;
+
+class UnusedPrivateFieldCheckWithIgnoredAnnotation {
+
+  @Inject
+  private int unusedField; // Noncompliant [[sc=15;ec=26]] {{Remove this unused "unusedField" private field.}}
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/unused/UnusedPrivateFieldCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/unused/UnusedPrivateFieldCheckTest.java
@@ -61,4 +61,14 @@ class UnusedPrivateFieldCheckTest {
       .withQuickFixes()
       .verifyIssues();
   }
+
+  @Test
+  void test_ignored_annotation() {
+    UnusedPrivateFieldCheck check = new UnusedPrivateFieldCheck();
+    check.ignoreAnnotations = "javax.inject.Inject";
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/unused/UnusedPrivateFieldCheckWithIgnoredAnnotation.java"))
+      .withCheck(check)
+      .verifyIssues();
+  }
 }


### PR DESCRIPTION
Parameter `ignoreAnnotations` (default value "") can contain a list of annotation names (example: "javax.inject.Inject,jakarta.inject.Inject") which would be ignored by Analyzer. In other words, annotations are listed in `ignoreAnnotations` have no impact on analysis process. In other case they cause false-negative result of rule evaluation

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
