### PR TITLE
SONARJAVA-4881 Spring @Transactional and @Async annotations can be protected and package private

### DIFF
--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/spring/TransactionalMethodVisibilityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/spring/TransactionalMethodVisibilityCheckSample.java
@@ -5,12 +5,12 @@ import org.springframework.transaction.annotation.Transactional;
 class TransactionalMethodVisibilityCheckSample {
   // Cannot compile because a Transactional method should be overridable
   @org.springframework.transaction.annotation.Transactional
-  private void privateTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
+  private void privateTransactionalMethod() {} // Noncompliant {{Make this method non-"private" or remove the "@Transactional" annotation.}}
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   // Cannot compile because a Transactional method should be overridable
   @Transactional
-  private void privateTransactionalMethodWithImportBasedAnnotation() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
+  private void privateTransactionalMethodWithImportBasedAnnotation() {} // Noncompliant {{Make this method non-"private" or remove the "@Transactional" annotation.}}
 
   @org.xxx.Transactional
   private void privateMethodWithNonSpringAnnotation() {} // Compliant

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample.java
@@ -22,8 +22,7 @@ abstract class TransactionalMethodVisibilityCheckSample {
   }
 
   @Async
-  protected abstract Future<String> aMethod(); // Noncompliant
-
+  protected abstract Future<String> aMethod(); // Compliant
 
   @Async
   public Future<String> asyncMethod(){ // compliant
@@ -31,7 +30,17 @@ abstract class TransactionalMethodVisibilityCheckSample {
   }
 
   @Async
-  private  Future<String> asyncMethodPrivate(){ // Noncompliant {{Make this method "public" or remove the "@Async" annotation.}}
+  Future<String> defaultVisibilityAsyncMethod(){ // Compliant
+    return  null;
+  }
+
+  @Async
+  protected Future<String> protectedVisibilityAsyncMethod(){ // Compliant
+    return  null;
+  }
+
+  @Async
+  private  Future<String> privateAsyncMethod(){ // Noncompliant {{Make this method non-"private" or remove the "@Async" annotation.}}
     return  null;
   }
 
@@ -39,9 +48,11 @@ abstract class TransactionalMethodVisibilityCheckSample {
   public void publicTransactionalMethod() {} // Compliant
 
   @org.springframework.transaction.annotation.Transactional
-  protected void protectedTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
-//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  
+  protected void protectedTransactionalMethod() {} // Compliant
+
   @org.springframework.transaction.annotation.Transactional
-  void defaultVisibilityTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
+  void defaultVisibilityTransactionalMethod() {} // Compliant
+
+  @org.springframework.transaction.annotation.Transactional
+  private void privateTransactionalMethod() {} // Noncompliant {{Make this method non-"private" or remove the "@Transactional" annotation.}}
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodVisibilityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodVisibilityCheck.java
@@ -44,12 +44,12 @@ public class TransactionalMethodVisibilityCheck extends IssuableSubscriptionVisi
   @Override
   public void visitNode(Tree tree) {
     MethodTree method = (MethodTree) tree;
-    if (!method.symbol().isPublic()) {
+    if (method.symbol().isPrivate()) {
       proxyAnnotations.stream()
         .filter(annSymbol -> hasAnnotation(method, annSymbol))
         .forEach(annSymbol -> reportIssue(
           method.simpleName(),
-          "Make this method \"public\" or remove the \"" + annShortName.get(annSymbol) + "\" annotation."));
+          "Make this method non-\"private\" or remove the \"" + annShortName.get(annSymbol) + "\" annotation."));
     }
   }
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2230.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2230.json
@@ -1,5 +1,5 @@
 {
-  "title": "Methods with Spring proxying annotations should be public",
+  "title": "Methods with Spring proxying annotations should not be private",
   "type": "BUG",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
[SONARJAVA-4881](https://sonarsource.atlassian.net/browse/SONARJAVA-4881)

Since [Spring 6](https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html#transaction-declarative-annotations-method-visibility), `@Transactional` annotated methods are allowed to be protected and package-private. This change updates S2230 rule to only look for private methods. 


[SONARJAVA-4881]: https://sonarsource.atlassian.net/browse/SONARJAVA-4881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ