### PR TITLE
SONARJAVA-4685 Remove FP on invocation of non-bean methods

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/DirectBeanMethodInvocationWithoutProxyCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/DirectBeanMethodInvocationWithoutProxyCheckSample.java
@@ -103,6 +103,18 @@ public class DirectBeanMethodInvocationWithoutProxyCheckSample {
     }
   }
 
+  @Configuration(proxyBeanMethods = false)
+  static class InvokeNonBeanMethod {
+    public SimpleBean simpleBean() {
+      return new SimpleBean();
+    }
+
+    @Bean
+    public CompositeBean compositeBean() {
+      return new CompositeBean(simpleBean()); // Compliant, call to a method that is not a bean
+    }
+  }
+
 
   static class SimpleBean {
     // ...

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/DirectBeanMethodInvocationWithoutProxyCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/DirectBeanMethodInvocationWithoutProxyCheck.java
@@ -60,7 +60,7 @@ public class DirectBeanMethodInvocationWithoutProxyCheck extends IssuableSubscri
 
   private static Optional<AnnotationTree> getConfigurationAnnotation(ClassTree tree) {
     return tree.modifiers().annotations().stream()
-      .filter(annotationInstance -> annotationInstance.symbolType().is(CONFIGURATION_ANNOTATION))
+      .filter(annotation -> annotation.symbolType().is(CONFIGURATION_ANNOTATION))
       .findFirst();
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/DirectBeanMethodInvocationWithoutProxyCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/DirectBeanMethodInvocationWithoutProxyCheck.java
@@ -38,6 +38,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S6838")
 public class DirectBeanMethodInvocationWithoutProxyCheck extends IssuableSubscriptionVisitor {
+  private static final String BEAN_ANNOTATION = "org.springframework.context.annotation.Bean";
   private static final String CONFIGURATION_ANNOTATION = "org.springframework.context.annotation.Configuration";
   private static final String SCOPE_ANNOTATION = "org.springframework.context.annotation.Scope";
 
@@ -88,13 +89,18 @@ public class DirectBeanMethodInvocationWithoutProxyCheck extends IssuableSubscri
     public void visitMethodInvocation(MethodInvocationTree tree) {
       super.visitMethodInvocation(tree);
       MethodTree declaration = tree.methodSymbol().declaration();
-      if (declaration == null || hasPrototypeScope(declaration)) {
+      if (declaration == null || !isBeanMethod(declaration) || hasPrototypeScope(declaration)) {
         return;
       }
       Tree parent = declaration.parent();
       if (parent == parentClass) {
         locations.add(tree);
       }
+    }
+
+    private static boolean isBeanMethod(MethodTree tree) {
+      return tree.modifiers().annotations().stream()
+        .anyMatch(annotation -> annotation.symbolType().is(BEAN_ANNOTATION));
     }
 
     /*


### PR DESCRIPTION
Issues should only be raise when the method would be proxied if `proxyBeanMethods` was set to `true`. While this is the case for `@Bean` annotated methods, it is not the case for other methods.