### PR TITLE
SONARJAVA-5436 Suggest to add comment in message for S108

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyBlockCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyBlockCheck.java
@@ -30,7 +30,7 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "S108")
 public class EmptyBlockCheck extends IssuableSubscriptionVisitor {
 
-  private static final String MESSAGE = "Either remove or fill this block of code.";
+  private static final String MESSAGE = "Remove this block of code, fill it in, or add a comment explaining why it is empty.";
   private boolean isMethodBlock;
 
   @Override

--- a/java-checks/src/test/files/checks/EmptyBlock.java
+++ b/java-checks/src/test/files/checks/EmptyBlock.java
@@ -42,7 +42,7 @@ class EmptyBlock {
     }
 
 
-    switch (1) { // Noncompliant {{Either remove or fill this block of code.}}
+    switch (1) { // Noncompliant {{Remove this block of code, fill it in, or add a comment explaining why it is empty.}}
 //             ^
     }
 


### PR DESCRIPTION
[SONARJAVA-5436](https://sonarsource.atlassian.net/browse/SONARJAVA-5436)

This is to avoid user reporting FPs on this rule, but instead have them add comments about why the block is empty.

[SONARJAVA-5436]: https://sonarsource.atlassian.net/browse/SONARJAVA-5436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ