### PR TITLE
SONARJAVA-5522 S3052: Let DefaultInitializedFieldCheck handle underscores in float/double literals

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/DefaultInitializedFieldCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DefaultInitializedFieldCheckSample.java
@@ -21,10 +21,26 @@ class DefaultInitializedFieldCheckSample {
   float f1 = 0.f; // Noncompliant {{Remove this initialization to "0.f", the compiler will do that for you.}}
   float f2 = 1.f;
   float f3;
+  float f4 = 1_000_000F; // Compliant, not 0
+  float f5 = 1_000_000_000_000_000_000f; // Compliant, not 0
+  float f6 = 1_000_000; // Compliant, not 0
+  float f7 = 0_000_000; // Noncompliant {{Remove this initialization to "0_000_000", the compiler will do that for you.}}
+  float f8 = 0_000_000f; // Noncompliant {{Remove this initialization to "0_000_000f", the compiler will do that for you.}}
+  float f9 = (float) 1_000_000d; // Compliant, not 0
+  float f10 = 123_456e-7f; // Compliant, not 0
+  float f11 = 1_000.0f; // Compliant, not 0
   double d = 0.; // Noncompliant {{Remove this initialization to "0.", the compiler will do that for you.}}
   double d1 = 1.;
   double d2;
   double d3 = 0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001; // Compliant, not 0
+  double d4 = 1_000_000D; // Compliant, not 0
+  double d5 = 1_000_000_000_000_000_000d; // Compliant, not 0
+  double d6 = 1_000_000; // Compliant, not 0
+  double d7 = 0_000_000; // Noncompliant {{Remove this initialization to "0_000_000", the compiler will do that for you.}}
+  double d8 = 0_000_000d; // Noncompliant {{Remove this initialization to "0_000_000d", the compiler will do that for you.}}
+  double d9 = 1_000_000f; // Compliant, not 0
+  double d10 = 123_456e-7d; // Compliant, not 0
+  double d11 = 1_000.0f; // Compliant, not 0
   char c = 0; // Noncompliant {{Remove this initialization to "0", the compiler will do that for you.}}
   char c1 = '\u0000'; // Noncompliant {{Remove this initialization to "'\u0000'", the compiler will do that for you.}}
 //          ^^^^^^^^

--- a/java-checks/src/main/java/org/sonar/java/checks/DefaultInitializedFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DefaultInitializedFieldCheck.java
@@ -79,8 +79,9 @@ public class DefaultInitializedFieldCheck extends IssuableSubscriptionVisitor {
           .flatMap(numericalValue -> literalValue(expression));
       case FLOAT_LITERAL,
         DOUBLE_LITERAL:
-        return literalValue(expression)
-          .filter(numericalValue -> Double.doubleToLongBits(Double.valueOf(numericalValue)) == 0);
+        return Optional.ofNullable(LiteralUtils.doubleLiteralValue(expression))
+          .filter(numericalValue -> Double.doubleToLongBits(numericalValue) == 0)
+          .flatMap(numericalValue -> literalValue(expression));
       case TYPE_CAST:
         return getIfDefault(((TypeCastTree) expression).expression(), isPrimitive);
       default:

--- a/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -86,6 +86,16 @@ public class LiteralUtils {
   }
 
   @CheckForNull
+  public static Double doubleLiteralValue(ExpressionTree expression) {
+    if (expression.is(Kind.FLOAT_LITERAL, Kind.DOUBLE_LITERAL)) {
+      String value = ((LiteralTree) expression).value().replace("_", "");
+      
+      return Double.parseDouble(value);
+    }
+    return null;
+  }
+
+  @CheckForNull
   private static Integer minus(@Nullable Integer nullableInteger) {
     return nullableInteger == null ? null : -nullableInteger;
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -87,10 +87,16 @@ public class LiteralUtils {
 
   @CheckForNull
   public static Double doubleLiteralValue(ExpressionTree expression) {
+    int sign = 1;
+    if (expression.is(Kind.UNARY_MINUS, Kind.UNARY_PLUS)) {
+      sign = expression.is(Kind.UNARY_MINUS) ? -1 : 1;
+      expression = ((UnaryExpressionTree) expression).expression();
+    }
+
     if (expression.is(Kind.FLOAT_LITERAL, Kind.DOUBLE_LITERAL)) {
       String value = ((LiteralTree) expression).value().replace("_", "");
       
-      return Double.parseDouble(value);
+      return sign*Double.parseDouble(value);
     }
     return null;
   }

--- a/java-frontend/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
@@ -85,6 +85,28 @@ class LiteralUtilsTest {
   long y17 = 0XFFL;
   long y18 = 0B1100110L;
 
+  float f1 = 0f;
+  float f2 = 0.f;
+  float f3 = 123.45f;
+  float f4 = 1_000_000F;
+  float f5 = +1_000_000_000_000_000_000f;
+  float f6 = -1_000_000F;
+  float f7 = -.9f;
+  float f8 = 0x1.2p3f;
+  float f9 = 123_456e-7f;
+  float f10 = (float)0;
+  float f11 = 0;
+  float f13 = f1 + 0;
+  double d1 = 0.;
+  double d2 = 1.d;
+  double d3 = 0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001;
+  double d4 = -1_000_000D;
+  double d5 = +1_000_000_000_000_000_000d;
+  double d6 = 23_456e-7d;
+  double d7 = 0x1.2p3;
+  double d8 = 0;
+  double d9 = d1 + 0;
+
   String s1 = "";
   String s2 = " ";
   String s3 = "not_empty";
@@ -112,6 +134,30 @@ class LiteralUtilsTest {
         assertThat(LiteralUtils.intLiteralValue(variableTree.initializer())).isEqualTo(expectedIntegerValues[i++]);
       } else if (variableTree.simpleName().name().startsWith("y")) {
         assertThat(LiteralUtils.longLiteralValue(variableTree.initializer())).isEqualTo(expectedLongValues[j++]);
+      }
+    }
+  }
+
+  @Test
+  void test_float_value() {
+    Double[] expectedValues = {0d, 0.d, 123.45d, 1_000_000D, 1_000_000_000_000_000_000d, -1_000_000d, -.9d, 0x1.2p3d, 123_456e-7d, null, null, null};
+    int idx = 0;
+
+    for (VariableTree variableTree : variables) {
+      if (variableTree.simpleName().name().startsWith("f")) {
+        assertThat(LiteralUtils.doubleLiteralValue(variableTree.initializer())).isEqualTo(expectedValues[idx++]);
+      }
+    }
+  }
+
+  @Test
+  void test_double_value() {
+    Double[] expectedValues = {0., 1.d, 0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001, -1_000_000D, +1_000_000_000_000_000_000d, 23_456e-7d, 0x1.2p3, null , null};
+    int idx = 0;
+
+    for (VariableTree variableTree : variables) {
+      if (variableTree.simpleName().name().startsWith("d")) {
+        assertThat(LiteralUtils.doubleLiteralValue(variableTree.initializer())).isEqualTo(expectedValues[idx++]);
       }
     }
   }


### PR DESCRIPTION
[SONARJAVA-5522](https://sonarsource.atlassian.net/browse/SONARJAVA-5522)



[SONARJAVA-5522]: https://sonarsource.atlassian.net/browse/SONARJAVA-5522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ