### PR TITLE
[BUILD-2903] Update parent version to 68.0.0.247 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>67.0.0.241</version>
+    <version>68.0.0.247</version>
   </parent>
 
   <groupId>org.sonarsource.java</groupId>


### PR DESCRIPTION
# BUILD-2903 Update parent version

## Changes
* Update parent version to `68.0.0.247` in pom.xml
   That way the code uses the last published parent-oss version

## Why is this change of format for the version?
The project `parent-oss` use Jacoco 0.8.10 and this project renamed the license to `Eclipse Public License 2.0` which was not part of the license whitelist variants: `epl_v2|Eclipse Public License - v 2.0|Eclipse Public License`