### PR TITLE
SONARJAVA-5568 Create continuous releasability check

### DIFF
--- a/.github/workflows/ReleasabilityCheck.yml
+++ b/.github/workflows/ReleasabilityCheck.yml
@@ -1,0 +1,32 @@
+name: Releasability Check
+
+# Update releasability check. This workflow run continuously,
+# in contrast to the other releasability, which needs to be triggered manually.
+
+'on':
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  update_releasability_status:
+    runs-on: ubuntu-latest-large
+    name: Releasability Check
+    permissions:
+      id-token: write
+      statuses: write
+      contents: read
+    if: >-
+      (contains(fromJSON('["main", "master"]'),
+      github.event.check_suite.head_branch) ||
+      startsWith(github.event.check_suite.head_branch, 'dogfood-') ||
+      startsWith(github.event.check_suite.head_branch, 'branch-')) &&
+      github.event.check_suite.conclusion == 'success' &&
+      github.event.check_suite.app.slug == 'cirrus-ci'
+    steps:
+      -   uses: >-
+            SonarSource/gh-action_releasability/releasability-status@v2
+          with:
+            optional_checks: "Jira"
+          env:
+            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
[SONARJAVA-5568](https://sonarsource.atlassian.net/browse/SONARJAVA-5568)

Infra provides two similar but different checks (https://github.com/SonarSource/gh-action_releasability) so we cannot just add another trigger to the existing check.

It is not possible to test on a branch, but the code should be simple enough to copy-and-paste and then verify on master.

[SONARJAVA-5568]: https://sonarsource.atlassian.net/browse/SONARJAVA-5568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ