### PR TITLE
SONARJAVA-6215 Stop using Guava in ITs

### DIFF
--- a/its/autoscan/pom.xml
+++ b/its/autoscan/pom.xml
@@ -32,11 +32,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.it;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -228,7 +227,7 @@ public class AutoScanTest {
 
   private static List<String> generateSonarWay(OrchestratorRule orchestrator) {
     Set<String> results = new TreeSet<>(RULE_KEY_COMPARATOR);
-    ProfileGenerator.generate(orchestrator, "Sonar Way", ImmutableMap.of(), Collections.emptySet(), Collections.emptySet(), results);
+    ProfileGenerator.generate(orchestrator, "Sonar Way", Map.of(), Collections.emptySet(), Collections.emptySet(), results);
     return new ArrayList<>(results);
   }
 

--- a/its/autoscan/src/test/java/org/sonar/java/it/ProfileGenerator.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/ProfileGenerator.java
@@ -16,13 +16,12 @@
  */
 package org.sonar.java.it;
 
-import com.google.common.io.Files;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.locator.FileLocation;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -90,7 +89,7 @@ public class ProfileGenerator {
         .append("</profile>");
 
       File file = File.createTempFile("profile", ".xml");
-      Files.asCharSink(file, StandardCharsets.UTF_8).write(sb);
+      Files.writeString(file.toPath(), sb);
       LOG.info("Restoring profile to SonarQube");
       orchestrator.getServer().restoreProfile(FileLocation.of(file));
       file.delete();

--- a/its/autoscan/src/test/java/org/sonar/java/it/ProfileGenerator.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/ProfileGenerator.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.it;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.sonar.orchestrator.container.Server;
 import com.sonar.orchestrator.junit4.OrchestratorRule;
@@ -47,7 +46,7 @@ public class ProfileGenerator {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProfileGenerator.class);
 
-  static void generate(OrchestratorRule orchestrator, ImmutableMap<String, ImmutableMap<String, String>> rulesParameters,
+  static void generate(OrchestratorRule orchestrator, Map<String, Map<String, String>> rulesParameters,
     Set<String> excluded, Set<String> subsetOfEnabledRules, Set<String> activatedRuleKeys) {
     generate(orchestrator, null, rulesParameters, excluded, subsetOfEnabledRules, activatedRuleKeys);
   }
@@ -55,7 +54,7 @@ public class ProfileGenerator {
   /**
    * @return the list of enabled rule keys for the given profile
    */
-  static void generate(OrchestratorRule orchestrator, @Nullable String qualityProfile, ImmutableMap<String, ImmutableMap<String, String>> rulesParameters,
+  static void generate(OrchestratorRule orchestrator, @Nullable String qualityProfile, Map<String, Map<String, String>> rulesParameters,
     Set<String> excluded, Set<String> subsetOfEnabledRules, Set<String> activatedRuleKeys) {
     try {
       LOG.info("Generating profile containing all the rules");

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -45,11 +45,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -64,11 +64,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <scope>provided</scope>

--- a/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
@@ -17,8 +17,6 @@
 package org.sonar.java.it;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.sonar.orchestrator.build.Build;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.MavenBuild;
@@ -40,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -79,7 +78,7 @@ public class JavaRulingTest {
    * mvn test -DsonarRules=S100,S101
    * }</pre>
    */
-  private static final ImmutableSet<String> SUBSET_OF_ENABLED_RULES = ImmutableSet.copyOf(
+  private static final Set<String> SUBSET_OF_ENABLED_RULES = Set.copyOf(
       Splitter.on(',').trimResults().omitEmptyStrings().splitToList(
           System.getProperty("sonarRules", "")
       )
@@ -114,23 +113,20 @@ public class JavaRulingTest {
 
   @BeforeClass
   public static void prepare_quality_profiles() throws Exception {
-    ImmutableMap<String, ImmutableMap<String, String>> rulesParameters = ImmutableMap.<String, ImmutableMap<String, String>>builder()
-      .put(
-        "S1120",
-        ImmutableMap.of("indentationLevel", "4"))
-      .put(
+    Map<String, Map<String, String>> rulesParameters = Map.of(
+        "S1120", Map.of("indentationLevel", "4"),
         "S1451",
-        ImmutableMap.of(
+        Map.of(
           "headerFormat",
           """
             
             /*
              * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
-             * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms."""))
-      .put("S5961", ImmutableMap.of("MaximumAssertionNumber", "50"))
-      .put("S6539", ImmutableMap.of("couplingThreshold", "20"))
-      .build();
-    ImmutableSet<String> disabledRules = ImmutableSet.of(
+             * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms."""),
+        "S5961", Map.of("MaximumAssertionNumber", "50"),
+        "S6539", Map.of("couplingThreshold", "20")
+      );
+    Set<String> disabledRules = Set.of(
       "S1874",
       "CycleBetweenPackages",
       // disable because it generates too many issues, performance reasons

--- a/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.it;
 
-import com.google.common.base.Splitter;
 import com.sonar.orchestrator.build.Build;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.MavenBuild;
@@ -78,11 +77,11 @@ public class JavaRulingTest {
    * mvn test -DsonarRules=S100,S101
    * }</pre>
    */
-  private static final Set<String> SUBSET_OF_ENABLED_RULES = Set.copyOf(
-      Splitter.on(',').trimResults().omitEmptyStrings().splitToList(
-          System.getProperty("sonarRules", "")
-      )
-  );
+  private static final Set<String> SUBSET_OF_ENABLED_RULES =
+    Arrays.stream(System.getProperty("sonarRules", "").split(","))
+      .map(String::trim)
+      .filter(s -> !s.isEmpty())
+      .collect(Collectors.toSet());
 
   @ClassRule
   public static TemporaryFolder tmpDumpOldFolder = new TemporaryFolder();

--- a/its/ruling/src/test/java/org/sonar/java/it/ProfileGenerator.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/ProfileGenerator.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.it;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.locator.FileLocation;
@@ -45,7 +44,7 @@ public class ProfileGenerator {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProfileGenerator.class);
 
-  static void generate(OrchestratorRule orchestrator, ImmutableMap<String, ImmutableMap<String, String>> rulesParameters,
+  static void generate(OrchestratorRule orchestrator, Map<String, Map<String, String>> rulesParameters,
     Set<String> excluded, Set<String> subsetOfEnabledRules, Set<String> activatedRuleKeys) {
     generate(orchestrator, null, rulesParameters, excluded, subsetOfEnabledRules, activatedRuleKeys);
   }
@@ -53,7 +52,7 @@ public class ProfileGenerator {
   /**
    * @return the list of enabled rule keys for the given profile
    */
-  static void generate(OrchestratorRule orchestrator, @Nullable String qualityProfile, ImmutableMap<String, ImmutableMap<String, String>> rulesParameters,
+  static void generate(OrchestratorRule orchestrator, @Nullable String qualityProfile, Map<String, Map<String, String>> rulesParameters,
     Set<String> excluded, Set<String> subsetOfEnabledRules, Set<String> activatedRuleKeys) {
     try {
       LOG.info("Generating profile containing all the rules");

--- a/its/ruling/src/test/java/org/sonar/java/it/ProfileGenerator.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/ProfileGenerator.java
@@ -16,12 +16,11 @@
  */
 package org.sonar.java.it;
 
-import com.google.common.io.Files;
 import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.locator.FileLocation;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,7 +87,7 @@ public class ProfileGenerator {
         .append("</profile>");
 
       File file = File.createTempFile("profile", ".xml");
-      Files.asCharSink(file, StandardCharsets.UTF_8).write(sb);
+      Files.writeString(file.toPath(), sb);
       LOG.info("Restoring profile to SonarQube");
       orchestrator.getServer().restoreProfile(FileLocation.of(file));
       file.delete();


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency removal:**
  - Removed Guava from `pom.xml` files in `autoscan`, `plugin/tests`, and `ruling` modules.
- **Refactoring:**
  - Replaced Guava's `Splitter`, `ImmutableSet`, `ImmutableMap`, and `Files` with native Java alternatives like `java.util.Map`, `java.util.Set`, and `java.nio.file.Files`.
  - Updated `ProfileGenerator` and `JavaRulingTest` to use standard collection factories and `Files.writeString`.

<sub>This will update automatically on new commits.</sub>