### PR TITLE
Make CognitiveComplexityMethodCheck more flexible

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/CognitiveComplexityMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CognitiveComplexityMethodCheck.java
@@ -31,18 +31,21 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S3776")
-public class CognitiveComplexityMethodCheck  extends IssuableSubscriptionVisitor {
+public class CognitiveComplexityMethodCheck extends IssuableSubscriptionVisitor {
 
   private static final int DEFAULT_MAX = 15;
 
   @RuleProperty(
-          key = "Threshold",
-          description = "The maximum authorized complexity.",
-          defaultValue = "" + DEFAULT_MAX)
+    key = "Threshold",
+    description = "The maximum authorized complexity.",
+    defaultValue = "" + DEFAULT_MAX)
   private int max = DEFAULT_MAX;
 
-	@RuleProperty(key = "Ignored Method names", description = "Ignored Method names, separated by ';'", defaultValue = "")
-	private String ignoredMethods = "";
+  @RuleProperty(
+    key = "Ignored Method names",
+    description = "Ignored Method names, separated by ';'",
+    defaultValue = "")
+  private String ignoredMethods = "";
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -67,17 +70,15 @@ public class CognitiveComplexityMethodCheck  extends IssuableSubscriptionVisitor
     this.max = max;
   }
 
-	public void setIgnoredMethods(String ignoredMethods) {
-		this.ignoredMethods = ignoredMethods;
-	}
+  public void setIgnoredMethods(String ignoredMethods) {
+    this.ignoredMethods = ignoredMethods;
+  }
 
-	private boolean isExcluded(MethodTree methodTree) {
-		return MethodTreeUtils.isEqualsMethod(methodTree)
-				||
-				MethodTreeUtils.isHashCodeMethod(methodTree)
-				||
-				Arrays.stream(ignoredMethods.split(";"))
-						.map(ignoredMethodName -> MethodTreeUtils.isNamed(methodTree, ignoredMethodName))
-						.reduce(Boolean.FALSE, (base, acc) -> base || acc);
+  private boolean isExcluded(MethodTree methodTree) {
+    return MethodTreeUtils.isEqualsMethod(methodTree) ||
+      MethodTreeUtils.isHashCodeMethod(methodTree) ||
+      Arrays.stream(ignoredMethods.split(";"))
+        .map(ignoredMethodName -> MethodTreeUtils.isNamed(methodTree, ignoredMethodName))
+        .reduce(Boolean.FALSE, (base, acc) -> base || acc);
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/MethodTreeUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/MethodTreeUtils.java
@@ -23,7 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+
 import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
 import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.ModifiersUtils;
@@ -80,8 +83,8 @@ public final class MethodTreeUtils {
     return isPublic(m) && !isStatic(m) && hasHashCodeSignature;
   }
 
-  private static boolean isNamed(MethodTree m, String name) {
-    return name.equals(m.simpleName().name());
+	public static boolean isNamed(MethodTree m, String name) {
+		return StringUtils.isNotBlank(name) && name.equals(m.simpleName().name());
   }
 
   private static boolean isStatic(MethodTree m) {

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/MethodTreeUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/MethodTreeUtils.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
@@ -83,8 +82,8 @@ public final class MethodTreeUtils {
     return isPublic(m) && !isStatic(m) && hasHashCodeSignature;
   }
 
-	public static boolean isNamed(MethodTree m, String name) {
-		return StringUtils.isNotBlank(name) && name.equals(m.simpleName().name());
+  public static boolean isNamed(MethodTree m, String name) {
+    return StringUtils.isNotBlank(name) && name.equals(m.simpleName().name());
   }
 
   private static boolean isStatic(MethodTree m) {
@@ -131,14 +130,12 @@ public final class MethodTreeUtils {
 
   public static Optional<MethodInvocationTree> subsequentMethodInvocation(Tree tree, MethodMatchers methodMatchers) {
     return consecutiveMethodInvocation(tree)
-      .map(consecutiveMethod ->
-        methodMatchers.matches(consecutiveMethod) ?
-          consecutiveMethod : subsequentMethodInvocation(consecutiveMethod, methodMatchers).orElse(null));
+      .map(consecutiveMethod -> methodMatchers.matches(consecutiveMethod) ? consecutiveMethod : subsequentMethodInvocation(consecutiveMethod, methodMatchers).orElse(null));
   }
 
   @VisibleForTesting
   static boolean hasKind(@Nullable Tree tree, Tree.Kind kind) {
-    return tree != null &&  tree.kind() == kind;
+    return tree != null && tree.kind() == kind;
   }
 
   public static class MethodInvocationCollector extends BaseTreeVisitor {

--- a/java-checks/src/test/files/checks/CognitiveComplexityMethodCheckMax0.java
+++ b/java-checks/src/test/files/checks/CognitiveComplexityMethodCheckMax0.java
@@ -330,5 +330,38 @@ class CognitiveComplexityCheck {
     }
     return 42;
   }
+
+  String getIgnoredWeight(int i){
+    if (i <=0) {
+      return "no weight";
+    }
+    if (i < 10) {
+      return "light";
+    }
+    if (i < 20) {
+      return "medium";
+    }
+    if (i < 30) {
+      return "heavy";
+    }
+    return "very heavy";
+  }
+
+  void noNestingForIfElseIfIgnored() {
+    while (true) {
+      if (true) {
+        for (;;) {
+          if (true) {
+          } else if (true) {
+          } else {
+            if (true) {
+            }
+          }
+
+          if (true) {}
+        }
+      }
+    }
+  }
 }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/CognitiveComplexityMethodCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CognitiveComplexityMethodCheckTest.java
@@ -29,6 +29,7 @@ class CognitiveComplexityMethodCheckTest {
 
     CognitiveComplexityMethodCheck check = new CognitiveComplexityMethodCheck();
     check.setMax(0);
+	check.setIgnoredMethods("getIgnoredWeight;noNestingForIfElseIfIgnored");
     CheckVerifier.newVerifier()
       .onFile("src/test/files/checks/CognitiveComplexityMethodCheckMax0.java")
       .withCheck(check)

--- a/java-checks/src/test/java/org/sonar/java/checks/CognitiveComplexityMethodCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CognitiveComplexityMethodCheckTest.java
@@ -29,7 +29,7 @@ class CognitiveComplexityMethodCheckTest {
 
     CognitiveComplexityMethodCheck check = new CognitiveComplexityMethodCheck();
     check.setMax(0);
-	check.setIgnoredMethods("getIgnoredWeight;noNestingForIfElseIfIgnored");
+    check.setIgnoredMethods("getIgnoredWeight;noNestingForIfElseIfIgnored");
     CheckVerifier.newVerifier()
       .onFile("src/test/files/checks/CognitiveComplexityMethodCheckMax0.java")
       .withCheck(check)


### PR DESCRIPTION
- Add configuration for CognitiveComplexityMethodCheck to make ignored methods configurable (in addition to equals and hashCode)
- Add testcases
- Make MethodTreeUtils#isNamed public for use in CognitiveComplexityMethodCheck
