### PR TITLE
SONARJAVA-5740 Stop using StringUtils::trim

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/DisallowedConstructorCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DisallowedConstructorCheck.java
@@ -50,7 +50,7 @@ public class DisallowedConstructorCheck extends AbstractMethodDetection {
       } else {
         String[] trimmedArgs = new String[args.length];
         for (int i = 0; i < trimmedArgs.length; i++) {
-          trimmedArgs[i] = StringUtils.trim(args[i]);
+          trimmedArgs[i] = args[i].trim();
         }
         return invocationMatcher.addParametersMatcher(trimmedArgs).build();
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/DisallowedMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DisallowedMethodCheck.java
@@ -62,7 +62,7 @@ public class DisallowedMethodCheck extends AbstractMethodDetection {
       } else {
         String[] trimmedArgs = new String[args.length];
         for (int i = 0; i < trimmedArgs.length; i++) {
-          trimmedArgs[i] = StringUtils.trim(args[i]);
+          trimmedArgs[i] = args[i].trim();
         }
         return parametersBuilder.addParametersMatcher(trimmedArgs).build();
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/PatternUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PatternUtils.java
@@ -28,7 +28,7 @@ public final class PatternUtils {
     String[] p = StringUtils.split(patterns, ',');
     WildcardPattern[] result = new WildcardPattern[p.length];
     for (int i = 0; i < result.length; i++) {
-      result[i] = WildcardPattern.create(StringUtils.trim(p[i]), ".");
+      result[i] = WildcardPattern.create(p[i].trim(), ".");
     }
     return result;
   }


### PR DESCRIPTION
[SONARJAVA-5740](https://sonarsource.atlassian.net/browse/SONARJAVA-5740)

We can use standard String::trim() because the results of splitting a String cannot be null.

[SONARJAVA-5740]: https://sonarsource.atlassian.net/browse/SONARJAVA-5740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ