### PR TITLE
SONARJAVA-4881 With Spring 6, @Transactional and @Async annotated methods don't need to be public

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample.java
@@ -10,19 +10,6 @@ abstract class TransactionalMethodVisibilityCheckSample {
     @Transactional
     int bar(); // Compliant
   }
-  
-  private interface B {
-    @Transactional
-    int bar(); // Compliant
-  }
-
-  private interface A {
-    @Async
-    int bar(); // Compliant
-  }
-
-  @Async
-  protected abstract Future<String> aMethod(); // Compliant
 
   @Async
   public Future<String> asyncMethod(){ // compliant
@@ -30,29 +17,10 @@ abstract class TransactionalMethodVisibilityCheckSample {
   }
 
   @Async
-  Future<String> defaultVisibilityAsyncMethod(){ // Compliant
-    return  null;
-  }
-
-  @Async
-  protected Future<String> protectedVisibilityAsyncMethod(){ // Compliant
-    return  null;
-  }
-
-  @Async
-  private  Future<String> privateAsyncMethod(){ // Noncompliant {{Make this method non-"private" or remove the "@Async" annotation.}}
+  private  Future<String> privateAsyncMethod(){ // Noncompliant {{Make this method "public" or remove the "@Async" annotation.}}
     return  null;
   }
 
   @org.springframework.transaction.annotation.Transactional
   public void publicTransactionalMethod() {} // Compliant
-
-  @org.springframework.transaction.annotation.Transactional
-  protected void protectedTransactionalMethod() {} // Compliant
-
-  @org.springframework.transaction.annotation.Transactional
-  void defaultVisibilityTransactionalMethod() {} // Compliant
-
-  @org.springframework.transaction.annotation.Transactional
-  private void privateTransactionalMethod() {} // Noncompliant {{Make this method non-"private" or remove the "@Transactional" annotation.}}
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample.java
@@ -22,8 +22,7 @@ abstract class TransactionalMethodVisibilityCheckSample {
   }
 
   @Async
-  protected abstract Future<String> aMethod(); // Noncompliant
-
+  protected abstract Future<String> aMethod(); // Compliant
 
   @Async
   public Future<String> asyncMethod(){ // compliant
@@ -31,7 +30,17 @@ abstract class TransactionalMethodVisibilityCheckSample {
   }
 
   @Async
-  private  Future<String> asyncMethodPrivate(){ // Noncompliant {{Make this method "public" or remove the "@Async" annotation.}}
+  Future<String> defaultVisibilityAsyncMethod(){ // Compliant
+    return  null;
+  }
+
+  @Async
+  protected Future<String> protectedVisibilityAsyncMethod(){ // Compliant
+    return  null;
+  }
+
+  @Async
+  private  Future<String> privateAsyncMethod(){ // Noncompliant {{Make this method non-"private" or remove the "@Async" annotation.}}
     return  null;
   }
 
@@ -39,9 +48,11 @@ abstract class TransactionalMethodVisibilityCheckSample {
   public void publicTransactionalMethod() {} // Compliant
 
   @org.springframework.transaction.annotation.Transactional
-  protected void protectedTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
-//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  
+  protected void protectedTransactionalMethod() {} // Compliant
+
   @org.springframework.transaction.annotation.Transactional
-  void defaultVisibilityTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
+  void defaultVisibilityTransactionalMethod() {} // Compliant
+
+  @org.springframework.transaction.annotation.Transactional
+  private void privateTransactionalMethod() {} // Noncompliant {{Make this method non-"private" or remove the "@Transactional" annotation.}}
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample_Spring5.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodVisibilityCheckSample_Spring5.java
@@ -1,0 +1,33 @@
+package checks.spring;
+
+import java.util.concurrent.Future;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
+
+abstract class TransactionalMethodVisibilityCheckSample_Spring5 {
+  
+  public interface C {
+    @Transactional
+    int bar(); // Compliant
+  }
+  
+  @Async
+  protected abstract Future<String> aMethod(); // Noncompliant
+
+  @Async
+  Future<String> defaultVisibilityAsyncMethod(){ // Noncompliant
+    return  null;
+  }
+
+  @Async
+  protected Future<String> protectedVisibilityAsyncMethod(){ // Noncompliant
+    return  null;
+  }
+
+  @org.springframework.transaction.annotation.Transactional
+  protected void protectedTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
+//               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  @org.springframework.transaction.annotation.Transactional
+  void defaultVisibilityTransactionalMethod() {} // Noncompliant {{Make this method "public" or remove the "@Transactional" annotation.}}
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodVisibilityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodVisibilityCheck.java
@@ -19,14 +19,18 @@ package org.sonar.java.checks.spring;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.DependencyVersionAware;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.Version;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S2230")
-public class TransactionalMethodVisibilityCheck extends IssuableSubscriptionVisitor {
+public class TransactionalMethodVisibilityCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
 
   private static final List<String> proxyAnnotations = List.of(
     "org.springframework.transaction.annotation.Transactional",
@@ -62,4 +66,8 @@ public class TransactionalMethodVisibilityCheck extends IssuableSubscriptionVisi
     return false;
   }
 
+  @Override
+  public boolean isCompatibleWithDependencies(Function<String, Optional<Version>> dependencyFinder) {
+    return dependencyFinder.apply("spring-tx").map(version -> version.isLowerThan("6.0")).orElse(false);
+  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/TransactionalMethodVisibilityCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/TransactionalMethodVisibilityCheckTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java.checks.spring;
 
+import java.io.File;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
@@ -30,6 +32,24 @@ class TransactionalMethodVisibilityCheckTest {
       .onFile(mainCodeSourcesPath("checks/spring/TransactionalMethodVisibilityCheckSample.java"))
       .withCheck(new TransactionalMethodVisibilityCheck())
       .verifyIssues();
+  }
+
+  @Test
+  void test_Spring5() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/TransactionalMethodVisibilityCheckSample_Spring5.java"))
+      .withCheck(new TransactionalMethodVisibilityCheck())
+      .verifyIssues();
+  }
+
+  /** Check that with Spring 6, we do not raise issues on protected and package private methods. */
+  @Test
+  void test_Spring6() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/TransactionalMethodVisibilityCheckSample_Spring5.java"))
+      .withCheck(new TransactionalMethodVisibilityCheck())
+      .withClassPath(List.of(new File("spring-tx-6.0.1.jar")))
+      .verifyNoIssues();
   }
 
   @Test

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2230.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2230.json
@@ -1,5 +1,5 @@
 {
-  "title": "Methods with Spring proxying annotations should be public",
+  "title": "Methods with Spring proxying annotations should not be private",
   "type": "BUG",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
https://sonarsource.atlassian.net/browse/SONARJAVA-4881


Since [Spring 6](https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html#transaction-declarative-annotations-method-visibility), @Transactional annotated methods are allowed to be protected and package-private.
This PR updates the rule S2230 to only apply to projects where Spring appears with a version less than 6.

This is based on the PR https://github.com/SonarSource/sonar-java/pull/5092

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
