### PR TITLE
SONARJAVA-6246 Update Develocity URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   USE_DEVELOCITY: true
-  DEVELOCITY_URL: https://develocity-public.sonar.build/
+  DEVELOCITY_URL: https://develocity.sonar.build/
   MAVEN_OUTPUT_ARGS: "--errors --show-version"
 
 jobs:

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,6 +1,6 @@
 <develocity>
   <server>
-    <url>https://develocity-public.sonar.build</url>
+    <url>https://develocity.sonar.build</url>
   </server>
   <buildCache>
     <local>


### PR DESCRIPTION
* Due to change migration to sonar public runners (https://github.com/SonarSource/sonar-java/pull/5547) we need to update develocity url.
* Tested: inspected https://github.com/SonarSource/sonar-java/actions/runs/24241237463/job/70776118301 (logs on the build step) for develocity stack traces.