### PR TITLE
S1186: Ignore empty methods with @CacheEvict annotation

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/EmptyMethodsCheckNoSemantics.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyMethodsCheckNoSemantics.java
@@ -2,6 +2,7 @@ package checks;
 
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.cache.annotation.CacheEvict;
 
 class EmptyMethodsCheckNoSemantics {
   class A {
@@ -186,12 +187,18 @@ class EmptyMethodsCheckNoSemantics {
 
   private class ExceptionalCompliantCases {
     @org.aspectj.lang.annotation.Pointcut()
-    void foo() {
+    void foo() {  // Compliant
 
     }
 
     @Pointcut()
-    void bar() {}
+    void bar() {}  // Compliant
+
+    @org.springframework.cache.annotation.CacheEvict(cacheNames = "flowers", allEntries = true)
+    void evictAll() {}  // Compliant
+
+    @CacheEvict(value = "flowers", key = "{#name}")
+    void evict(String name) {}  // Compliant
 
     @Before("")
     void stillTriggerOnOtherAnnotations() {} // Noncompliant

--- a/java-checks-test-sources/default/src/main/java/checks/EmptyMethodsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyMethodsCheckSample.java
@@ -2,6 +2,7 @@ package checks;
 
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.cache.annotation.CacheEvict;
 
 class EmptyMethodsCheckSample {
   class A {
@@ -186,12 +187,18 @@ class EmptyMethodsCheckSample {
 
   private class ExceptionalCompliantCases {
     @org.aspectj.lang.annotation.Pointcut()
-    void foo() {
+    void foo() {  // Compliant
 
     }
 
     @Pointcut()
-    void bar() {}
+    void bar() {}  // Compliant
+
+    @org.springframework.cache.annotation.CacheEvict(cacheNames = "flowers", allEntries = true)
+    void evictAll() {}  // Compliant
+
+    @CacheEvict(value = "flowers", key = "{#name}")
+    void evict(String name) {}  // Compliant
 
     @Before("")
     void stillTriggerOnOtherAnnotations() {} // Noncompliant

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1186.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1186.html
@@ -14,6 +14,7 @@ functionality and are misleading to others as they might think the method implem
   <li> Public default (no-argument) constructors when there are other constructors in the class </li>
   <li> Empty methods in abstract classes </li>
   <li> Methods annotated with <code>@org.aspectj.lang.annotation.Pointcut()</code> </li>
+  <li> Methods annotated with <code>@org.springframework.cache.annotation.CacheEvict()</code> </li>
 </ul>
 <pre>
 public abstract class Animal {


### PR DESCRIPTION
Methods with the `@org.springframework.cache.annotation.CacheEvict` annotation usually are empty. Examples:

* https://www.baeldung.com/spring-boot-evict-cache#1-using-cacheevict
* https://java2practice.com/2013/03/23/spring-cacheable-and-cacheevict-explained-in-simple-terms/

Therefore S1186 should not complain about those empty methods and should ignore them.