### PR TITLE
SONARJAVA-5175 Remove subnet configuration from .cirrus.yml. This is provided by the cirrus-modules v3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,14 +37,12 @@ container_with_docker_definition: &CONTAINER_WITH_DOCKER_DEFINITION
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: t3.small
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
 
 win_vm_definition: &WINDOWS_VM_DEFINITION
   experimental: true # see https://github.com/cirruslabs/cirrus-ci-docs/issues/1051
   platform: windows
   region: eu-central-1
   type: c5.4xlarge # 3.6 GHz (3.9GHz single core) Intel Xeon Scalable Processor, 16 vCPU, 32 GiB Memory
-  subnet_id: ${CIRRUS_AWS_SUBNET}
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_TAG == "" && ($CIRRUS_PR != "" || $CIRRUS_BRANCH == "master" || $CIRRUS_BRANCH =~ "branch-.*" || $CIRRUS_BRANCH =~ "dogfood-on-.*")


### PR DESCRIPTION
[SONARJAVA-5175](https://sonarsource.atlassian.net/browse/SONARJAVA-5175)




[SONARJAVA-5175]: https://sonarsource.atlassian.net/browse/SONARJAVA-5175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ