### PR TITLE
SONARJAVA-4726 Reproducer and proposed fix for a crash in SelfAssignementCheck

### DIFF
--- a/java-checks-test-sources/src/main/java/checks/SelfAssignementCheck.java
+++ b/java-checks-test-sources/src/main/java/checks/SelfAssignementCheck.java
@@ -1,6 +1,12 @@
 package checks;
 
 class SelfAssignementCheck {
+  static int staticField = 0;
+  
+  static {
+    staticField = staticField;  // Noncompliant
+  }
+  
   int a, c = 0;
   int[] b = {0};
 

--- a/java-checks/src/main/java/org/sonar/java/checks/SelfAssignementCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SelfAssignementCheck.java
@@ -90,7 +90,7 @@ public class SelfAssignementCheck extends IssuableSubscriptionVisitor {
     MethodTree methodParent = (MethodTree) ExpressionUtils.getParentOfType(tree, Tree.Kind.METHOD, Tree.Kind.CONSTRUCTOR);
     String name = getName(tree.variable());
 
-    boolean isMethodParameter = methodParent.parameters().stream()
+    boolean isMethodParameter = methodParent != null && methodParent.parameters().stream()
       .map(p -> p.simpleName().name())
       .anyMatch(p -> p.equals(name));
 


### PR DESCRIPTION
A self assignement in a static block causes the check to fail with this error:

```
java.lang.NullPointerException: Cannot invoke "org.sonar.plugins.java.api.tree.MethodTree.parameters()" because "methodParent" is null
        at org.sonar.java.checks.SelfAssignementCheck.getQuickFix(SelfAssignementCheck.java:93)
        at org.sonar.java.checks.SelfAssignementCheck.lambda$visitNode$0(SelfAssignementCheck.java:81)
        at org.sonar.java.reporting.InternalJavaIssueBuilder.lambda$withQuickFix$0(InternalJavaIssueBuilder.java:176)
        at org.sonar.java.reporting.InternalJavaIssueBuilder.lambda$handleQuickFixes$2(InternalJavaIssueBuilder.java:247)
```

Please ensure your pull request adheres to the following guidelines: 

- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
