### PR TITLE
SONARJAVA-5610 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
@@ -93,6 +93,7 @@ public class AutoScanTest {
     String correctConfigIssues = absolutePathFor(TARGET_ACTUAL + PROJECT_KEY + "-mvn");
 
     MavenBuild mavenBuild = MavenBuild.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setPom(FileLocation.of(PROJECT_LOCATION + "pom.xml").getFile().getCanonicalFile())
       .addSonarGoal()
       .addArgument("-DskipTests")
@@ -115,6 +116,7 @@ public class AutoScanTest {
      * 2. Execute the analysis as sonar-scanner project, without any bytecode nor dependencies/libraries
      */
     SonarScanner sonarScannerBuild = SonarScanner.create(FileLocation.of(PROJECT_LOCATION).getFile())
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_NAME)
       .setProjectVersion("0.1.0-SNAPSHOT")

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/JspTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/JspTest.java
@@ -66,7 +66,7 @@ public class JspTest {
       return;
     }
 
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom(PROJECT))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom(PROJECT))
       .setCleanPackageSonarGoals()
       .setDebugLogs(true)
       .setProperty("sonar.scm.disabled", "true");

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/CacheEnabledTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/CacheEnabledTest.java
@@ -31,7 +31,8 @@ public class CacheEnabledTest {
 
   @Test
   public void test_cache_is_enabled() {
-    SonarScanner build = SonarScanner.create(TestUtils.projectDir("java-tutorial"))
+    SonarScanner build = TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("java-tutorial"))
       .setProperty("sonar.projectKey", "org.sonarsource.it.projects:java-tutorial")
       .setProperty("sonar.projectName", "java-tutorial")
       .setProperty("sonar.sources", "src/main/java")
@@ -46,7 +47,8 @@ public class CacheEnabledTest {
 
   @Test
   public void test_cache_is_disabled() {
-    SonarScanner build = SonarScanner.create(TestUtils.projectDir("java-tutorial"))
+    SonarScanner build = TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("java-tutorial"))
       .setProperty("sonar.projectKey", "org.sonarsource.it.projects:java-tutorial")
       .setProperty("sonar.projectName", "java-tutorial")
       .setProperty("sonar.sources", "src/main/java")

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/DuplicationTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/DuplicationTest.java
@@ -34,7 +34,8 @@ public class DuplicationTest {
 
   @Test
   public void duplication_should_be_computed_by_SQ() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("test-duplications")).setCleanPackageSonarGoals();
+    MavenBuild build = TestUtils.createMavenBuild()
+      .setPom(TestUtils.projectPom("test-duplications")).setCleanPackageSonarGoals();
 
     orchestrator.executeBuild(build);
 

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/ExternalReportTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/ExternalReportTest.java
@@ -35,7 +35,7 @@ public class ExternalReportTest {
 
   @Test
   public void checkstyle() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("checkstyle-external-report"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("checkstyle-external-report"))
       .setProperty("sonar.java.checkstyle.reportPaths", "target" + File.separator + "checkstyle-result.xml")
       .setGoals("org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:checkstyle", "sonar:sonar");
     orchestrator.executeBuild(build);
@@ -53,7 +53,7 @@ public class ExternalReportTest {
 
   @Test
   public void pmd() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("pmd-external-report"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("pmd-external-report"))
       .setProperty("sonar.java.pmd.reportPaths", "target" + File.separator + "pmd.xml")
       .setGoals("org.apache.maven.plugins:maven-pmd-plugin:3.10.0:pmd", "sonar:sonar");
     orchestrator.executeBuild(build);
@@ -72,7 +72,7 @@ public class ExternalReportTest {
 
   @Test
   public void spotbugs() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("spotbugs-external-report"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("spotbugs-external-report"))
       .setProperty("sonar.java.spotbugs.reportPaths", "target" + File.separator + "spotbugsXml.xml")
       .setGoals("clean package com.github.spotbugs:spotbugs-maven-plugin:4.5.3.0:spotbugs", "sonar:sonar");
     orchestrator.executeBuild(build);

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaClasspathTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaClasspathTest.java
@@ -200,7 +200,8 @@ public class JavaClasspathTest {
   private static void testJdk8ProjectWithModularJdk(boolean useJdkHomeProperty) {
     String projectKey = "use-jdk8-only-api-" + (useJdkHomeProperty ? "with" : "without") + "-jdkHome-property";
 
-    SonarScanner scanner = SonarScanner.create(TestUtils.projectDir("use-jdk8-only-api"))
+    SonarScanner scanner = TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("use-jdk8-only-api"))
       .setProperty("sonar.projectKey", projectKey)
       .setProperty("sonar.projectName", projectKey)
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")
@@ -269,7 +270,7 @@ public class JavaClasspathTest {
   }
 
   private static void mavenOnDitProject(String goal) {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("dit-check"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("dit-check"))
       .setGoals(goal)
       .setProperty("sonar.dynamicAnalysis", "false");
 
@@ -277,7 +278,8 @@ public class JavaClasspathTest {
   }
 
   private static SonarScanner aarProjectSonarScanner() {
-    return SonarScanner.create(TestUtils.projectDir("using-aar-dep"))
+    return TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("using-aar-dep"))
       .setProperty("sonar.projectKey", PROJECT_KEY_AAR)
       .setProperty("sonar.projectName", "using-aar-dep")
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")
@@ -285,7 +287,8 @@ public class JavaClasspathTest {
   }
 
   private static SonarScanner ditProjectSonarScanner() {
-    return SonarScanner.create(TestUtils.projectDir("dit-check"))
+    return TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("dit-check"))
       .setProperty("sonar.projectKey", PROJECT_KEY_DIT)
       .setProperty("sonar.projectName", "dit-check")
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaComplexityTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaComplexityTest.java
@@ -38,7 +38,7 @@ public class JavaComplexityTest {
 
   @BeforeClass
   public static void analyzeProject() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("java-complexity"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("java-complexity"))
       .setCleanSonarGoals()
       .setProperty("sonar.dynamicAnalysis", "false")
       .setProperty("sonar.java.binaries", "target");

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaExtensionsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaExtensionsTest.java
@@ -32,7 +32,7 @@ public class JavaExtensionsTest {
 
   @Test
   public void test() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("java-extension"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("java-extension"))
       .setCleanSonarGoals();
     TestUtils.provisionProject(orchestrator, "org.sonarsource.it.projects:java-extension","java-extension","java","java-extension");
     orchestrator.executeBuild(build);

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTest.java
@@ -47,7 +47,7 @@ public class JavaTest {
    */
   @Test
   public void shouldAcceptFilenamesWithDollar() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("dollar-in-names"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("dollar-in-names"))
       .setCleanPackageSonarGoals()
       .setProperty("sonar.dynamicAnalysis", "false");
     orchestrator.executeBuild(build);
@@ -62,7 +62,7 @@ public class JavaTest {
    */
   @Test
   public void shouldFailIfInvalidJavaPackage() {
-    MavenBuild build = MavenBuild.create()
+    MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("invalid-java-package"))
       .setCleanSonarGoals();
 
@@ -72,7 +72,7 @@ public class JavaTest {
 
   @Test
   public void measures_on_directory() {
-    MavenBuild build = MavenBuild.create()
+    MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("measures-on-directory"))
       .setCleanPackageSonarGoals();
     BuildResult result = orchestrator.executeBuildQuietly(build);
@@ -82,12 +82,12 @@ public class JavaTest {
 
   @Test
   public void multiple_package_in_directory_should_not_fail() {
-    MavenBuild inspection = MavenBuild.create()
+    MavenBuild inspection = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("multiple-packages-in-directory"))
       .setCleanPackageSonarGoals();
     BuildResult result = orchestrator.executeBuildQuietly(inspection);
     assertThat(result.getLastStatus()).isZero();
-    inspection = MavenBuild.create()
+    inspection = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("multiple-packages-in-directory"))
       .setProperty("sonar.skipPackageDesign", "true")
       .setGoals("sonar:sonar");
@@ -100,7 +100,8 @@ public class JavaTest {
    */
   @Test
   public void filtered_issues() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("filtered-issues"))
+    MavenBuild build = TestUtils.createMavenBuild()
+      .setPom(TestUtils.projectPom("filtered-issues"))
       .setCleanPackageSonarGoals();
 
     TestUtils.provisionProject(orchestrator, "org.example:example", "filtered-issues", "java", "filtered-issues");
@@ -122,7 +123,8 @@ public class JavaTest {
    */
   @Test
   public void support_jav_file_extension() {
-    SonarScanner scan = SonarScanner.create(TestUtils.projectDir("jav-file-extension"))
+    SonarScanner scan = TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("jav-file-extension"))
       .setProperty("sonar.projectKey", "jav-file-extension")
       .setProperty("sonar.projectName", "jav-file-extension")
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")
@@ -135,7 +137,8 @@ public class JavaTest {
 
   @Test
   public void support_change_of_extension_property() {
-    SonarScanner scan = SonarScanner.create(TestUtils.projectDir("jav-file-extension"))
+    SonarScanner scan = TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("jav-file-extension"))
       .setProperty("sonar.projectKey", "jav-file-extension")
       .setProperty("sonar.projectName", "jav-file-extension")
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")
@@ -152,7 +155,7 @@ public class JavaTest {
   public void should_execute_rule_on_test() {
     MavenLocation junit411 = MavenLocation.of("junit", "junit", "4.11");
     orchestrator.getConfiguration().locators().copyToDirectory(junit411, tmp.getRoot());
-    MavenBuild build = MavenBuild.create()
+    MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("java-inner-classes"))
       .setProperty("sonar.java.test.binaries", "target/test-classes")
       .setProperty("sonar.java.test.libraries", new File(tmp.getRoot(), junit411.getFilename()).getAbsolutePath())
@@ -166,7 +169,8 @@ public class JavaTest {
   public void java_aware_visitor_rely_on_java_version() {
     String sonarJavaSource = "sonar.java.source";
 
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("java-version-aware-visitor"))
+    MavenBuild build = TestUtils.createMavenBuild()
+      .setPom(TestUtils.projectPom("java-version-aware-visitor"))
       .setCleanSonarGoals();
     String projectKey = "java-version-aware-visitor";
     build.setProperties("sonar.projectKey", projectKey);
@@ -202,7 +206,8 @@ public class JavaTest {
     int numberIssuesWithJava6 = getMeasureAsInteger(projectKey, "violations");
     assertThat(numberIssuesWithJava6).isZero();
 
-    SonarScanner scan = SonarScanner.create(TestUtils.projectDir("java-version-aware-visitor"))
+    SonarScanner scan = TestUtils.createSonarScanner()
+      .setProjectDir(TestUtils.projectDir("java-version-aware-visitor"))
       .setProperty("sonar.projectKey", "org.example:example-scanner")
       .setProperty("sonar.projectName", "example")
       .setProperty("sonar.projectVersion", "1.0-SNAPSHOT")

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTutorialTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTutorialTest.java
@@ -33,7 +33,7 @@ public class JavaTutorialTest {
 
   @Test
   public void test() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("java-tutorial")).setCleanPackageSonarGoals();
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("java-tutorial")).setCleanPackageSonarGoals();
     String projectKey = "org.sonarsource.it.projects:java-tutorial";
     TestUtils.provisionProject(orchestrator, projectKey, "java-tutorial", "java", "java-tutorial");
     executeAndAssertBuild(build, projectKey);
@@ -43,7 +43,7 @@ public class JavaTutorialTest {
   public void test_as_batch_mode() {
     String projectKey = "org.sonarsource.it.projects:java-tutorial-batch";
     String projectName = "java-tutorial-batch";
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("java-tutorial"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("java-tutorial"))
       .setCleanPackageSonarGoals()
       .setProperty("sonar.projectKey", projectKey)
       .setProperty("sonar.projectName", projectName)

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/PackageInfoTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/PackageInfoTest.java
@@ -35,7 +35,7 @@ public class PackageInfoTest {
   @Test
   public void should_detect_package_info_issues() {
     String projectKey = "org.sonarsource.it.projects:package-info";
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("package-info"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("package-info"))
       .setCleanPackageSonarGoals()
       .setProperty("sonar.sources", "src/main/java,src/main/other-src")
       .setProperty("sonar.scm.disabled", "true");

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/Struts139Test.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/Struts139Test.java
@@ -37,8 +37,8 @@ public class Struts139Test {
 
   @BeforeClass
   public static void analyzeProject() {
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("struts-1.3.9-lite")).setGoals("clean verify");
-    MavenBuild analysis = MavenBuild.create(TestUtils.projectPom("struts-1.3.9-lite"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("struts-1.3.9-lite")).setGoals("clean verify");
+    MavenBuild analysis = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("struts-1.3.9-lite"))
       .setProperty("sonar.scm.disabled", "true")
       .setProperty("sonar.exclusions", "**/pom.xml")
       .setGoals("sonar:sonar");

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/SuppressWarningTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/SuppressWarningTest.java
@@ -38,7 +38,7 @@ public class SuppressWarningTest {
   @Test
   public void suppressWarnings_nosonar() {
     String projectKey = "org.sonarsource.it.projects:suppress-warnings";
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("suppress-warnings"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("suppress-warnings"))
       .setProperty("sonar.scm.disabled", "true")
       .setCleanPackageSonarGoals();
     TestUtils.provisionProject(ORCHESTRATOR, projectKey, "suppress-warnings", "java", "suppress-warnings");
@@ -59,7 +59,7 @@ public class SuppressWarningTest {
   @Ignore("temporarily ignored until SONARJAVA-4553 is fixed")
   public void suppressWarnings_also_supress_issues_of_other_analyzers() {
     String projectKey = "org.sonarsource.it.projects:suppress-warnings-pmd";
-    MavenBuild build = MavenBuild.create(TestUtils.projectPom("suppress-warnings-pmd"))
+    MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom("suppress-warnings-pmd"))
       .setProperty("sonar.scm.disabled", "true")
       .setCleanPackageSonarGoals();
     TestUtils.provisionProject(ORCHESTRATOR, projectKey, "suppress-warnings-pmd", "java", "suppress-warnings-pmd");

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/TestUtils.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/TestUtils.java
@@ -17,6 +17,8 @@
 package com.sonar.it.java.suite;
 
 import com.google.common.collect.Iterables;
+import com.sonar.orchestrator.build.MavenBuild;
+import com.sonar.orchestrator.build.SonarScanner;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit4.OrchestratorRule;
 import java.io.File;
@@ -91,5 +93,15 @@ public class TestUtils {
     Server server = orchestrator.getServer();
     server.provisionProject(projectKey, projectName);
     server.associateProjectToQualityProfile(projectKey, languageKey, profileName);
+  }
+
+  public static SonarScanner createSonarScanner() {
+    return SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true");
+  }
+
+  public static MavenBuild createMavenBuild() {
+    return MavenBuild.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true");
   }
 }

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/UnitTestsTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/UnitTestsTest.java
@@ -35,7 +35,7 @@ public class UnitTestsTest {
 
   @Test
   public void tests_without_main_code() {
-    MavenBuild build = MavenBuild.create()
+    MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("tests-without-main-code"))
       .setGoals("clean test-compile surefire:test", "sonar:sonar");
     orchestrator.executeBuild(build);
@@ -53,7 +53,7 @@ public class UnitTestsTest {
 
   @Test
   public void tests_with_report_name_suffix() {
-    MavenBuild build = MavenBuild.create()
+    MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("tests-surefire-suffix"))
       .setGoals("clean test-compile surefire:test -Dsurefire.reportNameSuffix=Run1", "test-compile surefire:test -Dsurefire.reportNameSuffix=Run2", "sonar:sonar");
     orchestrator.executeBuild(build);

--- a/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
@@ -391,6 +391,7 @@ public class JavaRulingTest {
   }
 
   private static void executeBuildWithCommonProperties(Build<?> build, String projectName, boolean buildQuietly) throws IOException {
+    build.setProperty("sonar.scanner.skipJreProvisioning", "true");
     build.setProperty("sonar.cpd.exclusions", "**/*")
       .setProperty("sonar.java.performance.measure", "true")
       .setProperty("sonar.java.performance.measure.path", "target/performance/sonar.java.performance.measure.json")


### PR DESCRIPTION
[SONARJAVA-5610](https://sonarsource.atlassian.net/browse/SONARJAVA-5610)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.


[SONARJAVA-5610]: https://sonarsource.atlassian.net/browse/SONARJAVA-5610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ