### PR TITLE
SONARJAVA-4445 Upgrade sonarlint-plugin-api to version 8.18

### DIFF
--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/InternalSensorContext.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/InternalSensorContext.java
@@ -126,6 +126,11 @@ public class InternalSensorContext extends InternalMockedSonarAPI implements Sen
   }
 
   @Override
+  public void markAsUnchanged(InputFile inputFile) {
+    throw notSupportedException("markAsUnchanged(InputFile)");
+  }
+
+  @Override
   public WriteCache nextCache() {
     return null;
   }

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalSensorContextTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalSensorContextTest.java
@@ -53,6 +53,14 @@ class InternalSensorContextTest {
     assertThat(context.project()).isNotNull();
     assertThat(context.project().isFile()).isFalse();
     assertThat(context.project().key()).isEqualTo("project");
+    assertThat(context.isCacheEnabled()).isFalse();
+    assertThat(context.previousCache()).isNull();
+    assertThat(context.nextCache()).isNull();
+  }
+
+  @Test
+  void methods_not_supported() {
+    SensorContext context = new InternalSensorContext();
 
     assertMethodNotSupported(() -> context.activeRules(), "InternalSensorContext::activeRules()");
     assertMethodNotSupported(() -> context.addContextProperty(null, null), "InternalSensorContext::addContextProperty(String,String)");
@@ -68,6 +76,7 @@ class InternalSensorContextTest {
     assertMethodNotSupported(() -> context.newSignificantCode(), "InternalSensorContext::newSignificantCode()");
     assertMethodNotSupported(() -> context.newSymbolTable(), "InternalSensorContext::newSymbolTable()");
     assertMethodNotSupported(() -> context.settings(), "InternalSensorContext::settings()");
+    assertMethodNotSupported(() -> context.markAsUnchanged(null), "InternalSensorContext::markAsUnchanged(InputFile)");
   }
 
   @Test

--- a/java-frontend/src/main/java/org/sonar/java/reporting/InternalJavaIssueBuilder.java
+++ b/java-frontend/src/main/java/org/sonar/java/reporting/InternalJavaIssueBuilder.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.java.reporting;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,6 +30,8 @@ import javax.annotation.Nullable;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.sensor.issue.NewIssue;
+import org.sonar.api.batch.sensor.issue.fix.NewInputFileEdit;
+import org.sonar.api.batch.sensor.issue.fix.NewQuickFix;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -39,9 +40,6 @@ import org.sonar.java.SonarComponents;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonarsource.sonarlint.plugin.api.issue.NewInputFileEdit;
-import org.sonarsource.sonarlint.plugin.api.issue.NewQuickFix;
-import org.sonarsource.sonarlint.plugin.api.issue.NewSonarLintIssue;
 
 public class InternalJavaIssueBuilder implements JavaIssueBuilderExtended {
 
@@ -250,13 +248,13 @@ public class InternalJavaIssueBuilder implements JavaIssueBuilderExtended {
       return;
     }
     if (isQuickFixCompatible) {
-      addQuickFixes(inputFile, ruleKey, flatQuickFixes, (NewSonarLintIssue) newIssue);
+      addQuickFixes(inputFile, ruleKey, flatQuickFixes, newIssue);
     } else {
       newIssue.setQuickFixAvailable(true);
     }
   }
 
-  private static void addQuickFixes(InputFile inputFile, RuleKey ruleKey, Iterable<JavaQuickFix> quickFixes, NewSonarLintIssue sonarLintIssue) {
+  private static void addQuickFixes(InputFile inputFile, RuleKey ruleKey, Iterable<JavaQuickFix> quickFixes, NewIssue sonarLintIssue) {
     try {
       for (JavaQuickFix quickFix : quickFixes) {
         NewQuickFix newQuickFix = sonarLintIssue.newQuickFix()

--- a/java-frontend/src/main/java/org/sonar/java/reporting/JavaQuickFix.java
+++ b/java-frontend/src/main/java/org/sonar/java/reporting/JavaQuickFix.java
@@ -42,7 +42,7 @@ public class JavaQuickFix {
   }
 
   /**
-   * See {@link org.sonarsource.sonarlint.plugin.api.issue.NewQuickFix#message(String) } for guidelines on format of the description.
+   * See {@link org.sonar.api.batch.sensor.issue.fix.NewQuickFix#message(String) } for guidelines on format of the description.
    *
    * @param description a description for this quick fix
    * @return the builder for this quick fix
@@ -52,7 +52,7 @@ public class JavaQuickFix {
   }
 
   /**
-   * See {@link org.sonarsource.sonarlint.plugin.api.issue.NewQuickFix#message(String) } for guidelines on format of the description.
+   * See {@link org.sonar.api.batch.sensor.issue.fix.NewQuickFix#message(String) } for guidelines on format of the description.
    *
    * @param description a description for this quick fix, following the {@link String#format(String, Object...)} formatting
    * @param args the arguments for the description

--- a/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
@@ -87,8 +87,14 @@ import static org.mockito.Mockito.when;
 @EnableRuleMigrationSupport
 class JavaFrontendTest {
 
-  public static final SonarRuntime SONARLINT_RUNTIME = SonarRuntimeImpl.forSonarLint(Version.create(6, 7));
-  public static final SonarRuntime SONARQUBE_RUNTIME = SonarRuntimeImpl.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
+
+  // sonarlint.plugin.api.version
+  public static final Version LATEST_SONARLINT_API_VERSION = Version.create(8, 18);
+  public static final SonarRuntime SONARLINT_RUNTIME = SonarRuntimeImpl.forSonarLint(LATEST_SONARLINT_API_VERSION);
+
+  //
+  private static final Version LATESTS_SONAR_API_VERSION = Version.create(8, 13);
+  public static final SonarRuntime SONARQUBE_RUNTIME = SonarRuntimeImpl.forSonarQube(LATESTS_SONAR_API_VERSION, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -86,7 +86,7 @@ import org.sonar.java.reporting.AnalyzerMessage;
 import org.sonar.plugins.java.api.CheckRegistrar;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JspCodeVisitor;
-import org.sonarsource.sonarlint.core.container.global.SonarLintRuntimeImpl;
+import org.sonarsource.sonarlint.core.plugin.commons.sonarapi.SonarLintRuntimeImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
     <sonar.version>9.5.0.56709</sonar.version>
-    <sonar.plugin.api.version>9.8.0.203</sonar.plugin.api.version>
-    <sonarlint.plugin.api.version>6.3.0.36253</sonarlint.plugin.api.version>
+    <sonar.plugin.api.version>9.13.0.360</sonar.plugin.api.version>
+    <sonarlint.plugin.api.version>8.18.0.70939</sonarlint.plugin.api.version>
     <analyzer.commons.version>2.5.0.1358</analyzer.commons.version>
     <orchestrator.version>3.40.0.183</orchestrator.version>
     <sslr.version>1.24.0.633</sslr.version>


### PR DESCRIPTION
Upgraded sonarlint-plugin-api to version 8.18 and sonar-plugin-api to version 9.13 in lockstep to facilitate the migration of the quickfixes API from sonarlint-plugin-apo to the common sonar-plugin-api.