### PR TITLE
SONARJAVA-5259 Migrate secondary locations in RedundantRegexAlternativesCheckSample to the new syntax

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/regex/RedundantRegexAlternativesCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/regex/RedundantRegexAlternativesCheckSample.java
@@ -9,60 +9,96 @@ public class RedundantRegexAlternativesCheckSample {
   public void f(Pattern pattern) {
     f(compile("" +
       "." +
-      "|a")); // Noncompliant  {{Remove or rework this redundant alternative.}} [[sc=9;ec=10;secondary=-1]]
+  //   ^>
+      "|a")); // Noncompliant  {{Remove or rework this redundant alternative.}}
+  //    ^
     f(compile("" +
-      "a" + // Noncompliant [[sc=8;ec=9;secondary=+1]]
+      "a" + // Noncompliant
+  //   ^
       "|."));
+  //    ^<
     f(compile("" +
       "(.)" +
-      "|(a)")); // Noncompliant [[sc=9;ec=12;secondary=-1]]
+  //   ^^^>
+      "|(a)")); // Noncompliant
+  //    ^^^
     f(compile("(a)|(.)")); // Compliant, the capturing group tells you which alternative was matched
     f(compile("a|(.)"));   // Compliant, the capturing group tells you which alternative was matched
     f(compile("(a)|."));   // Compliant, the capturing group tells you which alternative was matched
     f(compile("" +
       "a" +
-      "|b" + // Noncompliant [[sc=9;ec=10;secondary=+1]]
+      "|b" + // Noncompliant
+//      ^
       "|bc?"));
+//      ^^^<
     f(compile("" +
       "a" +
-      "|b" + // Noncompliant [[sc=9;ec=10;secondary=+1]]
+      "|b" + // Noncompliant
+//      ^
       "|bc*"));
+//      ^^^<
     f(compile("a|b|bc+"));
     f(compile("" +
       "a" +
       "|b" +
-      "|a" + // Noncompliant [[secondary=-2,+2,+4]]
-      "|b" + // Noncompliant [[secondary=-2,+2,+4]]
+      "|a" + // Noncompliant
+//      ^
+//     ^@-3<
+//      ^@+8<
+//      ^@+9<
+      "|b" + // Noncompliant
+//      ^
+//      ^@-7<
+//      ^@+4<
+//      ^@+5<
       "|a" +
       "|b" +
       "|a" +
       "|b"));
     f(compile("" +
-      "[1-2]" + // Noncompliant [[secondary=+1,+2,+3]]
+      "[1-2]" + // Noncompliant
+//     ^^^^^
       "|[1-4]" +
+//      ^^^^^<
       "|[1-8]" +
+//      ^^^^^<
       "|[1-3]"));
+//      ^^^^^<
     f(compile("" +
-      "1" +  // Noncompliant [[secondary=+1]]
+      "1" +  // Noncompliant
+//     ^
       "|[1-2]"));
+//      ^^^^^<
     f(compile("" +
-      "1" +  // Noncompliant [[secondary=+4,+1,+2,+3,+5,+6]]
+      "1" +  // Noncompliant
+//     ^
       "|2" +
+//      ^<
       "|[1-2]" +
+//      ^^^^^<
       "|4" +
+//      ^<
       "|[1-6]" + // the winner, the superset of all others
+//      ^^^^^<
       "|5" +
+//      ^<
       "|[2-5]"));
+//      ^^^^^<
     f(compile("" +
       "a" +
       "|b+" +
-      "|b" + // Noncompliant [[secondary=-1, +2]]
+//      ^^>
+      "|b" + // Noncompliant
+//      ^
       "|c" +
       "|b"));
+//      ^<
     f(compile("" +
       "a" +
-      "|b" + // Noncompliant [[secondary=+1]]
+      "|b" + // Noncompliant
+//      ^
       "|bb*"));
+//      ^^^<
     f(compile("|a"));
     f(compile("[ab]|a")); // Noncompliant
     f(compile(".*|a")); // Noncompliant


### PR DESCRIPTION
[SONARJAVA-5259](https://sonarsource.atlassian.net/browse/SONARJAVA-5259)



[SONARJAVA-5259]: https://sonarsource.atlassian.net/browse/SONARJAVA-5259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ