### PR TITLE
SONARJAVA-4598 - FP on S2259 when CollectionUtils and MapUtils are used from commons3

### DIFF
--- a/java-checks-test-sources/default/src/main/java/symbolicexecution/behaviorcache/CollectionUtilsIsEmpty.java
+++ b/java-checks-test-sources/default/src/main/java/symbolicexecution/behaviorcache/CollectionUtilsIsEmpty.java
@@ -5,13 +5,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections4.ListUtils;
 
 class CollectionUtilsIsEmpty {
   void fun() {
     List<Object> objects = null;
-    if (CollectionUtils.isEmpty(objects)) { // returns true if objects is null
+    if (org.apache.commons.collections.CollectionUtils.isEmpty(objects)) { // returns true if objects is null
       doSomething();
     } else if (objects.size() == 1) {
       doSomethingElse();
@@ -35,7 +33,7 @@ class CollectionUtilsIsEmpty {
   }
   void fun4() {
     List<Object> objects = null;
-    if (CollectionUtils.isNotEmpty(objects)) { // returns false if objects is null
+    if (org.apache.commons.collections.CollectionUtils.isNotEmpty(objects)) { // returns false if objects is null
       objects.size();
     } else {
       doSomethingElse();
@@ -47,6 +45,15 @@ class CollectionUtilsIsEmpty {
       map.clear();
     }
     if (org.apache.commons.collections4.MapUtils.isNotEmpty(map)) { // returns false if objects is null
+      map.clear();
+    }
+  }
+
+  void test_map_commons3(@Nullable Map<String, String> map) {
+    if (!org.apache.commons.collections.MapUtils.isEmpty(map)) { // returns true if objects is null
+      map.clear();
+    }
+    if (org.apache.commons.collections.MapUtils.isNotEmpty(map)) { // returns false if objects is null
       map.clear();
     }
   }
@@ -64,16 +71,16 @@ class CollectionUtilsIsEmpty {
   }
 
   void test_list(@Nullable List<String> list, List<String> defaultValue) {
-    List<String> listA = ListUtils.defaultIfNull(new ArrayList<>(), null);
+    List<String> listA = org.apache.commons.collections4.ListUtils.defaultIfNull(new ArrayList<>(), null);
     listA.clear();
 
-    List<String> listB = ListUtils.defaultIfNull(null, new ArrayList<>());
+    List<String> listB = org.apache.commons.collections4.ListUtils.defaultIfNull(null, new ArrayList<>());
     listB.clear();
 
-    List<String> listC = ListUtils.defaultIfNull(null, null);
+    List<String> listC = org.apache.commons.collections4.ListUtils.defaultIfNull(null, null);
     // listC is null and usage would raise S2259
 
-    List<String> listD = ListUtils.defaultIfNull(list, defaultValue);
+    List<String> listD = org.apache.commons.collections4.ListUtils.defaultIfNull(list, defaultValue);
     listD.clear();
   }
 

--- a/java-symbolic-execution/src/main/resources/org/sonar/java/se/xproc/org.apache.commons.collections.json
+++ b/java-symbolic-execution/src/main/resources/org/sonar/java/se/xproc/org.apache.commons.collections.json
@@ -1,32 +1,5 @@
 [
   {
-    "signature": "org.apache.commons.collections.MapUtils#size(Ljava/util/Map;)I",
-    "varArgs": false,
-    "declaredExceptions": [],
-    "yields": [
-      {
-        "parametersConstraints": [
-          [
-            "NULL"
-          ]
-        ],
-        "resultIndex": -1,
-        "resultConstraint": [
-          "ZERO"
-        ]
-      },
-      {
-        "parametersConstraints": [
-          [
-            "NOT_NULL"
-          ]
-        ],
-        "resultIndex": -1,
-        "resultConstraint": null
-      }
-    ]
-  },
-  {
     "signature": "org.apache.commons.collections4.MapUtils#size(Ljava/util/Map;)I",
     "varArgs": false,
     "declaredExceptions": [],

--- a/java-symbolic-execution/src/main/resources/org/sonar/java/se/xproc/org.apache.commons.collections.json
+++ b/java-symbolic-execution/src/main/resources/org/sonar/java/se/xproc/org.apache.commons.collections.json
@@ -1,5 +1,32 @@
 [
   {
+    "signature": "org.apache.commons.collections.MapUtils#size(Ljava/util/Map;)I",
+    "varArgs": false,
+    "declaredExceptions": [],
+    "yields": [
+      {
+        "parametersConstraints": [
+          [
+            "NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "ZERO"
+        ]
+      },
+      {
+        "parametersConstraints": [
+          [
+            "NOT_NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": null
+      }
+    ]
+  },
+  {
     "signature": "org.apache.commons.collections4.MapUtils#size(Ljava/util/Map;)I",
     "varArgs": false,
     "declaredExceptions": [],
@@ -28,6 +55,33 @@
   },
   {
     "signature": "org.apache.commons.collections4.IteratorUtils#size(Ljava/util/Iterator;)I",
+    "varArgs": false,
+    "declaredExceptions": [],
+    "yields": [
+      {
+        "parametersConstraints": [
+          [
+            "NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "ZERO"
+        ]
+      },
+      {
+        "parametersConstraints": [
+          [
+            "NOT_NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": null
+      }
+    ]
+  },
+  {
+    "signature": "org.apache.commons.collections.CollectionUtils#size(Ljava/lang/Object;)I",
     "varArgs": false,
     "declaredExceptions": [],
     "yields": [
@@ -135,6 +189,35 @@
     ]
   },
   {
+    "signature": "org.apache.commons.collections.CollectionUtils#isNotEmpty(Ljava/util/Collection;)Z",
+    "varArgs": false,
+    "declaredExceptions": [],
+    "yields": [
+      {
+        "parametersConstraints": [
+          [
+            "NOT_NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "TRUE",
+          "NOT_NULL"
+        ]
+      },
+      {
+        "parametersConstraints": [
+          []
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "FALSE",
+          "NOT_NULL"
+        ]
+      }
+    ]
+  },
+  {
     "signature": "org.apache.commons.collections4.CollectionUtils#isNotEmpty(Ljava/util/Collection;)Z",
     "varArgs": false,
     "declaredExceptions": [],
@@ -189,6 +272,35 @@
     ]
   },
   {
+    "signature": "org.apache.commons.collections.MapUtils#isEmpty(Ljava/util/Map;)Z",
+    "varArgs": false,
+    "declaredExceptions": [],
+    "yields": [
+      {
+        "parametersConstraints": [
+          []
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "TRUE",
+          "NOT_NULL"
+        ]
+      },
+      {
+        "parametersConstraints": [
+          [
+            "NOT_NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "FALSE",
+          "NOT_NULL"
+        ]
+      }
+    ]
+  },
+  {
     "signature": "org.apache.commons.collections4.MapUtils#isEmpty(Ljava/util/Map;)Z",
     "varArgs": false,
     "declaredExceptions": [],
@@ -206,6 +318,35 @@
       {
         "parametersConstraints": [
           ["NOT_NULL"]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "FALSE",
+          "NOT_NULL"
+        ]
+      }
+    ]
+  },
+  {
+    "signature": "org.apache.commons.collections.MapUtils#isNotEmpty(Ljava/util/Map;)Z",
+    "varArgs": false,
+    "declaredExceptions": [],
+    "yields": [
+      {
+        "parametersConstraints": [
+          [
+            "NOT_NULL"
+          ]
+        ],
+        "resultIndex": -1,
+        "resultConstraint": [
+          "TRUE",
+          "NOT_NULL"
+        ]
+      },
+      {
+        "parametersConstraints": [
+          []
         ],
         "resultIndex": -1,
         "resultConstraint": [

--- a/java-symbolic-execution/src/test/java/org/sonar/java/se/xproc/BehaviorCacheTest.java
+++ b/java-symbolic-execution/src/test/java/org/sonar/java/se/xproc/BehaviorCacheTest.java
@@ -198,8 +198,8 @@ class BehaviorCacheTest {
     }
 
     assertThat(behaviorCache.behaviors).isEmpty();
-    assertThat(behaviorCache.hardcodedBehaviors()).hasSize(235);
-    assertThat(logTester.logs(Level.DEBUG)).containsOnly("[SE] Loaded 235 hardcoded method behaviors.");
+    assertThat(behaviorCache.hardcodedBehaviors()).hasSize(238);
+    assertThat(logTester.logs(Level.DEBUG)).containsOnly("[SE] Loaded 238 hardcoded method behaviors.");
   }
 
   @Test


### PR DESCRIPTION
[Issue link](https://sonarsource.atlassian.net/browse/SONARJAVA-4598)

Append missing behaviors in org.apache.commons.collections.json

org.apache.commons.collections.MapUtils#size(Ljava/util/Map;)I 
org.apache.commons.collections.CollectionUtils#size(Ljava/lang/Object;)I org.apache.commons.collections.CollectionUtils#isNotEmpty(Ljava/util/Collection;)Z org.apache.commons.collections.MapUtils#isEmpty(Ljava/util/Map;)Z org.apache.commons.collections.MapUtils#isNotEmpty(Ljava/util/Map;)Z

Please ensure your pull request adheres to the following guidelines: 

- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [X] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [X] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
