### PR TITLE
SONARJAVA-5338 Fix variable owner in the case of lambdas

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -194,6 +194,15 @@ abstract class JSymbol implements Symbol {
     if (!variableBinding.isRecordComponent()) {
       IMethodBinding declaringMethod = variableBinding.getDeclaringMethod();
       if (declaringMethod != null) {
+        IBinding declaringMember = declaringMethod.getDeclaringMember();
+        // declaringMember is non-null in the case of lambdas
+        if (declaringMember != null) {
+          if (declaringMember instanceof IMethodBinding methodBinding) {
+            return sema.methodSymbol(methodBinding);
+          } else if (declaringMember instanceof IVariableBinding varBinding) {
+            return sema.variableSymbol(varBinding);
+          }
+        }
         // local variable
         return sema.methodSymbol(declaringMethod);
       }
@@ -203,6 +212,10 @@ abstract class JSymbol implements Symbol {
         return sema.typeSymbol(declaringClass);
       }
     }
+    return ownerOfRecordComponentConstant(variableBinding);
+  }
+
+  private Symbol ownerOfRecordComponentConstant(IVariableBinding variableBinding) {
     Tree node = sema.declarations.get(variableBinding);
     if (node == null) {
       // array.length


### PR DESCRIPTION
[SONARJAVA-5338](https://sonarsource.atlassian.net/browse/SONARJAVA-5338)

The computation of owners in lambdas was returning the interface method implemented by the lambda (for instance accept for Function) which doesn't allow distinguishing between symbols declared in different lambdas in different methods with the same variable name.

