### PR TITLE
SONARJAVA-5522 Let DefaultInitializedFieldCheck handle underscores in float/double

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/DefaultInitializedFieldCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DefaultInitializedFieldCheckSample.java
@@ -21,10 +21,26 @@ class DefaultInitializedFieldCheckSample {
   float f1 = 0.f; // Noncompliant {{Remove this initialization to "0.f", the compiler will do that for you.}}
   float f2 = 1.f;
   float f3;
+  float f4 = 1_000_000F; // Compliant, not 0
+  float f5 = 1_000_000_000_000_000_000f; // Compliant, not 0
+  float f6 = 1_000_000; // Compliant, not 0
+  float f7 = 0_000_000; // Noncompliant {{Remove this initialization to "0_000_000", the compiler will do that for you.}}
+  float f8 = 0_000_000f; // Noncompliant {{Remove this initialization to "0_000_000f", the compiler will do that for you.}}
+  float f9 = (float) 1_000_000d; // Compliant, not 0
+  float f10 = 123_456e-7f; // Compliant, not 0
+  float f11 = 1_000.0f; // Compliant, not 0
   double d = 0.; // Noncompliant {{Remove this initialization to "0.", the compiler will do that for you.}}
   double d1 = 1.;
   double d2;
   double d3 = 0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001; // Compliant, not 0
+  double d4 = 1_000_000D; // Compliant, not 0
+  double d5 = 1_000_000_000_000_000_000d; // Compliant, not 0
+  double d6 = 1_000_000; // Compliant, not 0
+  double d7 = 0_000_000; // Noncompliant {{Remove this initialization to "0_000_000", the compiler will do that for you.}}
+  double d8 = 0_000_000d; // Noncompliant {{Remove this initialization to "0_000_000d", the compiler will do that for you.}}
+  double d9 = 1_000_000f; // Compliant, not 0
+  double d10 = 123_456e-7d; // Compliant, not 0
+  double d11 = 1_000.0f; // Compliant, not 0
   char c = 0; // Noncompliant {{Remove this initialization to "0", the compiler will do that for you.}}
   char c1 = '\u0000'; // Noncompliant {{Remove this initialization to "'\u0000'", the compiler will do that for you.}}
 //          ^^^^^^^^

--- a/java-checks/src/main/java/org/sonar/java/checks/DefaultInitializedFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DefaultInitializedFieldCheck.java
@@ -79,8 +79,9 @@ public class DefaultInitializedFieldCheck extends IssuableSubscriptionVisitor {
           .flatMap(numericalValue -> literalValue(expression));
       case FLOAT_LITERAL,
         DOUBLE_LITERAL:
-        return literalValue(expression)
-          .filter(numericalValue -> Double.doubleToLongBits(Double.valueOf(numericalValue)) == 0);
+        return Optional.ofNullable(LiteralUtils.doubleLiteralValue(expression))
+          .filter(numericalValue -> Double.doubleToLongBits(numericalValue) == 0)
+          .flatMap(numericalValue -> literalValue(expression));
       case TYPE_CAST:
         return getIfDefault(((TypeCastTree) expression).expression(), isPrimitive);
       default:

--- a/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -86,6 +86,16 @@ public class LiteralUtils {
   }
 
   @CheckForNull
+  public static Double doubleLiteralValue(ExpressionTree expression) {
+    if (expression.is(Kind.FLOAT_LITERAL, Kind.DOUBLE_LITERAL)) {
+      String value = ((LiteralTree) expression).value().replace("_", "");
+      
+      return Double.parseDouble(value);
+    }
+    return null;
+  }
+
+  @CheckForNull
   private static Integer minus(@Nullable Integer nullableInteger) {
     return nullableInteger == null ? null : -nullableInteger;
   }


### PR DESCRIPTION
Hello,
I've noticed that `DefaultInitializedFieldCheck` crashes when using underscores in the declaration of float/double litterals.
This should hopefully fix the issue.
If someone at SonarSource can please create a JIRA I can amend the commit message.
Please let me know if this is misguided or if you think there's a better way!
Thanks!