### PR TITLE
Sample of code reproducing a crash in the division by zero check

### DIFF
--- a/java-checks-test-sources/src/main/java/symbolicexecution/checks/MethodInvocationLeadingToDivisionByZero.java
+++ b/java-checks-test-sources/src/main/java/symbolicexecution/checks/MethodInvocationLeadingToDivisionByZero.java
@@ -66,6 +66,22 @@ class MethodInvocationLeadingToDivisionByZero {
     divByZeroIfZero(0); // Noncompliant {{A division by zero will occur when invoking method "divByZeroIfZero()".}}
   }
 
+  String foo8(Integer v) {
+    String x = "";
+    x += switch(v) { // Compliant - no division by zero but this shouldn't cause the check to crash
+      case 0, 5, 12 -> "x";
+      case 1 -> "a";
+      case 2 -> {
+        StringBuilder sb = new StringBuilder("abc");
+        sb.append("<br>");
+        yield sb.toString();
+      }
+      default -> "y";
+    };
+
+    return x;
+  }
+
   static int divByZeroIfZero(int i) {
     if (i == 0) {
       return 7 / i; // Noncompliant {{Make sure "i" can't be zero before doing this division.}}


### PR DESCRIPTION
This PR is a code sample causing the division by zero check to fail.
Follow up of the discussion started here: https://community.sonarsource.com/t/divisionbyzerocheck-error-with-and-switch-expression/82974

Maybe this comment in `ExplodedGraphWalker` gives a clue to the problem?
[      // FIXME this logic do not work with patterns from JDK17, as we need to consume the pattern adequately.
](https://github.com/SonarSource/sonar-java/blob/ef0fb9d219e24e8b158611657076eee5ec7aa936/java-symbolic-execution/src/main/java/org/sonar/java/se/ExplodedGraphWalker.java#L533)

Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
