### PR TITLE
Revert SONARJAVA-4559 faulty implementation

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
+++ b/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
@@ -95,11 +95,6 @@ public class SonarComponents {
    * Setting it to true or false, forces the behavior from the analyzer independently of the server.
    */
   public static final String SONAR_CAN_SKIP_UNCHANGED_FILES_KEY = "sonar.java.skipUnchanged";
-  /**
-   * When logging jproblems reported by the ECJ parser, messages should be prefixed with the related filename.
-   * When this filename is missing, this constant should be used instead.
-   */
-  private static final String JPROBLEM_WITHOUT_FILENAME = "No file specified";
 
   private static final Version SONARLINT_6_3 = Version.parse("6.3");
   private static final Version SONARQUBE_9_2 = Version.parse("9.2");
@@ -110,7 +105,7 @@ public class SonarComponents {
 
   private final ClasspathForMain javaClasspath;
   private final ClasspathForTest javaTestClasspath;
-  private final Map<String, Set<JProblem>> undefinedTypes = new HashMap<>();
+  private final Set<JProblem> undefinedTypes = new HashSet<>();
 
   private final CheckFactory checkFactory;
   @Nullable
@@ -500,57 +495,44 @@ public class SonarComponents {
   }
 
   public void collectUndefinedTypes(Set<JProblem> undefinedTypes) {
-    collectUndefinedTypes(JPROBLEM_WITHOUT_FILENAME, undefinedTypes);
-  }
-
-  public void collectUndefinedTypes(String filename, Set<JProblem> jProblems) {
-    this.undefinedTypes.computeIfAbsent(filename, key -> new HashSet<>())
-      .addAll(jProblems);
+    this.undefinedTypes.addAll(undefinedTypes);
   }
 
   public void logUndefinedTypes() {
-    if (undefinedTypes.isEmpty()) {
-      return;
-    }
-    javaClasspath.logSuspiciousEmptyLibraries();
-    if (!isAutoScan()) {
-      // In autoscan, test + main code are analyzed in the same batch, and we do not make the distinction between
-      // test and main libraries, everything is inside "sonar.java.libraries", it is expected to let the test property empty.
-      javaTestClasspath.logSuspiciousEmptyLibraries();
-    }
-    logUndefinedTypes(LOGGED_MAX_NUMBER_UNDEFINED_TYPES);
+    if (!undefinedTypes.isEmpty()) {
+      javaClasspath.logSuspiciousEmptyLibraries();
+      if (!isAutoScan()) {
+        // In autoscan, test + main code are analyzed in the same batch, and we do not make the distinction between
+        // test and main libraries, everything is inside "sonar.java.libraries", it is expected to let the test property empty.
+        javaTestClasspath.logSuspiciousEmptyLibraries();
+      }
+      logUndefinedTypes(LOGGED_MAX_NUMBER_UNDEFINED_TYPES);
 
-    // clear the set so only new undefined types will be logged
-    undefinedTypes.clear();
+      // clear the set so only new undefined types will be logged
+      undefinedTypes.clear();
+    }
   }
 
   private void logUndefinedTypes(int maxLines) {
-    HashSet<JProblem> allProblems = undefinedTypes.values().stream()
-      .collect(HashSet::new, Set::addAll, Set::addAll);
-    for (String filename: undefinedTypes.keySet()) {
-      logParserMessages(
-        filename,
-        allProblems.stream()
-          .filter(m -> m.type() == JProblem.Type.UNDEFINED_TYPE),
-        maxLines,
-        "Unresolved imports/types have been detected during analysis. Enable DEBUG mode to see them.",
-        "Unresolved imports/types:"
-      );
-      logParserMessages(
-        filename,
-        allProblems.stream()
-          .filter(m -> m.type() == JProblem.Type.PREVIEW_FEATURE_USED),
-        maxLines,
-        "Use of preview features have been detected during analysis. Enable DEBUG mode to see them.",
-        "Use of preview features:"
-      );
-    }
+    logParserMessages(
+      undefinedTypes.stream()
+        .filter(m -> m.type() == JProblem.Type.UNDEFINED_TYPE),
+      maxLines,
+      "Unresolved imports/types have been detected during analysis. Enable DEBUG mode to see them.",
+      "Unresolved imports/types:"
+    );
+    logParserMessages(
+      undefinedTypes.stream()
+        .filter(m -> m.type() == JProblem.Type.PREVIEW_FEATURE_USED),
+      maxLines,
+      "Use of preview features have been detected during analysis. Enable DEBUG mode to see them.",
+      "Use of preview features:"
+    );
   }
 
-  private static void logParserMessages(String filename, Stream<JProblem> messages, int maxLines, String warningMessage, String debugMessage) {
+  private static void logParserMessages(Stream<JProblem> messages, int maxLines, String warningMessage, String debugMessage) {
     final List<String> messagesList = messages
       .map(Object::toString)
-      .map(message -> filename + " - " + message)
       .sorted()
       .collect(Collectors.toList());
     int messagesListSize = messagesList.size();
@@ -579,5 +561,4 @@ public class SonarComponents {
   public SensorContext context() {
     return context;
   }
-
 }

--- a/java-frontend/src/main/java/org/sonar/java/ast/JavaAstScanner.java
+++ b/java-frontend/src/main/java/org/sonar/java/ast/JavaAstScanner.java
@@ -130,7 +130,7 @@ public class JavaAstScanner {
     try {
       JavaTree.CompilationUnitTreeImpl ast = result.get();
       visitor.visitFile(ast, sonarComponents != null && sonarComponents.fileCanBeSkipped(inputFile));
-      collectUndefinedTypes(inputFile.filename(), ast.sema.undefinedTypes());
+      collectUndefinedTypes(ast.sema.undefinedTypes());
       cleanUp.accept(ast);
     } catch (RecognitionException e) {
       checkInterrupted(e);
@@ -154,9 +154,9 @@ public class JavaAstScanner {
     ast.sema.getEnvironmentCleaner().run();
   }
 
-  private void collectUndefinedTypes(String filename, Set<JProblem> undefinedTypes) {
+  private void collectUndefinedTypes(Set<JProblem> undefinedTypes) {
     if (sonarComponents != null) {
-      sonarComponents.collectUndefinedTypes(filename, undefinedTypes);
+      sonarComponents.collectUndefinedTypes(undefinedTypes);
     }
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
@@ -623,10 +623,8 @@ class JavaFrontendTest {
     assertTrue(logTester.logs(Level.WARN).stream().noneMatch(l -> l.endsWith("Unresolved imports/types have been detected during analysis. Enable DEBUG mode to see them.")));
     assertTrue(logTester.logs(Level.WARN).stream().anyMatch(l -> l.endsWith("Use of preview features have been detected during analysis. Enable DEBUG mode to see them.")));
     // We should keep this message or we won't have anything actionable in the debug logs to understand the warning
-    assertThat(logTester.logs(Level.DEBUG).stream())
-      .hasSize(1)
-      .map(l -> l.replace("\r\n", "\n"))
-      .allMatch(l -> l.startsWith("Use of preview features:\n") && l.endsWith("- The Java feature 'Sealed Types' is only available with source level 17 and above"));
+    assertTrue(logTester.logs(Level.DEBUG).stream().anyMatch(l -> l.replace("\r\n", "\n").endsWith("Use of preview features:\n" +
+      "- The Java feature 'Sealed Types' is only available with source level 17 and above")));
     assertThat(mainCodeIssueScannerAndFilter.scanFileInvocationCount).isEqualTo(1);
     assertThat(testCodeIssueScannerAndFilter.scanFileInvocationCount).isZero();
   }

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -884,30 +884,6 @@ class SonarComponentsTest {
     }
 
     @Test
-    void filename_is_prepended_to_undefined_types_logs() {
-      String source = generateSource(26);
-      String filename = "org/sonarsource/package/MyFile.java";
-      sonarComponents.collectUndefinedTypes(
-        filename,
-        ((JavaTree.CompilationUnitTreeImpl) JParserTestUtils.parse(source)).sema.undefinedTypes()
-      );
-      sonarComponents.logUndefinedTypes();
-
-      assertThat(logTester.logs(Level.WARN)).containsExactly("Unresolved imports/types have been detected during analysis. Enable DEBUG mode to see them.");
-
-      List<String> debugLogs = logTester.logs(Level.DEBUG);
-      assertThat(debugLogs).hasSize(1);
-
-      List<String> debugLines = Arrays.stream(debugLogs.get(0).split("\\n"))
-        .skip(1)
-        .filter(line -> !"- ...".equals(line))
-        .collect(Collectors.toList());
-      assertThat(debugLines)
-        .hasSize(50)
-        .allMatch(line -> line.startsWith("- org/sonarsource/package/MyFile.java - "));
-    }
-
-    @Test
     void log_only_50_undefined_types() {
       String source = generateSource(26);
 


### PR DESCRIPTION
The current implementation does not provide the best approach to log common issues between files and currently only logs the filename instead of the full path.

This reverts commit d165c98dcb4db03c450ca1ffcf416e00853f29ea.