### PR TITLE
SONARJAVA-5128 Disable Optional parameter check for autowired methods

### DIFF
--- a/java-checks-test-sources/default/src/main/java/filters/SpringFilter.java
+++ b/java-checks-test-sources/default/src/main/java/filters/SpringFilter.java
@@ -1,6 +1,7 @@
 package filters;
 
 import java.util.List;
+import java.util.Optional;
 import javax.servlet.http.HttpServlet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +19,15 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 public class SpringFilter {
+
+  static class S3553 {
+    @Autowired
+    public void initStuff(Optional<List<Component>> injectedIfAvailable, Service service) // NoIssue
+    {
+    }
+
+    public void notAutowired(Optional<List<Component>> injectedIfAvailable) {} // WithIssue
+  }
 
   static class S100 {
     static class S100_1 implements org.springframework.data.repository.Repository<Person, Long> {
@@ -159,4 +169,5 @@ public class SpringFilter {
       private javax.sql.DataSource myDB; // WithIssue
     }
   }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/filters/SpringFilter.java
+++ b/java-checks/src/main/java/org/sonar/java/filters/SpringFilter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import org.sonar.java.checks.AtLeastOneConstructorCheck;
 import org.sonar.java.checks.MethodOnlyCallsSuperCheck;
+import org.sonar.java.checks.OptionalAsParameterCheck;
 import org.sonar.java.checks.ServletInstanceFieldCheck;
 import org.sonar.java.checks.TooManyParametersCheck;
 import org.sonar.java.checks.helpers.ExpressionsHelper;
@@ -62,7 +63,8 @@ public class SpringFilter extends BaseTreeVisitorIssueFilter {
       /* S107_ */ TooManyParametersCheck.class,
       /* S1185 */ MethodOnlyCallsSuperCheck.class,
       /* S1258 */ AtLeastOneConstructorCheck.class,
-      /* S2226 */ ServletInstanceFieldCheck.class);
+      /* S2226 */ ServletInstanceFieldCheck.class,
+      /* S3553 */ OptionalAsParameterCheck.class);
   }
 
   @Override
@@ -89,6 +91,7 @@ public class SpringFilter extends BaseTreeVisitorIssueFilter {
       SymbolMetadata methodMetadata = symbol.metadata();
       excludeLinesIfTrue(S107_METHOD_ANNOTATION_EXCEPTIONS.stream().anyMatch(methodMetadata::isAnnotatedWith), reportTree, TooManyParametersCheck.class);
       excludeLinesIfTrue(isRepositoryPropertyExpression(symbol), reportTree, BadMethodNameCheck.class);
+      excludeLinesIfTrue(methodMetadata.isAnnotatedWith(AUTOWIRED), reportTree, OptionalAsParameterCheck.class);
     }
     super.visitMethod(tree);
   }


### PR DESCRIPTION
[SONARJAVA-5128](https://sonarsource.atlassian.net/browse/SONARJAVA-5128)

When the method is marked as autowired, it makes sense to have some optional parameter because of the way Spring resolve dependencies.



[SONARJAVA-5128]: https://sonarsource.atlassian.net/browse/SONARJAVA-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ