### PR TITLE
SONARJAVA-5341 Fix FP reported for too many cases on switches when enum types are unknown

### DIFF
--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/SwitchWithTooManyCasesCheckCustom.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/SwitchWithTooManyCasesCheckCustom.java
@@ -30,4 +30,22 @@ class SwitchWithTooManyCasesCheckCustom {
     };
   }
 
+  int bar(UnknowEnumType e) {
+    switch (e) { // Compliant, when a type is unknown, we can't know if it's an enum
+      case A:
+        return 1;
+      case B:
+        return 2;
+      case C:
+        return 3;
+      case D:
+        return 4;
+      case E:
+        return 5;
+      case F:
+        return 6;
+      case G:
+        return 7;
+    }
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/SwitchWithTooManyCasesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/SwitchWithTooManyCasesCheck.java
@@ -21,8 +21,10 @@ import java.util.Arrays;
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.java.checks.helpers.TernaryValue;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.CaseGroupTree;
 import org.sonar.plugins.java.api.tree.SwitchTree;
@@ -47,7 +49,7 @@ public class SwitchWithTooManyCasesCheck extends IssuableSubscriptionVisitor {
   @Override
   public void visitNode(Tree tree) {
     SwitchTree switchTree = (SwitchTree) tree;
-    if (isSwitchOverEnum(switchTree)) {
+    if (isSwitchOverEnum(switchTree).maybeTrue()) {
       return;
     }
 
@@ -64,8 +66,8 @@ public class SwitchWithTooManyCasesCheck extends IssuableSubscriptionVisitor {
     }
   }
 
-  private static boolean isSwitchOverEnum(SwitchTree switchStatementTree) {
-    Type type = switchStatementTree.expression().symbolType();
-    return type.symbol().isEnum();
+  private static TernaryValue isSwitchOverEnum(SwitchTree switchStatementTree) {
+    Symbol.TypeSymbol typeSymbol = switchStatementTree.expression().symbolType().symbol();
+    return typeSymbol.isUnknown() ? TernaryValue.UNKNOWN : TernaryValue.of(typeSymbol.isEnum());
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/TernaryValue.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/TernaryValue.java
@@ -1,0 +1,36 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.helpers;
+
+import javax.annotation.Nullable;
+
+/** Represents the three possible values in three-valued logic. */
+public enum TernaryValue {
+  TRUE, FALSE, UNKNOWN;
+
+  public static TernaryValue of(boolean b) {
+    return b ? TRUE : FALSE;
+  }
+
+  public static TernaryValue of(@Nullable Boolean b) {
+    return b == null ? UNKNOWN : of(b.booleanValue());
+  }
+
+  public boolean maybeTrue() {
+    return this != FALSE;
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/TernaryValueTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/TernaryValueTest.java
@@ -1,0 +1,32 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TernaryValueTest {
+
+  @Test
+  void maybeTrue() {
+    assertTrue(TernaryValue.of(true).maybeTrue());
+    assertTrue(TernaryValue.of(null).maybeTrue());
+    assertFalse(TernaryValue.of(false).maybeTrue());
+    assertTrue(TernaryValue.of(Boolean.TRUE).maybeTrue());
+  }
+}


### PR DESCRIPTION
[SONARJAVA-5341](https://sonarsource.atlassian.net/browse/SONARJAVA-5341)

When we don't know if the symbol in the switch is an enum, we shouldn't raise that issue.


[SONARJAVA-5341]: https://sonarsource.atlassian.net/browse/SONARJAVA-5341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ