### PR TITLE
java-custom-rules-example should only be downloaded when there are Ja…

### DIFF
--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -86,6 +86,7 @@
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
           <requirePlugins>java:${project.version}</requirePlugins>
+          <requiredForLanguages>java</requiredForLanguages>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Update the java-custom-rules-example to illustrate the use of the <requiredForLanguages> property introduced with SonarQube 10.4

With this property, the custom plugin is only downloaded from the server when there are files matching the language of the plugin: Java files. It's a mandatory property to benefit from this enhancement globally at the server level. Without it, if there are Java files in the project to scan and this property is not set, the server will crash saying that there is a plugin not compatible. This is due to the fact that the custom Java plugins have a strong dependency on the parent analyzer (SonarJava) providing the APIs. 