### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/PrepareNextIteration.yml
+++ b/.github/workflows/PrepareNextIteration.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   Next-Iteration-Job:
     name: Next Iteration Job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ToggleLockBranch_job:
     name: Toggle lock branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/UpdateRuleMetadata.yml
+++ b/.github/workflows/UpdateRuleMetadata.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   UpdateRuleMetadata_job:
     name: Update Rule Metadata
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   dogfood_merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper

--- a/.github/workflows/mark-prs-stale.yml
+++ b/.github/workflows/mark-prs-stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   releasability-job:
     name: Releasability check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write      # required by SonarSource/vault-action-wrapper
       contents: read       # required by checkout

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -14,7 +14,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - name: Send Slack Notification
         env:


### PR DESCRIPTION
[BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073)

Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ