### PR TITLE
SONARJAVA-5427 verify log size is within a specified range instead of an exact value to fix flaky test

### DIFF
--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -280,8 +280,9 @@ class JavaAstScannerTest {
       ));
 
     List<String> logs = globalLogTester.logs(Level.INFO);
-    assertThat(TestUtils.filterOutAnalysisProgressLogLines(logs)).hasSize(3)
-      .contains("1/1 source file has been analyzed");
+    List<String> filteredLogs = TestUtils.filterOutAnalysisProgressLogLines(logs);
+    assertThat(filteredLogs).contains("1/1 source file has been analyzed");
+    assertThat(filteredLogs.size()).isBetween(3,4);
     assertThat(logTester.logs(Level.ERROR)).containsExactly(
       "Unable to parse source file : 'src/test/files/metrics/Java15SwitchExpression.java'",
       "Parse error at line 3 column 13: Switch Expressions are supported from Java 14 onwards only"


### PR DESCRIPTION
[SONARJAVA-5427](https://sonarsource.atlassian.net/browse/SONARJAVA-5427)



[SONARJAVA-5427]: https://sonarsource.atlassian.net/browse/SONARJAVA-5427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ