### PR TITLE
BUILD-4131 Use GitHub token from Vault instead of Github stored token

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -20,7 +20,6 @@ jobs:
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper
-      contents: write # required to grant GITHUB_TOKEN writing permission
     steps:
     - name: get secrets
       id: secrets
@@ -28,9 +27,10 @@ jobs:
       with:
         secrets: |
           development/kv/data/slack webhook | SLACK_WEBHOOK;
+          development/github/token/{REPO_OWNER_NAME_DASH}-dogfood-merge token | dogfood_token;
     - name: git octopus step
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).dogfood_token }}
       id: dogfood
       uses: SonarSource/gh-action_dogfood_merge@v1
       with:


### PR DESCRIPTION
# BUILD-4131 Use GitHub token from Vault instead of Github stored token

## Changes
* Use GitHub token from Vault instead of Github stored token
  That way it can be rotated in an easier manner


## Checks

- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Unit tests are passing and you provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
- [ ] If there is a [Jira](http://jira.sonarsource.com/browse/SONARJAVA) ticket available, please make your commits and pull request start with the ticket number (SONARJAVA-XXXX)
