### PR TITLE
[BUILD-2836] Update parent version to 67.0.0.241 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>66.0.234</version>
+    <version>67.0.0.241</version>
   </parent>
 
   <groupId>org.sonarsource.java</groupId>


### PR DESCRIPTION
# BUILD-2836 Update parent version

## Changes
* Update parent version to `67.0.0.241` in pom.xml
   That way the code uses the last published parent-oss version

## Why is this change of format for the version?
The project `parent-oss` now follows the standardized pattern used across the SonarSource organization for versioning: `x.x.x.buildnumber`.