### PR TITLE
SONARJAVA-5239 Remove obsolete test that uses removed SonarQube metric

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaComplexityTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaComplexityTest.java
@@ -26,7 +26,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.it.java.suite.JavaTestSuite.getMeasure;
 import static com.sonar.it.java.suite.JavaTestSuite.getMeasureAsInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -85,11 +84,6 @@ public class JavaComplexityTest {
   @Test
   public void testProjectComplexity() {
     assertThat(getMeasureAsInteger(PROJECT, "complexity")).isEqualTo(16);
-  }
-
-  @Test
-  public void shouldNotPersistDistributionOnFiles() {
-    assertThat(getMeasure(JavaTestSuite.keyFor(PROJECT, "complexity/", "Helloworld.java"), "function_complexity_distribution")).isNull();
   }
 
   @Test


### PR DESCRIPTION
Part of [SONARJAVA-5239](https://sonarsource.atlassian.net/browse/SONARJAVA-5239)

Remove obsolete test that prevents QA from succeeding.

[SONARJAVA-5239]: https://sonarsource.atlassian.net/browse/SONARJAVA-5239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ