### PR TITLE
BUILD-4576 node instance type update

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ container_definition: &CONTAINER_DEFINITION
         - key: node.kubernetes.io/instance-type
           operator: In
           values:
-            - m4.4xlarge # 2.4 GHz Intel Xeon E5-2676 v3** Processor, 16 vCPU, 64 GiB Memory
+            - m6a.8xlarge # 3.6 GHz 3rd generation AMD EPYC processors (AMD EPYC 7R13), 18 vCPU, 64 GiB Memory
 
 win_vm_definition: &WINDOWS_VM_DEFINITION
   experimental: true # see https://github.com/cirruslabs/cirrus-ci-docs/issues/1051


### PR DESCRIPTION
There is an infrastructure change on CirrusCI EKS cluster: we are about to replace all the various node instance types with unique `m6a.8xlarge`.
This PR updates the reference. An alternative would be to remove the nodeSelectorTerms. If another instance type is required, this will require additional work on the cluster node groups.

See https://github.com/SonarSource/cirrus-ci-infra/pull/114
To be merged after deployment to prod: https://github.com/SonarSource/cirrus-ci-infra/actions/runs/8007883775/job/21873413072