### PR TITLE
Update eclipse dependencies

### DIFF
--- a/jdt/pom.xml
+++ b/jdt/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.eclipse.jdt</groupId>
         <artifactId>org.eclipse.jdt.core</artifactId>
-        <version>3.33.0</version>
+        <version>3.34.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.platform</groupId>
@@ -39,27 +39,27 @@
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.18.200</version>
+        <version>3.19.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.26.100</version>
+        <version>3.27.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.jobs</artifactId>
-        <version>3.13.300</version>
+        <version>3.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.8.200</version>
+        <version>3.9.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.text</artifactId>
-        <version>3.12.300</version>
+        <version>3.9.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
Update the `org.sonarsource.java:jdt org.eclipse.jdt:org.eclipse.jdt.core` and `org.eclipse.platform:*` dependencies.

I submit this PR for two reasons:
1. It's generally a good idea to keep dependencies up to date
2. The dependencies currently used by this project have pom's with `<modelVersion>4.0</modelVersion>` which causes problems with Gradle. The updated dependencies have pom's this that issue, using `<modelVersion>4.0.0</modelVersion>` . This problem was originally reported at https://github.com/eclipse-platform/eclipse.platform/issues/180

- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
