### PR TITLE
SONARJAVA-5550 Add some pom configuration to cleanup build logs and improve build caching

### DIFF
--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -1025,6 +1025,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <compilerArgs>
+            <arg>-Xlint:-deprecation</arg>
+          </compilerArgs>
           <release>23</release>
           <source>23</source>
           <target>23</target>

--- a/java-symbolic-execution/java-symbolic-execution-checks-test-sources/pom.xml
+++ b/java-symbolic-execution/java-symbolic-execution-checks-test-sources/pom.xml
@@ -39,6 +39,33 @@
           <release>17</release>
           <source>17</source>
           <target>17</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.38</version>
+            </path>
+            <path>
+              <groupId>org.eclipse.sisu</groupId>
+              <artifactId>org.eclipse.sisu.inject</artifactId>
+              <version>0.3.0</version>
+            </path>
+            <path>
+              <groupId>org.immutables</groupId>
+              <artifactId>value</artifactId>
+              <version>2.7.1</version>
+            </path>
+            <path>
+              <groupId>org.apache.logging.log4j</groupId>
+              <artifactId>log4j-core</artifactId>
+              <version>2.17.1</version>
+            </path>
+            <path>
+              <groupId>org.netbeans.api</groupId>
+              <artifactId>org-netbeans-api-annotations-common</artifactId>
+              <version>RELEASE125</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
[SONARJAVA-5550](https://sonarsource.atlassian.net/browse/SONARJAVA-5550)

Added `<arg>-Xlint:-deprecation</arg>` to remove deprecation warnings during maven-compiler in java-checks-test-sources, as we do not care about the code there.

Also specified for the symbolic-execution test sources modules all the annotation processors, to allow develocity to leverage the cache for that module. Locally improved my build time by ~8 secs

[SONARJAVA-5550]: https://sonarsource.atlassian.net/browse/SONARJAVA-5550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ