### PR TITLE
mg/SONARJAVA-4506

### DIFF
--- a/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/NoSonar.html
+++ b/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/NoSonar.html
@@ -1,3 +1,4 @@
+<h2>Why is this an issue?</h2>
 <p>Any issue to quality rule can be deactivated with the <code>NOSONAR</code> marker. This marker is pretty useful to exclude false-positive results
 but it can also be used abusively to hide real quality flaws.</p>
 <p>This rule raises an issue when <code>NOSONAR</code> is used.</p>


### PR DESCRIPTION
Because the rule has a non-numeric key, it is not automatically updated by rule-api. In order to update the rule, you must first generate the rule metadata and then overwrite the data to have it in the file that matches the non-numeric key.

    java -jar ../rule-api-....jar generate -rule S1291
    mv java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1291.html java-checks/src/main/resources/org/sonar/l10n/java/rules/java/NoSonar.html
    mv java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1291.json java-checks/src/main/resources/org/sonar/l10n/java/rules/java/NoSonar.json
