### PR TITLE
SONARJAVA-5256 Consider classes extending AssertJ AbstractAssert as assertion classes

### DIFF
--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -225,6 +225,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.spring.initializr</groupId>
+      <artifactId>initializr-generator-test</artifactId>
+      <version>0.21.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-acl</artifactId>
       <version>5.1.1.RELEASE</version>

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsInTestsCheck/AssertJ.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsInTestsCheck/AssertJ.java
@@ -1,5 +1,6 @@
 package checks.tests.AssertionsInTestsCheck;
 
+import io.spring.initializr.generator.test.buildsystem.maven.MavenBuildAssert;
 import java.util.List;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.Assertions;
@@ -11,6 +12,11 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public abstract class AssertJ {
+
+  @Test
+  public void usingExtendedAssert() {
+    new MavenBuildAssert("Hello").hasPackaging("war");
+  }
 
   interface Visitor {
     void visit(Object object);

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -51,7 +51,8 @@ public final class UnitTestUtils {
     "(allMatch|assert|contains|doesNot|has|is|returns|satisfies)([A-Z].*)?").asMatchPredicate();
 
   private static final Pattern ASSERTJ_ASSERTION_CLASSNAME_PATTERN = Pattern.compile("org\\.assertj\\.core\\.api\\.[a-zA-Z]+Assert");
-  private static final Predicate<Type> ASSERTJ_ASSERTION_TYPE_PREDICATE = type -> ASSERTJ_ASSERTION_CLASSNAME_PATTERN.matcher(type.fullyQualifiedName()).matches();
+  private static final Predicate<Type> ASSERTJ_ASSERTION_TYPE_PREDICATE = type -> ASSERTJ_ASSERTION_CLASSNAME_PATTERN.matcher(type.fullyQualifiedName()).matches()
+    || type.isSubtypeOf("org.assertj.core.api.AbstractAssert");
 
   public static final MethodMatchers ASSERTION_INVOCATION_MATCHERS = MethodMatchers.or(
     // fest 1.x / 2.X


### PR DESCRIPTION
[SONARJAVA-5256](https://sonarsource.atlassian.net/browse/SONARJAVA-5256)

Fixes some false positive introduced by the previous PR for rule S2699


[SONARJAVA-5256]: https://sonarsource.atlassian.net/browse/SONARJAVA-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ