### PR TITLE
BUILD-4131 Use GitHub token from Vault instead of sonartech api token

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -20,7 +20,6 @@ jobs:
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper
-      contents: write # required to grant GITHUB_TOKEN writing permission
     steps:
     - name: get secrets
       id: secrets
@@ -28,9 +27,10 @@ jobs:
       with:
         secrets: |
           development/kv/data/slack webhook | SLACK_WEBHOOK;
+          development/github/token/{REPO_OWNER_NAME_DASH}-dogfood-merge token | dogfood_token;
     - name: git octopus step
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).dogfood_token }}
       id: dogfood
       uses: SonarSource/gh-action_dogfood_merge@v1
       with:


### PR DESCRIPTION
# BUILD-4131 Use GitHub token from Vault instead of GitHub

## Changes
* Retrieve Github token from Hashicorp Vault instead of the one stored in Github secrets
  That way it no longer depends on a technical user account and can be rotated easily

## Depends on
* https://github.com/SonarSource/re-terraform-aws-vault/pull/823

## Checks
Please ensure your pull request adheres to the following guidelines: 

- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Unit tests are passing and you provided a unit test for your fix
- [x] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [x] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
