### PR TITLE
SONARJAVA-5098 Fix regexp that finds '\n'

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/PrintfMisuseCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PrintfMisuseCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
@@ -391,7 +392,8 @@ public class PrintfMisuseCheck extends AbstractPrintfChecker {
   }
 
   private void checkLineFeed(String formatString, MethodInvocationTree mit) {
-    if (formatString.contains("\\n")) {
+    Pattern pattern = Pattern.compile("(?<!\\\\)\\n", Pattern.CASE_INSENSITIVE);
+    if (pattern.matcher(formatString).find()) {
       reportIssue(mit, "%n should be used in place of \\n to produce the platform-specific line separator.");
     }
   }


### PR DESCRIPTION
* 'String#contains()` method finds '\\n' as a false-positive new line symbol. In several cases symbols, including 'n', may follow an escaped backslash to generate '\n' as a printed out string, e.g. LaTeX code generator.

- [ ] Unit tests are passing
- [ ] Provided a unit test for your fix
- [ ] ITs should pass : To run ITs locally, checkout the [README](https://github.com/SonarSource/sonar-java/blob/master/README.md) of the project.
