### PR TITLE
SONARJAVA-5609 Update commons-beanutils from 1.9.4 to 1.11.0 to suppress alert about CVE-2025-48734

### DIFF
--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -493,7 +493,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>1.11.0</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/sonar-java-plugin/src/test/files/maven/pom.xml
+++ b/sonar-java-plugin/src/test/files/maven/pom.xml
@@ -6,7 +6,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>1.11.0</version>
     </dependency>
   </dependencies>
 

--- a/sonar-java-plugin/src/test/files/maven2/pom.xml
+++ b/sonar-java-plugin/src/test/files/maven2/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>1.11.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[SONARJAVA-5609](https://sonarsource.atlassian.net/browse/SONARJAVA-5609)



[SONARJAVA-5609]: https://sonarsource.atlassian.net/browse/SONARJAVA-5609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ