### PR TITLE
Reduce rule S6912 scope

### DIFF
--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S6912.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S6912.json
@@ -1,5 +1,0 @@
-{
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java": [
-852
-]
-}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S6912.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S6912.json
@@ -1,5 +1,0 @@
-{
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/JDBCSessionDataStore.java": [
-852
-]
-}


### PR DESCRIPTION
Reduce the rule scope to raise issues only on Statements executed in the loop body directly, i.e. not enclosed in other instructions.

