### PR TITLE
SONARJAVA-5417 Exclude test fixtures from SCA analysis

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,7 +95,7 @@ test_analyze_task:
     - *log_develocity_url_script
     - source cirrus-env BUILD
     # ignore duplications in the SE engine plugin, as it will be moved away from sonar-java at some point
-    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.excludedManifests="**/test/files/**,**/test/resources/**"
+    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.excludedManifests="**/test/files/**,**/test/resources/**,its/plugin/projects/**"
     - cd docs/java-custom-rules-example
     - mvn clean package -f pom_SQ_10_6_LATEST.xml --batch-mode
     - cd "${CIRRUS_WORKING_DIR}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,7 +95,7 @@ test_analyze_task:
     - *log_develocity_url_script
     - source cirrus-env BUILD
     # ignore duplications in the SE engine plugin, as it will be moved away from sonar-java at some point
-    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/**
+    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.excludedManifests="**/test/files/**,**/test/resources/**"
     - cd docs/java-custom-rules-example
     - mvn clean package -f pom_SQ_10_6_LATEST.xml --batch-mode
     - cd "${CIRRUS_WORKING_DIR}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,7 +95,7 @@ test_analyze_task:
     - *log_develocity_url_script
     - source cirrus-env BUILD
     # ignore duplications in the SE engine plugin, as it will be moved away from sonar-java at some point
-    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.excludedManifests="**/test/files/**,**/test/resources/**,its/plugin/projects/**"
+    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.excludedManifests="**/test/files/**, **/test/resources/**, its/plugin/projects/**, java-checks-test-sources/**, its/sources/**,"
     - cd docs/java-custom-rules-example
     - mvn clean package -f pom_SQ_10_6_LATEST.xml --batch-mode
     - cd "${CIRRUS_WORKING_DIR}"


### PR DESCRIPTION
[SONARJAVA-5417](https://sonarsource.atlassian.net/browse/SONARJAVA-5417)

Update the CI SCA configuration to exclude a few directories that appear to contain test fixtures. Since test fixtures are generally not relevant for SCA, this change should help remove false positives and improve scan performance.

If these exclusions don't quite match your needs, I'm happy to further adjust the PR. Alternatively, code owners can choose to close this PR and create your own PR. Ultimately, you have the final say on which files should be analyzed for SCA.

After this change, the following files will be analyzed by SCA:
```
check-list/maven-dependency-tree.txt
docs/java-custom-rules-example/maven-dependency-tree.txt
docs/java-custom-rules-example/pom.xml
docs/maven-dependency-tree.txt
docs/pom.xml
external-reports/maven-dependency-tree.txt
external-reports/pom.xml
its/autoscan/maven-dependency-tree.txt
its/autoscan/pom.xml
its/maven-dependency-tree.txt
its/plugin/maven-dependency-tree.txt
its/plugin/plugins/java-extension-plugin/maven-dependency-tree.txt
its/plugin/plugins/java-extension-plugin/pom.xml
its/plugin/plugins/maven-dependency-tree.txt
its/plugin/plugins/pom.xml
its/plugin/pom.xml
its/plugin/tests/maven-dependency-tree.txt
its/plugin/tests/pom.xml
its/pom.xml
its/ruling/maven-dependency-tree.txt
its/ruling/pom.xml
java-checks-aws/maven-dependency-tree.txt
java-checks-aws/pom.xml
java-checks-common/maven-dependency-tree.txt
java-checks-common/pom.xml
java-checks-test-sources/aws/maven-dependency-tree.txt
java-checks-test-sources/aws/pom.xml
java-checks-test-sources/default/maven-dependency-tree.txt
java-checks-test-sources/default/pom.xml
java-checks-test-sources/java-17/maven-dependency-tree.txt
java-checks-test-sources/java-17/pom.xml
java-checks-test-sources/maven-dependency-tree.txt
java-checks-test-sources/pom.xml
java-checks-test-sources/spring-3.2/maven-dependency-tree.txt
java-checks-test-sources/spring-3.2/pom.xml
java-checks-test-sources/test-classpath-reader/maven-dependency-tree.txt
java-checks-test-sources/test-classpath-reader/pom.xml
java-checks-testkit/maven-dependency-tree.txt
java-checks-testkit/pom.xml
java-checks/maven-dependency-tree.txt
java-checks/pom.xml
java-frontend/maven-dependency-tree.txt
java-frontend/pom.xml
java-jsp/maven-dependency-tree.txt
java-jsp/pom.xml
java-surefire/maven-dependency-tree.txt
java-surefire/pom.xml
java-symbolic-execution/java-symbolic-execution-checks-test-sources/maven-dependency-tree.txt
java-symbolic-execution/java-symbolic-execution-checks-test-sources/pom.xml
java-symbolic-execution/java-symbolic-execution-plugin/maven-dependency-tree.txt
java-symbolic-execution/java-symbolic-execution-plugin/pom.xml
java-symbolic-execution/maven-dependency-tree.txt
java-symbolic-execution/pom.xml
maven-dependency-tree.txt
pom.xml
sonar-java-plugin/maven-dependency-tree.txt
sonar-java-plugin/pom.xml
```


[SONARJAVA-5417]: https://sonarsource.atlassian.net/browse/SONARJAVA-5417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ