### PR TITLE
SONARJAVA-5173 Fix broken docs for SQ_10_6.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,6 +94,9 @@ test_analyze_task:
     - source cirrus-env BUILD
     # ignore duplications in the SE engine plugin, as it will be moved away from sonar-java at some point
     - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/**
+    - cd docs/java-custom-rules-example
+    - mvn clean package -f pom_SQ_10_6_LATEST.xml --batch-mode
+    - cd "${CIRRUS_WORKING_DIR}"
     - ./check-license-compliance.sh
   cleanup_before_cache_script: cleanup_maven_repository
 

--- a/docs/java-custom-rules-example/pom_SQ_10_6_LATEST.xml
+++ b/docs/java-custom-rules-example/pom_SQ_10_6_LATEST.xml
@@ -19,7 +19,8 @@
   <description>Java Custom Rules Example for SonarQube</description>
 
   <properties>
-    <sonar.plugin.api.version>9.14.0.375</sonar.plugin.api.version>
+    <!-- TODO: Next time bump it up to the LTS version. -->
+    <sonar.plugin.api.version>10.7.0.2191</sonar.plugin.api.version>
     <sonarjava.version>8.0.1.36337</sonarjava.version>
     <!-- Don't forget to update this version of JaCoCo -->
     <jacoco.version>0.8.10</jacoco.version>
@@ -64,6 +65,13 @@
       <groupId>org.sonarsource.java</groupId>
       <artifactId>java-checks-testkit</artifactId>
       <version>${sonarjava.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.sonarsource.api.plugin</groupId>
+      <artifactId>sonar-plugin-api-test-fixtures</artifactId>
+      <version>${sonar.plugin.api.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
[SONARJAVA-5173](https://sonarsource.atlassian.net/browse/SONARJAVA-5173)

We were not able to compile some tests, because
org.sonar.api.testfixtures.log.LogTester moved to
sonar-plugin-api-test-fixtures.

Tested with `mvn clean install -f pom_SQ_10_6_LATEST.xml`


[SONARJAVA-5173]: https://sonarsource.atlassian.net/browse/SONARJAVA-5173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ