### PR TITLE
SONARJAVA-5265 S6906 ClassCastException: IdentifierTreeImpl cannot be cast to MemberSelectExpressionTree

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/VirtualThreadNotSynchronizedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/VirtualThreadNotSynchronizedCheckSample.java
@@ -2,6 +2,9 @@ package checks;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class VirtualThreadNotSynchronizedCheckSample {
 
@@ -158,4 +161,14 @@ public class VirtualThreadNotSynchronizedCheckSample {
   interface Fooable {
     void foo();
   }
+
+  public static abstract class DefaultThreadPoolExecutor extends ThreadPoolExecutor {
+    protected DefaultThreadPoolExecutor() {
+      super(2,4,20,TimeUnit.SECONDS, null);
+    }
+    void submit(RunnableFuture<Void> runnableFuture) {
+      execute( runnableFuture ); // Compliant, custom ThreadPoolExecutor
+    }
+  }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheck.java
@@ -109,14 +109,13 @@ public class VirtualThreadNotSynchronizedCheck extends IssuableSubscriptionVisit
     private static boolean isRunnableInVirtualThread(MethodInvocationTree tree) {
       return tree.methodSelect() instanceof MemberSelectExpressionTree methodSelect &&
         switch (tree.methodSymbol().name()) {
-          case "start", "unstarted" -> isCallToOfVirtual(methodSelect);
-          case "execute", "submit" -> isCallToExecutorServiceWithVirtualTasks(methodSelect);
+          case "start", "unstarted" -> isCallToOfVirtual(methodSelect.expression());
+          case "execute", "submit" -> isCallToExecutorServiceWithVirtualTasks(methodSelect.expression());
           default -> true;
         };
     }
 
-    private static boolean isCallToOfVirtual(MemberSelectExpressionTree methodSelect) {
-      var callSiteExpression = methodSelect.expression();
+    private static boolean isCallToOfVirtual(ExpressionTree callSiteExpression) {
       if (callSiteExpression.symbolType().is(OF_VIRTUAL)) {
         return true;
       }
@@ -127,8 +126,7 @@ public class VirtualThreadNotSynchronizedCheck extends IssuableSubscriptionVisit
         .anyMatch(it -> it.symbolType().is(OF_VIRTUAL));
     }
 
-    private static boolean isCallToExecutorServiceWithVirtualTasks(MemberSelectExpressionTree methodSelect) {
-      var callSiteExpression = methodSelect.expression();
+    private static boolean isCallToExecutorServiceWithVirtualTasks(ExpressionTree callSiteExpression) {
       if (isCallToExecutorServiceBuilderWithVirtualTasks(callSiteExpression)) {
         return true;
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheck.java
@@ -107,15 +107,16 @@ public class VirtualThreadNotSynchronizedCheck extends IssuableSubscriptionVisit
     }
 
     private static boolean isRunnableInVirtualThread(MethodInvocationTree tree) {
-      return switch (tree.methodSymbol().name()) {
-        case "start", "unstarted" -> isCallToOfVirtual(tree);
-        case "execute", "submit" -> isCallToExecutorServiceWithVirtualTasks(tree);
-        default -> true;
-      };
+      return tree.methodSelect() instanceof MemberSelectExpressionTree methodSelect &&
+        switch (tree.methodSymbol().name()) {
+          case "start", "unstarted" -> isCallToOfVirtual(methodSelect);
+          case "execute", "submit" -> isCallToExecutorServiceWithVirtualTasks(methodSelect);
+          default -> true;
+        };
     }
 
-    private static boolean isCallToOfVirtual(MethodInvocationTree tree) {
-      var callSiteExpression = ((MemberSelectExpressionTree) tree.methodSelect()).expression();
+    private static boolean isCallToOfVirtual(MemberSelectExpressionTree methodSelect) {
+      var callSiteExpression = methodSelect.expression();
       if (callSiteExpression.symbolType().is(OF_VIRTUAL)) {
         return true;
       }
@@ -126,8 +127,8 @@ public class VirtualThreadNotSynchronizedCheck extends IssuableSubscriptionVisit
         .anyMatch(it -> it.symbolType().is(OF_VIRTUAL));
     }
 
-    private static boolean isCallToExecutorServiceWithVirtualTasks(MethodInvocationTree tree) {
-      var callSiteExpression = ((MemberSelectExpressionTree) tree.methodSelect()).expression();
+    private static boolean isCallToExecutorServiceWithVirtualTasks(MemberSelectExpressionTree methodSelect) {
+      var callSiteExpression = methodSelect.expression();
       if (isCallToExecutorServiceBuilderWithVirtualTasks(callSiteExpression)) {
         return true;
       }


### PR DESCRIPTION
[SONARJAVA-5265](https://sonarsource.atlassian.net/browse/SONARJAVA-5265)



[SONARJAVA-5265]: https://sonarsource.atlassian.net/browse/SONARJAVA-5265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ