### PR TITLE
SONARJAVA java:S1166 (either log or rethrow exception) should not raise an issue when using unnamed variables (conflict with rule java:S7467)

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/CatchUsesExceptionWithContextCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/CatchUsesExceptionWithContextCheck.java
@@ -65,6 +65,33 @@ class CatchUsesExceptionWithContextCheck {
         System.out.println("" + e);
       }
     }
+
+    // Unnamed exception variables
+    try {
+    } catch (Exception _) {                     // Compliant
+    }
+
+    try {
+    } catch (Exception _) {                     // Compliant
+      try {
+      } catch (Exception _) {                   // Compliant
+      }
+    }
+
+    try {
+    } catch (Exception _) {                     // Compliant
+      try {
+      } catch (Exception z) { // Noncompliant {{Either log or rethrow this exception.}}
+      }
+    }
+
+    try {
+    } catch (Exception e) {                     // Compliant
+      System.out.println(e);
+      try {
+      } catch (Exception _) {                   // Compliant
+      }
+    }
   }
 
   private void g() {

--- a/java-checks/src/main/java/org/sonar/java/checks/CatchUsesExceptionWithContextCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CatchUsesExceptionWithContextCheck.java
@@ -174,7 +174,8 @@ public class CatchUsesExceptionWithContextCheck extends BaseTreeVisitor implemen
       Symbol exception = tree.parameter().symbol();
       usageStatusStack.addFirst(new UsageStatus(exception.usages()));
       super.visitCatch(tree);
-      if (usageStatusStack.pop().isInvalid() && !exception.isUnknown()) {
+      if (usageStatusStack.pop().isInvalid() && !exception.isUnknown()
+        && !isExceptionVariableUnnamed(tree.parameter())) {
         context.reportIssue(this, tree.parameter(), "Either log or rethrow this exception.");
       }
     }
@@ -205,6 +206,10 @@ public class CatchUsesExceptionWithContextCheck extends BaseTreeVisitor implemen
     }
     super.visitMemberSelectExpression(tree);
 
+  }
+
+  private boolean isExceptionVariableUnnamed(VariableTree parameter) {
+        return parameter.simpleName().isUnnamedVariable();
   }
 
   private boolean isExcludedType(Tree tree) {


### PR DESCRIPTION
Part of RSPEC

See description of problem in discussion 
[Request: Update rule java:S1166 (either log or rethrow) for cases using unnamed varliables](https://community.sonarsource.com/t/request-update-rule-java-s1166-either-log-or-rethrow-for-cases-using-unnamed-varliables/157666)

Please note:
The check if variable is unnamed is delibarately in 
```
  @Override
  public void visitCatch(CatchTree tree) {
    if (!isExcludedType(tree.parameter().type()) && !excludedCatchTrees.contains(tree)) {
      Symbol exception = tree.parameter().symbol();
      usageStatusStack.addFirst(new UsageStatus(exception.usages()));
      super.visitCatch(tree);
      if (usageStatusStack.pop().isInvalid() && !exception.isUnknown()
        **&& !isExceptionVariableUnnamed(tree.parameter())) {**
        context.reportIssue(this, tree.parameter(), "Either log or rethrow this exception.");
      }
    }
  }
```
and _not_ together with the excluded cases (like ParseException etc.) in the first line.

to allow for deeper evaluation like this (excerpt from the test cases):
Otherwise no issue (possibly not very likly but not an excluded case) would not be raised for the inner catch.

    try {
    } catch (Exception _) {                     // Compliant
      try {
      } catch (Exception z) { // Noncompliant {{Either log or rethrow this exception.}}
      }
    }