### PR TITLE
SONARJAVA-6141 Save ncloc metric on test files

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/Struts139Test.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/Struts139Test.java
@@ -59,7 +59,8 @@ public class Struts139Test {
     String fileKey = componentKey("org/apache/struts/action/", "Action.java");
     assertThat(getMeasureAsInteger(fileKey, "files")).isEqualTo(1);
     assertThat(getMeasureAsInteger(PROJECT_STRUTS, "lines")).isEqualTo(65059);
-    assertThat(getMeasureAsInteger(PROJECT_STRUTS, "ncloc")).isEqualTo(27577);
+    assertThat(getMeasureAsInteger(PROJECT_STRUTS, "ncloc"))
+      .isIn(27577, /*FIXME SONAR-27110 Can be removed when ITs will be run with SQS 2026.2+*/33231);
     // 208 getter/setter
     assertThat(getMeasureAsInteger(PROJECT_STRUTS, "functions")).isEqualTo(2730 + 208);
 

--- a/java-frontend/src/main/java/org/sonar/java/Measurer.java
+++ b/java-frontend/src/main/java/org/sonar/java/Measurer.java
@@ -64,8 +64,11 @@ public class Measurer extends SubscriptionVisitor {
     @Override
     public void scanFile(JavaFileScannerContext context) {
       sonarFile = context.getInputFile();
-      var metricsComputer = ((MetricsScannerContext)context).getMetricsComputer();
+      var metricsComputer = ((MetricsScannerContext) context).getMetricsComputer();
       noSonarFilter.noSonarInFile(sonarFile, metricsComputer.getNoSonarLines(context.getTree()));
+      if (!isSonarLintContext()) {
+        saveMetricOnFile(CoreMetrics.NCLOC, metricsComputer.getLinesOfCode(context.getTree()));
+      }
     }
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/Measurer.java
+++ b/java-frontend/src/main/java/org/sonar/java/Measurer.java
@@ -66,9 +66,10 @@ public class Measurer extends SubscriptionVisitor {
       sonarFile = context.getInputFile();
       var metricsComputer = ((MetricsScannerContext) context).getMetricsComputer();
       noSonarFilter.noSonarInFile(sonarFile, metricsComputer.getNoSonarLines(context.getTree()));
-      if (!isSonarLintContext()) {
-        saveMetricOnFile(CoreMetrics.NCLOC, metricsComputer.getLinesOfCode(context.getTree()));
+      if (isSonarLintContext()) {
+        return;
       }
+      saveMetricOnFile(CoreMetrics.NCLOC, metricsComputer.getLinesOfCode(context.getTree()));
     }
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
@@ -89,6 +89,21 @@ class MeasurerTest {
     checkMetric("EmptyFile.java", "ncloc", 0);
   }
 
+  @Test
+  void verify_ncloc_metric_on_test_file() {
+    String relativePath = PathUtils.sanitize(new File(BASE_DIR, "LinesOfCode.java").getPath());
+    InputFile inputFile = TestUtils.inputFile("", new File(relativePath), InputFile.Type.TEST);
+    context.fileSystem().add(inputFile);
+
+    Measurer measurer = new Measurer(context, mock(NoSonarFilter.class));
+    JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), mockSonarComponents(), measurer, new NoOpTelemetry(), null, null);
+
+    frontend.scan(Collections.emptyList(), Collections.singletonList(inputFile), Collections.emptyList());
+
+    assertThat(context.measures(inputFile.key())).hasSize(1);
+    assertThat(context.measure(inputFile.key(), "ncloc").value()).isEqualTo(2);
+  }
+
   /**
    * Utility method to quickly get metric out of a file.
    */


### PR DESCRIPTION
Enable saving the NCLOC metric for test files in TestFileMeasurer, skipped in SonarLint context, consistent with main file behavior.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
