### PR TITLE
SONARJAVA-5304 Improve issue message in case of array type cast in S6201

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/InstanceOfPatternMatching.java
+++ b/java-checks-test-sources/default/src/main/java/checks/InstanceOfPatternMatching.java
@@ -4,6 +4,20 @@ import java.util.Map;
 
 public abstract class InstanceOfPatternMatching {
 
+  private static String booleanArray(Object o){
+    if(o instanceof boolean[]){ // Noncompliant {{Replace this instanceof check and cast with 'instanceof boolean[] booleanArray'}}
+      return Boolean.toString(((boolean[])o)[0]);
+    }
+    return "not a boolean array";
+  }
+
+  private static String booleanArray2(Object o){
+    if(o instanceof boolean[][]){ // Noncompliant {{Replace this instanceof check and cast with 'instanceof boolean[][] booleanArrayArray'}}
+      return Boolean.toString(((boolean[][])o)[0][0]);
+    }
+    return "not a boolean array";
+  }
+
   int if1(Object o) {
     if (o instanceof String) { // Noncompliant {{Replace this instanceof check and cast with 'instanceof String str'}}
 //      ^^^^^^^^^^^^^^^^^^^

--- a/java-checks/src/main/java/org/sonar/java/checks/InstanceOfPatternMatchingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InstanceOfPatternMatchingCheck.java
@@ -171,7 +171,8 @@ public class InstanceOfPatternMatchingCheck extends IssuableSubscriptionVisitor 
       Type type = tree.symbolType();
       if (!type.isUnknown() && type.equals(instanceOf.type().symbolType())
         && SyntacticEquivalence.areEquivalentIncludingSameVariables(tree.expression(), instanceOf.expression())) {
-        report(instanceOf, tree, tree.type().symbolType().name().toLowerCase(Locale.ROOT));
+        Type symbolType = tree.type().symbolType();
+        report(instanceOf, tree, makeVariableNameForType(symbolType));
       }
     }
 
@@ -181,5 +182,9 @@ public class InstanceOfPatternMatchingCheck extends IssuableSubscriptionVisitor 
       JavaFileScannerContext.Location secondary = new JavaFileScannerContext.Location("Location of the cast", cast);
       reportIssue(instanceOf, message, Collections.singletonList(secondary), null);
     }
+  }
+
+  private static String makeVariableNameForType(Type type) {
+    return type.name().toLowerCase(Locale.ROOT).replace("[]", "Array");
   }
 }


### PR DESCRIPTION
[SONARJAVA-5304](https://sonarsource.atlassian.net/browse/SONARJAVA-5304)

Array type names cannot directly be used as variable names as they contain square brackets ([]).


[SONARJAVA-5304]: https://sonarsource.atlassian.net/browse/SONARJAVA-5304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ