### PR TITLE
SONARJAVA-5670 Make SonarComponents in JavaFrontend not @Nullable.

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
+++ b/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
@@ -687,5 +687,4 @@ public class SonarComponents extends CheckRegistrar.RegistrarContext {
   public Configuration getConfiguration() {
     return context.config();
   }
-  
 }

--- a/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
+++ b/java-frontend/src/main/java/org/sonar/java/SonarComponents.java
@@ -687,4 +687,5 @@ public class SonarComponents extends CheckRegistrar.RegistrarContext {
   public Configuration getConfiguration() {
     return context.config();
   }
+
 }

--- a/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
@@ -79,6 +79,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sonar.java.InputFileUtils.addFile;
+import static org.sonar.java.TestUtils.mockSonarComponents;
 
 @EnableRuleMigrationSupport
 class JavaFrontendTest {
@@ -179,7 +180,7 @@ class JavaFrontendTest {
 
   @Test
   void scanning_empty_project_should_be_logged_in_batch() {
-    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), sonarComponents, new Measurer(sensorContext, mock(NoSonarFilter.class)), mock(JavaResourceLocator.class), mainCodeIssueScannerAndFilter);
+    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), mockSonarComponents(), new Measurer(sensorContext, mock(NoSonarFilter.class)), mock(JavaResourceLocator.class), mainCodeIssueScannerAndFilter);
     frontend.scan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
 
     assertThat(logTester.logs(Level.INFO)).containsExactly(
@@ -405,7 +406,7 @@ class JavaFrontendTest {
 
     JavaFrontend frontend = new JavaFrontend(
       new JavaVersionImpl(),
-      null,
+      mockSonarComponents(),
       mock(Measurer.class),
       mock(JavaResourceLocator.class),
       mainCodeIssueScannerAndFilter
@@ -423,12 +424,12 @@ class JavaFrontendTest {
   }
 
   @Test
-  void test_getters_with_null_sonarComponents() {
-    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), null, new Measurer(sensorContext, mock(NoSonarFilter.class)), mock(JavaResourceLocator.class), mainCodeIssueScannerAndFilter);
-    assertThat(frontend.isAutoScan()).isFalse();
-    assertThat(frontend.isFileByFileEnabled()).isFalse();
-    assertThat(frontend.analysisCancelled()).isFalse();
-    assertThat(frontend.getBatchModeSizeInKB()).isEqualTo(-1L);
+  void test_validate_mockSonarComponents() {
+    SonarComponents mock = mockSonarComponents();
+    assertThat(mock.isAutoScan()).isFalse();
+    assertThat(mock.isFileByFileEnabled()).isFalse();
+    assertThat(mock.analysisCancelled()).isFalse();
+    assertThat(mock.getBatchModeSizeInKB()).isEqualTo(-1L);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
@@ -51,6 +51,7 @@ import org.sonar.api.scan.issue.filter.FilterableIssue;
 import org.sonar.api.scan.issue.filter.IssueFilterChain;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
+import org.sonar.java.caching.CacheContextImpl;
 import org.sonar.java.classpath.ClasspathForMain;
 import org.sonar.java.classpath.ClasspathForTest;
 import org.sonar.java.exceptions.ApiMismatchException;
@@ -423,6 +424,10 @@ class JavaFrontendTest {
       );
   }
 
+  /**
+   * Ensure that changes the mock, which may be needed when it is shared with other tests,
+   * do not affect JavaFrontendTest.
+   */
   @Test
   void test_validate_mockSonarComponents() {
     SonarComponents mock = mockSonarComponents();
@@ -430,6 +435,7 @@ class JavaFrontendTest {
     assertThat(mock.isFileByFileEnabled()).isFalse();
     assertThat(mock.analysisCancelled()).isFalse();
     assertThat(mock.getBatchModeSizeInKB()).isEqualTo(-1L);
+    assertThat(CacheContextImpl.of(mock).isCacheEnabled()).isFalse();
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/JavaVersionAwareVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaVersionAwareVisitorTest.java
@@ -31,6 +31,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.sonar.java.TestUtils.mockSonarComponents;
 
 class JavaVersionAwareVisitorTest {
 
@@ -77,7 +78,7 @@ class JavaVersionAwareVisitorTest {
 
   private void checkIssues(JavaVersion version) {
     messages.clear();
-    JavaFrontend frontend = new JavaFrontend(version, null, mock(Measurer.class), null, null, javaChecks);
+    JavaFrontend frontend = new JavaFrontend(version, mockSonarComponents(), mock(Measurer.class), null, null, javaChecks);
     frontend.scan(Collections.singletonList(TestUtils.inputFile("src/test/files/JavaVersionAwareChecks.java")),
       Collections.emptyList(), Collections.emptyList());
   }

--- a/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
@@ -29,6 +29,7 @@ import org.sonar.plugins.java.api.JavaCheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.sonar.java.TestUtils.mockSonarComponents;
 
 class MeasurerTest {
 
@@ -92,7 +93,7 @@ class MeasurerTest {
     context.fileSystem().add(inputFile);
 
     Measurer measurer = new Measurer(context, mock(NoSonarFilter.class));
-    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), null, measurer, null, null, new JavaCheck[0]);
+    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), mockSonarComponents(), measurer, null, null);
 
     frontend.scan(Collections.singletonList(inputFile), Collections.emptyList(), Collections.emptyList());
 

--- a/java-frontend/src/test/java/org/sonar/java/MeasurerTester.java
+++ b/java-frontend/src/test/java/org/sonar/java/MeasurerTester.java
@@ -34,6 +34,7 @@ import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 
 import static org.mockito.Mockito.mock;
+import static org.sonar.java.TestUtils.mockSonarComponents;
 
 public abstract class MeasurerTester {
 
@@ -50,7 +51,7 @@ public abstract class MeasurerTester {
       .forEach(fs::add);
 
     Measurer measurer = new Measurer(context, mock(NoSonarFilter.class));
-    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), null, measurer, mock(JavaResourceLocator.class), null, new JavaCheck[0]);
+    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), mockSonarComponents(), measurer, mock(JavaResourceLocator.class), null);
     List<InputFile> files = StreamSupport.stream(fs.inputFiles().spliterator(), false).toList();
     frontend.scan(files, Collections.emptyList(), Collections.emptyList());
   }

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -22,14 +22,11 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.java.exceptions.ApiMismatchException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -130,6 +130,10 @@ public class TestUtils {
     return filterOutAnalysisProgressLogLines(logs.stream());
   }
 
+  /**
+   * Creates a Mockito test double for {@link SonarComponents}, pre-configured to avoid
+   * nulls in unit tests and remove the need for null checks in production code.
+   */
   public static SonarComponents mockSonarComponents() {
     SonarComponents mock = mock(SonarComponents.class);
     when(mock.isSonarLintContext()).thenReturn(true);

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -19,7 +19,6 @@ package org.sonar.java;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.sonar.api.batch.fs.InputFile;
@@ -138,11 +137,11 @@ public class TestUtils {
     SonarComponents mock = mock(SonarComponents.class);
     when(mock.isSonarLintContext()).thenReturn(true);
     when(mock.getBatchModeSizeInKB()).thenReturn(-1L);
-    when(mock.getJavaClasspath()).thenReturn(new ArrayList<>());
-    when(mock.getJavaTestClasspath()).thenReturn(new ArrayList<>());
-    when(mock.getJspClasspath()).thenReturn(new ArrayList<>());
-    when(mock.testChecks()).thenReturn(new ArrayList<>());
-    when(mock.jspChecks()).thenReturn(new ArrayList<>());
+    when(mock.getJavaClasspath()).thenReturn(List.of());
+    when(mock.getJavaTestClasspath()).thenReturn(List.of());
+    when(mock.getJspClasspath()).thenReturn(List.of());
+    when(mock.testChecks()).thenReturn(List.of());
+    when(mock.jspChecks()).thenReturn(List.of());
     return mock;
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -19,14 +19,19 @@ package org.sonar.java;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.java.exceptions.ApiMismatchException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestUtils {
   private TestUtils() {
@@ -126,5 +131,17 @@ public class TestUtils {
 
   public static List<String> filterOutAnalysisProgressLogLines(List<String> logs) {
     return filterOutAnalysisProgressLogLines(logs.stream());
+  }
+
+  public static SonarComponents mockSonarComponents() {
+    SonarComponents mock = mock(SonarComponents.class);
+    when(mock.isSonarLintContext()).thenReturn(true);
+    when(mock.getBatchModeSizeInKB()).thenReturn(-1L);
+    when(mock.getJavaClasspath()).thenReturn(new ArrayList<>());
+    when(mock.getJavaTestClasspath()).thenReturn(new ArrayList<>());
+    when(mock.getJspClasspath()).thenReturn(new ArrayList<>());
+    when(mock.testChecks()).thenReturn(new ArrayList<>());
+    when(mock.jspChecks()).thenReturn(new ArrayList<>());
+    return mock;
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/ast/visitors/FileLinesVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/visitors/FileLinesVisitorTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonar.java.TestUtils.mockSonarComponents;
 
 class FileLinesVisitorTest {
 
@@ -50,7 +51,7 @@ class FileLinesVisitorTest {
     SonarComponents sonarComponents = mock(SonarComponents.class);
     when(sonarComponents.fileLinesContextFor(Mockito.any(InputFile.class))).thenReturn(context);
 
-    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), null, mock(Measurer.class), null, null, new FileLinesVisitor(sonarComponents));
+    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), mockSonarComponents(), mock(Measurer.class), null, null, new FileLinesVisitor(sonarComponents));
 
     frontend.scan(Collections.singletonList(inputFile), Collections.emptyList(), Collections.emptyList());
   }

--- a/java-frontend/src/test/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitorTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.sonar.java.TestUtils.mockSonarComponents;
 
 @EnableRuleMigrationSupport
 class SyntaxHighlighterVisitorTest {
@@ -254,7 +255,7 @@ class SyntaxHighlighterVisitorTest {
 
   private void scan(InputFile inputFile) {
     JavaVersion javaVersion = JParserConfig.MAXIMUM_SUPPORTED_JAVA_VERSION;
-    JavaFrontend frontend = new JavaFrontend(javaVersion, null, mock(Measurer.class), null, null, syntaxHighlighterVisitor);
+    JavaFrontend frontend = new JavaFrontend(javaVersion, mockSonarComponents(), mock(Measurer.class), null, null, syntaxHighlighterVisitor);
     frontend.scan(Collections.singletonList(inputFile), Collections.emptyList(), Collections.emptyList());
   }
 


### PR DESCRIPTION
[SONARJAVA-5670](https://sonarsource.atlassian.net/browse/SONARJAVA-5670)

Null SonarComponents is used only tests. JavaFrontend is created in JavaSensor, which calls a method on SonarComponents before it is passed the the constructor, therefore the parameter can never be null in production.

Replacing those nulls with mocks will simplify the production code.


[SONARJAVA-5670]: https://sonarsource.atlassian.net/browse/SONARJAVA-5670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ