### PR TITLE
SONARJAVA-4664 Disable deployment of java-check-test-sources artifacts

### DIFF
--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -951,12 +951,13 @@
           <argLine>--enable-preview</argLine>
         </configuration>
       </plugin>
-      <!--
-      We don't want to publish any artifacts from this module in artifactory or maven central.
-      Unfortunately, "org.jfrog.buildinfo : artifactory-maven-plugin" only supports maven.deploy.skip=true at the project level
-      and not in a submodule. If the bellow plugins are disabled (<phase>none</phase>), it's a workaround to
-      not generate ".jar" "-sources.jar" and "-javadoc.jar".
-      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.simplify4u.plugins</groupId>
         <artifactId>sign-maven-plugin</artifactId>

--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -18,6 +18,7 @@
     <sonar.skip>true</sonar.skip>
     <forbiddenapis.skip>true</forbiddenapis.skip>
     <skipTests>true</skipTests>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <!--
@@ -949,13 +950,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>--enable-preview</argLine>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,14 @@
     <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
   </properties>
 
+  <distributionManagement>
+    <repository>
+      <id>local-folder</id>
+      <name>Local folder to test deployment configuration</name>
+      <url>file:./local-deployment</url>
+    </repository>
+  </distributionManagement>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Can be tested by adding a local repository to the top-level pom and running `mvn clean deploy`.

An example of a local repository in your pom.xml
```xml
<distributionManagement>
    <repository>
        <id>local-folder</id>
        <name>Local folder to test deployment configuration</name>
        <url>file:./local-deployment</url>
    </repository>
</distributionManagement>
```