### PR TITLE
SONARJAVA-5421 Fix NPE in S2225 on return in void lambdas

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/ToStringReturningNullCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/ToStringReturningNullCheckSample.java
@@ -32,6 +32,13 @@ class ToStringReturningNullCheckSampleD {
   }
 }
 
+class ToStringReturningNullCheckSampleE {
+  public String toString() {
+    java.util.List.of("foo").forEach(s -> {return;});
+    return "bar";
+  }
+}
+
 class QuickFixesA{
   public String toString() {
     return (null); // Noncompliant [[quickfixes=qf1]]


### PR DESCRIPTION
[SONARJAVA-5421](https://sonarsource.atlassian.net/browse/SONARJAVA-5421)

With this changes, we check whether we are inside a lambda in the interesting method before looking at return statement.
This has the effect of avoiding some null pointer exceptions.

[SONARJAVA-5421]: https://sonarsource.atlassian.net/browse/SONARJAVA-5421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ