### PR TITLE
SONARJAVA-4420 Fix exception due to stack pollution

### DIFF
--- a/java-checks-test-sources/src/main/java/symbolicexecution/checks/ConditionAlwaysTrueOrFalseNoExceptionOnBranchingStatementsLogicalAndOrTestCase.java
+++ b/java-checks-test-sources/src/main/java/symbolicexecution/checks/ConditionAlwaysTrueOrFalseNoExceptionOnBranchingStatementsLogicalAndOrTestCase.java
@@ -1,0 +1,52 @@
+package symbolicexecution.checks;
+
+public abstract class ConditionAlwaysTrueOrFalseNoExceptionOnBranchingStatementsLogicalAndOrTestCase {
+  boolean aBoolean;
+  final void foo() {}
+
+  final void if_and() {
+    while (true) {
+      if (false && aBoolean) // Noncompliant
+        foo();
+
+      foo();
+    }
+  }
+
+  final void if_or() {
+    while (true) {
+      if (true || aBoolean) // Noncompliant
+        foo();
+
+      foo();
+    }
+  }
+
+  final void while_and() {
+    while (true) {
+      while (false && aBoolean) // Noncompliant
+        foo();
+
+      foo();
+    }
+  }
+
+  final void for_and() {
+    while (true) {
+      for (; false && aBoolean ; ) // Noncompliant
+        foo();
+
+      foo();
+    }
+  }
+
+  final void do_and() {
+    while (true) {
+      do {
+        foo();
+      } while (false && false); // Noncompliant
+
+      foo();
+    }
+  }
+}

--- a/java-symbolic-execution/src/test/java/org/sonar/java/se/checks/ConditionAlwaysTrueOrFalseCheckTest.java
+++ b/java-symbolic-execution/src/test/java/org/sonar/java/se/checks/ConditionAlwaysTrueOrFalseCheckTest.java
@@ -127,6 +127,16 @@ class ConditionAlwaysTrueOrFalseCheckTest {
   }
 
   @Test
+  void ensure_branching_statements_dont_cause_exception() {
+    // Checks flow iterating through the correct parent
+    SECheckVerifier.newVerifier()
+      .onFile(testSourcesPath("symbolicexecution/checks/ConditionAlwaysTrueOrFalseNoExceptionOnBranchingStatementsLogicalAndOrTestCase.java"))
+      .withChecks(new ConditionalUnreachableCodeCheck(), new BooleanGratuitousExpressionsCheck())
+      .withClassPath(SETestUtils.CLASS_PATH)
+      .verifyIssues();
+  }
+
+  @Test
   void test_transitivity() {
     SECheckVerifier.newVerifier()
       .onFile(testSourcesPath("symbolicexecution/checks/Transitivity.java"))


### PR DESCRIPTION
Previously, we regularly nuked the stack. Since 82ee22d49f959284e72470110998c507129ce948 we don't do this anymore and instead try to handle the stack in a bit more coordinated manner. However, for logical AND and OR operations, this exposed some stack pollution. This commit works around a prior hack to avoid this stack pollution.
