### PR TITLE
[NO JIRA] Improve CI performance, split compile, test and analysis

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,8 +63,10 @@ build_task:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   build_script:
     - source cirrus-env BUILD
-    - regular_mvn_build_deploy_analyze -Dsonar.analysisCache.enabled=true
-    - ./check-license-compliance.sh
+    - which set_maven_build_version
+    - false
+    #- regular_mvn_build_deploy_analyze -Dsonar.analysisCache.enabled=true
+    #- ./check-license-compliance.sh
   cleanup_before_cache_script: cleanup_maven_repository
 
 ws_scan_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,7 @@ win_vm_definition: &WINDOWS_VM_DEFINITION
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")
 
-build_task:
+common_build_definition: &COMMON_BUILD_DEFINITION
   eks_container:
     <<: *CONTAINER_DEFINITION
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j19-latest
@@ -61,17 +61,23 @@ build_task:
     DEPLOY_PULL_REQUEST: true
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
+
+build_compile_task:
+  <<: *COMMON_BUILD_DEFINITION
   build_script:
     - source cirrus-env BUILD
-    - which set_maven_build_version
-    - false
-    #- regular_mvn_build_deploy_analyze -Dsonar.analysisCache.enabled=true
-    #- ./check-license-compliance.sh
+    - regular_mvn_build_deploy_analyze -Dmaven.test.skip=true -Dsonar.skip=true
+  cleanup_before_cache_script: cleanup_maven_repository
+
+build_test_analyze_task:
+  <<: *COMMON_BUILD_DEFINITION
+  build_script:
+    - source cirrus-env BUILD
+    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true
+    - ./check-license-compliance.sh
   cleanup_before_cache_script: cleanup_maven_repository
 
 ws_scan_task:
-  depends_on:
-    - build
   <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
@@ -86,7 +92,7 @@ ws_scan_task:
   whitesource_script:
     - source cirrus-env QA
     - source set_maven_build_version $BUILD_NUMBER
-    - mvn clean install -DskipTests -pl '!java-checks-test-sources,!java-checks-test-sources/default,!java-checks-test-sources/aws'
+    - mvn clean install -Dmaven.test.skip=true -pl '!java-checks-test-sources,!java-checks-test-sources/default,!java-checks-test-sources/aws'
     - source ws_scan.sh
   allow_failures: "true"
   always:
@@ -94,8 +100,6 @@ ws_scan_task:
       path: "whitesource/**/*"
 
 qa_os_win_task:
-  depends_on:
-    - build
   <<: *WINDOWS_VM_DEFINITION
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
@@ -106,7 +110,7 @@ qa_os_win_task:
 
 plugin_qa_task:
   depends_on:
-    - build
+    - build_compile
   <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
@@ -133,7 +137,7 @@ plugin_qa_task:
 
 sanity_task:
   depends_on:
-    - build
+    - build_compile
   <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
@@ -151,7 +155,7 @@ sanity_task:
 
 ruling_task:
   depends_on:
-    - build
+    - build_compile
   <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
@@ -179,7 +183,7 @@ ruling_task:
 
 ruling_win_task:
   depends_on:
-    - build
+    - build_compile
   <<: *ONLY_SONARSOURCE_QA
   <<: *WINDOWS_VM_DEFINITION
   maven_cache:
@@ -200,7 +204,7 @@ ruling_win_task:
 
 autoscan_task:
   depends_on:
-    - build
+    - build_compile
   <<: *ONLY_SONARSOURCE_QA
   eks_container:
     <<: *CONTAINER_DEFINITION
@@ -222,6 +226,8 @@ autoscan_task:
 
 promote_task:
   depends_on:
+    - build_compile
+    - build_test_analyze
     - qa_os_win
     - sanity
     - ruling


### PR DESCRIPTION
The goal is to experiment with a new build method that separates the build from the tests and analysis. This will allow us to start the integration tests just after the build and not wait for the analysis to be completed.