### PR TITLE
SONARJAVA-5303 Replace logTester by ThreadLocalLogTester

### DIFF
--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.testfixtures.log.LogAndArguments;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -127,9 +126,5 @@ public class TestUtils {
 
   public static List<String> filterOutAnalysisProgressLogLines(List<String> logs) {
     return filterOutAnalysisProgressLogLines(logs.stream());
-  }
-
-  public static List<String> filterOutAnalysisProgressLogMessages(List<LogAndArguments> logs) {
-    return filterOutAnalysisProgressLogLines(logs.stream().map(LogAndArguments::getRawMsg));
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/testing/ThreadLocalLogTester.java
+++ b/java-frontend/src/test/java/org/sonar/java/testing/ThreadLocalLogTester.java
@@ -63,12 +63,25 @@ public class ThreadLocalLogTester implements AfterEachCallback, BeforeEachCallba
       .toList();
   }
 
-  public List<String> logs(Level level) {
+  private List<ILoggingEvent> events(Level level) {
     ch.qos.logback.classic.Level logBackLevel = ch.qos.logback.classic.Level.toLevel(level.toString());
     return appender.list.stream()
       .filter(event -> event.getLevel().toInt() == logBackLevel.toInt())
+      .toList();
+  }
+
+  public List<String> logs(Level level) {
+    return getFormattedMessages(events(level));
+  }
+
+  private static List<String> getFormattedMessages(List<ILoggingEvent> events) {
+    return events.stream()
       .map(ILoggingEvent::getFormattedMessage)
       .toList();
+  }
+
+  public List<String> rawMessages(Level level) {
+    return events(level).stream().map(ILoggingEvent::getMessage).toList();
   }
 
   public ThreadLocalLogTester clear() {
@@ -83,6 +96,7 @@ public class ThreadLocalLogTester implements AfterEachCallback, BeforeEachCallba
   public static class ThreadLocalAppender extends ListAppender<ILoggingEvent> {
     private final Thread filteringThread;
     private ch.qos.logback.classic.Level logBackLevel;
+
     public ThreadLocalAppender(Thread filteringThread) {
       this.filteringThread = filteringThread;
     }


### PR DESCRIPTION
[SONARJAVA-5303](https://sonarsource.atlassian.net/browse/SONARJAVA-5303)

With this change we should avoid the togs being polluted by messages coming from different threads.


[SONARJAVA-5303]: https://sonarsource.atlassian.net/browse/SONARJAVA-5303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ