### PR TITLE
SONARJAVA-5101 Fix FP on S5860 when Regex are used in lambdas

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
@@ -1,7 +1,10 @@
 package checks.regex;
 
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 abstract class UnusedGroupNamesCheck {
 
@@ -296,4 +299,34 @@ abstract class UnusedGroupNamesCheck {
   @org.hibernate.validator.constraints.URL(regexp = "(?<group>[a-z])") // Noncompliant
   String url;
 
+  static class GroupUsedInMethodReference {
+    private static final Pattern NAME_WITH_QUOTED_VALUE =
+      Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Compliant
+
+    public static Map<String, String> hiddenUsage(List<String> strings) {
+      return strings.stream()
+        .map(NAME_WITH_QUOTED_VALUE::matcher)
+        .filter(Matcher::matches)
+        .collect(Collectors.toMap(
+          nv -> nv.group("name"),
+          nv -> nv.group("value"))
+        );
+    }
+  }
+
+  static class GroupUsedInLambda {
+    private static final Pattern NAME_WITH_QUOTED_VALUE =
+      Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Compliant
+
+    public static Map<String, String> hiddenUsage(List<String> strings) {
+
+      return strings.stream()
+        .map(s -> NAME_WITH_QUOTED_VALUE.matcher(s))
+        .filter(Matcher::matches)
+        .collect(Collectors.toMap(
+          nv -> nv.group("name"),
+          nv -> nv.group("value"))
+        );
+    }
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
@@ -319,13 +319,26 @@ abstract class UnusedGroupNamesCheck {
       Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Compliant
 
     public static Map<String, String> hiddenUsage(List<String> strings) {
-
       return strings.stream()
         .map(s -> NAME_WITH_QUOTED_VALUE.matcher(s))
         .filter(Matcher::matches)
         .collect(Collectors.toMap(
           nv -> nv.group("name"),
           nv -> nv.group("value"))
+        );
+    }
+  }
+
+  // Do not consider RE escaping if the method in lambda is not "leaking" it
+  // (matcher replaced with hashCode).
+  static class GroupNotUsedInLambda {
+    private static final Pattern NAME_WITH_QUOTED_VALUE =
+      Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Noncompliant
+
+    public static Map<String, String> noUsage(List<String> strings) {
+      return strings.stream()
+        .map(s -> NAME_WITH_QUOTED_VALUE.hashCode())
+        .collect(Collectors.toMap(hc -> hc.toString(), unused -> "s")
         );
     }
   }

--- a/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
@@ -300,7 +300,7 @@ abstract class UnusedGroupNamesCheck {
   @org.hibernate.validator.constraints.URL(regexp = "(?<group>[a-z])") // Noncompliant
   String url;
 
-  static class GroupUsedInMethodReference {
+  static class GroupUsedViaMethodReference {
     private static final Pattern NAME_WITH_QUOTED_VALUE =
       Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Compliant
 
@@ -317,20 +317,19 @@ abstract class UnusedGroupNamesCheck {
 
   // Do not consider RE escaping if the method reference is not "leaking" it
   // (matcher replaced with flags).
-  static class GroupNotUsedInMethodReference {
+  static class GroupNotUsedViaMethodReference {
     private static final Pattern NAME_WITH_QUOTED_VALUE =
       Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Noncompliant
 
     public static int noUsage(List<String> strings) {
-      return Stream
-        .generate(NAME_WITH_QUOTED_VALUE::flags)
+      return Stream.generate(NAME_WITH_QUOTED_VALUE::flags)
         .limit(1)
         .findFirst()
         .get();
     }
   }
 
-  static class GroupUsedInLambda {
+  static class GroupUsedViaLambda {
     private static final Pattern NAME_WITH_QUOTED_VALUE =
       Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Compliant
 
@@ -347,7 +346,7 @@ abstract class UnusedGroupNamesCheck {
 
   // Do not consider RE escaping if the method in lambda is not "leaking" it
   // (matcher replaced with hashCode).
-  static class GroupNotUsedInLambda {
+  static class GroupNotUsedViaLambda {
     private static final Pattern NAME_WITH_QUOTED_VALUE =
       Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Noncompliant
 

--- a/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/regex/UnusedGroupNamesCheck.java
@@ -344,6 +344,24 @@ abstract class UnusedGroupNamesCheck {
     }
   }
 
+  static class GroupUsedViaBlockInLambda {
+    private static final Pattern NAME_WITH_QUOTED_VALUE =
+      Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$"); // Compliant
+
+    public static Map<String, String> hiddenUsage(List<String> strings) {
+      return strings.stream()
+        .map(s -> {
+          System.out.println("testing usage inside a block in a lambda");
+          return NAME_WITH_QUOTED_VALUE.matcher(s);
+        })
+        .filter(Matcher::matches)
+        .collect(Collectors.toMap(
+          nv -> nv.group("name"),
+          nv -> nv.group("value"))
+        );
+    }
+  }
+
   // Do not consider RE escaping if the method in lambda is not "leaking" it
   // (matcher replaced with hashCode).
   static class GroupNotUsedViaLambda {

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/AbstractRegexCheckTrackingMatchers.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/AbstractRegexCheckTrackingMatchers.java
@@ -185,10 +185,13 @@ public abstract class AbstractRegexCheckTrackingMatchers extends AbstractRegexCh
    * and therefore must add it to the {@link #escapingRegexes}.
    */
   private void onMethodReferenceFound(MethodReferenceTree methodReference) {
-    if (matchers.matches(methodReference)
-      && methodReference.expression() instanceof ExpressionTree expressionTree) {
-      getRegex(expressionTree).ifPresent(escapingRegexes::add);
-    }
+    Optional.of(methodReference)
+      .filter(matchers::matches)
+      .map(MethodReferenceTree::expression)
+      .filter(ExpressionTree.class::isInstance)
+      .map(ExpressionTree.class::cast)
+      .flatMap(this::getRegex)
+      .ifPresent(escapingRegexes::add);
   }
 
   private Optional<RegexParseResult> getRegex(ExpressionTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/AbstractRegexCheckTrackingMatchers.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/AbstractRegexCheckTrackingMatchers.java
@@ -181,8 +181,8 @@ public abstract class AbstractRegexCheckTrackingMatchers extends AbstractRegexCh
   }
 
   private void onMethodReferenceFound(MethodReferenceTree methodReference) {
-    Tree expression = methodReference.expression();
-    if( expression instanceof ExpressionTree expressionTree) {
+    if (matchers.matches(methodReference)
+      && methodReference.expression() instanceof ExpressionTree expressionTree) {
       getRegex(expressionTree).ifPresent(escapingRegexes::add);
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/regex/AbstractRegexCheckTrackingMatchers.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/regex/AbstractRegexCheckTrackingMatchers.java
@@ -180,6 +180,10 @@ public abstract class AbstractRegexCheckTrackingMatchers extends AbstractRegexCh
     }
   }
 
+  /**
+   * When method reference is used on a pattern, we can no longer analyze it,
+   * and therefore must add it to the {@link #escapingRegexes}.
+   */
   private void onMethodReferenceFound(MethodReferenceTree methodReference) {
     if (matchers.matches(methodReference)
       && methodReference.expression() instanceof ExpressionTree expressionTree) {
@@ -234,6 +238,10 @@ public abstract class AbstractRegexCheckTrackingMatchers extends AbstractRegexCh
     }
   }
 
+  /**
+   * Track ownership of pattern when they are assigned to variables and
+   * add them to {@link #escapingRegexes}, when we cannot track them.
+   */
   private void handleAssignment(MethodInvocationTree mit, RegexParseResult regex) {
     Tree parent = mit.parent();
     if (parent.is(Tree.Kind.VARIABLE, Tree.Kind.ASSIGNMENT)) {


### PR DESCRIPTION
[SONARJAVA-5101](https://sonarsource.atlassian.net/browse/SONARJAVA-5101)

There is an existing mechanism to track regex that escape analysis when they are passed in a constructor to another class or returned. We use the same mechanism to exclude regex used in lambdas and method references.

[SONARJAVA-5101]: https://sonarsource.atlassian.net/browse/SONARJAVA-5101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ