### PR TITLE
SONARJAVA-4634 Test for duplicates in credential method json file

### DIFF
--- a/java-checks-aws/src/test/java/org/sonar/java/checks/security/HardCodedCredentialsShouldNotBeUsedCheckTest.java
+++ b/java-checks-aws/src/test/java/org/sonar/java/checks/security/HardCodedCredentialsShouldNotBeUsedCheckTest.java
@@ -17,12 +17,16 @@
 package org.sonar.java.checks.security;
 
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.sonar.api.testfixtures.log.LogAndArguments;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.java.checks.helpers.CredentialMethod;
+import org.sonar.java.checks.helpers.CredentialMethodsLoader;
 import org.sonar.java.checks.verifier.CheckVerifier;
 import org.sonar.java.checks.verifier.TestUtils;
 
@@ -45,6 +49,85 @@ class HardCodedCredentialsShouldNotBeUsedCheckTest {
       .containsOnly("Could not load methods from \"non-existing-file.json\".");
   }
 
+  private enum ComparisonResult {
+    DISTINCT {
+      @Override
+      public ComparisonResult and(ComparisonResult other) {
+        return DISTINCT;
+      }
+    }, SAME {
+      @Override
+      public ComparisonResult and(ComparisonResult other) {
+        return other;
+      }
+    }, MAY_INTERSECT {
+      @Override
+      public ComparisonResult and(ComparisonResult other) {
+        if (other == DISTINCT) {
+          return DISTINCT;
+        }
+        return MAY_INTERSECT;
+      }
+    };
+
+    /**
+     * This is kind of a three valued logic, where and describe how the combination of two parts compares to another combination of two parts, given that we know how the small
+     * parts compare.
+     */
+    public abstract ComparisonResult and(ComparisonResult other);
+  }
+
+  private ComparisonResult compareMethodDescriptors(CredentialMethod method, CredentialMethod other) {
+    if (!method.cls.equals(other.cls) || !method.name.equals(other.name)) {
+      return ComparisonResult.DISTINCT;
+    }
+    if (method.args.size() != other.args.size()) {
+      return ComparisonResult.DISTINCT;
+    }
+    ComparisonResult result = ComparisonResult.SAME;
+    for (int i = 0; i < method.args.size(); i++) {
+      if (method.args.get(i).equals(other.args.get(i))) {
+        result = result.and(ComparisonResult.SAME);
+      } else if (method.args.get(i).equals("*") || other.args.get(i).equals("*")) {
+        result = result.and(ComparisonResult.MAY_INTERSECT);
+      } else {
+        return ComparisonResult.DISTINCT;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Count the number of method that may intersect. Assert that no two descriptor are exactly the same.
+   */
+  private int countIntersectingMethodsDescriptors(List<CredentialMethod> methods) {
+    int count = 0;
+    for (int i = 0; i < methods.size(); i++) {
+      for (int j = i + 1; j < methods.size(); j++) {
+        var comparisonResult = compareMethodDescriptors(methods.get(i), methods.get(j));
+        assertThat(comparisonResult)
+          .as("credential method entries " + methods.get(i) + " and " + methods.get(j) + " are not the same")
+          .isNotEqualTo(ComparisonResult.SAME);
+        if (comparisonResult == ComparisonResult.MAY_INTERSECT) {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  @Test
+  void test_credential_file_content() throws IOException {
+    Map<String, List<CredentialMethod>> methods = CredentialMethodsLoader
+      .load(HardCodedCredentialsShouldNotBeUsedCheck.CREDENTIALS_METHODS_FILE);
+    Integer intersectCount =
+      methods.values().stream().map(this::countIntersectingMethodsDescriptors)
+        .reduce(Integer::sum)
+        .orElse(0);
+    // There are three potential intersections we know of. We have checked manually that there are no actual method in the intersection.
+    assertThat(intersectCount).isEqualTo(3);
+    assertThat(methods).hasSize(2730);
+  }
 
   @Test
   void test() {

--- a/java-checks-common/src/main/java/org/sonar/java/checks/helpers/CredentialMethod.java
+++ b/java-checks-common/src/main/java/org/sonar/java/checks/helpers/CredentialMethod.java
@@ -57,4 +57,10 @@ public class CredentialMethod {
       .build();
     return methodMatcher;
   }
+
+  /** This is intended for debugging and testing. */
+  @Override
+  public String toString() {
+    return cls + "#" + name + args + "@" + indices ;
+  }
 }

--- a/java-checks-common/src/test/java/org/sonar/java/checks/helpers/CredentialMethodTest.java
+++ b/java-checks-common/src/test/java/org/sonar/java/checks/helpers/CredentialMethodTest.java
@@ -47,4 +47,10 @@ class CredentialMethodTest {
     MethodMatchers methodMatcher = equalsMatcher.methodMatcher();
     assertThat(equalsMatcher.methodMatcher()).isSameAs(methodMatcher);
   }
+
+  /** Since toString is only used for debugging, we don't need strong guarantees on it. */
+  @Test
+  void test_toString() {
+    assertThat(new CredentialMethod("Foo", "bar", List.of("java.lang.String"), List.of(1)).toString()).isNotEmpty();
+  }
 }


### PR DESCRIPTION
[SONARJAVA-4634](https://sonarsource.atlassian.net/browse/SONARJAVA-4634)

Adding a test for duplicated entries found a few cases where we could have false positives because of wildcard usage.

[SONARJAVA-4634]: https://sonarsource.atlassian.net/browse/SONARJAVA-4634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ