### PR TITLE
SONARCH-708, SONARJAVA-5497: Extend SonarJava CheckRegistrar API for registering custom file scanner hooks

### DIFF
--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/TestCheckRegistrarContext.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/TestCheckRegistrarContext.java
@@ -24,9 +24,11 @@ import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rule.RuleScope;
 import org.sonar.api.rules.RuleAnnotationUtils;
 import org.sonar.plugins.java.api.CheckRegistrar;
 import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScanner;
 
 public class TestCheckRegistrarContext extends CheckRegistrar.RegistrarContext {
 
@@ -52,16 +54,34 @@ public class TestCheckRegistrarContext extends CheckRegistrar.RegistrarContext {
 
   @Override
   public void registerMainSharedCheck(JavaCheck check, Collection<RuleKey> ruleKeys) {
+    registerMainHook(check);
+    mainRuleKeys.addAll(ruleKeys);
+  }
+
+  private void registerMainHook(JavaCheck check) {
     mainCheckClasses.add(check.getClass());
     mainCheckInstances.add(check);
-    mainRuleKeys.addAll(ruleKeys);
   }
 
   @Override
   public void registerTestSharedCheck(JavaCheck check, Collection<RuleKey> ruleKeys) {
+    registerTestHook(check);
+    testRuleKeys.addAll(ruleKeys);
+  }
+
+  private void registerTestHook(JavaCheck check) {
     testCheckClasses.add(check.getClass());
     testCheckInstances.add(check);
-    testRuleKeys.addAll(ruleKeys);
+  }
+
+  @Override
+  public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
+    if (ruleScope != RuleScope.TEST) {
+      registerMainHook(scanner);
+    }
+    if (ruleScope != RuleScope.MAIN) {
+      registerTestHook(scanner);
+    }
   }
 
   @Override

--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/TestCheckRegistrarContext.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/TestCheckRegistrarContext.java
@@ -76,10 +76,10 @@ public class TestCheckRegistrarContext extends CheckRegistrar.RegistrarContext {
 
   @Override
   public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
-    if (ruleScope != RuleScope.TEST) {
+    if (ruleScope == RuleScope.MAIN || ruleScope == RuleScope.ALL) {
       registerMainHook(scanner);
     }
-    if (ruleScope != RuleScope.MAIN) {
+    if (ruleScope == RuleScope.TEST || ruleScope == RuleScope.ALL) {
       registerTestHook(scanner);
     }
   }

--- a/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
+++ b/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
@@ -309,10 +309,10 @@ public class SonarComponents extends CheckRegistrar.RegistrarContext {
 
   @Override
   public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
-    if (ruleScope != RuleScope.TEST) {
+    if (ruleScope == RuleScope.MAIN || ruleScope == RuleScope.ALL) {
       mainChecks.add(scanner);
     }
-    if (ruleScope != RuleScope.MAIN) {
+    if (ruleScope == RuleScope.TEST || ruleScope == RuleScope.ALL) {
       testChecks.add(scanner);
     }
   }

--- a/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
+++ b/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
@@ -56,6 +56,7 @@ import org.sonar.api.config.Configuration;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rule.RuleScope;
 import org.sonar.api.utils.Version;
 import org.sonar.java.annotations.VisibleForTesting;
 import org.sonar.java.caching.ContentHashCache;
@@ -69,6 +70,7 @@ import org.sonar.java.reporting.AnalyzerMessage;
 import org.sonar.java.reporting.JavaIssue;
 import org.sonar.plugins.java.api.CheckRegistrar;
 import org.sonar.plugins.java.api.JavaCheck;
+import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JspCodeVisitor;
 import org.sonar.plugins.java.api.caching.SonarLintCache;
 import org.sonarsource.api.sonarlint.SonarLintSide;
@@ -302,6 +304,16 @@ public class SonarComponents extends CheckRegistrar.RegistrarContext {
   public void registerTestSharedCheck(JavaCheck check, Collection<RuleKey> ruleKeys) {
     if (hasAtLeastOneActiveRule(ruleKeys)) {
       testChecks.add(check);
+    }
+  }
+
+  @Override
+  public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
+    if (ruleScope != RuleScope.TEST) {
+      mainChecks.add(scanner);
+    }
+    if (ruleScope != RuleScope.MAIN) {
+      testChecks.add(scanner);
     }
   }
 

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/CheckRegistrar.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/CheckRegistrar.java
@@ -25,6 +25,7 @@ import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.Checks;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rule.RuleScope;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.java.Preconditions;
 import org.sonar.java.annotations.Beta;
@@ -168,6 +169,13 @@ public interface CheckRegistrar {
      * RuleKey automatically.
      */
     public void registerMainSharedCheck(JavaCheck check, Collection<RuleKey> ruleKeys) {
+      // to be overridden
+    }
+
+    /**
+     * Registers a custom file scanner not related to any rule or repository.
+     */
+    public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
       // to be overridden
     }
 

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/CheckRegistrar.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/CheckRegistrar.java
@@ -174,6 +174,8 @@ public interface CheckRegistrar {
 
     /**
      * Registers a custom file scanner not related to any rule or repository.
+     * CheckRegistrars call this function to register a custom file scanner for execution during the analysis
+     * on all source files that match the given rule scope (MAIN, TEST or ALL).
      */
     public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
       // to be overridden

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/CheckRegistrar.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/CheckRegistrar.java
@@ -176,6 +176,7 @@ public interface CheckRegistrar {
      * Registers a custom file scanner not related to any rule or repository.
      * CheckRegistrars call this function to register a custom file scanner for execution during the analysis
      * on all source files that match the given rule scope (MAIN, TEST or ALL).
+     * Custom file scanners reporting an issue will have no effect, since no rule is associated.
      */
     public void registerCustomFileScanner(RuleScope ruleScope, JavaFileScanner scanner) {
       // to be overridden

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -416,22 +416,20 @@ class SonarComponentsTest {
     CheckFactory specificCheckFactory = new CheckFactory(noActiveRules);
     SensorContextTester specificContext = SensorContextTester.create(new File(".")).setActiveRules(noActiveRules);
 
-    class MainScanner implements JavaFileScanner {
+    class DummyScanner implements JavaFileScanner {
       @Override
       public void scanFile(JavaFileScannerContext context) {
+        // Dummy implementation. We just need the class instance
       }
     }
 
-    class TestScanner implements JavaFileScanner {
-      @Override
-      public void scanFile(JavaFileScannerContext context) {
-      }
+    class MainScanner extends DummyScanner {
     }
 
-    class AllScanner implements JavaFileScanner {
-      @Override
-      public void scanFile(JavaFileScannerContext context) {
-      }
+    class TestScanner extends DummyScanner {
+    }
+
+    class AllScanner extends DummyScanner {
     }
 
     SonarComponents sonarComponents = new SonarComponents(fileLinesContextFactory, null, null,

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -517,7 +517,7 @@ class SonarComponentsTest {
     JavaFileScanner customScanner = scannerContext -> {
       // empty
     };
-    CheckRegistrar registrar =registrarContext ->
+    CheckRegistrar registrar = registrarContext ->
       registrarContext.registerCustomFileScanner(RuleScope.ALL, customScanner);
     SonarComponents sonarComponents = new SonarComponents(fileLinesContextFactory, null, null,
       null, checkFactory, context.activeRules(), new CheckRegistrar[]{registrar});

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -513,6 +513,21 @@ class SonarComponentsTest {
   }
 
   @Test
+  void no_issue_when_reporting_from_custom_file_scanner() {
+    JavaFileScanner customScanner = scannerContext -> {
+      // empty
+    };
+    CheckRegistrar registrar =registrarContext ->
+      registrarContext.registerCustomFileScanner(RuleScope.ALL, customScanner);
+    SonarComponents sonarComponents = new SonarComponents(fileLinesContextFactory, null, null,
+      null, checkFactory, context.activeRules(), new CheckRegistrar[]{registrar});
+    sonarComponents.setSensorContext(context);
+
+    sonarComponents.addIssue(TestUtils.emptyInputFile("file.java"), customScanner, 0, "message", null);
+    verify(context, never()).newIssue();
+  }
+
+  @Test
   void add_issue_or_parse_error() {
     JavaCheck expectedCheck = new CustomCheck();
     CheckRegistrar expectedRegistrar = getRegistrar(expectedCheck);

--- a/java-frontend/src/test/java/org/sonar/plugins/java/api/CheckRegistrarTest.java
+++ b/java-frontend/src/test/java/org/sonar/plugins/java/api/CheckRegistrarTest.java
@@ -27,7 +27,6 @@ import org.sonar.api.rule.RuleKey;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -95,15 +94,6 @@ class CheckRegistrarTest {
       "register 2 autoscan rules.",
       "register 3 instantiated main checks.",
       "register 3 instantiated test checks.");
-  }
-
-  @Test
-  void cover_empty_default_implementations() {
-    var context = new CheckRegistrar.RegistrarContext();
-    // Required for test coverage: we call the empty default implementation of the "registerCustomFileScanner" method
-    // and assert that it returns "void" normally. This is equivalent to asserting that it does not return abnormally,
-    // i.e., does not throw an exception.
-    assertDoesNotThrow(() -> context.registerCustomFileScanner(null, null));
   }
 
   private static class TestInternalRegistration extends CheckRegistrar.RegistrarContext {

--- a/java-frontend/src/test/java/org/sonar/plugins/java/api/CheckRegistrarTest.java
+++ b/java-frontend/src/test/java/org/sonar/plugins/java/api/CheckRegistrarTest.java
@@ -27,6 +27,7 @@ import org.sonar.api.rule.RuleKey;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +95,12 @@ class CheckRegistrarTest {
       "register 2 autoscan rules.",
       "register 3 instantiated main checks.",
       "register 3 instantiated test checks.");
+  }
+
+  @Test
+  void empty_default_method_coverage() {
+    var context = new CheckRegistrar.RegistrarContext();
+    assertDoesNotThrow(() -> context.registerCustomFileScanner(null, null));
   }
 
   private static class TestInternalRegistration extends CheckRegistrar.RegistrarContext {

--- a/java-frontend/src/test/java/org/sonar/plugins/java/api/CheckRegistrarTest.java
+++ b/java-frontend/src/test/java/org/sonar/plugins/java/api/CheckRegistrarTest.java
@@ -98,8 +98,11 @@ class CheckRegistrarTest {
   }
 
   @Test
-  void empty_default_method_coverage() {
+  void cover_empty_default_implementations() {
     var context = new CheckRegistrar.RegistrarContext();
+    // Required for test coverage: we call the empty default implementation of the "registerCustomFileScanner" method
+    // and assert that it returns "void" normally. This is equivalent to asserting that it does not return abnormally,
+    // i.e., does not throw an exception.
     assertDoesNotThrow(() -> context.registerCustomFileScanner(null, null));
   }
 


### PR DESCRIPTION
[SONARCH-708](https://sonarsource.atlassian.net/browse/SONARCH-708)



[SONARCH-708]: https://sonarsource.atlassian.net/browse/SONARCH-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ