### PR TITLE
SONARJAVA-5438 Fix false positive in S125 for comments ending with semicolon

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/CommentedCode.java
+++ b/java-checks-test-sources/default/src/main/java/checks/CommentedCode.java
@@ -17,6 +17,14 @@ package checks;
  */
 public class CommentedCode {
 
+  // The following comments should not be detected as code
+  // This is a natural sentence that ends with a semicolon; not code at all.
+  // (TR) xxx xx xx xxx x xxx xx xxxx xx xxx xx xx xxxx; clearly not code
+  // Licensed under the Apache License, Version 2.0 (the "License"); normal text
+  /*
+   * Licensed under the Apache License, Version 2.0 (the "License"); more text
+   */
+
   /**
    * No detection of commented-out code in Javadoc for field
    * for (Visitor visitor : visitors) {

--- a/java-checks/src/main/java/org/sonar/java/checks/JavaFootprint.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/JavaFootprint.java
@@ -30,7 +30,9 @@ public final class JavaFootprint implements LanguageFootprint {
   private final Set<Detector> detectors = new HashSet<>();
 
   public JavaFootprint() {
-    detectors.add(new EndWithDetector(0.95, '}', ';', '{'));
+    // Reduce probability for semicolon to avoid false positives with natural language
+    detectors.add(new EndWithDetector(0.95, '}', '{'));
+    detectors.add(new EndWithDetector(0.3, ';'));
     detectors.add(new KeywordsDetector(0.7, "++", "||", "&&"));
     detectors.add(new KeywordsDetector(0.3, "public", "abstract", "class", "implements", "extends", "return", "throw",
         "private", "protected", "enum", "continue", "assert", "package", "synchronized", "boolean", "this", "double", "instanceof",


### PR DESCRIPTION
[SONARJAVA-5438](https://sonarsource.atlassian.net/browse/SONARJAVA-5438)



* Improve detection of natural language comments with semicolons

* Add test cases for license headers and natural text

* Reduce probability of semicolon detection in non-code contexts

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SONARJAVA-5438]: https://sonarsource.atlassian.net/browse/SONARJAVA-5438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ