### PR TITLE
SONARJAVA-5338 Do not compare method binding key for non-lambdas

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/StaticMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StaticMethodCheckSample.java
@@ -8,6 +8,16 @@ import java.util.Map;
 import java.util.HashMap;
 import javax.annotation.Nullable;
 
+class GenericClass1<R extends Record> {
+  private final int recursiveMethod(int x) { // Noncompliant {{Make "recursiveMethod" a "static" method.}}
+    if (x <= 0) {
+      return 0;
+    } else {
+      return x * recursiveMethod(x - 1);
+    }
+  }
+}
+
 class Utilities {
   private static String magicWord = "magic";
   private static String string = magicWord; // coverage

--- a/java-checks-test-sources/default/src/main/java/checks/VarCanBeUsedCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/VarCanBeUsedCheck.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -146,6 +147,23 @@ public class VarCanBeUsedCheck {
   }
 }
 
+class VarCanBeUsedInLambdas {
+  public static final Comparator<Integer> COMPARATOR = (e1, e2) -> {
+    int compare = Integer.compare(e1, e2); // Noncompliant {{Declare this local variable with "var" instead.}}
+    return compare != 0 ? compare : Integer.compare(e2, e1);
+  };
+
+  public static int foo() {
+    java.util.function.IntSupplier supplier = () -> {
+      var sum = 0;
+      for (int i = 0; i < 10; i++) { // Noncompliant {{Declare this local variable with "var" instead.}}
+        sum += i;
+      }
+      return sum;
+    };
+    return supplier.getAsInt();
+  }
+}
 
 class Abc {
   static Abc getAbc() {

--- a/java-frontend/src/main/java/org/sonar/java/model/JMethodSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JMethodSymbol.java
@@ -71,6 +71,10 @@ final class JMethodSymbol extends JSymbol implements Symbol.MethodSymbol {
     return (IMethodBinding) binding;
   }
 
+  public boolean isLambda() {
+    return methodBinding().getDeclaringMember() != null;
+  }
+
   @Override
   public List<Type> parameterTypes() {
     if (parameterTypes == null) {
@@ -207,5 +211,11 @@ final class JMethodSymbol extends JSymbol implements Symbol.MethodSymbol {
   @Override
   public boolean isNativeMethod() {
     return !isUnknown() && Modifier.isNative(binding.getModifiers());
+  }
+
+  /** This is for debugging and doesn't follow a guaranteed format. */
+  @Override
+  public String toString() {
+    return binding.getKey();
   }
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -84,10 +84,7 @@ abstract class JSymbol implements Symbol {
           other
         );
       case IBinding.METHOD:
-        return areEqualMethods(
-          this,
-          other
-        );
+        return areEqualMethods((JMethodSymbol) this, (JMethodSymbol) other);
       default:
         return super.equals(obj);
     }
@@ -100,12 +97,10 @@ abstract class JSymbol implements Symbol {
       && thisVariableSymbol.owner().equals(otherVariableSymbol.owner());
   }
 
-  private static boolean areEqualMethods(JSymbol thisMethodSymbol, JSymbol otherMethodSymbol) {
+  private static boolean areEqualMethods(JMethodSymbol thisMethodSymbol, JMethodSymbol otherMethodSymbol) {
     IMethodBinding thisBinding = (IMethodBinding) thisMethodSymbol.binding;
     IMethodBinding otherBinding = (IMethodBinding) otherMethodSymbol.binding;
-    if (thisMethodSymbol instanceof JMethodSymbol jMethodSymbol &&
-      otherMethodSymbol instanceof JMethodSymbol otherJMethodSymbol &&
-      jMethodSymbol.isLambda() && otherJMethodSymbol.isLambda()) {
+    if (thisMethodSymbol.isLambda() && otherMethodSymbol.isLambda()) {
       return Objects.equals(thisBinding.getKey(), otherBinding.getKey());
     }
     return thisMethodSymbol.name().equals(otherMethodSymbol.name())

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -17,7 +17,6 @@
 package org.sonar.java.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -103,11 +102,7 @@ abstract class JSymbol implements Symbol {
   private static boolean areEqualMethods(JSymbol thisMethodSymbol, JSymbol otherMethodSymbol) {
     IMethodBinding thisBinding = (IMethodBinding) thisMethodSymbol.binding;
     IMethodBinding otherBinding = (IMethodBinding) otherMethodSymbol.binding;
-    return thisMethodSymbol.name().equals(otherMethodSymbol.name())
-      && thisMethodSymbol.owner().equals(otherMethodSymbol.owner())
-      && Arrays.equals(thisBinding.getParameterTypes(), otherBinding.getParameterTypes())
-      && Arrays.equals(thisBinding.getTypeParameters(), otherBinding.getTypeParameters())
-      && Arrays.equals(thisBinding.getTypeArguments(), otherBinding.getTypeArguments());
+    return Objects.equals(thisBinding.getKey(), otherBinding.getKey());
   }
 
   @Override
@@ -194,7 +189,6 @@ abstract class JSymbol implements Symbol {
     if (!variableBinding.isRecordComponent()) {
       IMethodBinding declaringMethod = variableBinding.getDeclaringMethod();
       if (declaringMethod != null) {
-        // local variable
         return sema.methodSymbol(declaringMethod);
       }
       ITypeBinding declaringClass = variableBinding.getDeclaringClass();
@@ -203,6 +197,10 @@ abstract class JSymbol implements Symbol {
         return sema.typeSymbol(declaringClass);
       }
     }
+    return ownerOfRecordComponentConstant(variableBinding);
+  }
+
+  private Symbol ownerOfRecordComponentConstant(IVariableBinding variableBinding) {
     Tree node = sema.declarations.get(variableBinding);
     if (node == null) {
       // array.length

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -17,6 +17,7 @@
 package org.sonar.java.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -102,7 +103,16 @@ abstract class JSymbol implements Symbol {
   private static boolean areEqualMethods(JSymbol thisMethodSymbol, JSymbol otherMethodSymbol) {
     IMethodBinding thisBinding = (IMethodBinding) thisMethodSymbol.binding;
     IMethodBinding otherBinding = (IMethodBinding) otherMethodSymbol.binding;
-    return Objects.equals(thisBinding.getKey(), otherBinding.getKey());
+    if (thisMethodSymbol instanceof JMethodSymbol jMethodSymbol &&
+      otherMethodSymbol instanceof JMethodSymbol otherJMethodSymbol &&
+      jMethodSymbol.isLambda() && otherJMethodSymbol.isLambda()) {
+      return Objects.equals(thisBinding.getKey(), otherBinding.getKey());
+    }
+    return thisMethodSymbol.name().equals(otherMethodSymbol.name())
+      && thisMethodSymbol.owner().equals(otherMethodSymbol.owner())
+      && Arrays.equals(thisBinding.getParameterTypes(), otherBinding.getParameterTypes())
+      && Arrays.equals(thisBinding.getTypeParameters(), otherBinding.getTypeParameters())
+      && Arrays.equals(thisBinding.getTypeArguments(), otherBinding.getTypeArguments());
   }
 
   @Override

--- a/java-frontend/src/test/java/org/sonar/java/model/JSymbolTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JSymbolTest.java
@@ -33,6 +33,7 @@ import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
@@ -42,6 +43,8 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sonar.java.model.assertions.SymbolAssert.assertThat;
@@ -161,6 +164,40 @@ class JSymbolTest {
     assertThat(cu.sema.methodSymbol(m.methodBinding))
       .as("of method")
       .hasOwner(cu.sema.typeSymbol(c1.typeBinding));
+  }
+
+  @Test
+  void owner_lambdaVariable_variableBinding() {
+    JavaTree.CompilationUnitTreeImpl cu = test("""
+      class C {
+        java.util.function.Function<Integer, Integer> variableBinding = i -> i;
+      }
+      """
+    );
+    var classTree = (ClassTreeImpl) cu.types().get(0);
+    var lambda = (LambdaExpressionTree) ((VariableTree) classTree.members().get(0)).initializer();
+    var i = (IdentifierTree) lambda.body();
+    Symbol owner = i.symbol().owner();
+    assertTrue(owner instanceof JMethodSymbol methodSymbol && methodSymbol.isLambda());
+  }
+
+  @Test
+  void owner_lambdaVariable_methodBinding() {
+    JavaTree.CompilationUnitTreeImpl cu = test("""
+      class C {
+         void foo() {
+             java.util.function.Function<Long, Long> methodBinding = l -> l;
+          }
+      }
+      """
+    );
+    ClassTreeImpl classTree = (ClassTreeImpl) cu.types().get(0);
+    MethodTree method = (MethodTree) classTree.members().get(0);
+    VariableTree bindingInsideMethod = (VariableTree) method.block().body().get(0);
+    LambdaExpressionTree lambda = (LambdaExpressionTree) bindingInsideMethod.initializer();
+    VariableTree l = lambda.parameters().get(0);
+    Symbol owner = l.symbol().owner();
+    assertTrue(owner instanceof JMethodSymbol methodSymbol && methodSymbol.isLambda());
   }
 
   @Test
@@ -600,6 +637,27 @@ class JSymbolTest {
       ClassTreeImpl c1 = (ClassTreeImpl) cu.types().get(0);
       return cu.sema.variableSymbol(((VariableTreeImpl) c1.members().get(memberIndex)).variableBinding);
     }
+  }
+
+  @Test
+  void testEquality_twoLambdas() {
+    CompilationUnitTree cu = test("""
+      class C {
+        F k = s -> {};
+        F j = s -> {};
+        interface F extends java.util.function.Consumer<String> {}
+      }
+      """);
+    ClassTree classTree = (ClassTree) cu.types().get(0);
+    var k = (VariableTree) classTree.members().get(0);
+    var lambda1 = (LambdaExpressionTree) k.initializer();
+    Symbol.MethodSymbol methodSymbol1 = lambda1.symbol();
+
+    var j = (VariableTree) classTree.members().get(1);
+    var lambda2 = (LambdaExpressionTree) j.initializer();
+    Symbol.MethodSymbol methodSymbol2 = lambda2.symbol();
+
+    assertNotEquals(methodSymbol1, methodSymbol2);
   }
 
   private static JavaTree.CompilationUnitTreeImpl test(String source) {


### PR DESCRIPTION
[SONARJAVA-5338](https://sonarsource.atlassian.net/browse/SONARJAVA-5338)

We observed that in some cases, in particular recursive method inside generic classes, the same method binding could be attributed different keys. The changes in this PR work around this problem by only using the key comparison for lambda methods (which cannot be recursive). 

[SONARJAVA-5338]: https://sonarsource.atlassian.net/browse/SONARJAVA-5338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ