### PR TITLE
SONARJAVA-5542 chore: use the renamed sonar.sca.exclusions property

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -95,7 +95,7 @@ test_analyze_task:
     - *log_develocity_url_script
     - source cirrus-env BUILD
     # ignore duplications in the SE engine plugin, as it will be moved away from sonar-java at some point
-    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.excludedManifests="**/test/files/**, **/test/resources/**, its/plugin/projects/**, java-checks-test-sources/**, its/sources/**,"
+    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dmaven.deploy.skip=true -Dsonar.analysisCache.enabled=true -Dsonar.cpd.exclusions=java-symbolic-execution/** -Dsonar.sca.exclusions="**/test/files/**, **/test/resources/**, its/plugin/projects/**, java-checks-test-sources/**, its/sources/**,"
     - cd docs/java-custom-rules-example
     - mvn clean package -f pom_SQ_10_6_LATEST.xml --batch-mode
     - cd "${CIRRUS_WORKING_DIR}"


### PR DESCRIPTION
[SONARJAVA-5542](https://sonarsource.atlassian.net/browse/SONARJAVA-5542)

`sonar.sca.excludedManifests` is deprecated in SQS 2025.3 and is replaced with `sonar.sca.exlusions`. The behavior is exactly the same, this is just a rename to better match other sonar properties.

[SONARJAVA-5542]: https://sonarsource.atlassian.net/browse/SONARJAVA-5542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ