### PR TITLE
[NO JIRA] Fix not consistent maven module names

### DIFF
--- a/java-checks-test-sources/aws/pom.xml
+++ b/java-checks-test-sources/aws/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>aws</artifactId>
 
-  <name>SonarQube Java :: AWS Checks Test Sources</name>
+  <name>SonarQube Java :: Checks Test Sources :: AWS</name>
 
   <properties>
     <sonar.skip>true</sonar.skip>

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -12,7 +12,7 @@
 
   <artifactId>default</artifactId>
 
-  <name>SonarQube Java :: Default Checks Test Sources</name>
+  <name>SonarQube Java :: Checks Test Sources :: Default</name>
 
   <properties>
     <sonar.skip>true</sonar.skip>

--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -13,7 +13,7 @@
   <artifactId>java-checks-test-sources</artifactId>
   <packaging>pom</packaging>
 
-  <name>SonarQube Java :: Test Sources</name>
+  <name>SonarQube Java :: Checks Test Sources :: Parent Pom</name>
 
   <modules>
     <module>aws</module>

--- a/java-checks-test-sources/test-classpath-reader/pom.xml
+++ b/java-checks-test-sources/test-classpath-reader/pom.xml
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>test-classpath-reader</artifactId>
+  <name>SonarQube Java :: Checks Test Sources :: Test Classpath Reader</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
From
```
[INFO] SonarQube Java :: Test Sources ..................... SUCCESS [  0.006 s]
[INFO] SonarQube Java :: AWS Checks Test Sources .......... SUCCESS [  0.010 s]
[INFO] SonarQube Java :: Default Checks Test Sources ...... SUCCESS [  0.449 s]
[INFO] test-classpath-reader ............ SUCCESS [  0.009 s]
```
To
```
[INFO] SonarQube Java :: Checks Test Sources :: Parent Pom SUCCESS [  0.004 s]
[INFO] SonarQube Java :: Checks Test Sources :: AWS ....... SUCCESS [  0.004 s]
[INFO] SonarQube Java :: Checks Test Sources :: Default ... SUCCESS [  0.005 s]
[INFO] SonarQube Java :: Checks Test Sources :: Test Classpath Reader SUCCESS [  0.005 s]
 ```