### PR TITLE
SONARJAVA-4876 FP in rule S2386 when collection was created with `Stream.toList()`

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/PublicStaticMutableMembersCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/PublicStaticMutableMembersCheckSample.java
@@ -66,6 +66,8 @@ public class PublicStaticMutableMembersCheckSample {
 
   public static final List LIST = Arrays.asList("a"); // Noncompliant
 
+  public static final List<String> STREAM_TO_LIST = Stream.of("").toList(); // Compliant
+
   public static final List PROPER_LIST = Collections.unmodifiableList(Arrays.asList("a"));
 
   public static final List EMPTY_ARRAY_LIST = new ArrayList(Arrays.asList()); // Noncompliant

--- a/java-checks/src/main/java/org/sonar/java/checks/PublicStaticMutableMembersCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PublicStaticMutableMembersCheck.java
@@ -67,6 +67,7 @@ public class PublicStaticMutableMembersCheck extends IssuableSubscriptionVisitor
     MethodMatchers.create().ofAnyType().name(MutableMembersUsageCheck::containsImmutableLikeTerm).withAnyParameters().build(),
     // Java 9s
     MethodMatchers.create().ofTypes("java.util.Set", "java.util.List", "java.util.Map").names("of", "ofEntries", "copyOf").withAnyParameters().build(),
+    MethodMatchers.create().ofTypes("java.util.stream.Stream").names("toList").addWithoutParametersMatcher().build(),
     // apache...
     MethodMatchers.create()
       // commons 3.X


### PR DESCRIPTION
[SONARJAVA-4876](https://sonarsource.atlassian.net/browse/SONARJAVA-4876)



[SONARJAVA-4876]: https://sonarsource.atlassian.net/browse/SONARJAVA-4876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ