### PR TITLE
SONARJAVA-5755 FP on S1133 when using forRemoval=false

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/DeprecatedTagPresenceCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DeprecatedTagPresenceCheck.java
@@ -24,8 +24,9 @@ import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.sonar.java.checks.helpers.DeprecatedCheckerHelper.deprecatedAnnotation;
-import static org.sonar.java.checks.helpers.DeprecatedCheckerHelper.reportTreeForDeprecatedTree;
 import static org.sonar.java.checks.helpers.DeprecatedCheckerHelper.hasJavadocDeprecatedTag;
+import static org.sonar.java.checks.helpers.DeprecatedCheckerHelper.isMarkedForRemoval;
+import static org.sonar.java.checks.helpers.DeprecatedCheckerHelper.reportTreeForDeprecatedTree;
 
 @Rule(key = "S1133")
 public class DeprecatedTagPresenceCheck extends IssuableSubscriptionVisitor {
@@ -37,7 +38,7 @@ public class DeprecatedTagPresenceCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
-    if (hasDeprecatedAnnotation(tree) || hasJavadocDeprecatedTag(tree)) {
+    if (!isMarkedForRemoval(tree, false) && (hasDeprecatedAnnotation(tree) || hasJavadocDeprecatedTag(tree))) {
       reportIssue(reportTreeForDeprecatedTree(tree), "Do not forget to remove this deprecated code someday.");
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComposedRequestMappingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComposedRequestMappingCheck.java
@@ -37,6 +37,8 @@ import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.NewArrayTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
+import static org.sonar.java.model.ExpressionUtils.annotationAttributeName;
+
 @Rule(key = "S4488")
 public class SpringComposedRequestMappingCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
 
@@ -62,7 +64,7 @@ public class SpringComposedRequestMappingCheck extends IssuableSubscriptionVisit
     AnnotationTree annotation = (AnnotationTree) tree;
     if (annotation.symbolType().is("org.springframework.web.bind.annotation.RequestMapping")) {
       List<ExpressionTree> methodValues = annotation.arguments().stream()
-        .filter(argument -> "method".equals(attributeName(argument)))
+        .filter(argument -> "method".equals(annotationAttributeName(argument)))
         .flatMap(SpringComposedRequestMappingCheck::extractValues)
         .toList();
 
@@ -92,15 +94,6 @@ public class SpringComposedRequestMappingCheck extends IssuableSubscriptionVisit
       }
     }
     return "";
-  }
-
-  private static String attributeName(ExpressionTree expression) {
-    if (expression.is(Tree.Kind.ASSIGNMENT)) {
-      AssignmentExpressionTree assignment = (AssignmentExpressionTree) expression;
-      // assignment.variable() in annotation is always a Tree.Kind.IDENTIFIER
-      return ((IdentifierTree) assignment.variable()).name();
-    }
-    return "value";
   }
 
   private static Stream<ExpressionTree> extractValues(ExpressionTree argument) {

--- a/java-checks/src/test/files/checks/DeprecatedTagPresenceCheck.java
+++ b/java-checks/src/test/files/checks/DeprecatedTagPresenceCheck.java
@@ -1,5 +1,11 @@
 class Foo {
 
+  @Deprecated(forRemoval = true)
+  public String getName; // Noncompliant
+
+  @Deprecated(forRemoval = false)
+  public String getName; // Compliant
+
   @Deprecated
   public int foo; // Noncompliant {{Do not forget to remove this deprecated code someday.}}
 //           ^^^

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/DeprecatedCheckerHelperTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/DeprecatedCheckerHelperTest.java
@@ -1,3 +1,19 @@
+/*
+ * SonarQube Java
+ * Copyright (C) 2012-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource SA.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
 package org.sonar.java.checks.helpers;
 
 import org.junit.jupiter.api.Test;
@@ -14,6 +30,7 @@ class DeprecatedCheckerHelperTest {
     assertValue("@Deprecated(forRemoval = false)", "forRemoval", false, Boolean.class);
     assertValue("@Deprecated(value = \"test\")", "value", "test", String.class);
     assertValue("@Deprecated(since = 42)", "since", 42, Integer.class);
+    assertValue("@Deprecated(\"Descr\")", "value", "Descr", String.class);
   }
 
   private <T> void assertValue(String annotationSourceCode, String attributeName, T expectedValue, Class<T> type) {

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/DeprecatedCheckerHelperTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/DeprecatedCheckerHelperTest.java
@@ -1,0 +1,31 @@
+package org.sonar.java.checks.helpers;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DeprecatedCheckerHelperTest {
+
+  @Test
+  void getAnnotationAttributeValue() {
+    assertValue("@Deprecated(forRemoval = true)", "forRemoval", true, Boolean.class);
+    assertValue("@Deprecated(forRemoval = false)", "forRemoval", false, Boolean.class);
+    assertValue("@Deprecated(value = \"test\")", "value", "test", String.class);
+    assertValue("@Deprecated(since = 42)", "since", 42, Integer.class);
+  }
+
+  private <T> void assertValue(String annotationSourceCode, String attributeName, T expectedValue, Class<T> type) {
+    var classTree = parseClass(annotationSourceCode + " class A {}");
+    var annotation = DeprecatedCheckerHelper.deprecatedAnnotation(classTree);
+    T value = DeprecatedCheckerHelper.getAnnotationAttributeValue(annotation, attributeName, type).orElse(null);
+    assertEquals(expectedValue, value);
+  }
+
+  private ClassTree parseClass(String code) {
+    CompilationUnitTree compilationUnitTree = JParserTestUtils.parse(code);
+    return (ClassTree) compilationUnitTree.types().get(0);
+  }
+
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -390,4 +390,13 @@ public final class ExpressionUtils {
     return null;
   }
 
+  public static String annotationAttributeName(ExpressionTree expression) {
+    if (expression.is(Tree.Kind.ASSIGNMENT)) {
+      AssignmentExpressionTree assignment = (AssignmentExpressionTree) expression;
+      // assignment.variable() in annotation is always a Tree.Kind.IDENTIFIER
+      return ((IdentifierTree) assignment.variable()).name();
+    }
+    return "value";
+  }
+
 }

--- a/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
@@ -44,6 +44,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isPrivate;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.sonar.java.model.ExpressionUtils.isInvocationOnVariable;
 import static org.sonar.java.model.ExpressionUtils.skipParenthesesUpwards;
@@ -467,6 +468,24 @@ class ExpressionUtilsTest {
     assertThat(ExpressionUtils.areVariablesSame(condition.rightOperand(), initializer.trueExpression(), false)).isFalse();
     assertThat(ExpressionUtils.areVariablesSame(initializer.trueExpression(), condition.leftOperand(), false)).isFalse();
     assertThat(ExpressionUtils.areVariablesSame(initializer.falseExpression(), condition.rightOperand(), false)).isFalse();
+  }
+
+  @Test
+  void testAnnotationAttributeName(){
+    var unit = JParserTestUtils.parse("""
+      interface A {
+        @Deprecated(forRemoval = true)
+        void m();
+        @MyAnnotation("noArgName")
+        void m2();
+      }""");
+    var classTree = (ClassTree) unit.types().get(0);
+    var methodTree = (MethodTree) classTree.members().get(0);
+    var annotation = methodTree.modifiers().annotations().get(0).arguments().get(0);
+    assertEquals("forRemoval", ExpressionUtils.annotationAttributeName(annotation));
+    methodTree = (MethodTree) classTree.members().get(1);
+    annotation = methodTree.modifiers().annotations().get(0).arguments().get(0);
+    assertEquals("value", ExpressionUtils.annotationAttributeName(annotation));
   }
 
 }


### PR DESCRIPTION
[SONARJAVA-5755](https://sonarsource.atlassian.net/browse/SONARJAVA-5755)

This PR aims to allow deprecated code to be used without having an issue raised whenever the `@Deprecated` annotation is marked with `forRemoval = false`, as that code is not planned for future removal.

As part of the change, a utility method to extract the name of an annotation attribute was extracted from an existing check `SpringComposedRequestMappingCheck` into `ExpressionUtils`. About this I am not 100% sure about the utility method's name, and if the method should also consider more cases than `Tree.Kind.ASSIGNMENT`

[SONARJAVA-5755]: https://sonarsource.atlassian.net/browse/SONARJAVA-5755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ