### PR TITLE
SONARJAVA-5352 Fix multi-quality rules severity mappings

### DIFF
--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1133.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1133.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "INFO"
     },
     "attribute": "CLEAR"
   },

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1135.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1135.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "INFO"
     },
     "attribute": "COMPLETE"
   },

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2115.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2115.json
@@ -3,7 +3,7 @@
   "type": "VULNERABILITY",
   "code": {
     "impacts": {
-      "SECURITY": "HIGH"
+      "SECURITY": "BLOCKER"
     },
     "attribute": "TRUSTWORTHY"
   },

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S3688.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S3688.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "INFO"
     },
     "attribute": "CONVENTIONAL"
   },

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6437.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6437.json
@@ -3,7 +3,7 @@
   "type": "VULNERABILITY",
   "code": {
     "impacts": {
-      "SECURITY": "HIGH"
+      "SECURITY": "BLOCKER"
     },
     "attribute": "TRUSTWORTHY"
   },

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6485.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6485.json
@@ -3,7 +3,7 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   },

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6809.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6809.json
@@ -7,7 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6809",
   "sqKey": "S6809",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6814.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6814.json
@@ -7,7 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6814",
   "sqKey": "S6814",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6816.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6816.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6816",
   "sqKey": "S6816",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6817.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6817.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6817",
   "sqKey": "S6817",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6818.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6818.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6818",
   "sqKey": "S6818",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6829",
   "sqKey": "S6829",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6830.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6830.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6830",
   "sqKey": "S6830",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6837.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6837.json
@@ -16,7 +16,7 @@
   "quickfix": "targeted",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "CLEAR"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6857.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6857.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6857",
   "sqKey": "S6857",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6863.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6863.json
@@ -17,7 +17,7 @@
   "quickfix": "infeasible",
   "code": {
     "impacts": {
-      "RELIABILITY": "LOW"
+      "RELIABILITY": "MEDIUM"
     },
     "attribute": "DISTINCT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6876.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6876.json
@@ -9,7 +9,7 @@
   "tags": [
     "java21"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6876",
   "sqKey": "S6876",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6877.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6877.json
@@ -9,7 +9,7 @@
   "tags": [
     "java21"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6877",
   "sqKey": "S6877",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6878.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6878.json
@@ -9,7 +9,7 @@
   "tags": [
     "java21"
   ],
-  "defaultSeverity": "Minor",
+  "defaultSeverity": "Major",
   "ruleSpecification": "RSPEC-6878",
   "sqKey": "S6878",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6881.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6881.json
@@ -10,7 +10,7 @@
     "java21",
     "multi-threading"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-6881",
   "sqKey": "S6881",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6889.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6889.json
@@ -18,7 +18,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6891.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6891.json
@@ -18,7 +18,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6898.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6898.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6904.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6904.json
@@ -18,7 +18,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6905.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6905.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6909.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6909.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6912.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6912.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6914.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6914.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6923.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6923.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "CONVENTIONAL"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6926.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6926.json
@@ -17,7 +17,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "LOW"
+      "MAINTAINABILITY": "MEDIUM"
     },
     "attribute": "EFFICIENT"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7178.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7178.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-7178",
   "sqKey": "S7178",
   "scope": "Main",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7184.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7184.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-7184",
   "sqKey": "S7184",
   "scope": "All",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7185.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7185.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-7185",
   "sqKey": "S7185",
   "scope": "All",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7186.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7186.json
@@ -9,7 +9,7 @@
   "tags": [
     "spring"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-7186",
   "sqKey": "S7186",
   "scope": "All",

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7190.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S7190.json
@@ -7,9 +7,10 @@
     "constantCost": "5min"
   },
   "tags": [
-    "spring", "tests"
+    "spring",
+    "tests"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-7190",
   "sqKey": "S7190",
   "scope": "Tests",

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "JAVA"
   ],
-  "latest-update": "2025-02-14T14:49:23.786310Z",
+  "latest-update": "2025-02-25T10:26:12.753953200Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": false


### PR DESCRIPTION
[SONARJAVA-5352](https://sonarsource.atlassian.net/browse/SONARJAVA-5352)

This fix was introduced on the 8.9 bugfix branch for the LTA of SQ, and it fixes the mapping of multi-quality rules between their `code.impacts` and their `defaultSeverity`.

### LOW to INFO

- S1133
- S1135
- S3688

### LOW to MEDIUM

- S6485
- S6837
- S6863
- S6889
- S6891
- S6898
- S6904
- S6909
- S6912
- S6914
- S6923
- S6926

### HIGH to BLOCKER:

- S2115
- S6437

### Minor to Major

- S6829
- S6830
- S6878
- S6905

### Major to Critical

- S6809
- S6814
- S6816
- S6817
- S6818
- S6857
- S6876
- S6877
- S6881
- S7178
- S7184
- S7185
- S7186
- S7190

[SONARJAVA-5352]: https://sonarsource.atlassian.net/browse/SONARJAVA-5352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ