### PR TITLE
BUILD-10889: upgrade vault-action-wrapper to 3.4.0

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: get secrets
       id: secrets
-      uses: SonarSource/vault-action-wrapper@d1c1ab4ca5ad07fd9cdfe1eff038a39673dfca64  # tag=2.4.2-1
+      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820  # v3.4.0
       with:
         secrets: |
           development/kv/data/slack webhook | SLACK_WEBHOOK;


### PR DESCRIPTION
Part of https://sonarsource.atlassian.net/browse/BUILD-10889.

Fixing https://github.com/SonarSource/sonar-java/actions/runs/24206598266/job/70663937404.
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
