### PR TITLE
SONARJAVA-5256 Fix false positives on S2699 for AssertJ assertions

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2699",
   "hasTruePositives": true,
-  "falseNegatives": 151,
+  "falseNegatives": 152,
   "falsePositives": 1
 }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsInTestsCheck/AssertJ.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsInTestsCheck/AssertJ.java
@@ -248,4 +248,19 @@ public abstract class AssertJ {
     new java.util.ArrayList<Boolean>().forEach(java.util.Objects::isNull);
   }
 
+  @Test
+  public void bdd_assertions_then_no_exception_is_thrown_by(){
+    org.assertj.core.api.BDDAssertions.thenNoException() // Compliant
+      .isThrownBy(() -> { throw new Throwable(); });
+  }
+
+  @Test
+  public void bdd_assertions_then_no_exception_as() { // Noncompliant
+    org.assertj.core.api.BDDAssertions.thenNoException().as("description");
+  }
+
+  @Test
+  public void bdd_assertions_then_true_is_true(){
+    org.assertj.core.api.BDDAssertions.then(true).isTrue(); // Compliant
+  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/UnitTestUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/UnitTestUtilsTest.java
@@ -1,0 +1,37 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.sonar.java.checks.helpers.UnitTestUtils.ASSERTJ_ASSERTION_METHODS_PREDICATE;
+
+
+class UnitTestUtilsTest {
+
+  @Test
+  void testAssertJAssertionMethodPattern() {
+    assertTrue(ASSERTJ_ASSERTION_METHODS_PREDICATE.test("returns"));
+    assertTrue(ASSERTJ_ASSERTION_METHODS_PREDICATE.test("contains"));
+    assertTrue(ASSERTJ_ASSERTION_METHODS_PREDICATE.test("containsAString"));
+    assertTrue(ASSERTJ_ASSERTION_METHODS_PREDICATE.test("doesNotThrow"));
+    assertTrue(ASSERTJ_ASSERTION_METHODS_PREDICATE.test("allMatchFoo"));
+    assertFalse(ASSERTJ_ASSERTION_METHODS_PREDICATE.test("hasten"));
+  }
+}


### PR DESCRIPTION
[SONARJAVA-5256](https://sonarsource.atlassian.net/browse/SONARJAVA-5256)

There are many methods that can be used to write assertions with AssertJ. The previous pattern was only recognizing a couple of assertJ classes.
With this PR we generalize the pattern for recognizing AssertJ assertion methods so that it applies to many of these classes.

[SONARJAVA-5256]: https://sonarsource.atlassian.net/browse/SONARJAVA-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ