### PR TITLE
A “NullPointerException” could be thrown; “ofNullable()” can return null

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -377,7 +377,7 @@ abstract class JSymbol implements Symbol {
         if (returnType == null) {
           return Symbols.EMPTY_METADATA;
         }
-        return new JSymbolMetadata(sema, this, getAnnotations(returnType), binding.getAnnotations());
+        return new JSymbolMetadata(sema, this, returnType.getTypeAnnotations(), binding.getAnnotations());
       default:
         return new JSymbolMetadata(sema, this, binding.getAnnotations());
     }

--- a/java-symbolic-execution/java-symbolic-execution-checks-test-sources/pom.xml
+++ b/java-symbolic-execution/java-symbolic-execution-checks-test-sources/pom.xml
@@ -1017,6 +1017,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/java-symbolic-execution/java-symbolic-execution-checks-test-sources/src/main/java/symbolicexecution/checks/OptionalOfNullableCall_javax.java
+++ b/java-symbolic-execution/java-symbolic-execution-checks-test-sources/src/main/java/symbolicexecution/checks/OptionalOfNullableCall_javax.java
@@ -1,0 +1,12 @@
+package symbolicexecution.checks;
+
+import java.util.Optional;
+import javax.annotation.CheckForNull;
+
+record OptionalOfNullableCall_javax(@CheckForNull String attribute) {
+
+  public Optional<String> foo() {
+    return Optional.ofNullable(attribute).filter("foo"::equals);
+  }
+
+}

--- a/java-symbolic-execution/java-symbolic-execution-checks-test-sources/src/main/java/symbolicexecution/checks/OptionalOfNullableCall_jspecify.java
+++ b/java-symbolic-execution/java-symbolic-execution-checks-test-sources/src/main/java/symbolicexecution/checks/OptionalOfNullableCall_jspecify.java
@@ -1,0 +1,12 @@
+package symbolicexecution.checks;
+
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+record OptionalOfNullableCall_jspecify(@Nullable String attribute) {
+
+  public Optional<String> foo() {
+    return Optional.ofNullable(attribute).filter("foo"::equals);
+  }
+
+}

--- a/java-symbolic-execution/java-symbolic-execution-plugin/src/test/java/org/sonar/java/se/checks/NullDereferenceCheckTest.java
+++ b/java-symbolic-execution/java-symbolic-execution-plugin/src/test/java/org/sonar/java/se/checks/NullDereferenceCheckTest.java
@@ -16,12 +16,12 @@
  */
 package org.sonar.java.se.checks;
 
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.se.SECheckVerifier;
 import org.sonar.java.se.utils.SETestUtils;
-
-import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 
 class NullDereferenceCheckTest {
 
@@ -128,6 +128,24 @@ class NullDereferenceCheckTest {
   void test_booleanValue_method() {
     SECheckVerifier.newVerifier()
       .onFile(mainCodeSourcesPath("symbolicexecution/checks/NullFromBooleanValueCall.java"))
+      .withChecks(new NullDereferenceCheck())
+      .withClassPath(SETestUtils.CLASS_PATH)
+      .verifyNoIssues();
+  }
+
+  @Test
+  void test_optional_of_nullable_jspecify() {
+    SECheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("symbolicexecution/checks/OptionalOfNullableCall_jspecify.java"))
+      .withChecks(new NullDereferenceCheck())
+      .withClassPath(SETestUtils.CLASS_PATH)
+      .verifyNoIssues();
+  }
+
+  @Test
+  void test_optional_of_nullable_javax() {
+    SECheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("symbolicexecution/checks/OptionalOfNullableCall_javax.java"))
       .withChecks(new NullDereferenceCheck())
       .withClassPath(SETestUtils.CLASS_PATH)
       .verifyNoIssues();


### PR DESCRIPTION
Reproducer + hacky fix for https://community.sonarsource.com/t/a-nullpointerexception-could-be-thrown-ofnullable-can-return-null/134892 .

The hacky fix breaks `org.sonar.java.checks.ChangeMethodContractCheckTest#test`.

IMHO, nullable annotations on method generic return parameters are structurally wrongly implemented. A nullable annotation on the return type or a generic element of the return type is viewed as the same by analyzer.