### PR TITLE
SONARJAVA-5216 S1871 Consider variable identity when testing branch equivalence.

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/IdenticalCasesInSwitchCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/IdenticalCasesInSwitchCheckSample.java
@@ -220,7 +220,7 @@ class IdenticalCasesInSwitchCheckSample {
   static class A extends Parent {};
   static class B extends Parent {};
 
-  // Edge case FP.
+  // Edge case involving variables introduced with `instanceof`.
   // See: https://community.sonarsource.com/t/fp-java-s1871-branch-code-block-is-the-same/130645
   void variablesBoundInInstanceOf() {
     Parent p1 = new A();
@@ -230,17 +230,16 @@ class IdenticalCasesInSwitchCheckSample {
       p2 = new A();
     }
 
+    // No problem when `a` refers to different variables.
     Parent p = null;
     if (p1 instanceof A a) {
-//                         ^[el=+3;ec=5]> 1 {{Original}}
       p = a;
     }
-    else if (p2 instanceof A a) { // Noncompliant {{This branch's code block is the same as the block for the branch on line 234.}}
-//                              ^[el=+3;ec=5]
+    else if (p2 instanceof A a) {
       p = a;
     }
 
-    // Renaming variables fixes the issue.
+    // Variables have different names and identities.
     if (p1 instanceof A a1) {
       p = a1;
     }

--- a/java-checks-test-sources/default/src/main/java/checks/IdenticalCasesInSwitchCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/IdenticalCasesInSwitchCheckSample.java
@@ -216,4 +216,36 @@ class IdenticalCasesInSwitchCheckSample {
   private void f(int i) {
   }
 
+  static class Parent {};
+  static class A extends Parent {};
+  static class B extends Parent {};
+
+  // Edge case FP.
+  // See: https://community.sonarsource.com/t/fp-java-s1871-branch-code-block-is-the-same/130645
+  void variablesBoundInInstanceOf() {
+    Parent p1 = new A();
+    Parent p2 = new B();
+    if(Math.random() < 0.5) {
+      p1 = new B();
+      p2 = new A();
+    }
+
+    Parent p = null;
+    if (p1 instanceof A a) {
+//                         ^[el=+3;ec=5]> 1 {{Original}}
+      p = a;
+    }
+    else if (p2 instanceof A a) { // Noncompliant {{This branch's code block is the same as the block for the branch on line 234.}}
+//                              ^[el=+3;ec=5]
+      p = a;
+    }
+
+    // Renaming variables fixes the issue.
+    if (p1 instanceof A a1) {
+      p = a1;
+    }
+    else if (p2 instanceof A a2) {
+      p = a2;
+    }
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/IdenticalCasesInSwitchCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/IdenticalCasesInSwitchCheck.java
@@ -134,7 +134,7 @@ public class IdenticalCasesInSwitchCheck extends IssuableSubscriptionVisitor {
       for (int j = i + 1; j < allBranches.size(); j++) {
         StatementTree statement1 = allBranches.get(i);
         StatementTree statement2 = allBranches.get(j);
-        if (SyntacticEquivalence.areEquivalent(statement1, statement2)) {
+        if (SyntacticEquivalence.areEquivalentIncludingSameVariables(statement1, statement2)) {
           duplicates.add(statement2);
           ifElseChain.branches.computeIfAbsent(statement1, k -> new HashSet<>()).add(statement2);
         }


### PR DESCRIPTION
[SONARJAVA-5216](https://sonarsource.atlassian.net/browse/SONARJAVA-5216) Consider variable identity when testing branch equivalence. 



[SONARJAVA-5216]: https://sonarsource.atlassian.net/browse/SONARJAVA-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ