### PR TITLE
SONARJAVA-5786 Bump org.springframework:spring-expression 6.1.21 -> 6.2.11 because of CVE-2025-41249

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>6.1.21</version>
+        <version>6.2.11</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
[SONARJAVA-5786](https://sonarsource.atlassian.net/browse/SONARJAVA-5786)

[SONARJAVA-5786]: https://sonarsource.atlassian.net/browse/SONARJAVA-5786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ