### PR TITLE
SONARJAVA-6253 Ensure integration tests do not share cache

### DIFF
--- a/.github/actions/write-file/action.yml
+++ b/.github/actions/write-file/action.yml
@@ -1,0 +1,23 @@
+name: Write File
+description: Writes a file with the given content
+
+inputs:
+  file-path:
+    description: 'Path to the file to write.'
+    required: true
+  content:
+    description: 'Content to write to the file.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Write Content to File
+      shell: bash
+      env:
+        FILE_PATH: ${{ inputs.file-path }}
+        CONTENT: ${{ inputs.content }}
+      run: |
+        mkdir -p "$(dirname "$FILE_PATH")"
+        echo "$CONTENT" > "$FILE_PATH"
+        echo "$CONTENT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Ensure Separate Job Cache Key
         uses: ./.github/actions/write-file
         with:
-          file-path: just_for_cache_key_calculation/pom.xml
+          file-path: target/just_for_cache_key_calculation/pom.xml
           content: ${{ github.job }}-${{ toJSON(matrix.item) }}
       - name: Configure Maven
         uses: SonarSource/ci-github-actions/config-maven@v1
@@ -149,7 +149,7 @@ jobs:
       - name: Ensure Separate Job Cache Key
         uses: ./.github/actions/write-file
         with:
-          file-path: just_for_cache_key_calculation/pom.xml
+          file-path: target/just_for_cache_key_calculation/pom.xml
           content: ${{ github.job }}-${{ matrix.sq_version }}
       - name: Configure Maven
         uses: SonarSource/ci-github-actions/config-maven@v1
@@ -199,7 +199,7 @@ jobs:
       - name: Ensure Separate Job Cache Key
         uses: ./.github/actions/write-file
         with:
-          file-path: just_for_cache_key_calculation/pom.xml
+          file-path: target/just_for_cache_key_calculation/pom.xml
           content: ${{ github.job }}
       - uses: SonarSource/ci-github-actions/config-maven@v1
         with:
@@ -281,7 +281,7 @@ jobs:
       - name: Ensure Separate Job Cache Key
         uses: ./.github/actions/write-file
         with:
-          file-path: just_for_cache_key_calculation/pom.xml
+          file-path: target/just_for_cache_key_calculation/pom.xml
           content: ${{ github.job }}
       - uses: SonarSource/ci-github-actions/config-maven@v1
         with:
@@ -338,7 +338,7 @@ jobs:
       - name: Ensure Separate Job Cache Key
         uses: ./.github/actions/write-file
         with:
-          file-path: just_for_cache_key_calculation/pom.xml
+          file-path: target/just_for_cache_key_calculation/pom.xml
           content: ${{ github.job }}
       - uses: SonarSource/ci-github-actions/config-maven@v1
         with:
@@ -397,7 +397,7 @@ jobs:
       - name: Ensure Separate Job Cache Key
         uses: ./.github/actions/write-file
         with:
-          file-path: just_for_cache_key_calculation/pom.xml
+          file-path: target/just_for_cache_key_calculation/pom.xml
           content: ${{ github.job }}
       - name: Configure Maven
         uses: SonarSource/ci-github-actions/config-maven@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,11 @@ jobs:
           version: 2025.7.12
       - name: Select Java Version
         run: mise use java@21
+      - name: Ensure Separate Job Cache Key
+        uses: ./.github/actions/write-file
+        with:
+          file-path: just_for_cache_key_calculation/pom.xml
+          content: ${{ github.job }}-${{ toJSON(matrix.item) }}
       - name: Configure Maven
         uses: SonarSource/ci-github-actions/config-maven@v1
         with:
@@ -141,6 +146,11 @@ jobs:
           version: 2025.7.12
       - name: Select Java Version
         run: mise use java@21
+      - name: Ensure Separate Job Cache Key
+        uses: ./.github/actions/write-file
+        with:
+          file-path: just_for_cache_key_calculation/pom.xml
+          content: ${{ github.job }}-${{ matrix.sq_version }}
       - name: Configure Maven
         uses: SonarSource/ci-github-actions/config-maven@v1
         with:
@@ -186,6 +196,11 @@ jobs:
           secrets: |
             development/kv/data/next url | SONAR_HOST_URL;
             development/kv/data/next token | SONAR_TOKEN;
+      - name: Ensure Separate Job Cache Key
+        uses: ./.github/actions/write-file
+        with:
+          file-path: just_for_cache_key_calculation/pom.xml
+          content: ${{ github.job }}
       - uses: SonarSource/ci-github-actions/config-maven@v1
         with:
           artifactory-reader-role: private-reader
@@ -263,6 +278,11 @@ jobs:
           secrets: |
             development/kv/data/next url | SONAR_HOST_URL;
             development/kv/data/next token | SONAR_TOKEN;
+      - name: Ensure Separate Job Cache Key
+        uses: ./.github/actions/write-file
+        with:
+          file-path: just_for_cache_key_calculation/pom.xml
+          content: ${{ github.job }}
       - uses: SonarSource/ci-github-actions/config-maven@v1
         with:
           artifactory-reader-role: private-reader
@@ -315,6 +335,11 @@ jobs:
             development/kv/data/next url | SONAR_HOST_URL;
             development/kv/data/next token | SONAR_TOKEN;
             development/github/token/licenses-ro token | GITHUB_TOKEN;
+      - name: Ensure Separate Job Cache Key
+        uses: ./.github/actions/write-file
+        with:
+          file-path: just_for_cache_key_calculation/pom.xml
+          content: ${{ github.job }}
       - uses: SonarSource/ci-github-actions/config-maven@v1
         with:
           artifactory-reader-role: private-reader
@@ -369,6 +394,11 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
         with:
           version: 2025.7.12
+      - name: Ensure Separate Job Cache Key
+        uses: ./.github/actions/write-file
+        with:
+          file-path: just_for_cache_key_calculation/pom.xml
+          content: ${{ github.job }}
       - name: Configure Maven
         uses: SonarSource/ci-github-actions/config-maven@v1
         with:


### PR DESCRIPTION
Use separate caches for plugin, ruling, and other ITs. See [SONARJAVA-6253](https://sonarsource.atlassian.net/browse/SONARJAVA-6253) for details.

[SONARJAVA-6253]: https://sonarsource.atlassian.net/browse/SONARJAVA-6253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ