### PR TITLE
SONARJAVA-5728 Improve the LiteralTree to provide the unescaped and unquoted content

### DIFF
--- a/its/ruling/src/test/resources/eclipse-jetty/java-S2437.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S2437.json
@@ -1,0 +1,7 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/UnixCrypt.java": [
+425,
+460,
+460
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S2437.json
+++ b/its/ruling/src/test/resources/guava/java-S2437.json
@@ -1,0 +1,5 @@
+{
+"com.google.guava:guava:src/com/google/common/primitives/UnsignedInteger.java": [
+55
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S4248.json
+++ b/its/ruling/src/test/resources/guava/java-S4248.json
@@ -1,7 +1,4 @@
 {
-"com.google.guava:guava:src/com/google/common/net/InternetDomainName.java": [
-510
-],
 "com.google.guava:guava:src/com/google/common/net/PercentEscaper.java": [
 100
 ]

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/TextBlocksDuplicatedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/TextBlocksDuplicatedCheckSample.java
@@ -91,6 +91,7 @@ class ConstantAlreadyDefined {
 //                     ^[sl=89;el=90;ec=15]<
     System.out.println("""
       blabla           """);
+//                     ^[sl=92;el=93;ec=26]<
     System.out.println("""
       blabla           
       """);

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/regex/SingleCharacterAlternationWithTextBlocks.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/regex/SingleCharacterAlternationWithTextBlocks.java
@@ -21,6 +21,10 @@ public class SingleCharacterAlternationWithTextBlocks {
       (?x)(
       a|b
       )"""); // Noncompliant@-1 [[sc=7;ec=10]]
+    // Equivalent to "a|b|\n " - note the space
+    str.matches("""
+      a|b|
+       """); // Noncompliant@-1 [[sc=7;ec=10]]
   }
 
   void compliant(String str) {
@@ -30,10 +34,6 @@ public class SingleCharacterAlternationWithTextBlocks {
     str.matches("""
       a|b
       """);
-    // Equivalent to "a|b|\n " - note the space
-    str.matches("""
-      a|b|
-       """);
   }
 
 }

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/regex/SingleCharacterAlternationWithTextBlocks.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/regex/SingleCharacterAlternationWithTextBlocks.java
@@ -21,7 +21,7 @@ public class SingleCharacterAlternationWithTextBlocks {
       (?x)(
       a|b
       )"""); // Noncompliant@-1 [[sc=7;ec=10]]
-    // Equivalent to "a|b|\n " - note the space
+    // Equivalent to "a|b|\n" - note the space
     str.matches("""
       a|b|
        """); // Noncompliant@-1 [[sc=7;ec=10]]

--- a/java-checks-test-sources/default/src/main/java/checks/MathClampRangeCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/MathClampRangeCheckSample.java
@@ -44,8 +44,8 @@ public class MathClampRangeCheckSample {
     Math.clamp(0, i2, 10); // Noncompliant {{Change the "clamp(value,min,max)"'s arguments so "value" is not always less than "max".}}
     Math.clamp(10L, 0, l3); // Noncompliant {{Change the "clamp(value,min,max)"'s arguments so "min" is not always less than "value".}}
 
-    Math.clamp(d1, 10.0d, 0.0d); // FN limitation, ExpressionTree.asConstant() does not support "double"
-    Math.clamp(0.0f, f2, 10.0f); // FN limitation, ExpressionTree.asConstant() does not support "float"
+    Math.clamp(d1, 10.0d, 0.0d); // Noncompliant {{Change the "clamp(value,min,max)"'s arguments so "max" is not always less than "min".}}
+    Math.clamp(0.0f, f2, 10.0f); // Noncompliant {{Change the "clamp(value,min,max)"'s arguments so "value" is not always less than "max".}}
   }
 
   int unknownValue() {

--- a/java-checks-test-sources/default/src/main/java/checks/RegexPatternsNeedlesslyCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/RegexPatternsNeedlesslyCheckSample.java
@@ -68,8 +68,9 @@ class RegexPatternsNeedlesslyCheckSample {
     param.split("\\"); // Noncompliant
     param.split("/a"); // Noncompliant
     param.split("\\a"); // Noncompliant
+    param.split("\\^"); // Compliant
+    param.split("\\$"); // Compliant
 
-    param.split("\\a"); // Noncompliant
     param.split("\\2"); // Noncompliant
     param.split("\\-"); // Compliant  -- second character is not a letter or digit
     param.split("\\*"); // Compliant    * is a metacharacter

--- a/java-checks-test-sources/default/src/main/java/checks/ShiftOnIntOrLongCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/ShiftOnIntOrLongCheckSample.java
@@ -94,7 +94,8 @@ class ShiftOnIntOrLongCheckSample {
     a = 0xfffffffffffffffeL << 7;
     a = 0xffffffffffffffffL << 7;
     a = 0x8000000000000000L << 7;
-    a = 1 << 0x8000000000000000L;
+    // 0x8000000000000000L == -9223372036854775808 == Long.MIN_VALUE
+    a = 1 << 0x8000000000000000L; // Noncompliant {{Remove this useless shift}}
   }
 
   public int returnInt() {

--- a/java-checks-test-sources/default/src/main/java/checks/UnnecessaryBitOperationCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/UnnecessaryBitOperationCheck.java
@@ -28,7 +28,7 @@ class UnnecessaryBitOperationCheck {
     resultLong = bitMaskLong & returnLong(); // Compliant
     resultLong = bitMaskLong & 0x0F; // Compliant
     
-    resultLong = bitMaskLong & 0xFFFFFFFFFFFFFFFFL; // Compliant
+    resultLong = bitMaskLong & 0xFFFFFFFFFFFFFFFFL; // Noncompliant {{Remove this unnecessary bit operation.}}
     resultLong = bitMaskLong & 0xFFFFFFFFFFFFFFFEL; // Compliant
     resultLong = bitMaskLong & 0x8000000000000000L; // Compliant
     resultLong = 0x8000000000000000L & bitMaskLong; // Compliant

--- a/java-checks/src/main/java/org/sonar/java/checks/ControlCharacterInLiteralCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ControlCharacterInLiteralCheck.java
@@ -22,7 +22,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
-import org.sonar.java.model.LiteralUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -68,16 +67,15 @@ public class ControlCharacterInLiteralCheck extends IssuableSubscriptionVisitor 
 
   @Override
   public void visitNode(Tree tree) {
-    LiteralTree literal = (LiteralTree) tree;
-    String literalValue = LiteralUtils.getAsStringValue(literal);
-    Matcher matcher = null;
+    String literalValue = ((LiteralTree) tree).unquotedValue();
+    Matcher matcher;
     if (allowTabsInTextBlocks && tree.is(Tree.Kind.TEXT_BLOCK)) {
       matcher = CONTROL_CHARACTERS_WITHOUT_TABS_PATTERN.matcher(literalValue);
     } else {
       matcher = CONTROL_CHARACTERS_PATTERN.matcher(literalValue);
     }
     if (matcher.find()) {
-      reportIssue(literal,  String.format(MESSAGE_FORMAT, literalValue.codePointAt(matcher.start())));
+      reportIssue(tree,  String.format(MESSAGE_FORMAT, literalValue.codePointAt(matcher.start())));
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/RegexPatternsNeedlesslyCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RegexPatternsNeedlesslyCheck.java
@@ -17,7 +17,6 @@
 package org.sonar.java.checks;
 
 import java.util.Optional;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
 import org.sonar.java.model.ExpressionUtils;
@@ -98,8 +97,7 @@ public class RegexPatternsNeedlesslyCheck extends AbstractMethodDetection {
    * (2) two-char String and the first char is the backslash and the second is not the ascii digit or ascii letter.
    *
    */
-  private static boolean exceptionSplitMethod(String argValue) {
-    String regex = StringEscapeUtils.unescapeJava(argValue);
+  private static boolean exceptionSplitMethod(String regex) {
     char ch;
     return ((regex.length() == 1 && ".$|()[{^?*+\\".indexOf(ch = regex.charAt(0)) == -1) ||
       (regex.length() == 2 &&

--- a/java-checks/src/main/java/org/sonar/java/checks/security/PubliclyWritableDirectoriesCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/PubliclyWritableDirectoriesCheck.java
@@ -57,9 +57,9 @@ public class PubliclyWritableDirectoriesCheck extends IssuableSubscriptionVisito
     "/Users/Shared",
     "/private/tmp",
     "/private/var/tmp",
-    "\\\\Windows\\\\Temp",
-    "\\\\Temp",
-    "\\\\TMP");
+    "\\Windows\\Temp",
+    "\\Temp",
+    "\\TMP");
 
   private static final Set<String> TMP_DIR_ENV = SetUtils.immutableSetOf("TMP", "TMPDIR");
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/ModelAttributeNamingConventionForSpELCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/ModelAttributeNamingConventionForSpELCheck.java
@@ -20,14 +20,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.model.LiteralUtils;
 import org.sonar.java.model.declaration.VariableTreeImpl;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.StringLiteralTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S6806")
@@ -66,7 +65,7 @@ public class ModelAttributeNamingConventionForSpELCheck extends AbstractMethodDe
 
   private void checkExpression(ExpressionTree argumentTree, ExpressionTree reportTree) {
     if (argumentTree.is(Tree.Kind.STRING_LITERAL)) {
-      checkStringLiteralAndReport(argumentTree, reportTree);
+      checkStringLiteralAndReport((StringLiteralTree) argumentTree, reportTree);
     } else if (argumentTree.is(Tree.Kind.IDENTIFIER)) {
       checkIdentifier((IdentifierTree) argumentTree);
     } else if (argumentTree.is(Tree.Kind.MEMBER_SELECT)) {
@@ -76,10 +75,8 @@ public class ModelAttributeNamingConventionForSpELCheck extends AbstractMethodDe
     }
   }
 
-  private void checkStringLiteralAndReport(ExpressionTree tree, ExpressionTree reportTree) {
-    LiteralTree literalTree = (LiteralTree) tree;
-    String literalValue = LiteralUtils.getAsStringValue(literalTree);
-    Matcher matcher = pattern.matcher(literalValue);
+  private void checkStringLiteralAndReport(StringLiteralTree tree, ExpressionTree reportTree) {
+    Matcher matcher = pattern.matcher(tree.stringValue());
     if (!matcher.matches()) {
       reportIssue(reportTree,
         "Attribute names must begin with a letter (a-z, A-Z), underscore (_), or dollar sign ($) and can be followed by letters, digits, underscores, or dollar signs.");

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/MethodTreeUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/MethodTreeUtilsTest.java
@@ -19,7 +19,9 @@ package org.sonar.java.checks.helpers;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.sonar.java.model.InternalSyntaxToken;
 import org.sonar.java.model.expression.LiteralTreeImpl;
+import org.sonar.java.model.expression.NullLiteralTreeImpl;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
@@ -38,6 +40,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.sonar.java.checks.helpers.MethodTreeUtils.lamdaArgumentAt;
 import static org.sonar.java.checks.helpers.MethodTreeUtils.parentMethodInvocationOfArgumentAtPos;
 
@@ -164,7 +167,7 @@ class MethodTreeUtilsTest {
     LiteralTree literal3 = (LiteralTree) mathMax.arguments().get(1);
     NewClassTree newThread = (NewClassTree) ((VariableTree) members.get(2)).initializer();
     LiteralTree literal4 = (LiteralTree) newThread.arguments().get(0);
-    LiteralTreeImpl expressionWithoutParent = new LiteralTreeImpl(Tree.Kind.STRING_LITERAL, null);
+    LiteralTreeImpl expressionWithoutParent = new NullLiteralTreeImpl(mock(InternalSyntaxToken.class));
 
     assertThat(parentMethodInvocationOfArgumentAtPos(null, 0)).isNull();
     assertThat(parentMethodInvocationOfArgumentAtPos(expressionWithoutParent, 0)).isNull();

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -236,20 +236,11 @@ public final class ExpressionUtils {
     if (expression.is(Tree.Kind.IDENTIFIER)) {
       return resolveIdentifier((IdentifierTree) expression);
     }
-    if (expression.is(Tree.Kind.BOOLEAN_LITERAL)) {
-      return Boolean.parseBoolean(((LiteralTree) expression).value());
-    }
-    if (expression.is(Tree.Kind.STRING_LITERAL, Tree.Kind.TEXT_BLOCK)) {
-      return LiteralUtils.getAsStringValue((LiteralTree) expression);
-    }
     if (expression instanceof UnaryExpressionTree unaryExpressionTree) {
       return resolveUnaryExpression(unaryExpressionTree);
     }
-    if (expression.is(Tree.Kind.INT_LITERAL)) {
-      return LiteralUtils.intLiteralValue(expression);
-    }
-    if (expression.is(Tree.Kind.LONG_LITERAL)) {
-      return LiteralUtils.longLiteralValue(expression);
+    if (expression instanceof LiteralTree literalTree) {
+      return literalTree.parsedValue();
     }
     if (expression.is(Tree.Kind.PLUS)) {
       return resolvePlus((BinaryExpressionTree) expression);

--- a/java-frontend/src/main/java/org/sonar/java/model/JParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JParser.java
@@ -279,7 +279,7 @@ public class JParser {
 
   private static final Predicate<IProblem> IS_UNDEFINED_TYPE_ERROR = error -> (error.getID() & IProblem.UndefinedType) != 0;
 
-  private static final java.util.regex.Pattern EMPTY_TEXT_BLOCK_PATTERN = java.util.regex.Pattern.compile("\"\"\"\\R[ \t\f]++\"\"\"");
+  private static final java.util.regex.Pattern EMPTY_TEXT_BLOCK_PATTERN = java.util.regex.Pattern.compile("\"\"\"\\R[ \t\f]*+(\\\\\\R[ \t\f]*+)?\"\"\"");
 
   /**
    * @param unitName see {@link ASTParser#setUnitName(String)}

--- a/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/LiteralUtils.java
@@ -16,13 +16,13 @@
  */
 package org.sonar.java.model;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IntLiteralTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.LongLiteralTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
@@ -35,8 +35,8 @@ public class LiteralUtils {
 
   @CheckForNull
   public static Integer intLiteralValue(ExpressionTree expression) {
-    if (expression.is(Tree.Kind.INT_LITERAL)) {
-      return intLiteralValue((LiteralTree) expression);
+    if (expression instanceof IntLiteralTree intLiteralTree) {
+      return intLiteralTree.intValue();
     }
     if (expression.is(Tree.Kind.UNARY_MINUS, Tree.Kind.UNARY_PLUS)) {
       UnaryExpressionTree unaryExp = (UnaryExpressionTree) expression;
@@ -46,57 +46,91 @@ public class LiteralUtils {
     return null;
   }
 
-  private static Integer intLiteralValue(LiteralTree literal) {
-    String literalValue = literal.value().replace("_", "");
-    if (literalValue.startsWith("0b") || literalValue.startsWith("0B")) {
-      // assume it is used as bit mask
-      return Integer.parseUnsignedInt(literalValue.substring(2), 2);
-    }
-    return Long.decode(literalValue).intValue();
-  }
-
   @CheckForNull
   public static Long longLiteralValue(ExpressionTree tree) {
     ExpressionTree expression = tree;
 
-    int sign = tree.is(Kind.UNARY_MINUS) ? -1 : 1;
+    long sign = tree.is(Kind.UNARY_MINUS) ? -1L : 1L;
     if (tree.is(Kind.UNARY_MINUS, Kind.UNARY_PLUS)) {
       expression = ((UnaryExpressionTree) tree).expression();
     }
 
-    if (expression.is(Kind.INT_LITERAL, Kind.LONG_LITERAL)) {
-      String value = trimLongSuffix(((LiteralTree) expression).value());
-      // long as hexadecimal can be written using underscore to separate groups
-      value = value.replace("_", "");
-      try {
-        if (value.startsWith("0b") || value.startsWith("0B")) {
-          return sign * Long.valueOf(value.substring(2), 2);
-        }
-        return sign * Long.decode(value);
-      } catch (NumberFormatException e) {
-        // Long.decode() may fail in case of very large long number written in hexadecimal. In such situation, we ignore the number.
-        // Note that Long.MAX_VALUE = "0x7FFF_FFFF_FFFF_FFFFL", but it is possible to write larger numbers in hexadecimal
-        // to be used as mask in bitwise operation. For instance:
-        // 0x8000_0000_0000_0000L (MAX_VALUE + 1),
-        // 0xFFFF_FFFF_FFFF_FFFFL (only ones),
-        // 0xFFFF_FFFF_FFFF_FFFEL (only ones except least significant bit), ...
-      }
+    if (expression instanceof LongLiteralTree longLiteralTree) {
+      return sign * longLiteralTree.longValue();
+    } else if(expression instanceof IntLiteralTree intLiteralTree) {
+      return sign * intLiteralTree.intValue();
     }
     return null;
   }
 
+  public static long parseJavaLiteralLong(String tokenValue) {
+    String value = stripUnderscores(tokenValue);
+    int end = literalLongEndWithoutSuffix(value);
+    char ch0 = end > 0 ? value.charAt(0) : 0;
+    char ch1 = end > 1 ? value.charAt(1) : 0;
+    boolean negative = false;
+    int start = 0;
+    if (ch0 == '-' || ch0 == '+') {
+      negative = ch0 == '-';
+      start++;
+      ch0 = ch1;
+      ch1 = end > 2 ? value.charAt(2) : 0;
+    }
+    if (ch0 == '0') {
+      if (ch1 == 'x' || ch1 == 'X') {
+        return internalParseLong(start + 2, end, value, 16, negative);
+      } else if (ch1 == 'b' || ch1 == 'B') {
+        return internalParseLong(start + 2, end, value, 2, negative);
+      } else if (ch1 >= '0' && ch1 <= '9') {
+        return internalParseLong(start + 1, end, value, 8, negative);
+      }
+    } else if (ch0 == '#') {
+      return internalParseLong(start + 1, end, value, 16, negative);
+    }
+    return internalParseLong(start, end, value, 10, negative);
+  }
+
+  private static int literalLongEndWithoutSuffix(String value) {
+    int end = value.length();
+    char lastCh = end > 0 ? value.charAt(end - 1) : 0;
+    if (lastCh == 'L' || lastCh == 'l') {
+      end--;
+    }
+    return end;
+  }
+
+  private static long internalParseLong(int start, int length, String value, int radix, boolean negative) {
+    if (start == length) {
+      // return 0 for an empty string instead of throwing a NumberFormatException("Zero length string")
+      return 0;
+    }
+    long result = Long.parseUnsignedLong(value, start, length, radix);
+    return negative ? -result : result;
+  }
+
+  public static double parseJavaLiteralDouble(String tokenValue) {
+    return Double.parseDouble(stripUnderscores(tokenValue));
+  }
+
+  private static String stripUnderscores(String value) {
+    if (value.indexOf('_') != -1) {
+      return value.replace("_", "");
+    }
+    return value;
+  }
+
   @CheckForNull
   public static Double doubleLiteralValue(ExpressionTree expression) {
-    int sign = 1;
+    double sign = 1;
     if (expression.is(Kind.UNARY_MINUS, Kind.UNARY_PLUS)) {
-      sign = expression.is(Kind.UNARY_MINUS) ? -1 : 1;
+      sign = expression.is(Kind.UNARY_MINUS) ? -1d : 1d;
       expression = ((UnaryExpressionTree) expression).expression();
     }
-
-    if (expression.is(Kind.FLOAT_LITERAL, Kind.DOUBLE_LITERAL)) {
-      String value = ((LiteralTree) expression).value().replace("_", "");
-      
-      return sign*Double.parseDouble(value);
+    if (expression instanceof LiteralTree literalTree) {
+      Object parsedValue = literalTree.parsedValue();
+      if (parsedValue instanceof Number number) {
+        return sign * number.doubleValue();
+      }
     }
     return null;
   }
@@ -164,50 +198,97 @@ public class LiteralUtils {
     return tree.is(Kind.UNARY_MINUS) && isOne(((UnaryExpressionTree) tree).expression());
   }
 
-  public static String getAsStringValue(LiteralTree tree) {
-    if (!tree.is(Kind.TEXT_BLOCK)) {
-      return tree.is(Kind.STRING_LITERAL) ? trimQuotes(tree.value()) : tree.value();
-    }
-    String[] lines = tree.value().split("\r?\n");
-    int indent = indentationOfTextBlock(lines);
 
-    return Arrays.stream(lines)
-      .skip(1)
-      .map(String::stripTrailing)
-      .map(s -> stripIndent(indent, s))
-      .collect(Collectors.joining("\n"))
-      .replaceAll("\"\"\"$", "");
-  }
-
-  private static String stripIndent(int indent, String s) {
-    return s.isEmpty() ? s : s.substring(indent);
-  }
-
-  public static int indentationOfTextBlock(String[] lines) {
-    return Arrays.stream(lines).skip(1)
-      .filter(LiteralUtils::isNonEmptyLine)
-      .mapToInt(LiteralUtils::getIndentation)
-      .min().orElse(0);
-  }
-
-  private static boolean isNonEmptyLine(String line) {
-    return line.chars().anyMatch(LiteralUtils::isNotWhiteSpace);
+  public static String unwrapIfPresent(String token, char delimiter) {
+    int len = token.length();
+    int start = (len > 0 && token.charAt(0) == delimiter) ? 1 : 0;
+    int end = ((len - start) > 0 && token.charAt(len - 1) == delimiter) ? (len - 1) : len;
+    return token.substring(start, end);
   }
 
   /**
-   * @return Whether c is not a white space character according to the space-stripping rules of text blocks, i.e. whether
-   *         it's a space, tab or form feed
+   * The escaped characters stay escaped, {@link String#translateEscapes()} is not used.
+   * See <a href="https://docs.oracle.com/javase/specs/jls/se24/html/jls-3.html#jls-3.10.6">jls-3.10.6</a> for details.
    */
-  private static boolean isNotWhiteSpace(int c) {
-    return c != ' ' && c != '\t' && c != '\f';
+  public static String removeTextBlockQuoteIndentationAndTrailingWhitespaces(String token) {
+    int start = 0;
+    int end = token.length();
+    if (end == 0) {
+      return token;
+    }
+    // remove leading """
+    start = moveIndexIfMatches(token, start, end, 1, 3, '"');
+    // ignore whitespaces after the leading """
+    start = moveIndexWhileWhiteSpaces(token, start, end);
+    // ignore the first new line \r?\n|\r
+    start = moveIndexIfMatches(token, start, end, 1, 1, '\r');
+    start = moveIndexIfMatches(token, start, end, 1, 1, '\n');
+    // remove ending """
+    if (end > start) {
+      end = moveIndexIfMatches(token, end - 1, start, -1, 3, '"') + 1;
+    }
+    return token.substring(start, end).stripIndent();
   }
 
-  private static int getIndentation(String line) {
-    for (int i = 0; i < line.length(); ++i) {
-      if (isNotWhiteSpace(line.charAt(i))) {
+  /**
+   * Moves the index in the given direction while the character at the index matches the given value.
+   * @param token the string to check
+   * @param index the starting index
+   * @param direction 1 for forward, -1 for backward
+   * @param count max move count or -1 for no limit
+   * @param value character to match
+   * @return the new index after moving
+   */
+  private static int moveIndexIfMatches(String token, int index, int limit, int direction, int count, char value) {
+    while (count != 0 && index != limit && (token.charAt(index) == value)) {
+      index += direction;
+      count--;
+    }
+    return index;
+  }
+
+  private static int moveIndexWhileWhiteSpaces(String token, int index, int limit) {
+    while (index != limit && isWhiteSpace(token.charAt(index))) {
+      index++;
+    }
+    return index;
+  }
+
+  public static int indentationOfTextBlock(String[] lines) {
+    int minIndentation = Integer.MAX_VALUE;
+    // ignore line 0, it contains only """[ \t\f]* and should be ignored to compute the indentation
+    for (int i = 1; i < lines.length; i++) {
+      minIndentation = Math.min(singleLineIndentation(lines[i], minIndentation), minIndentation);
+    }
+    return minIndentation == Integer.MAX_VALUE ? 0 : minIndentation;
+  }
+
+  /**
+   * @return true if c is a white space character (space, tab or form feed) according to the space-stripping rules of text blocks
+   * See <a href="https://docs.oracle.com/javase/specs/jls/se24/html/jls-3.html#jls-3.10.6">jls-3.10.6</a> for details.
+   */
+  private static boolean isWhiteSpace(int c) {
+    return c == ' ' || c == '\t' || c == '\f';
+  }
+
+  private static int singleLineIndentation(String line, int defaultIfBlank) {
+    int len = line.length();
+    for (int i = 0; i < len; i++) {
+      if (!isWhiteSpace(line.charAt(i))) {
         return i;
       }
     }
-    return line.length();
+    return defaultIfBlank;
   }
+
+  public static int lineCount(String content) {
+    int count = 1;
+    int pos = content.indexOf('\n');
+    while (pos != -1) {
+      count++;
+      pos = content.indexOf('\n', pos + 1);
+    }
+    return count;
+  }
+
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/BooleanLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/BooleanLiteralTreeImpl.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.plugins.java.api.tree.BooleanLiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+public class BooleanLiteralTreeImpl extends LiteralTreeImpl implements BooleanLiteralTree {
+
+  private final boolean booleanValue;
+
+  public BooleanLiteralTreeImpl(InternalSyntaxToken token, boolean booleanValue) {
+    super(Tree.Kind.BOOLEAN_LITERAL, token);
+    this.booleanValue = booleanValue;
+  }
+
+  @Override
+  public boolean booleanValue() {
+    return booleanValue;
+  }
+
+  @Override
+  public Object parsedValue() {
+    return booleanValue;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/CharLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/CharLiteralTreeImpl.java
@@ -28,7 +28,7 @@ public class CharLiteralTreeImpl extends LiteralTreeImpl implements CharLiteralT
 
   public CharLiteralTreeImpl(InternalSyntaxToken token, char charValue) {
     super(Tree.Kind.CHAR_LITERAL, token);
-    this.unquotedValue = LiteralUtils.unwrapIfPresent(token.text(), '\'');
+    this.unquotedValue = LiteralUtils.unquote(token.text(), '\'');
     this.charValue = charValue;
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/CharLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/CharLiteralTreeImpl.java
@@ -16,48 +16,35 @@
  */
 package org.sonar.java.model.expression;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
 import org.sonar.java.model.InternalSyntaxToken;
-import org.sonar.plugins.java.api.tree.LiteralTree;
-import org.sonar.plugins.java.api.tree.SyntaxToken;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.tree.CharLiteralTree;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.TreeVisitor;
 
-public abstract class LiteralTreeImpl extends AssessableExpressionTree implements LiteralTree {
+public class CharLiteralTreeImpl extends LiteralTreeImpl implements CharLiteralTree {
 
-  private final Kind kind;
-  private final InternalSyntaxToken token;
+  private final String unquotedValue;
+  private final char charValue;
 
-  protected LiteralTreeImpl(Kind kind, InternalSyntaxToken token) {
-    this.kind = Objects.requireNonNull(kind);
-    this.token = token;
+  public CharLiteralTreeImpl(InternalSyntaxToken token, char charValue) {
+    super(Tree.Kind.CHAR_LITERAL, token);
+    this.unquotedValue = LiteralUtils.unwrapIfPresent(token.text(), '\'');
+    this.charValue = charValue;
   }
 
   @Override
-  public Kind kind() {
-    return kind;
+  public String unquotedValue() {
+    return unquotedValue;
   }
 
   @Override
-  public String value() {
-    return token.text();
+  public char charValue() {
+    return charValue;
   }
 
   @Override
-  public SyntaxToken token() {
-    return token;
-  }
-
-  @Override
-  public void accept(TreeVisitor visitor) {
-    visitor.visitLiteral(this);
-  }
-
-  @Override
-  public List<Tree> children() {
-    return Collections.<Tree>singletonList(token);
+  public Object parsedValue() {
+    return charValue;
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/DoubleLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/DoubleLiteralTreeImpl.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.tree.DoubleLiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+public class DoubleLiteralTreeImpl extends LiteralTreeImpl implements DoubleLiteralTree {
+
+  private final double doubleValue;
+
+  public DoubleLiteralTreeImpl(InternalSyntaxToken token) {
+    this(token, LiteralUtils.parseJavaLiteralDouble(token.text()));
+  }
+
+  public DoubleLiteralTreeImpl(InternalSyntaxToken token, double doubleValue) {
+    super(Tree.Kind.DOUBLE_LITERAL, token);
+    this.doubleValue = doubleValue;
+  }
+
+  @Override
+  public double doubleValue() {
+    return doubleValue;
+  }
+
+  @Override
+  public Object parsedValue() {
+    return doubleValue;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/FloatLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/FloatLiteralTreeImpl.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.tree.FloatLiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+public class FloatLiteralTreeImpl extends LiteralTreeImpl implements FloatLiteralTree {
+
+  private final float floatValue;
+
+  public FloatLiteralTreeImpl(InternalSyntaxToken token) {
+    this(token, (float) LiteralUtils.parseJavaLiteralDouble(token.text()));
+  }
+
+  public FloatLiteralTreeImpl(InternalSyntaxToken token, float floatValue) {
+    super(Tree.Kind.FLOAT_LITERAL, token);
+    this.floatValue = floatValue;
+  }
+
+  @Override
+  public float floatValue() {
+    return floatValue;
+  }
+
+  @Override
+  public Object parsedValue() {
+    return floatValue;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/IntLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/IntLiteralTreeImpl.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.tree.IntLiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+public class IntLiteralTreeImpl extends LiteralTreeImpl implements IntLiteralTree {
+
+  private final int intValue;
+
+  public IntLiteralTreeImpl(InternalSyntaxToken token) {
+    this(token, (int) LiteralUtils.parseJavaLiteralLong(token.text()));
+  }
+
+  public IntLiteralTreeImpl(InternalSyntaxToken token, int intValue) {
+    super(Tree.Kind.INT_LITERAL, token);
+    this.intValue = intValue;
+  }
+
+  @Override
+  public int intValue() {
+    return intValue;
+  }
+
+  @Override
+  public Object parsedValue() {
+    return intValue;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/LongLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/LongLiteralTreeImpl.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.tree.LongLiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+public class LongLiteralTreeImpl extends LiteralTreeImpl implements LongLiteralTree {
+
+  private final long longValue;
+
+  public LongLiteralTreeImpl(InternalSyntaxToken token) {
+    this(token, LiteralUtils.parseJavaLiteralLong(token.text()));
+  }
+
+  public LongLiteralTreeImpl(InternalSyntaxToken token, long longValue) {
+    super(Tree.Kind.LONG_LITERAL, token);
+    this.longValue = longValue;
+  }
+
+  @Override
+  public long longValue() {
+    return longValue;
+  }
+
+  @Override
+  public Object parsedValue() {
+    return longValue;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/NullLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/NullLiteralTreeImpl.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.plugins.java.api.tree.Tree;
+
+public class NullLiteralTreeImpl extends LiteralTreeImpl {
+
+  public NullLiteralTreeImpl(InternalSyntaxToken token) {
+    super(Tree.Kind.NULL_LITERAL, token);
+  }
+
+  @Override
+  public Object parsedValue() {
+    return null;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/StringLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/StringLiteralTreeImpl.java
@@ -30,7 +30,7 @@ public class StringLiteralTreeImpl extends LiteralTreeImpl implements StringLite
     if (kind == Kind.TEXT_BLOCK) {
       this.unquotedValue = LiteralUtils.removeTextBlockQuoteIndentationAndTrailingWhitespaces(token.text());
     } else {
-      this.unquotedValue = LiteralUtils.unwrapIfPresent(token.text(), '"');
+      this.unquotedValue = LiteralUtils.unquote(token.text(), '"');
     }
     this.stringValue = stringValue;
   }

--- a/java-frontend/src/main/java/org/sonar/java/model/expression/StringLiteralTreeImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/expression/StringLiteralTreeImpl.java
@@ -1,0 +1,53 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.tree.StringLiteralTree;
+
+public class StringLiteralTreeImpl extends LiteralTreeImpl implements StringLiteralTree {
+
+  private final String unquotedValue;
+  private final String stringValue;
+
+  public StringLiteralTreeImpl(Kind kind, InternalSyntaxToken token, String stringValue) {
+    super(kind, token);
+    if (kind == Kind.TEXT_BLOCK) {
+      this.unquotedValue = LiteralUtils.removeTextBlockQuoteIndentationAndTrailingWhitespaces(token.text());
+    } else {
+      this.unquotedValue = LiteralUtils.unwrapIfPresent(token.text(), '"');
+    }
+    this.stringValue = stringValue;
+  }
+
+  @Override
+  public String unquotedValue() {
+    return unquotedValue;
+  }
+
+  @Override
+  public String stringValue() {
+    return stringValue;
+  }
+
+  @Override
+  public Object parsedValue() {
+    return stringValue;
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/BooleanLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/BooleanLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface BooleanLiteralTree extends LiteralTree {
+
+  /**
+   * @return the parsed boolean value
+   */
+  boolean booleanValue();
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/CharLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/CharLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface CharLiteralTree extends LiteralTree {
+
+  /**
+   * @return the unescaped and unquoted content of the char literal
+   */
+  char charValue();
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/DoubleLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/DoubleLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface DoubleLiteralTree extends LiteralTree {
+
+  /**
+   * @return the parsed double literal value
+   */
+  double doubleValue();
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/FloatLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/FloatLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface FloatLiteralTree extends LiteralTree {
+
+  /**
+   * @return the parsed float literal value
+   */
+  float floatValue();
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/IntLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/IntLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface IntLiteralTree extends LiteralTree {
+
+  /**
+   * @return the parsed int literal value
+   */
+  int intValue();
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/LiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/LiteralTree.java
@@ -42,7 +42,28 @@ import org.sonar.java.annotations.Beta;
 @Beta
 public interface LiteralTree extends ExpressionTree {
 
+  /**
+   * @return the raw source code value of the literal (the parsed token), including quotes for string literals.
+   */
   String value();
 
+  /**
+   * @return The source code value of the literal without the surrounding quotes around char or string literals.
+   * The escaped characters stay escaped, {@link String#translateEscapes()} is not used.
+   * If the string literal is a text block, indentation, first line break and all trailing whitespaces are also removed.
+   */
+  default String unquotedValue() {
+    return value();
+  }
+
+  /**
+   * @return the literal runtime value. It could be: null, Boolean, String, Character, Long, Integer.
+   * Note, you can access the matching return type and support primitives by using the subtypes of {@link LiteralTree}:
+   * {@link BooleanLiteralTree#booleanValue()}, {@link StringLiteralTree#stringValue()}, {@link CharLiteralTree#charValue()},
+   * {@link LongLiteralTree#longValue()}, {@link IntLiteralTree#intValue()}.
+   */
+  Object parsedValue();
+
   SyntaxToken token();
+
 }

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/LongLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/LongLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface LongLiteralTree extends LiteralTree {
+
+  /**
+   * @return the parsed long literal value
+   */
+  long longValue();
+
+}

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/StringLiteralTree.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/tree/StringLiteralTree.java
@@ -1,0 +1,26 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.plugins.java.api.tree;
+
+public interface StringLiteralTree extends LiteralTree {
+
+  /**
+   * @return the unescaped, unindented and unquoted content of the string literal
+   */
+  String stringValue();
+
+}

--- a/java-frontend/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/LiteralUtilsTest.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.java.model.LiteralUtils.parseJavaLiteralLong;
 
 class LiteralUtilsTest {
 
@@ -405,6 +406,32 @@ class LiteralUtilsTest {
     assertThat(LiteralUtils.indentationOfTextBlock(withEmptyLine)).isEqualTo(4);
     String[] withIndentedEmptyLine = {"\"\"\"", "    abc", " \t\f", "    \"\"\""};
     assertThat(LiteralUtils.indentationOfTextBlock(withIndentedEmptyLine)).isEqualTo(4);
+  }
+
+  @Test
+  void parse_java_literal_long() {
+    assertThat(parseJavaLiteralLong("")).isZero();
+    assertThat(parseJavaLiteralLong("0")).isZero();
+    assertThat(parseJavaLiteralLong("+0l")).isZero();
+    assertThat(parseJavaLiteralLong("-0L")).isZero();
+
+    assertThat(parseJavaLiteralLong("2")).isEqualTo(2);
+    assertThat(parseJavaLiteralLong("+2L")).isEqualTo(2);
+    assertThat(parseJavaLiteralLong("-2")).isEqualTo(-2);
+
+    assertThat(parseJavaLiteralLong("0xFF")).isEqualTo(255);
+    assertThat(parseJavaLiteralLong("0101")).isEqualTo(65);
+    assertThat(parseJavaLiteralLong("+0b0101L")).isEqualTo(5);
+    assertThat(parseJavaLiteralLong("#0F")).isEqualTo(15);
+  }
+
+  @Test
+  void line_count() {
+    assertThat(LiteralUtils.lineCount("a")).isEqualTo(1);
+    assertThat(LiteralUtils.lineCount("a\n")).isEqualTo(2);
+    assertThat(LiteralUtils.lineCount("a\nb")).isEqualTo(2);
+    assertThat(LiteralUtils.lineCount("a\nb\n")).isEqualTo(3);
+    assertThat(LiteralUtils.lineCount("a\nb\nc")).isEqualTo(3);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/model/expression/LiteralTreeImplTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/expression/LiteralTreeImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.model.expression;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.model.JParserTestUtils;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.ListTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.NewArrayTree;
+import org.sonar.plugins.java.api.tree.VariableTree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiteralTreeImplTest {
+
+  @Test
+  void parsed_value() throws IOException {
+    // begin samples
+    Object[] samples = {
+      // null
+      null,
+      // boolean
+      true,
+      false,
+      // int
+      0,
+      1,
+      1_000_000,
+      // Integer.MIN_VALUE,
+      0x80000000,
+      // Integer.MAX_VALUE,
+      0x7fffffff,
+      // -1
+      0xffffffff,
+      // long
+      42L,
+      // float
+      1.2f,
+      // double
+      1.2d,
+      // character
+      'a',
+      // character with escaped character
+      '\n',
+      '\u26A0',
+      // empty string
+      "",
+      // empty text box
+      """
+        """,
+      // string with escaped characters
+      "\"\u26A0a\012cdef\"",
+      // string with escaped new lines
+      "1\r\n2\r\n3\r\n",
+      // text block without indentation
+      """
+        line 1
+        line 2
+        """,
+      // text block with 2 space indentation
+      """
+          line 1
+          line 2
+        """,
+      // text block with escaped characters
+      """
+        \u26A0 line\t1
+        \u26A0 line\t2
+        """,
+      // text block with ending whitespace
+      """
+          line 3  \s
+          line 4  \s
+        """,
+      // text block without a new line at the end
+      """
+        line 5  \s
+        line 6""",
+      // text block with tailing space before the end are trimmed
+      """
+        line 7  \s
+        line 8  """
+    };
+    // end samples
+    String aboveSamplesSourceCode = "class A {\n    " +
+      extractJavaSourceCodeFromTheCurrentFileBetween("// begin samples\n", "// end samples\n") +
+      "\n}";
+
+    CompilationUnitTree compilationUnit = JParserTestUtils.parse(aboveSamplesSourceCode);
+    NewArrayTree samplesArray = (NewArrayTree) ((VariableTree) ((ClassTree) compilationUnit.types().get(0)).members().get(0)).initializer();
+
+    ListTree<ExpressionTree> initializers = samplesArray.initializers();
+    for (int i = 0; i < initializers.size(); i++) {
+      LiteralTree initializer = (LiteralTree) initializers.get(i);
+      assertThat(initializer.parsedValue())
+        .describedAs("For string at index " + i + " with token " + initializer.value())
+        .isEqualTo(samples[i]);
+    }
+  }
+
+  @NotNull
+  private String extractJavaSourceCodeFromTheCurrentFileBetween(String startTag, String endTag) throws IOException {
+    Path thisJavaFilePath = Path.of("src", "test", "java", this.getClass().getName().replace('.', '/').concat(".java"));
+    String sourceCode = Files.readString(thisJavaFilePath);
+    int samplesStart = sourceCode.indexOf(startTag);
+    int samplesEnd = sourceCode.indexOf(endTag);
+    if (samplesStart == -1 || samplesEnd == -1) {
+      throw new IllegalStateException("Could not find tags in " + thisJavaFilePath);
+    }
+    return sourceCode.substring(samplesStart, samplesEnd);
+  }
+
+}

--- a/java-frontend/src/test/java/org/sonar/java/model/expression/LiteralTreeImplTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/expression/LiteralTreeImplTest.java
@@ -24,11 +24,18 @@ import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.JParserTestUtils;
 import org.sonar.plugins.java.api.tree.Arguments;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BooleanLiteralTree;
+import org.sonar.plugins.java.api.tree.CharLiteralTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.plugins.java.api.tree.DoubleLiteralTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.FloatLiteralTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.IntLiteralTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.LongLiteralTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.StringLiteralTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,13 +46,10 @@ class LiteralTreeImplTest {
 
   @Test
   void null_literal() {
-    var literal = parseTree(null).asLiteral();
-    assertThat(literal.value())
-      .isEqualTo("null");
-    assertThat(literal.unquotedValue())
-      .isEqualTo("null");
-    assertThat(literal.parsedValue())
-      .isNull();
+    var literal = (LiteralTree) parseTree(null).tree();
+    assertThat(literal.value()).isEqualTo("null");
+    assertThat(literal.unquotedValue()).isEqualTo("null");
+    assertThat(literal.parsedValue()).isNull();
   }
 
   @Test
@@ -57,23 +61,17 @@ class LiteralTreeImplTest {
 
   @Test
   void boolean_literal() {
-    var falseLiteral = parseTree(false).asLiteral();
-    assertThat(falseLiteral.value())
-      .isEqualTo("false");
-    assertThat(falseLiteral.unquotedValue())
-      .isEqualTo("false");
-    assertThat(falseLiteral.parsedValue())
-      .isInstanceOf(Boolean.class)
-      .isSameAs(Boolean.FALSE);
+    var falseLiteral = (BooleanLiteralTree) parseTree(false).tree();
+    assertThat(falseLiteral.value()).isEqualTo("false");
+    assertThat(falseLiteral.unquotedValue()).isEqualTo("false");
+    assertThat(falseLiteral.parsedValue()).isInstanceOf(Boolean.class).isSameAs(Boolean.FALSE);
+    assertThat(falseLiteral.booleanValue()).isFalse();
 
-    var trueLiteral = parseTree(true).asLiteral();
-    assertThat(trueLiteral.value())
-      .isEqualTo("true");
-    assertThat(trueLiteral.unquotedValue())
-      .isEqualTo("true");
-    assertThat(trueLiteral.parsedValue())
-      .isInstanceOf(Boolean.class)
-      .isSameAs(Boolean.TRUE);
+    var trueLiteral = (BooleanLiteralTree) parseTree(true).tree();
+    assertThat(trueLiteral.value()).isEqualTo("true");
+    assertThat(trueLiteral.unquotedValue()).isEqualTo("true");
+    assertThat(trueLiteral.parsedValue()).isInstanceOf(Boolean.class).isSameAs(Boolean.TRUE);
+    assertThat(trueLiteral.booleanValue()).isTrue();
   }
 
   @Test
@@ -96,14 +94,11 @@ class LiteralTreeImplTest {
 
   @Test
   void int_literal() {
-    var literal = parseTree(1_000).asLiteral();
-    assertThat(literal.value())
-      .isEqualTo("1_000");
-    assertThat(literal.unquotedValue())
-      .isEqualTo("1_000");
-    assertThat(literal.parsedValue())
-      .isInstanceOf(Integer.class)
-      .isEqualTo(1000);
+    var literal = (IntLiteralTree) parseTree(1_000).tree();
+    assertThat(literal.value()).isEqualTo("1_000");
+    assertThat(literal.unquotedValue()).isEqualTo("1_000");
+    assertThat(literal.parsedValue()).isInstanceOf(Integer.class).isEqualTo(1000);
+    assertThat(literal.intValue()).isEqualTo(1000);
   }
 
   @Test
@@ -155,14 +150,11 @@ class LiteralTreeImplTest {
 
   @Test
   void long_literal() {
-    var literal = parseTree(1_000L).asLiteral();
-    assertThat(literal.value())
-      .isEqualTo("1_000L");
-    assertThat(literal.unquotedValue())
-      .isEqualTo("1_000L");
-    assertThat(literal.parsedValue())
-      .isInstanceOf(Long.class)
-      .isEqualTo(1000L);
+    var literal = (LongLiteralTree) parseTree(1_000L).tree();
+    assertThat(literal.value()).isEqualTo("1_000L");
+    assertThat(literal.unquotedValue()).isEqualTo("1_000L");
+    assertThat(literal.parsedValue()).isInstanceOf(Long.class).isEqualTo(1000L);
+    assertThat(literal.longValue()).isEqualTo(1000L);
   }
 
   @Test
@@ -217,14 +209,11 @@ class LiteralTreeImplTest {
 
   @Test
   void float_literal() {
-    var literal = parseTree(1_000.0000f).asLiteral();
-    assertThat(literal.value())
-      .isEqualTo("1_000.0000f");
-    assertThat(literal.unquotedValue())
-      .isEqualTo("1_000.0000f");
-    assertThat(literal.parsedValue())
-      .isInstanceOf(Float.class)
-      .isEqualTo(1000.0f);
+    var literal = (FloatLiteralTree) parseTree(1_000.0000f).tree();
+    assertThat(literal.value()).isEqualTo("1_000.0000f");
+    assertThat(literal.unquotedValue()).isEqualTo("1_000.0000f");
+    assertThat(literal.parsedValue()).isInstanceOf(Float.class).isEqualTo(1000.0f);
+    assertThat(literal.floatValue()).isEqualTo(1000.0f);
   }
 
   @Test
@@ -270,14 +259,11 @@ class LiteralTreeImplTest {
 
   @Test
   void double_literal() {
-    var literal = parseTree(1_000.0000d).asLiteral();
-    assertThat(literal.value())
-      .isEqualTo("1_000.0000d");
-    assertThat(literal.unquotedValue())
-      .isEqualTo("1_000.0000d");
-    assertThat(literal.parsedValue())
-      .isInstanceOf(Double.class)
-      .isEqualTo(1000.0);
+    var literal = (DoubleLiteralTree) parseTree(1_000.0000d).tree();
+    assertThat(literal.value()).isEqualTo("1_000.0000d");
+    assertThat(literal.unquotedValue()).isEqualTo("1_000.0000d");
+    assertThat(literal.parsedValue()).isInstanceOf(Double.class).isEqualTo(1000.0);
+    assertThat(literal.doubleValue()).isEqualTo(1000.0);
   }
 
   @Test
@@ -326,25 +312,29 @@ class LiteralTreeImplTest {
 
   @Test
   void char_literal() {
-    var lit = parseTree('a').asLiteral();
-    assertThat(lit.value()/*        */).isEqualTo("'a'");
-    assertThat(lit.unquotedValue()/**/).isEqualTo("a");
-    assertThat(lit.parsedValue()/*  */).isEqualTo('a').isInstanceOf(Character.class);
+    var lit = (CharLiteralTree) parseTree('a').tree();
+    assertThat(lit.value()).isEqualTo("'a'");
+    assertThat(lit.unquotedValue()).isEqualTo("a");
+    assertThat(lit.parsedValue()).isEqualTo('a').isInstanceOf(Character.class);
+    assertThat(lit.charValue()).isEqualTo('a');
 
-    lit = parseTree('\b').asLiteral();
-    assertThat(lit.value()/*        */).isEqualTo("'\\b'");
-    assertThat(lit.unquotedValue()/**/).isEqualTo("\\b");
-    assertThat(lit.parsedValue()/*  */).isEqualTo('\b').isInstanceOf(Character.class);
+    lit = (CharLiteralTree) parseTree('\b').tree();
+    assertThat(lit.value()).isEqualTo("'\\b'");
+    assertThat(lit.unquotedValue()).isEqualTo("\\b");
+    assertThat(lit.parsedValue()).isEqualTo('\b').isInstanceOf(Character.class);
+    assertThat(lit.charValue()).isEqualTo('\b');
 
-    lit = parseTree('\u0041').asLiteral();
-    assertThat(lit.value()/*        */).isEqualTo("'\\u0041'");
-    assertThat(lit.unquotedValue()/**/).isEqualTo("\\u0041");
-    assertThat(lit.parsedValue()/*  */).isEqualTo('A').isInstanceOf(Character.class);
+    lit = (CharLiteralTree) parseTree('\u0041').tree();
+    assertThat(lit.value()).isEqualTo("'\\u0041'");
+    assertThat(lit.unquotedValue()).isEqualTo("\\u0041");
+    assertThat(lit.parsedValue()).isEqualTo('A').isInstanceOf(Character.class);
+    assertThat(lit.charValue()).isEqualTo('A');
 
-    lit = parseTree('\101').asLiteral();
-    assertThat(lit.value()/*        */).isEqualTo("'\\101'");
-    assertThat(lit.unquotedValue()/**/).isEqualTo("\\101");
-    assertThat(lit.parsedValue()/*  */).isEqualTo('A').isInstanceOf(Character.class);
+    lit = (CharLiteralTree) parseTree('\101').tree();
+    assertThat(lit.value()).isEqualTo("'\\101'");
+    assertThat(lit.unquotedValue()).isEqualTo("\\101");
+    assertThat(lit.parsedValue()).isEqualTo('A').isInstanceOf(Character.class);
+    assertThat(lit.charValue()).isEqualTo('A');
   }
 
   @Test
@@ -380,55 +370,44 @@ class LiteralTreeImplTest {
 
   @Test
   void string_literal() {
-    var empty = parseTree("").asLiteral();
-    assertThat(empty.value())
-      .isEqualTo("\"\"");
-    assertThat(empty.unquotedValue())
-      .isEmpty();
-    assertThat(empty.parsedValue())
-      .isEqualTo("");
+    var empty = (StringLiteralTree) parseTree("").tree();
+    assertThat(empty.value()).isEqualTo("\"\"");
+    assertThat(empty.unquotedValue()).isEmpty();
+    assertThat(empty.parsedValue()).isEqualTo("");
+    assertThat(empty.stringValue()).isEmpty();
 
-    var letters = parseTree("abcdef").asLiteral();
-    assertThat(letters.value())
-      .isEqualTo("\"abcdef\"");
-    assertThat(letters.unquotedValue())
-      .isEqualTo("abcdef");
-    assertThat(letters.parsedValue())
-      .isEqualTo("abcdef");
+    var letters = (StringLiteralTree) parseTree("abcdef").tree();
+    assertThat(letters.value()).isEqualTo("\"abcdef\"");
+    assertThat(letters.unquotedValue()).isEqualTo("abcdef");
+    assertThat(letters.parsedValue()).isEqualTo("abcdef");
+    assertThat(letters.stringValue()).isEqualTo("abcdef");
 
-    var newLine = parseTree(" abc '\s'\n def\n").asLiteral();
-    assertThat(newLine.value())
-      .isEqualTo("\" abc '\\s'\\n def\\n\"");
-    assertThat(newLine.unquotedValue())
-      .isEqualTo(" abc '\\s'\\n def\\n");
-    assertThat(newLine.parsedValue())
-      .isEqualTo("""
-         abc ' '
-         def
-        """);
+    var newLine = (StringLiteralTree) parseTree(" abc '\s'\n def\n").tree();
+    assertThat(newLine.value()).isEqualTo("\" abc '\\s'\\n def\\n\"");
+    assertThat(newLine.unquotedValue()).isEqualTo(" abc '\\s'\\n def\\n");
+    assertThat(newLine.parsedValue()).isEqualTo(" abc ' '\n def\n");
+    assertThat(newLine.stringValue()).isEqualTo(" abc ' '\n def\n");
 
-    var unicodeEscape = parseTree(" \u0061 \u0062 \u0063 ").asLiteral();
-    assertThat(unicodeEscape.value())
-      .isEqualTo("\" \\u0061 \\u0062 \\u0063 \"");
-    assertThat(unicodeEscape.unquotedValue())
-      .isEqualTo(" \\u0061 \\u0062 \\u0063 ");
-    assertThat(unicodeEscape.parsedValue())
-      .isEqualTo(" a b c ");
+    var unicodeEscape = (StringLiteralTree) parseTree(" \u0061 \u0062 \u0063 ").tree();
+    assertThat(unicodeEscape.value()).isEqualTo("\" \\u0061 \\u0062 \\u0063 \"");
+    assertThat(unicodeEscape.unquotedValue()).isEqualTo(" \\u0061 \\u0062 \\u0063 ");
+    assertThat(unicodeEscape.parsedValue()).isEqualTo(" a b c ");
+    assertThat(unicodeEscape.stringValue()).isEqualTo(" a b c ");
 
-    var octalEscape = parseTree(" \101 \102 \103 ").asLiteral();
-    assertThat(octalEscape.value())
-      .isEqualTo("\" \\101 \\102 \\103 \"");
-    assertThat(octalEscape.unquotedValue())
-      .isEqualTo(" \\101 \\102 \\103 ");
-    assertThat(octalEscape.parsedValue())
-      .isEqualTo(" A B C ");
+    var octalEscape = (StringLiteralTree) parseTree(" \101 \102 \103 ").tree();
+    assertThat(octalEscape.value()).isEqualTo("\" \\101 \\102 \\103 \"");
+    assertThat(octalEscape.unquotedValue()).isEqualTo(" \\101 \\102 \\103 ");
+    assertThat(octalEscape.parsedValue()).isEqualTo(" A B C ");
+    assertThat(octalEscape.stringValue()).isEqualTo(" A B C ");
 
-    var escapeLimits = parseTree(" \b \s \t \n \f \r \" \' \\ \0 \00 \000 \377 \u0000 \uffff ").asLiteral();
+    var escapeLimits = (StringLiteralTree) parseTree(" \b \s \t \n \f \r \" \' \\ \0 \00 \000 \377 \u0000 \uffff ").tree();
     assertThat(escapeLimits.value())
       .isEqualTo("\" \\b \\s \\t \\n \\f \\r \\\" \\' \\\\ \\0 \\00 \\000 \\377 \\u0000 \\uffff \"");
     assertThat(escapeLimits.unquotedValue())
       .isEqualTo(" \\b \\s \\t \\n \\f \\r \\\" \\' \\\\ \\0 \\00 \\000 \\377 \\u0000 \\uffff ");
     assertThat(escapeLimits.parsedValue())
+      .isEqualTo(" \b \s \t \n \f \r \" \' \\ \0 \00 \000 \377 \u0000 \uffff ");
+    assertThat(escapeLimits.stringValue())
       .isEqualTo(" \b \s \t \n \f \r \" \' \\ \0 \00 \000 \377 \u0000 \uffff ");
   }
 
@@ -459,17 +438,15 @@ class LiteralTreeImplTest {
 
   @Test
   void text_block_literal() {
-    var empty = parseTree("""
-      """).asLiteral();
-    assertThat(empty.value())
-      .isEqualTo("\"\"\"\n      \"\"\"");
-    assertThat(empty.unquotedValue())
-      .isEmpty();
-    assertThat(empty.parsedValue())
-      .isEqualTo("");
+    var empty = (StringLiteralTree) parseTree("""
+      """).tree();
+    assertThat(empty.value()).isEqualTo("\"\"\"\n      \"\"\"");
+    assertThat(empty.unquotedValue()).isEmpty();
+    assertThat(empty.parsedValue()).isEqualTo("");
+    assertThat(empty.stringValue()).isEmpty();
 
-    var letters = parseTree("""
-      abcdef  """).asLiteral();
+    var letters = (StringLiteralTree) parseTree("""
+      abcdef  """).tree();
     assertThat(letters.value())
       .isEqualTo("\"\"\"\n      abcdef  \"\"\"");
     assertThat(letters.unquotedValue())
@@ -477,10 +454,10 @@ class LiteralTreeImplTest {
     assertThat(letters.parsedValue())
       .isEqualTo("abcdef");
 
-    var severalLines = parseTree("""
+    var severalLines = (StringLiteralTree) parseTree("""
         abc '\s'
         def
-      """).asLiteral();
+      """).tree();
     assertThat(severalLines.value())
       .isEqualTo("\"\"\"\n        abc '\\s'\n        def\n      \"\"\"");
     assertThat(severalLines.unquotedValue())
@@ -488,10 +465,10 @@ class LiteralTreeImplTest {
     assertThat(severalLines.parsedValue())
       .isEqualTo("  abc ' '\n  def\n");
 
-    var lineContinuation = parseTree("""
+    var lineContinuation = (StringLiteralTree) parseTree("""
        abc \
        def \
-      """).asLiteral();
+      """).tree();
     assertThat(lineContinuation.value())
       .isEqualTo("\"\"\"\n       abc \\\n       def \\\n      \"\"\"");
     assertThat(lineContinuation.unquotedValue())
@@ -500,31 +477,35 @@ class LiteralTreeImplTest {
     assertThat(lineContinuation.parsedValue())
       .isEqualTo(" abc  def ");
 
-    var unicodeEscape = parseTree("""
-      \u0061 \u0062 \u0063""").asLiteral();
+    var unicodeEscape = (StringLiteralTree) parseTree("""
+      \u0061 \u0062 \u0063""").tree();
     assertThat(unicodeEscape.value())
       .isEqualTo("\"\"\"\n      \\u0061 \\u0062 \\u0063\"\"\"");
     assertThat(unicodeEscape.unquotedValue())
       .isEqualTo("\\u0061 \\u0062 \\u0063");
     assertThat(unicodeEscape.parsedValue())
       .isEqualTo("a b c");
+    assertThat(unicodeEscape.stringValue())
+      .isEqualTo("a b c");
   }
 
   @Test
   void text_block_literal_escapes() {
 
-    var octalEscape = parseTree("""
-      \101 \102 \103""").asLiteral();
+    var octalEscape = (StringLiteralTree) parseTree("""
+      \101 \102 \103""").tree();
     assertThat(octalEscape.value())
       .isEqualTo("\"\"\"\n      \\101 \\102 \\103\"\"\"");
     assertThat(octalEscape.unquotedValue())
       .isEqualTo("\\101 \\102 \\103");
     assertThat(octalEscape.parsedValue())
       .isEqualTo("A B C");
+    assertThat(octalEscape.stringValue())
+      .isEqualTo("A B C");
 
     TreeAndValue ecjBug1 = parseTree("""
       before \'\" after""");
-    var ecjBug1Literal = ecjBug1.asLiteral();
+    var ecjBug1Literal = (StringLiteralTree) ecjBug1.tree();
     assertThat(ecjBug1Literal.value())
       .isEqualTo("\"\"\"\n      before \\'\\\" after\"\"\"");
     assertThat(ecjBug1Literal.unquotedValue())
@@ -538,7 +519,7 @@ class LiteralTreeImplTest {
     TreeAndValue ecjBug2 = parseTree("""
         \
       """);
-    var ecjBug2Literal = ecjBug2.asLiteral();
+    var ecjBug2Literal = (StringLiteralTree) ecjBug2.tree();
     assertThat(ecjBug2Literal.value())
       .isEqualTo("\"\"\"\n        \\\n      \"\"\"");
     assertThat(ecjBug2Literal.unquotedValue())
@@ -640,10 +621,6 @@ class LiteralTreeImplTest {
   }
 
   record TreeAndValue(ExpressionTree tree, Object value) {
-    public LiteralTree asLiteral() {
-      return (LiteralTree) tree;
-    }
-
     @Override
     public String toString() {
       return "At line " + lineOf(tree) +

--- a/java-frontend/src/test/java/org/sonar/java/model/expression/LiteralTreeImplTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/expression/LiteralTreeImplTest.java
@@ -16,34 +16,99 @@
  */
 package org.sonar.java.model.expression;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import org.jetbrains.annotations.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.JParserTestUtils;
-import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Arguments;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
-import org.sonar.plugins.java.api.tree.ListTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
-import org.sonar.plugins.java.api.tree.NewArrayTree;
-import org.sonar.plugins.java.api.tree.VariableTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LiteralTreeImplTest {
 
+  private static CompilationUnitTree currentSourceCodeCache;
+
   @Test
-  void parsed_value() throws IOException {
-    // begin samples
-    Object[] samples = {
-      // null
-      null,
-      // boolean
-      true,
-      false,
-      // int
+  void null_literal() {
+    var literal = parseTree(null).asLiteral();
+    assertThat(literal.value())
+      .isEqualTo("null");
+    assertThat(literal.unquotedValue())
+      .isEqualTo("null");
+    assertThat(literal.parsedValue())
+      .isNull();
+  }
+
+  @Test
+  void null_literal_values() {
+    assertResolveAsConstantMatch(parseTrees(
+      // we don't support cast, so we accidentally have the good answer for null literal
+      (String) null));
+  }
+
+  @Test
+  void boolean_literal() {
+    var falseLiteral = parseTree(false).asLiteral();
+    assertThat(falseLiteral.value())
+      .isEqualTo("false");
+    assertThat(falseLiteral.unquotedValue())
+      .isEqualTo("false");
+    assertThat(falseLiteral.parsedValue())
+      .isInstanceOf(Boolean.class)
+      .isSameAs(Boolean.FALSE);
+
+    var trueLiteral = parseTree(true).asLiteral();
+    assertThat(trueLiteral.value())
+      .isEqualTo("true");
+    assertThat(trueLiteral.unquotedValue())
+      .isEqualTo("true");
+    assertThat(trueLiteral.parsedValue())
+      .isInstanceOf(Boolean.class)
+      .isSameAs(Boolean.TRUE);
+  }
+
+  @Test
+  void boolean_literal_values() {
+    assertResolveAsConstantMatch(parseTrees(
+      !true,
+      !false));
+
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      true && true,
+      true && false,
+      false && true,
+      false && false,
+      true || true,
+      true || false,
+      false || true,
+      false || false));
+  }
+
+  @Test
+  void int_literal() {
+    var literal = parseTree(1_000).asLiteral();
+    assertThat(literal.value())
+      .isEqualTo("1_000");
+    assertThat(literal.unquotedValue())
+      .isEqualTo("1_000");
+    assertThat(literal.parsedValue())
+      .isInstanceOf(Integer.class)
+      .isEqualTo(1000);
+  }
+
+  @Test
+  void int_literal_values() {
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
       0,
       1,
       1_000_000,
@@ -51,28 +116,446 @@ class LiteralTreeImplTest {
       0x80000000,
       // Integer.MAX_VALUE,
       0x7fffffff,
+      2147483647,
+      0x7fffffff,
+      0xfffffffe,
+      // -1
+      0xffffffff));
+    assertResolveAsConstantMatch(parseTrees(
+      0,
+      1,
+      -1,
+      1_000_000,
+      -1_000_000,
+      // Integer.MIN_VALUE,
+      0x80000000,
+      -0x80000000,
+      -2147483648,
+      // Integer.MAX_VALUE,
+      0x7fffffff,
+      -0x7fffffff,
+      2147483647,
+      0x7fffffff,
+      -0x7fffffff,
+      0xfffffffe,
+      -0xfffffffe,
+      -0xffffffff,
       // -1
       0xffffffff,
-      // long
-      42L,
-      // float
-      1.2f,
-      // double
-      1.2d,
-      // character
+      0 + 0,
+      1 + 1,
+      (1 + (1)),
+      0xffffffff + 1,
+      0xffffffff - 1,
+      10 - 2,
+      2 * -3,
+      0xffffffff * 2,
+      0xffffffff * 0xffffffff));
+  }
+
+  @Test
+  void long_literal() {
+    var literal = parseTree(1_000L).asLiteral();
+    assertThat(literal.value())
+      .isEqualTo("1_000L");
+    assertThat(literal.unquotedValue())
+      .isEqualTo("1_000L");
+    assertThat(literal.parsedValue())
+      .isInstanceOf(Long.class)
+      .isEqualTo(1000L);
+  }
+
+  @Test
+  void long_literal_values() {
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
+      0L,
+      1L,
+      1_000_000L,
+      // Long.MIN_VALUE,
+      0x8000000000000000L,
+      // Long.MAX_VALUE,
+      0x7fffffffffffffffL,
+      0x7fFfFfFfFfFfFfFfL,
+      9223372036854775807L,
+      0xfffffffffffffffeL,
+      // -1
+      0xffffffffffffffffL));
+    assertResolveAsConstantMatch(parseTrees(
+      0L,
+      1L,
+      -1L,
+      1_000_000L,
+      -1_000_000L,
+      4_000_000_000_000_000_000L,
+      // Integer.MIN_VALUE,
+      0x8000000000000000L,
+      -9223372036854775808L,
+      // Long.MAX_VALUE,
+      0x7fffffffffffffffL,
+      -0x7fffffffffffffffL,
+      0x7fFfFfFfFfFfFfFfL,
+      -0x7fFfFfFfFfFfFfFfL,
+      9223372036854775807L,
+      -9223372036854775807L,
+      0xfffffffffffffffeL,
+      -0xfffffffffffffffeL,
+      // -1
+      0xffffffffffffffffL));
+
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      0L + 0L,
+      1L + 1L,
+      (1L + (1L)),
+      0xffffffffffffffffL + 1L,
+      0xffffffffffffffffL - 1L,
+      10L - 2L,
+      2L * -3L,
+      0xffffffffffffffffL * 2L,
+      0xffffffffffffffffL * 0xffffffffffffffffL));
+  }
+
+  @Test
+  void float_literal() {
+    var literal = parseTree(1_000.0000f).asLiteral();
+    assertThat(literal.value())
+      .isEqualTo("1_000.0000f");
+    assertThat(literal.unquotedValue())
+      .isEqualTo("1_000.0000f");
+    assertThat(literal.parsedValue())
+      .isInstanceOf(Float.class)
+      .isEqualTo(1000.0f);
+  }
+
+  @Test
+  void float_literal_values() {
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
+      0.0,
+      0.0f,
+      1f,
+      1.0,
+      1_000_000.0f,
+      // Long.MIN_VALUE,
+      0x0.000002P-126f,
+      1.4e-45f,
+      // Long.MAX_VALUE,
+      0x1.fffffeP+127f,
+      3.4028235e+38f,
+      1.1f,
+      .0f));
+    assertResolveAsConstantMatch(parseTrees(
+      (1.1f)));
+
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      -0.0f,
+      -1f,
+      -1_000_000.0f,
+      // Float.MIN_VALUE,
+      -0x0.000002P-126f,
+      -1.4e-45f,
+      // Float.MAX_VALUE,
+      -0x1.fffffeP+127f,
+      -3.4028235e+38f,
+      -1.1f,
+      (-1.1f),
+      -.0f,
+      0.0f + 0.0f,
+      1.0f + 1.0f,
+      (1.0f + (1.0f)),
+      3.4028235e+38f + 1.0e+38f,
+      1.4e-45f - 1.0e-45f,
+      3.4028235e+38f * -2.0f));
+  }
+
+  @Test
+  void double_literal() {
+    var literal = parseTree(1_000.0000d).asLiteral();
+    assertThat(literal.value())
+      .isEqualTo("1_000.0000d");
+    assertThat(literal.unquotedValue())
+      .isEqualTo("1_000.0000d");
+    assertThat(literal.parsedValue())
+      .isInstanceOf(Double.class)
+      .isEqualTo(1000.0);
+  }
+
+  @Test
+  void double_literal_values() {
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
+      0.0d,
+      1d,
+      1_000_000.0d,
+      // Double.MIN_VALUE,
+      0x0.0000000000001P-1022,
+      4.9e-324,
+      0x1.0p-1022,
+      0x0.000002P-126d,
+      1.4e-45d,
+      // Double.MAX_VALUE,
+      0x1.fffffffffffffP+1023,
+      1.7976931348623157e+308,
+      0x1.fffffeP+127d,
+      3.4028235e+38d,
+      1.1d,
+      .0f));
+    assertResolveAsConstantMatch(parseTrees(
+      (1.1d)));
+
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      -0.0d,
+      -1d,
+      -1_000_000.0d,
+      // Long.MIN_VALUE,
+      -0x0.000002P-126d,
+      -1.4e-45d,
+      // Long.MAX_VALUE,
+      -0x1.fffffeP+127d,
+      -3.4028235e+38d,
+      -1.1d,
+      (-1.1d),
+      -.0d,
+      0.0d + 0.0d,
+      1.0d + 1.0d,
+      (1.0d + (1.0d)),
+      3.4028235e+38d + 1.0e+38d,
+      1.4e-45d - 1.0e-45d,
+      3.4028235e+38d * -2.0d));
+  }
+
+  @Test
+  void char_literal() {
+    var lit = parseTree('a').asLiteral();
+    assertThat(lit.value()/*        */).isEqualTo("'a'");
+    assertThat(lit.unquotedValue()/**/).isEqualTo("a");
+    assertThat(lit.parsedValue()/*  */).isEqualTo('a').isInstanceOf(Character.class);
+
+    lit = parseTree('\b').asLiteral();
+    assertThat(lit.value()/*        */).isEqualTo("'\\b'");
+    assertThat(lit.unquotedValue()/**/).isEqualTo("\\b");
+    assertThat(lit.parsedValue()/*  */).isEqualTo('\b').isInstanceOf(Character.class);
+
+    lit = parseTree('\u0041').asLiteral();
+    assertThat(lit.value()/*        */).isEqualTo("'\\u0041'");
+    assertThat(lit.unquotedValue()/**/).isEqualTo("\\u0041");
+    assertThat(lit.parsedValue()/*  */).isEqualTo('A').isInstanceOf(Character.class);
+
+    lit = parseTree('\101').asLiteral();
+    assertThat(lit.value()/*        */).isEqualTo("'\\101'");
+    assertThat(lit.unquotedValue()/**/).isEqualTo("\\101");
+    assertThat(lit.parsedValue()/*  */).isEqualTo('A').isInstanceOf(Character.class);
+  }
+
+  @Test
+  void char_literal_values() {
+    // limitation: Bug in the ECJ parser, it fails to parse this file if we add in the following arguments the char literal '\s'
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
+      '0',
       'a',
-      // character with escaped character
+      ' ',
+      '\b',
+      '\t',
       '\n',
-      '\u26A0',
-      // empty string
+      '\f',
+      '\r',
+      '\"',
+      '\'',
+      '\\',
+      '\0',
+      '\00',
+      '\000',
+      '\377',
+      '\u0000',
+      '\u1234',
+      '\uffff'));
+    assertResolveAsConstantMatch(parseTrees(
+      ('a')));
+
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      'a' + 'a',
+      'a' - 2));
+  }
+
+  @Test
+  void string_literal() {
+    var empty = parseTree("").asLiteral();
+    assertThat(empty.value())
+      .isEqualTo("\"\"");
+    assertThat(empty.unquotedValue())
+      .isEmpty();
+    assertThat(empty.parsedValue())
+      .isEqualTo("");
+
+    var letters = parseTree("abcdef").asLiteral();
+    assertThat(letters.value())
+      .isEqualTo("\"abcdef\"");
+    assertThat(letters.unquotedValue())
+      .isEqualTo("abcdef");
+    assertThat(letters.parsedValue())
+      .isEqualTo("abcdef");
+
+    var newLine = parseTree(" abc '\s'\n def\n").asLiteral();
+    assertThat(newLine.value())
+      .isEqualTo("\" abc '\\s'\\n def\\n\"");
+    assertThat(newLine.unquotedValue())
+      .isEqualTo(" abc '\\s'\\n def\\n");
+    assertThat(newLine.parsedValue())
+      .isEqualTo("""
+         abc ' '
+         def
+        """);
+
+    var unicodeEscape = parseTree(" \u0061 \u0062 \u0063 ").asLiteral();
+    assertThat(unicodeEscape.value())
+      .isEqualTo("\" \\u0061 \\u0062 \\u0063 \"");
+    assertThat(unicodeEscape.unquotedValue())
+      .isEqualTo(" \\u0061 \\u0062 \\u0063 ");
+    assertThat(unicodeEscape.parsedValue())
+      .isEqualTo(" a b c ");
+
+    var octalEscape = parseTree(" \101 \102 \103 ").asLiteral();
+    assertThat(octalEscape.value())
+      .isEqualTo("\" \\101 \\102 \\103 \"");
+    assertThat(octalEscape.unquotedValue())
+      .isEqualTo(" \\101 \\102 \\103 ");
+    assertThat(octalEscape.parsedValue())
+      .isEqualTo(" A B C ");
+
+    var escapeLimits = parseTree(" \b \s \t \n \f \r \" \' \\ \0 \00 \000 \377 \u0000 \uffff ").asLiteral();
+    assertThat(escapeLimits.value())
+      .isEqualTo("\" \\b \\s \\t \\n \\f \\r \\\" \\' \\\\ \\0 \\00 \\000 \\377 \\u0000 \\uffff \"");
+    assertThat(escapeLimits.unquotedValue())
+      .isEqualTo(" \\b \\s \\t \\n \\f \\r \\\" \\' \\\\ \\0 \\00 \\000 \\377 \\u0000 \\uffff ");
+    assertThat(escapeLimits.parsedValue())
+      .isEqualTo(" \b \s \t \n \f \r \" \' \\ \0 \00 \000 \377 \u0000 \uffff ");
+  }
+
+  @Test
+  void string_literal_values() {
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
       "",
+      "a",
+      "abc",
+      "a\n\"\'c\n",
+      "'\u0040\u0041'",
+      "\"\u26A0a\012cdef\"",
+      "1\r\n2\r\n3\r\n",
+      "\\n\\t",
+      "\0\0\0"));
+    assertResolveAsConstantMatch(parseTrees(
+      "a" + "b",
+      "a" + 'b',
+      "a" + 2,
+      ("a"),
+      ("abc"),
+      ("a" + "\n")));
+
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      "a" + null));
+  }
+
+  @Test
+  void text_block_literal() {
+    var empty = parseTree("""
+      """).asLiteral();
+    assertThat(empty.value())
+      .isEqualTo("\"\"\"\n      \"\"\"");
+    assertThat(empty.unquotedValue())
+      .isEmpty();
+    assertThat(empty.parsedValue())
+      .isEqualTo("");
+
+    var letters = parseTree("""
+      abcdef  """).asLiteral();
+    assertThat(letters.value())
+      .isEqualTo("\"\"\"\n      abcdef  \"\"\"");
+    assertThat(letters.unquotedValue())
+      .isEqualTo("abcdef");
+    assertThat(letters.parsedValue())
+      .isEqualTo("abcdef");
+
+    var severalLines = parseTree("""
+        abc '\s'
+        def
+      """).asLiteral();
+    assertThat(severalLines.value())
+      .isEqualTo("\"\"\"\n        abc '\\s'\n        def\n      \"\"\"");
+    assertThat(severalLines.unquotedValue())
+      .isEqualTo("  abc '\\s'\n  def\n");
+    assertThat(severalLines.parsedValue())
+      .isEqualTo("  abc ' '\n  def\n");
+
+    var lineContinuation = parseTree("""
+       abc \
+       def \
+      """).asLiteral();
+    assertThat(lineContinuation.value())
+      .isEqualTo("\"\"\"\n       abc \\\n       def \\\n      \"\"\"");
+    assertThat(lineContinuation.unquotedValue())
+      // We don't remove the \\\n (line continuation) from the content
+      .isEqualTo(" abc \\\n def \\\n");
+    assertThat(lineContinuation.parsedValue())
+      .isEqualTo(" abc  def ");
+
+    var unicodeEscape = parseTree("""
+      \u0061 \u0062 \u0063""").asLiteral();
+    assertThat(unicodeEscape.value())
+      .isEqualTo("\"\"\"\n      \\u0061 \\u0062 \\u0063\"\"\"");
+    assertThat(unicodeEscape.unquotedValue())
+      .isEqualTo("\\u0061 \\u0062 \\u0063");
+    assertThat(unicodeEscape.parsedValue())
+      .isEqualTo("a b c");
+  }
+
+  @Test
+  void text_block_literal_escapes() {
+
+    var octalEscape = parseTree("""
+      \101 \102 \103""").asLiteral();
+    assertThat(octalEscape.value())
+      .isEqualTo("\"\"\"\n      \\101 \\102 \\103\"\"\"");
+    assertThat(octalEscape.unquotedValue())
+      .isEqualTo("\\101 \\102 \\103");
+    assertThat(octalEscape.parsedValue())
+      .isEqualTo("A B C");
+
+    TreeAndValue ecjBug1 = parseTree("""
+      before \'\" after""");
+    var ecjBug1Literal = ecjBug1.asLiteral();
+    assertThat(ecjBug1Literal.value())
+      .isEqualTo("\"\"\"\n      before \\'\\\" after\"\"\"");
+    assertThat(ecjBug1Literal.unquotedValue())
+      .isEqualTo("before \\'\\\" after");
+    assertThat(ecjBug1Literal.parsedValue())
+      // BUG in the ECJ parser, it replaces \'\" with '\ instead of '"
+      .isNotEqualTo(ecjBug1.value()).isEqualTo("before \'\\after");
+    // Knowing the Java parses it correctly
+    assertThat(ecjBug1.value()).isEqualTo("before \'\" after");
+
+    TreeAndValue ecjBug2 = parseTree("""
+        \
+      """);
+    var ecjBug2Literal = ecjBug2.asLiteral();
+    assertThat(ecjBug2Literal.value())
+      .isEqualTo("\"\"\"\n        \\\n      \"\"\"");
+    assertThat(ecjBug2Literal.unquotedValue())
+      .isEqualTo("  \\\n");
+    assertThat(ecjBug2Literal.parsedValue())
+      // BUG in the ECJ parser, it does not keep the 2 spaces
+      .isNotEqualTo(ecjBug2.value()).isEqualTo("");
+    // Knowing the Java parses it as 2 spaces
+    assertThat(ecjBug2.value()).isEqualTo("  ");
+  }
+
+  @Test
+  void text_block_literal_values() {
+    assertLiteralParsedValuesAndResolveAsConstantMatch(parseTrees(
       // empty text box
       """
         """,
-      // string with escaped characters
-      "\"\u26A0a\012cdef\"",
-      // string with escaped new lines
-      "1\r\n2\r\n3\r\n",
       // text block without indentation
       """
         line 1
@@ -88,6 +571,18 @@ class LiteralTreeImplTest {
         \u26A0 line\t1
         \u26A0 line\t2
         """,
+      // text block with line continuation
+      """
+          with continuation \
+          end \
+        """,
+      // empty string with line continuations:
+      """
+        \
+        """,
+      // text block with all escaped characters
+      """
+        \" \b \s \t \n \f \r \' \\ \0 \00 \000 \377 \u0000 \uffff """,
       // text block with ending whitespace
       """
           line 3  \s
@@ -100,35 +595,127 @@ class LiteralTreeImplTest {
       // text block with tailing space before the end are trimmed
       """
         line 7  \s
-        line 8  """
-    };
-    // end samples
-    String aboveSamplesSourceCode = "class A {\n    " +
-      extractJavaSourceCodeFromTheCurrentFileBetween("// begin samples\n", "// end samples\n") +
-      "\n}";
+        line 8  """));
+    assertResolveAsConstantMatch(parseTrees(
+      """
+        line 9
+        """ + "line10\n"));
 
-    CompilationUnitTree compilationUnit = JParserTestUtils.parse(aboveSamplesSourceCode);
-    NewArrayTree samplesArray = (NewArrayTree) ((VariableTree) ((ClassTree) compilationUnit.types().get(0)).members().get(0)).initializer();
+    // limitation, not yet supported:
+    assertResolveAsConstantIsNull(parseTrees(
+      """
+        \s""" + null));
+  }
 
-    ListTree<ExpressionTree> initializers = samplesArray.initializers();
-    for (int i = 0; i < initializers.size(); i++) {
-      LiteralTree initializer = (LiteralTree) initializers.get(i);
-      assertThat(initializer.parsedValue())
-        .describedAs("For string at index " + i + " with token " + initializer.value())
-        .isEqualTo(samples[i]);
+  private void assertLiteralParsedValuesAndResolveAsConstantMatch(List<TreeAndValue> treeAndValues) {
+    assertLiteralParsedValuesMatch(treeAndValues);
+    assertResolveAsConstantMatch(treeAndValues);
+  }
+
+  private void assertLiteralParsedValuesMatch(List<TreeAndValue> treeAndValues) {
+    for (TreeAndValue treeAndValue : treeAndValues) {
+      assertThat(treeAndValue.tree())
+        .describedAs(treeAndValue.toString())
+        .isInstanceOf(LiteralTree.class);
+      assertThat(((LiteralTree) treeAndValue.tree()).parsedValue())
+        .describedAs(treeAndValue.toString())
+        .isEqualTo(treeAndValue.value());
     }
   }
 
-  @NotNull
-  private String extractJavaSourceCodeFromTheCurrentFileBetween(String startTag, String endTag) throws IOException {
-    Path thisJavaFilePath = Path.of("src", "test", "java", this.getClass().getName().replace('.', '/').concat(".java"));
-    String sourceCode = Files.readString(thisJavaFilePath);
-    int samplesStart = sourceCode.indexOf(startTag);
-    int samplesEnd = sourceCode.indexOf(endTag);
-    if (samplesStart == -1 || samplesEnd == -1) {
-      throw new IllegalStateException("Could not find tags in " + thisJavaFilePath);
+  private void assertResolveAsConstantMatch(List<TreeAndValue> treeAndValues) {
+    for (TreeAndValue treeAndValue : treeAndValues) {
+      assertThat(ExpressionUtils.resolveAsConstant(treeAndValue.tree()))
+        .describedAs(treeAndValue.toString())
+        .isEqualTo(treeAndValue.value());
     }
-    return sourceCode.substring(samplesStart, samplesEnd);
+  }
+
+  private void assertResolveAsConstantIsNull(List<TreeAndValue> treeAndValues) {
+    for (TreeAndValue treeAndValue : treeAndValues) {
+      assertThat(ExpressionUtils.resolveAsConstant(treeAndValue.tree()))
+        .describedAs(treeAndValue.toString())
+        .isNull();
+    }
+  }
+
+  record TreeAndValue(ExpressionTree tree, Object value) {
+    public LiteralTree asLiteral() {
+      return (LiteralTree) tree;
+    }
+
+    @Override
+    public String toString() {
+      return "At line " + lineOf(tree) +
+        ", tree: " + tree.getClass().getSimpleName() +
+        ", value = (" + (value != null ? value.getClass().getSimpleName() : "Object") + ") " + value;
+    }
+  }
+
+  private static List<TreeAndValue> parseTrees(Object... values) {
+    return parseTrees(callerLineNumber(), currentMethodName(), values);
+  }
+
+  private static TreeAndValue parseTree(Object value) {
+    return parseTrees(callerLineNumber(), currentMethodName(), new Object[] {value}).get(0);
+  }
+
+  private static List<TreeAndValue> parseTrees(int line, String methodName, Object... values) {
+    Arguments arguments = parseMethodArguments(line, methodName, values);
+    if (arguments.size() != values.length) {
+      throw new IllegalStateException("Expected the same number of arguments as values, but found: " + arguments.size() + " vs " + values.length);
+    }
+    var result = new ArrayList<TreeAndValue>();
+    for (int i = 0; i < arguments.size(); i++) {
+      result.add(new TreeAndValue(arguments.get(i), values[i]));
+    }
+    return result;
+  }
+
+  private static Arguments parseMethodArguments(int line, String methodName, Object... values) {
+    Arguments arguments = findArgumentsOfMethod(line, methodName);
+    if (arguments.size() != values.length) {
+      throw new IllegalStateException("Expected the same number of arguments as values, but found: " + arguments.size() + " vs " + values.length);
+    }
+    return arguments;
+  }
+
+  private static Arguments findArgumentsOfMethod(int line, String methodName) {
+    var array = new ArrayList<Arguments>();
+    parseCurrentSourceCode().accept(new BaseTreeVisitor() {
+      @Override
+      public void visitMethodInvocation(MethodInvocationTree tree) {
+        if (tree.methodSelect() instanceof IdentifierTree identifier && identifier.name().equals(methodName) && lineOf(identifier) == line) {
+          array.add(tree.arguments());
+        }
+        super.visitMethodInvocation(tree);
+      }
+    });
+    if (array.size() != 1) {
+      throw new IllegalStateException("Expected exactly one method " + methodName + " at line " + line + ", but found: " + array.size());
+    }
+    return array.get(0);
+  }
+
+  private static int lineOf(Tree tree) {
+    return tree.firstToken().range().start().line();
+  }
+
+  private static CompilationUnitTree parseCurrentSourceCode() {
+    if (currentSourceCodeCache == null) {
+      Path thisJavaFilePath = Path.of("src", "test", "java",
+        LiteralTreeImplTest.class.getName().replace('.', '/').concat(".java"));
+      currentSourceCodeCache = JParserTestUtils.parse(thisJavaFilePath.toFile());
+    }
+    return currentSourceCodeCache;
+  }
+
+  private static int callerLineNumber() {
+    return Thread.currentThread().getStackTrace()[3].getLineNumber();
+  }
+
+  private static String currentMethodName() {
+    return Thread.currentThread().getStackTrace()[2].getMethodName();
   }
 
 }

--- a/java-frontend/src/test/java/org/sonar/java/reporting/JavaTextEditTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/reporting/JavaTextEditTest.java
@@ -20,7 +20,7 @@ import java.io.File;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.model.JParserTestUtils;
-import org.sonar.java.model.expression.LiteralTreeImpl;
+import org.sonar.java.model.expression.NullLiteralTreeImpl;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
@@ -62,7 +62,7 @@ class JavaTextEditTest {
 
   @Test
   void test_insert_before_no_token_tree() {
-    LiteralTree brokenLiteral = new LiteralTreeImpl(Tree.Kind.STRING_LITERAL, null);
+    LiteralTree brokenLiteral = new NullLiteralTreeImpl(/* unexpected missing token */ null);
     assertThatThrownBy(() -> JavaTextEdit.insertBeforeTree(brokenLiteral, "replacement"))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Trying to insert a quick fix before a Tree without token.");
@@ -77,7 +77,7 @@ class JavaTextEditTest {
 
   @Test
   void test_insert_after_no_token_tree() {
-    LiteralTree brokenLiteral = new LiteralTreeImpl(Tree.Kind.STRING_LITERAL, null);
+    LiteralTree brokenLiteral = new NullLiteralTreeImpl(/* unexpected missing token */ null);
     assertThatThrownBy(() -> JavaTextEdit.insertAfterTree(brokenLiteral, "replacement"))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Trying to insert a quick fix after a Tree without token.");


### PR DESCRIPTION
[SONARJAVA-5728](https://sonarsource.atlassian.net/browse/SONARJAVA-5728)



[SONARJAVA-5728]: https://sonarsource.atlassian.net/browse/SONARJAVA-5728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ