### PR TITLE
SONARJAVA-5400 Fix false positive for S6241 and S6242 when builder is not AwsClientBuilder

### DIFF
--- a/java-checks-aws/src/main/java/org/sonar/java/checks/aws/AwsBuilderMethodFinder.java
+++ b/java-checks-aws/src/main/java/org/sonar/java/checks/aws/AwsBuilderMethodFinder.java
@@ -33,8 +33,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 public abstract class AwsBuilderMethodFinder extends IssuableSubscriptionVisitor {
 
   private static final String SDK_CLIENT_TYPE = "software.amazon.awssdk.core.SdkClient";
-  private static final String SDK_CLIENT_BUILDER_TYPE = "software.amazon.awssdk.utils.builder.SdkBuilder";
-  protected static final String AWS_CLIENT_BUILDER_TYPE = "software.amazon.awssdk.awscore.client.builder.AwsClientBuilder";
+  protected static final String SDK_CLIENT_BUILDER_TYPE = "software.amazon.awssdk.utils.builder.SdkBuilder";
   private static final MethodMatchers BUILD_METHOD = MethodMatchers.create()
     .ofSubTypes(SDK_CLIENT_BUILDER_TYPE)
     .names("build")

--- a/java-checks-aws/src/main/java/org/sonar/java/checks/aws/AwsCredentialsShouldBeSetExplicitlyCheck.java
+++ b/java-checks-aws/src/main/java/org/sonar/java/checks/aws/AwsCredentialsShouldBeSetExplicitlyCheck.java
@@ -22,7 +22,7 @@ import org.sonar.plugins.java.api.semantic.MethodMatchers;
 @Rule(key = "S6242")
 public class AwsCredentialsShouldBeSetExplicitlyCheck extends AwsBuilderMethodFinder {
   private static final MethodMatchers CREDENTIALS_METHOD = MethodMatchers.create()
-    .ofSubTypes(AWS_CLIENT_BUILDER_TYPE)
+    .ofSubTypes(SDK_CLIENT_BUILDER_TYPE)
     .names("credentialsProvider")
     .addParametersMatcher("software.amazon.awssdk.auth.credentials.AwsCredentialsProvider")
     .build();

--- a/java-checks-aws/src/main/java/org/sonar/java/checks/aws/AwsRegionShouldBeSetExplicitlyCheck.java
+++ b/java-checks-aws/src/main/java/org/sonar/java/checks/aws/AwsRegionShouldBeSetExplicitlyCheck.java
@@ -22,7 +22,7 @@ import org.sonar.plugins.java.api.semantic.MethodMatchers;
 @Rule(key = "S6241")
 public class AwsRegionShouldBeSetExplicitlyCheck extends AwsBuilderMethodFinder {
   private static final MethodMatchers REGION_METHOD = MethodMatchers.create()
-    .ofSubTypes(AWS_CLIENT_BUILDER_TYPE)
+    .ofSubTypes(SDK_CLIENT_BUILDER_TYPE)
     .names("region")
     .addParametersMatcher("software.amazon.awssdk.regions.Region")
     .build();

--- a/java-checks-test-sources/aws/pom.xml
+++ b/java-checks-test-sources/aws/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-sdk-java</artifactId>
-      <version>2.17.215</version>
+      <version>2.31.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/java-checks-test-sources/aws/src/main/java/checks/aws/AwsCredentialsShouldBeSetExplicitlyCheckSample.java
+++ b/java-checks-test-sources/aws/src/main/java/checks/aws/AwsCredentialsShouldBeSetExplicitlyCheckSample.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsPro
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -72,5 +73,15 @@ public class AwsCredentialsShouldBeSetExplicitlyCheckSample {
 
   static AwsClientBuilder getABuilder() {
     return S3Client.builder();
+  }
+
+  void s3asyncClient() {
+    var credentialsProvider = EnvironmentVariableCredentialsProvider.create();
+    try (var client = S3AsyncClient.crtBuilder() // Compliant
+      .region(Region.EU_CENTRAL_1)
+      .credentialsProvider(credentialsProvider)
+      .build()) {
+      client.waiter();
+    }
   }
 }

--- a/java-checks-test-sources/aws/src/main/java/checks/aws/AwsRegionShouldBeSetExplicitlyCheckSample.java
+++ b/java-checks-test-sources/aws/src/main/java/checks/aws/AwsRegionShouldBeSetExplicitlyCheckSample.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsPro
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -87,7 +88,15 @@ public class AwsRegionShouldBeSetExplicitlyCheckSample {
   void compliantInitializedInOtherMethod() {
     AwsClientBuilder builder = getABuilder(); // Compliant FN
     builder.build();
+  }
 
-
+  void s3asyncClient() {
+    var credentialsProvider = EnvironmentVariableCredentialsProvider.create();
+    try (var client = S3AsyncClient.crtBuilder() // Compliant
+      .region(Region.EU_CENTRAL_1)
+      .credentialsProvider(credentialsProvider)
+      .build()) {
+      client.waiter();
+    }
   }
 }


### PR DESCRIPTION
Previously these checks were only taking account calls on some specific kind of builders, but there can be other implementations.