### PR TITLE
Prepare for next development iteration 7.33.0-SNAPSHOT

### DIFF
--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>docs</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/external-reports/pom.xml
+++ b/external-reports/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>external-reports</artifactId>

--- a/its/autoscan/pom.xml
+++ b/its/autoscan/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-its</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-java-autoscan</artifactId>

--- a/its/plugin/plugins/java-extension-plugin/pom.xml
+++ b/its/plugin/plugins/java-extension-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>it-java-plugin-plugins</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-extension-plugin</artifactId>

--- a/its/plugin/plugins/pom.xml
+++ b/its/plugin/plugins/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>it-java-plugin</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-java-plugin-plugins</artifactId>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-its</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-java-plugin</artifactId>

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>it-java-plugin</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-java-plugin-tests</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-its</artifactId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-its</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-java-ruling</artifactId>

--- a/java-checks-aws/pom.xml
+++ b/java-checks-aws/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-checks-aws</artifactId>

--- a/java-checks-common/pom.xml
+++ b/java-checks-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-checks-common</artifactId>

--- a/java-checks-test-sources/aws/pom.xml
+++ b/java-checks-test-sources/aws/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-checks-test-sources</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>aws</artifactId>

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-checks-test-sources</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>default</artifactId>

--- a/java-checks-test-sources/java-17/pom.xml
+++ b/java-checks-test-sources/java-17/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-checks-test-sources</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-17</artifactId>

--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-checks-test-sources</artifactId>

--- a/java-checks-test-sources/test-classpath-reader/pom.xml
+++ b/java-checks-test-sources/test-classpath-reader/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java-checks-test-sources</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-classpath-reader</artifactId>

--- a/java-checks-testkit/pom.xml
+++ b/java-checks-testkit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-checks-testkit</artifactId>

--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-checks</artifactId>

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-frontend</artifactId>

--- a/java-jsp/pom.xml
+++ b/java-jsp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-jsp</artifactId>

--- a/java-surefire/pom.xml
+++ b/java-surefire/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-surefire</artifactId>

--- a/java-symbolic-execution/pom.xml
+++ b/java-symbolic-execution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>java-symbolic-execution</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.java</groupId>
   <artifactId>java</artifactId>
-  <version>7.32.0-SNAPSHOT</version>
+  <version>7.33.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SonarJava</name>
   <description>Code Analyzer for Java</description>

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.java</groupId>
     <artifactId>java</artifactId>
-    <version>7.32.0-SNAPSHOT</version>
+    <version>7.33.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-java-plugin</artifactId>


### PR DESCRIPTION
Before the merge of the PR: On [NEXT (SonarJava)](https://next.sonarqube.com/sonarqube/dashboard?id=org.sonarsource.java%3Ajava), go to the [activity panel](https://next.sonarqube.com/sonarqube/project/activity?graph=coverage&id=org.sonarsource.java%3Ajava) and rename the latest version X.Y.Z-SNAPSHOT into the newly released version number 7.32.0.35531 (or ask a RE Team/IT ops to do it for you)