### PR TITLE
Add .mailmap file to sort out contributors with multiple emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,160 @@
+Adam Gabryś <adam.gabrys@live.com>
+Adam Lehenbauer <adam.lehenbauer@gmail.com>
+Alban Auzeill <alban.auzeill@sonarsource.com>
+Alexandre Gigleux <gigleux_alexandre@yahoo.fr>
+Alexandre Gigleux <gigleux_alexandre@yahoo.fr> <alexandre.gigleux@gmail.com>
+Alix Lourme <alix.lourme@gmail.com>
+Amélie Renard <amelie.renard@sonarsource.com>
+Amélie Renard <amelie.renard@sonarsource.com> <44666826+amelie-renard-sonarsource@users.noreply.github.com>
+Andrea Guarino <andrea.guarino@sonarsource.com>
+Andrea Guarino <andrea.guarino@sonarsource.com> <38876543+andrea-guarino-sonarsource@users.noreply.github.com>
+Andreas Keefer <xtermi2@users.noreply.github.com>
+Andrei Epure <andrei.epure@sonarsource.com>
+Andrei Epure <andrei.epure@sonarsource.com> <38876598+andrei-epure-sonarsource@users.noreply.github.com>
+Antoine de Troostembergh <antoine.de.troostembergh@gmail.com>
+Anton Rybochkin <anton.rybochkin@axibase.com>
+Anurag870 <f2005870@gmail.com>
+Arnaud Brunet <arnaud.brunet@gmail.com>
+B1nj0y <idegorepl@gmail.com>
+Benjamin <github@binarycoded.com>
+Charles Andre Outin <charlesandre.outin@gmail.com> coutin <charlesandre.outin@gmail.com>
+Chris Gavin <chris@chrisgavin.me>
+Chrislain Razafimahefa <chrislain.razafimahefa@sonarsource.com>
+Chrislain Razafimahefa <chrislain.razafimahefa@sonarsource.com> <102787590+chrislain-razafimahefa-sonarsource@users.noreply.github.com>
+Christophe Zürn <christophe.zurn@sonarsource.com>
+Christophe Zürn <christophe.zurn@sonarsource.com> <36889251+christophe-zurn-sonarsource@users.noreply.github.com>
+David Gageot <david@gageot.net>
+David Pursehouse <dpursehouse@collab.net>
+David Racodon <david.racodon@gmail.com>
+David Rautureau <david.rautureau@sonarsource.com>
+Dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Didier Besset <didier.besset@sonarsource.com>
+Dinesh Bolkensteyn <dinesh.bolkensteyn@sonarsource.com>
+Dinesh Bolkensteyn <dinesh.bolkensteyn@sonarsource.com> <dinesh@dinsoft.net>
+Dominik Adamiak <dominik.adamiak@pega.com>
+Dorian Burihabwa <dorian.burihabwa@sonarsource.com>
+Dorian Burihabwa <dorian.burihabwa@sonarsource.com> <75226315+dorian-burihabwa-sonarsource@users.noreply.github.com>
+Duarte Meneses <duarte.meneses@sonarsource.com>
+Elena Vilchik <elena.vilchik@sonarsource.com>
+Elena Vilchik <elena.vilchik@sonarsource.com> <vilchik.elena@gmail.com>
+Enrique S. Filiage <filiagees@gmail.com>
+Eric Hartmann <hartmann.eric@gmail.com>
+Eric Hirlemann <eric.hirlemann@sonarsource>
+Eugene <echipachenko@gmail.com>
+Evgeny Mandrikov <mandrikov@gmail.com>
+Evgeny Mandrikov <mandrikov@gmail.com> <138671+Godin@users.noreply.github.com>
+Evgeny Mandrikov <mandrikov@gmail.com> <Godin@users.noreply.github.com>
+Fabrice Bellingard <fabrice.bellingard@sonarsource.com>
+Fernando Garcia <fergarrui@gmail.com>
+Freddy Mallet <freddy.mallet@gmail.com>
+Freddy Mallet <freddy.mallet@gmail.com> <freddy.mallet@sonarsource.com>
+Freddy Mallet <freddy.mallet@gmail.com> <fréddy.mallet@Gmail.com>
+G. Ann Campbell <ann.campbell@sonarsource.com>
+G. Ann Campbell <ann.campbell@sonarsource.com> <ganncamp@gmail.com>
+Grégoire Aubert <gregoire.aubert@sonarsource.com>
+Guillaume Dequenne <guillaume.dequenne@sonarsource.com>
+Guillaume Toison <86775455+gtoison@users.noreply.github.com>
+Gwelican-laptop <superfly@gwelican.eu>
+Harold Shinsato <harold.shinsato@tdameritrade.com>
+Irina Batinic <irina.batinic@sonarsource.com>
+Irina Batinic <irina.batinic@sonarsource.com> <117161143+irina-batinic-sonarsource@users.noreply.github.com>
+JMeterTea <33323555+jmetertea@users.noreply.github.com>
+Janos Gyerik <janos.gyerik@sonarsource.com>
+Janos Gyerik <janos.gyerik@sonarsource.com> <janos-ss@users.noreply.github.com>
+Janos Gyerik <janos.gyerik@sonarsource.com> <janos.gyerik@gmail.com>
+Jean-Baptiste Giraudeau <jb@giraudeau.info>
+Jean-Baptiste Lièvremont <jb.lievremont@gmail.com>
+Jeanne <nyjeanne@gmail.com>
+Jens Bannmann <jens.b@web.de>
+Jens Bannmann <jens.b@web.de> <bannmann+work_and_private@gmail.com>
+Johan <johnnei07@live.nl>
+Johann Beleites <johann.beleites@sonarsource.com>
+Johann Beleites <johann.beleites@sonarsource.com> <63855942+johann-beleites-sonarsource@users.noreply.github.com>
+Johnnei <johnnei07@live.nl>
+JoseLion <joseluis5000l@gmail.com>
+Julien Boucher <31621097+juboucher@users.noreply.github.com>
+Julien Carsique <julien.carsique@sonarsource.com>
+Julien Henry <julien.henry@sonarsource.com>
+Julien Henry <julien.henry@sonarsource.com> <henryju@yahoo.fr>
+Julien Herr <julien@herr.fr>
+Julien Herr <julien@herr.fr> <julien.herr@alcatel-lucent.com>
+Julien Lancelot <julien.lancelot@sonarsource.com>
+Julien Lancelot <julien.lancelot@sonarsource.com> <julien.lancelot@gmail.com>
+Kevin Ji <kevin.ji@outlook.com>
+Korbinian Würl <korbinianwuerl@googlemail.com>
+Krzysztof Kocel <Krzysztof.Kocel@vimn.com>
+Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
+Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl> <krzysztof.suszynski@coi.gov.pl>
+Larry Diamond <1066589+larrydiamond@users.noreply.github.com>
+Laszlo Hathazy <hathazy.laszlo@gmail.com>
+Leonardo Pilastri <leonardo.pilastri@sonarsource.com>
+Leonardo Pilastri <leonardo.pilastri@sonarsource.com> <115481625+leonardo-pilastri-sonarsource@users.noreply.github.com>
+Linda Martin <linda.martin@sonarsource.com>
+Lior Samuni <lsamuni@vmware.com>
+Luc Bonade <luc.bonade@maif.fr>
+Malena Ebert <63863184+malena-ebert-sonarsource@users.noreply.github.com>
+Marco Kaufmann <marco.kaufmann@sonarsource.com>
+Marco Kaufmann <marco.kaufmann@sonarsource.com> <83189575+kaufco@users.noreply.github.com>
+Margarita Nedzelska <margarita.nedzelska@sonarsource.com>
+Margarita Nedzelska <margarita.nedzelska@sonarsource.com> <70522623+margarita-nedzelska-sonarsource@users.noreply.github.com>
+Massimo Paladin <massimo.paladin@gmail.com>
+Mathias Åhsberg <mathias.ahsberg@gmail.com>
+Matti Pöllä <mpo@iki.fi>
+Michael Clarke <michael.m.clarke@gmail.com>
+Michael Gumowski <michael.gumowski@sonarsource.com>
+Michael Gumowski <michael.gumowski@sonarsource.com> <gumowski.michael@gmail.com>
+Michael Keppler <bananeweizen@gmx.de>
+Michael Keppler <bananeweizen@gmx.de> <michael.keppler@gmx.de>
+Michel Pawlak <michel.pawlak@gmail.com>
+Miguel Angel Jimenez <miguel.jimenez@aurea.com>
+Mike Birnstiehl <michael.birnstiehl@sonarsource.com>
+MishaDemianenko <mikhaylo.demianenko@neotechnology.com>
+Nat Luengnaruemitchai <natl@set.or.th>
+Nathan Osborn <nathan@mkosborn.plus.com>
+Nicolas Peru <nicolas.peru@sonarsource.com>
+Nicolas Peru <nicolas.peru@sonarsource.com> <nicolas.peru@gmail.com>
+Nito Moreno <nito@chainalysis.com>
+Odilon Alves Oliveira <odilontalk@gmail.com>
+Olcbean <olcbean@yahoo.com>
+Olcbean <olcbean@yahoo.com> <26058559+olcbean@users.noreply.github.com>
+Olivier Gaudin <gaudol@gmail.com>
+Orimarko <orimarko@gmail.com>
+Patrick M.J. Roth <patrick.mj.roth@bluewin.ch>
+Pierre-Yves Nicolas <pierre-yves.nicolas@sonarsource.com>
+Quentin Jaquier <quentin.jaquier@sonarsource.com>
+Quentin Jaquier <quentin.jaquier@sonarsource.com> <43733433+quentin-jaquier-sonarsource@users.noreply.github.com>
+RE-team-bot <release.engineers@sonarsource.com>
+René Wolfert <ne-tje@gmx.net>
+Rodrigo Carvalho Silva <rcsilva83@gmail.com>
+Samuel Mercier <samuel.mercier@sonarsource.com>
+Sebastian Hungerecker <sebastian.hungerecker@sonarsource.com>
+Sebastian Hungerecker <sebastian.hungerecker@sonarsource.com> <63844301+sebastian-hungerecker-sonarsource@users.noreply.github.com>
+Simon Brandhof <simon.brandhof@sonarsource.com>
+Simon Brandhof <simon.brandhof@sonarsource.com> <simon.brandhof@gmail.com>
+Simon Legner <Simon.Legner@gmail.com>
+Simon Schrottner <simon.schrottner@gmail.com>
+Simon Schrottner <simon.schrottner@gmail.com> <s.schrottner@netconomy.net>
+Slawomir Jaranowski <slawomir.jaranowski@payu.pl>
+Snyk Bot <snyk-bot@snyk.io>
+Sonartech <sonartech@sonarsource.com>
+Stas Vilchik <vilchiks@gmail.com>
+Steven Sheehy <steven.sheehy@hedera.com>
+Stylianos Agapiou <stylianos.agapiou@sonarsource.com>
+Stylianos Agapiou <stylianos.agapiou@sonarsource.com> <36889190+stylianos-agapiou-sonarsource@users.noreply.github.com>
+Sylvain Kuchen <sylvain.kuchen@sonarsource.com>
+Sylvain Laurent <slaurent@pictet.com>
+Sébastien Lesaint <sns-seb@users.noreply.github.com>
+Thomas Turrell-Croft <tom@berrycloud.co.uk>
+Thomas Vérin <thomas.verin@sonarsource.com>
+Thomas Vérin <thomas.verin@sonarsource.com> <thomas.verin@steria.ch>
+Thomas Vérin <thomas.verin@sonarsource.com> <thomas@verin.pro>
+Tibor Blenessy <tibor.blenessy@sonarsource.com>
+Tibor Blenessy <tibor.blenessy@sonarsource.com> <blenessy@gmail.com>
+Tibor Blenessy <tibor.blenessy@sonarsource.com> <saberduck@users.noreply.github.com>
+Tobias Gruetzmacher <tobias.gruetzmacher@inform-software.com>
+Vincenzo Laudizio <vincenzo.laudizio@gmail.com> troosan <vincenzo.laudizio@gmail.com>
+Will May <will.j.may@gmail.com>
+Wouter Admiraal <45544358+wouter-admiraal-sonarsource@users.noreply.github.com>
+Xu Huisheng <xyz20003@gmail.com>
+Yassin Kammoun <52890329+yassin-kammoun-sonarsource@users.noreply.github.com>
+Yves Dubois-Pèlerin <ivandalbosco@users.noreply.github.com>


### PR DESCRIPTION
Set up a `.mailmap` document to clean up the contributor list using various emails when committing (including internal developers from Sonar).

You can compare the differences in results when executing the following command line, before and after the commit.
```
git shortlog -sne
```