### PR TITLE
SONARJAVA-5637 Remove unused collection

### DIFF
--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/GeneratedCheckListTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/GeneratedCheckListTest.java
@@ -126,7 +126,6 @@ class GeneratedCheckListTest {
     }
 
     Set<String> keys = new HashSet<>();
-    Set<String> names = new HashSet<>();
     CustomRulesDefinition definition = new CustomRulesDefinition();
     RulesDefinition.Context context = new RulesDefinition.Context();
     definition.define(context);
@@ -135,7 +134,6 @@ class GeneratedCheckListTest {
     for (RulesDefinition.Rule rule : rules) {
       assertThat(keys).as("Duplicate key " + rule.key()).doesNotContain(rule.key());
       keys.add(rule.key());
-      names.add(rule.name());
       assertThat(getClass().getResource("/org/sonar/l10n/java/rules/" + GeneratedCheckList.REPOSITORY_KEY + "/" + keyMap.get(rule.key()) + ".html"))
         .overridingErrorMessage("No description for " + rule.key() + " " + keyMap.get(rule.key()))
         .isNotNull();


### PR DESCRIPTION
[SONARJAVA-5637](https://sonarsource.atlassian.net/browse/SONARJAVA-5637)

`names` set get elements added but is never queried.

[SONARJAVA-5637]: https://sonarsource.atlassian.net/browse/SONARJAVA-5637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ