### PR TITLE
SONARJAVA-5443, S6906: Ignore issues when Java version is >= 24

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheck.java
@@ -44,7 +44,7 @@ public class VirtualThreadNotSynchronizedCheck extends IssuableSubscriptionVisit
 
   @Override
   public boolean isCompatibleWithJavaVersion(JavaVersion version) {
-    return version.isJava21Compatible();
+    return version.isJava21Compatible() && !version.isJava24Compatible();
   }
 
   @Override

--- a/java-checks/src/test/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/VirtualThreadNotSynchronizedCheckTest.java
@@ -40,4 +40,13 @@ class VirtualThreadNotSynchronizedCheckTest {
       .withJavaVersion(20)
       .verifyNoIssues();
   }
+
+  @Test
+  void test_since_java24() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/VirtualThreadNotSynchronizedCheckSample.java"))
+      .withCheck(new VirtualThreadNotSynchronizedCheck())
+      .withJavaVersion(24)
+      .verifyNoIssues();
+  }
 }


### PR DESCRIPTION
[SONARJAVA-5443](https://sonarsource.atlassian.net/browse/SONARJAVA-5443)

Since java 24 synchronize block don't affect virtual thread pinning. Thus, we should not raise S6906 on version of java greater or equal to 24.


[SONARJAVA-5443]: https://sonarsource.atlassian.net/browse/SONARJAVA-5443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ