### PR TITLE
SONARJAVA-4376 Fix S2129 in the case of missing semantic

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/StringPrimitiveConstructorCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringPrimitiveConstructorCheckSample.java
@@ -1,7 +1,11 @@
 package checks;
 
+import com.google.api.client.http.HttpResponse;
+import com.google.common.primitives.Bytes;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.List;
 
 class StringPrimitiveConstructorCheckSample {
 
@@ -56,6 +60,22 @@ class StringPrimitiveConstructorCheckSample {
     BigInteger bigInteger3 = BigInteger.valueOf(-9223372036854775808L);
     BigDecimal doubleBigDecimal = BigDecimal.valueOf(1.1);
     Short myShort = (short) 0;
+  }
+
+  /**
+   * When semantics is not available, the type of the argument of the constructor will be unknown.
+   * We have to be careful to avoid false positives in that case.
+   */
+  String fromHtttp(HttpResponse response) throws IOException {
+    return new String(response.getContent().readAllBytes());
+  }
+
+  /**
+   * When semantics is not available, the type of the argument of the constructor will be unknown.
+   * We have to be careful to avoid false positives in that case.
+   */
+  public String formGuava(int i1, int i2) {
+    return new String(Bytes.toArray(List.of(i1, i2)));
   }
 }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/StringPrimitiveConstructorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringPrimitiveConstructorCheck.java
@@ -91,6 +91,11 @@ public class StringPrimitiveConstructorCheck extends IssuableSubscriptionVisitor
     if (isBigIntegerPotentiallyBiggerThanLong(newClassTree)) {
       return;
     }
+    if (newClassTree.arguments().stream().anyMatch(arg -> arg.symbolType().isUnknown())) {
+      // If the argument type is unknown the parser may take a wild guess at which constructor is used, which may cause false positives
+      return;
+    }
+
     if(matchers.matches(newClassTree)) {
       QuickFixHelper.newIssue(context)
         .forRule(this)

--- a/java-checks/src/test/java/org/sonar/java/checks/StringPrimitiveConstructorCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringPrimitiveConstructorCheckTest.java
@@ -30,4 +30,13 @@ class StringPrimitiveConstructorCheckTest {
       .withCheck(new StringPrimitiveConstructorCheck())
       .verifyIssues();
   }
+
+  @Test
+  void test_without_semantics() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StringPrimitiveConstructorCheckSample.java"))
+      .withCheck(new StringPrimitiveConstructorCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
 }


### PR DESCRIPTION
[SONARJAVA-4376](https://sonarsource.atlassian.net/browse/SONARJAVA-4376)

When semantic is missing for the argument of String constructor for instance, the parser takes a guess at which constructor it is and this may cause some false positives. The fix in this PR, skips the case where we detect an unknown in the argument types. The second sample is comming from SONARJAVA-5388



[SONARJAVA-4376]: https://sonarsource.atlassian.net/browse/SONARJAVA-4376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ