### PR TITLE
SONARJAVA-6251 Reduce test log noise by restricting debug to selected packages

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/it/java/JspTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/JspTest.java
@@ -72,7 +72,7 @@ public class JspTest {
 
     MavenBuild build = TestUtils.createMavenBuild().setPom(TestUtils.projectPom(PROJECT))
       .setCleanPackageSonarGoals()
-      .setDebugLogs(true)
+      .setProperty("org.slf4j.simpleLogger.log.org.sonarsource", "debug")
       .setProperty("sonar.scm.disabled", "true");
     TestUtils.provisionProject(ENTERPRISE_ORCHESTRATOR_OR_NULL, "org.sonarsource.it.projects:" + PROJECT, PROJECT, "java", "jsp");
     BuildResult buildResult = ENTERPRISE_ORCHESTRATOR_OR_NULL.executeBuild(build);

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/Java25FeaturesTelemetryTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/Java25FeaturesTelemetryTest.java
@@ -35,7 +35,7 @@ public class Java25FeaturesTelemetryTest {
     MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("java-features"))
       .setCleanPackageSonarGoals()
-      .setDebugLogs(true);
+      .setProperty("org.slf4j.simpleLogger.log.org.sonarsource", "debug");
 
     String projectKey = "org.sonarsource.it.projects:parent-project";
     TestUtils.provisionProject(orchestrator, projectKey, "java-features", "java", "multi-module");

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTutorialTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaTutorialTest.java
@@ -39,7 +39,7 @@ public class JavaTutorialTest {
     MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("java-tutorial"))
       .setCleanPackageSonarGoals()
-      .setDebugLogs(true);
+      .setProperty("org.slf4j.simpleLogger.log.org.sonarsource", "debug");
     String projectKey = "org.sonarsource.it.projects:java-tutorial";
     TestUtils.provisionProject(orchestrator, projectKey, "java-tutorial", "java", "java-tutorial");
     executeAndAssertBuild(build, projectKey);
@@ -54,7 +54,7 @@ public class JavaTutorialTest {
       .setProperty("sonar.projectKey", projectKey)
       .setProperty("sonar.projectName", projectName)
       .setProperty("sonar.java.experimental.batchModeSizeInKB", "8000")
-      .setDebugLogs(true);
+      .setProperty("org.slf4j.simpleLogger.log.org.sonarsource", "debug");
     TestUtils.provisionProject(orchestrator, projectKey, projectName, "java", "java-tutorial");
     executeAndAssertBuild(build, projectKey);
   }

--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/MultiModuleTelemetryTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/MultiModuleTelemetryTest.java
@@ -34,7 +34,7 @@ public class MultiModuleTelemetryTest {
     MavenBuild build = TestUtils.createMavenBuild()
       .setPom(TestUtils.projectPom("multi-module"))
       .setCleanPackageSonarGoals()
-      .setDebugLogs(true);
+      .setProperty("org.slf4j.simpleLogger.log.org.sonarsource", "debug");
 
     String projectKey = "org.sonarsource.it.projects:parent-project";
     TestUtils.provisionProject(orchestrator, projectKey, "multi-module", "java", "multi-module");


### PR DESCRIPTION
* Logs are used to test telemetry. `-X` implied by `setDebugLogs(true)` is too verbose - it is enough to use debug only on our own package.
* Reduction 50k lines -> 14k lines in Plugin QA LATEST_RELEASE.
* Also tested with DEV sq: https://github.com/SonarSource/sonar-java/actions/runs/24337680858