### PR TITLE
S1481 Suggest quickfix for for-each statements with unused variables

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/unused/UnusedLocalVariableCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/unused/UnusedLocalVariableCheck.java
@@ -11,6 +11,22 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+class UnusedLocalVariable {
+  private UnusedLocalVariable() {
+  }
+
+  public static int count(int[] elements) {
+    int count = 0;
+    for (int element : elements) { // Noncompliant[[quickfixes=qf_ulv]]
+//           ^^^^^^^
+      // fix@qf_ulv {{Replace unused local variable with _}}
+      // edit@qf_ulv [[sc=10;ec=21]]{{var _}}
+      count++;
+    }
+    return count;
+  }
+}
+
 class UnusedLocalVariableCheck {
 
   int unusedField;
@@ -49,7 +65,10 @@ class UnusedLocalVariableCheck {
     } catch (Exception _) {
     }
 
-    for (int a : new int[]{0, 1, 2}) { // Noncompliant
+    for (int a : new int[]{0, 1, 2}) { // Noncompliant[[quickfixes=qf_f1]]
+//           ^
+      // fix@qf_f1 {{Replace unused local variable with _}}
+      // edit@qf_f1 [[sc=10;ec=15]]{{var _}}
     }
 
     for (int i = 0; condition(); i++) { // Noncompliant


### PR DESCRIPTION
These unused variables can be replaced by `var _`.


