### PR TITLE
SONARJAVA-6247 Use orchestrator-cache in autoscan tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,7 +342,7 @@ jobs:
         run: >
           mvn clean package --batch-mode --errors --show-version
           --activate-profiles it-autoscan
-          "-Dsonar.runtimeVersion=$SQ_VERSION"
+          -Dsonar.runtimeVersion="$SQ_VERSION"
           -Dmaven.test.redirectTestOutputToFile=false
           -Dparallel=methods
           -DuseUnlimitedThreads=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,6 +299,7 @@ jobs:
       contents: write
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
+      SQ_VERSION: LATEST_RELEASE
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       # For now, the autoscan job need to execute two mvn commands:
@@ -328,6 +329,10 @@ jobs:
           mvn clean compile test-compile --batch-mode
       - name: Select Java 21
         run: mise use java@21
+      - name: Orchestrator Cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          sq-version: ${{ env.SQ_VERSION }}
       - name: Run autoscan tests
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_HOST_URL }}
@@ -337,7 +342,7 @@ jobs:
         run: >
           mvn clean package --batch-mode --errors --show-version
           --activate-profiles it-autoscan
-          -Dsonar.runtimeVersion=LATEST_RELEASE
+          "-Dsonar.runtimeVersion=$SQ_VERSION"
           -Dmaven.test.redirectTestOutputToFile=false
           -Dparallel=methods
           -DuseUnlimitedThreads=true


### PR DESCRIPTION
* We forgot autoscan when adding caching to plugin and ruling qa.
* Tested: https://github.com/SonarSource/sonar-java/actions/runs/24245885636/job/70792206325 downloads `sonarqube-enterprise-lw-2026.2.1.121354.zip` which was previousy caches by other qa jobs.