### PR TITLE
SONARJAVA-4829: Fix FP in S2694 on local classes

### DIFF
--- a/its/ruling/src/test/resources/guava/java-S2694.json
+++ b/its/ruling/src/test/resources/guava/java-S2694.json
@@ -2,4 +2,7 @@
 "com.google.guava:guava:src/com/google/common/cache/LocalCache.java": [
 4449
 ],
+"com.google.guava:guava:src/com/google/common/reflect/Types.java": [
+137
+]
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/InnerStaticClassesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InnerStaticClassesCheck.java
@@ -52,9 +52,6 @@ public class InnerStaticClassesCheck extends BaseTreeVisitor implements JavaFile
 
   @Override
   public void visitClass(ClassTree tree) {
-    if (!tree.is(Tree.Kind.CLASS)) {
-      return;
-    }
     Symbol.TypeSymbol symbol = tree.symbol();
     outerClasses.push(symbol);
     atLeastOneReference.push(Boolean.FALSE);
@@ -72,7 +69,7 @@ public class InnerStaticClassesCheck extends BaseTreeVisitor implements JavaFile
       }
       String message = "Make this a \"static\" inner class.";
       if(symbol.owner().isMethodSymbol()) {
-        message = "Make this local class a \"static\" inner class.";
+        message = "Extract this local class into a \"static\" inner class.";
       }
       context.reportIssue(this, reportTree, message);
     }

--- a/java-checks/src/test/files/checks/InnerStaticClassesCheckSample.java
+++ b/java-checks/src/test/files/checks/InnerStaticClassesCheckSample.java
@@ -89,7 +89,7 @@ class Fruit {
   }
 
   public void noncompliant() {
-    class Seed implements Interface { // Noncompliant {{Make this local class a "static" inner class.}}
+    class Seed implements Interface { // Noncompliant {{Extract this local class into a "static" inner class.}}
       public void foo() {
         return;
       }
@@ -222,3 +222,59 @@ class Other {
   static class Generic<X> {}
 }
 
+class Foo2 {
+  private String string;
+
+  public Foo2() {
+    class Bar { // Noncompliant {{Extract this local class into a "static" inner class.}}
+    }
+  }
+
+  public void method() {
+    class Baz { // Noncompliant {{Extract this local class into a "static" inner class.}}
+    }
+  }
+
+  record InnerFoo2Record() { // Compliant
+  }
+
+  enum InnerEnum { // Compliant
+    A, B, C;
+  }
+
+  @interface InnerAnnotation { // Compliant
+  }
+}
+
+record FooRecord() {
+  public FooRecord() {
+    class InnerBar { // Noncompliant {{Extract this local class into a "static" inner class.}}
+    }
+  }
+
+  public void method() {
+    class InnerBaz { // Noncompliant {{Extract this local class into a "static" inner class.}}
+    }
+  }
+
+  class InnerFoo { // Noncompliant
+  }
+
+  record InnerFooRecord() { // Compliant
+  }
+
+  enum InnerEnum { // Compliant
+    A, B, C;
+  }
+
+  @interface InnerAnnotation { // Compliant
+  }
+}
+
+@interface FooAnnotation {
+  class InnerFoo { // Compliant
+  }
+
+  record InnerFooRecord() { // Compliant
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/InnerStaticClassesCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/InnerStaticClassesCheckTest.java
@@ -27,7 +27,7 @@ class InnerStaticClassesCheckTest {
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile("src/test/files/checks/InnerStaticClassesCheck.java")
+      .onFile("src/test/files/checks/InnerStaticClassesCheckSample.java")
       .withCheck(new InnerStaticClassesCheck())
       .verifyIssues();
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2694.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2694.html
@@ -13,8 +13,8 @@ class and a nested one:</p>
 <h2>How to fix it</h2>
 <p>There are two scenarios in which this rule will raise an issue:</p>
 <ol>
-  <li> On a <code>inner class</code>: make it <code>static</code>. </li>
-  <li> On a <code>local class</code>: extract it as a <code>static</code> <em>inner class</em>. </li>
+  <li> On an <em>inner class</em>: make it <code>static</code>. </li>
+  <li> On a <em>local class</em>: extract it as a <code>static</code> <em>inner class</em>. </li>
 </ol>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2694.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2694.html
@@ -10,8 +10,16 @@ class and a nested one:</p>
   <li> an inner class can only be instantiated within the context of an instance of the outer class. </li>
   <li> a nested (<code>static</code>) class can be instantiated independently of the outer class. </li>
 </ul>
-<h3>Noncompliant code example</h3>
-<pre>
+<h2>How to fix it</h2>
+<p>There are two scenarios in which this rule will raise an issue:</p>
+<ol>
+  <li> On a <code>inner class</code>: make it <code>static</code>. </li>
+  <li> On a <code>local class</code>: extract it as a <code>static</code> <em>inner class</em>. </li>
+</ol>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<p>Inner classes that don’t use the outer class reference should be static.</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
 public class Fruit {
   // ...
 
@@ -26,8 +34,8 @@ public class Fruit {
   }
 }
 </pre>
-<h3>Compliant solution</h3>
-<pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
 public class Fruit {
   // ...
 
@@ -42,4 +50,62 @@ public class Fruit {
   }
 }
 </pre>
+<p>Local classes that don’t use the outer class reference should be extracted as a static inner classes.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+public class Foo {
+  public Foo() {
+    class Bar { // Noncompliant
+      void doSomething() {
+        // ...
+      }
+    }
+    new Bar().doSomething();
+  }
+
+  public void method() {
+    class Baz { // Noncompliant
+      void doSomething() {
+        // ...
+      }
+    }
+    new Baz().doSomething();
+  }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+public class Foo {
+  public Foo() {
+    new Bar().doSomething();
+  }
+
+  public void method()  {
+    new Baz().doSomething();
+  }
+
+  private static class Bar { // Compliant
+    void doSomething() {
+      // ...
+    }
+  }
+
+  private static class Baz { // Compliant
+    void doSomething() {
+      // ...
+    }
+  }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li> <a href="https://docs.oracle.com/javase/tutorial/java/javaOO/nested.html">Oracle Java SE - Nested Classes</a> </li>
+  <li> <a href="https://docs.oracle.com/javase/tutorial/java/javaOO/localclasses.html">Oracle Java SE - Local Classes</a> </li>
+</ul>
+<h3>Articles &amp; blog posts</h3>
+<ul>
+  <li> <a href="https://www.geeksforgeeks.org/difference-between-static-and-non-static-nested-class-in-java/">GeeksforGeeks - Difference between
+  static and non-static nested class in Java</a> </li>
+</ul>
 


### PR DESCRIPTION
The changes are split into 2 commits:

1. the first commit has the fix that avoids reporting in the case of local classes
2. the second commit is a rework to improve the readability and understanding of the implementation logic. It separates the state of the rule, i.e. the logic that detects if a nested class references an outer class into a nested static class.