### PR TITLE
SONARJAVA-5303 Fix flaky Windows QA build

### DIFF
--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -924,8 +924,8 @@ class SonarComponentsTest {
   @MethodSource("fileCanBeSkipped_only_logs_on_first_call_input")
   void fileCanBeSkipped_only_logs_on_the_first_call(SonarComponents sonarComponents, InputFile inputFile, String logMessage) throws IOException {
     // logs may be empty or contain some progress log line
-    assertThat(logTester.getLogs(Level.INFO))
-      .allMatch(log -> log.getRawMsg().matches("[0-9]+% analyzed"));
+    assertThat(
+      TestUtils.filterOutAnalysisProgressLogMessages(logTester.getLogs(Level.INFO))).isEmpty();
 
     SensorContext contextMock = mock(SensorContext.class);
     sonarComponents.setSensorContext(contextMock);
@@ -957,7 +957,7 @@ class SonarComponentsTest {
   @ParameterizedTest
   @MethodSource("provideInputsFor_canSkipUnchangedFiles")
   void canSkipUnchangedFiles(@CheckForNull Boolean overrideFlagVal, @CheckForNull Boolean apiResponseVal,
-    @CheckForNull Boolean expectedResult) throws ApiMismatchException {
+                             @CheckForNull Boolean expectedResult) throws ApiMismatchException {
     SensorContextTester sensorContextTester = SensorContextTester.create(new File(""));
     SonarComponents sonarComponents = new SonarComponents(
       fileLinesContextFactory,

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -923,7 +923,9 @@ class SonarComponentsTest {
   @ParameterizedTest
   @MethodSource("fileCanBeSkipped_only_logs_on_first_call_input")
   void fileCanBeSkipped_only_logs_on_the_first_call(SonarComponents sonarComponents, InputFile inputFile, String logMessage) throws IOException {
-    assertThat(logTester.getLogs(Level.INFO)).isEmpty();
+    // logs may be empty or contain some progress log line
+    assertThat(logTester.getLogs(Level.INFO))
+      .allMatch(log -> log.getRawMsg().matches("[0-9]+% analyzed"));
 
     SensorContext contextMock = mock(SensorContext.class);
     sonarComponents.setSensorContext(contextMock);

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -105,6 +105,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sonar.java.TestUtils.computeLineEndOffsets;
+import static org.sonar.java.TestUtils.filterOutAnalysisProgressLogMessages;
 
 @ExtendWith(MockitoExtension.class)
 class SonarComponentsTest {
@@ -925,20 +926,20 @@ class SonarComponentsTest {
   void fileCanBeSkipped_only_logs_on_the_first_call(SonarComponents sonarComponents, InputFile inputFile, String logMessage) throws IOException {
     // logs may be empty or contain some progress log line
     assertThat(
-      TestUtils.filterOutAnalysisProgressLogMessages(logTester.getLogs(Level.INFO))).isEmpty();
+      filterOutAnalysisProgressLogMessages(logTester.getLogs(Level.INFO))).isEmpty();
 
     SensorContext contextMock = mock(SensorContext.class);
     sonarComponents.setSensorContext(contextMock);
     when(inputFile.contents()).thenReturn("");
     sonarComponents.fileCanBeSkipped(inputFile);
-    List<LogAndArguments> logs = logTester.getLogs(Level.INFO);
+    List<String> logs = filterOutAnalysisProgressLogMessages(logTester.getLogs(Level.INFO));
     assertThat(logs).hasSize(1);
-    assertThat(logs.get(0).getRawMsg()).isEqualTo(logMessage);
+    assertThat(logs.get(0)).isEqualTo(logMessage);
 
     sonarComponents.fileCanBeSkipped(inputFile);
-    logs = logTester.getLogs(Level.INFO);
+    logs = filterOutAnalysisProgressLogMessages(logTester.getLogs(Level.INFO));
     assertThat(logs).hasSize(1);
-    assertThat(logs.get(0).getRawMsg()).isEqualTo(logMessage);
+    assertThat(logs.get(0)).isEqualTo(logMessage);
   }
 
   private static Stream<Arguments> provideInputsFor_canSkipUnchangedFiles() {

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -19,8 +19,12 @@ package org.sonar.java;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.testfixtures.log.LogAndArguments;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -115,5 +119,17 @@ public class TestUtils {
     } catch (Exception e) {
       throw new IllegalStateException(String.format("Unable to read file '%s", file.getAbsoluteFile()));
     }
+  }
+
+  private static List<String> filterOutAnalysisProgressLogLines(Stream<String> logs) {
+    return logs.filter(log -> !log.matches("[0-9]+% analyzed")).toList();
+  }
+
+  public static List<String> filterOutAnalysisProgressLogLines(List<String> logs) {
+    return filterOutAnalysisProgressLogLines(logs.stream());
+  }
+
+  public static List<String> filterOutAnalysisProgressLogMessages(List<LogAndArguments> logs) {
+    return filterOutAnalysisProgressLogLines(logs.stream().map(LogAndArguments::getRawMsg));
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -280,7 +280,7 @@ class JavaAstScannerTest {
       ));
 
     List<String> logs = globalLogTester.logs(Level.INFO);
-    assertThat(filterOutAnalysisProgressLogLines(logs)).hasSize(3)
+    assertThat(TestUtils.filterOutAnalysisProgressLogLines(logs)).hasSize(3)
       .contains("1/1 source file has been analyzed");
     assertThat(logTester.logs(Level.ERROR)).containsExactly(
       "Unable to parse source file : 'src/test/files/metrics/Java15SwitchExpression.java'",
@@ -293,11 +293,6 @@ class JavaAstScannerTest {
       .allMatch(log -> log.endsWith("module-info.java' file with misconfigured Java version."
         + " Please check that property 'sonar.java.source' is correctly configured (currently set to: 8) or exclude 'module-info.java' files from analysis."
         + " Such files only exist in Java9+ projects."));
-  }
-
-  private List<String> filterOutAnalysisProgressLogLines(List<String> logs) {
-    return logs.stream().filter(log -> !log.matches("[0-9]+% analyzed"))
-      .toList();
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -279,7 +279,8 @@ class JavaAstScannerTest {
         TestUtils.inputFile("src/test/resources/module-info.java")
       ));
 
-    assertThat(globalLogTester.logs(Level.INFO)).hasSize(3)
+    List<String> logs = globalLogTester.logs(Level.INFO);
+    assertThat(filterOutAnalysisProgressLogLines(logs)).hasSize(3)
       .contains("1/1 source file has been analyzed");
     assertThat(logTester.logs(Level.ERROR)).containsExactly(
       "Unable to parse source file : 'src/test/files/metrics/Java15SwitchExpression.java'",
@@ -292,6 +293,11 @@ class JavaAstScannerTest {
       .allMatch(log -> log.endsWith("module-info.java' file with misconfigured Java version."
         + " Please check that property 'sonar.java.source' is correctly configured (currently set to: 8) or exclude 'module-info.java' files from analysis."
         + " Such files only exist in Java9+ projects."));
+  }
+
+  private List<String> filterOutAnalysisProgressLogLines(List<String> logs) {
+    return logs.stream().filter(log -> !log.matches("[0-9]+% analyzed"))
+      .toList();
   }
 
   @Test


### PR DESCRIPTION
[SONARJAVA-5303](https://sonarsource.atlassian.net/browse/SONARJAVA-5303)

The Windows build task occasionally fails because a progress log line appears when the test runs a little longer than expected. With this change, the test accepts that the logs may contain some "XX% analyzed" lines.



[SONARJAVA-5303]: https://sonarsource.atlassian.net/browse/SONARJAVA-5303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ