### PR TITLE
SONARJAVA-6208 S2699: Add approve to assertion method name pattern

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2699",
   "hasTruePositives": true,
-  "falseNegatives": 157,
+  "falseNegatives": 158,
   "falsePositives": 1
 }

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -1016,6 +1016,18 @@
       <artifactId>junit-platform-suite</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.approvej</groupId>
+      <artifactId>core</artifactId>
+      <version>1.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+    <groupId>com.approvaltests</groupId>
+    <artifactId>approvaltests</artifactId>
+    <version>30.1.0</version>
+    <scope>test</scope>
+</dependency>
   </dependencies>
 
   <profiles>

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -1020,12 +1020,6 @@
       <groupId>org.approvej</groupId>
       <artifactId>core</artifactId>
       <version>1.6.0</version>
-    <dependency>
-      <groupId>org.approvej</groupId>
-      <artifactId>core</artifactId>
-      <version>1.6.0</version>
-      <scope>test</scope>
-    </dependency>
     <scope>test</scope>
 </dependency>
   </dependencies>

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -1020,12 +1020,12 @@
       <groupId>org.approvej</groupId>
       <artifactId>core</artifactId>
       <version>1.6.0</version>
+    <dependency>
+      <groupId>org.approvej</groupId>
+      <artifactId>core</artifactId>
+      <version>1.6.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-    <groupId>com.approvaltests</groupId>
-    <artifactId>approvaltests</artifactId>
-    <version>30.1.0</version>
     <scope>test</scope>
 </dependency>
   </dependencies>

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -1020,8 +1020,8 @@
       <groupId>org.approvej</groupId>
       <artifactId>core</artifactId>
       <version>1.6.0</version>
-    <scope>test</scope>
-</dependency>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsInTestsCheck/ApproveJ.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsInTestsCheck/ApproveJ.java
@@ -1,0 +1,32 @@
+package checks.tests.AssertionsInTestsCheck;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+import static org.approvej.ApprovalBuilder.approve;
+import static org.approvej.print.MultiLineStringPrintFormat.multiLineString;
+
+class ApproveJTest {
+
+  @Test
+  void contains_no_assertions() { // Noncompliant
+  }
+
+  public String hello() {return "hello";}
+
+  @Test
+  void approve_string() {
+    String result = hello();
+    approve(result)
+      .byFile();
+  }
+
+  public record Person(String name, LocalDate birthDate) {}
+
+  @Test
+  void approve_person() {
+    Person jane = new Person("Jane Doe", LocalDate.of(1990, 1, 1));
+    approve(jane).named("jane").printedAs(multiLineString()).byFile();
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -41,7 +41,7 @@ public final class UnitTestUtils {
 
   private static final String ORG_JUNIT_TEST = "org.junit.Test";
   public static final Pattern ASSERTION_METHODS_PATTERN = Pattern.compile(
-    "(assert|verify|fail|should|check|expect|validate|andExpect).*" +
+    "(assert|verify|fail|should|check|expect|validate|andExpect|approve).*" +
     // Eclipse Vert.x with JUnit 5 (VertxTestContext)
       "|laxCheckpoint|succeedingThenComplete");
   private static final Pattern TEST_METHODS_PATTERN = Pattern.compile("test.*|.*Test");

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/AssertionsInTestsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/AssertionsInTestsCheckTest.java
@@ -64,6 +64,7 @@ class AssertionsInTestsCheckTest {
     "JMockit",
     "Awaitility",
     "AssertJ",
+    "ApproveJ",
     "Custom"
   })
   void test(String framework) {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2699.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2699.html
@@ -3,6 +3,7 @@
 code under test.</p>
 <p>This rule raises an exception when no assertions from any of the following known frameworks are found in a test:</p>
 <ul>
+  <li>ApproveJ</li>
   <li>AssertJ</li>
   <li>Awaitility</li>
   <li>EasyMock</li>


### PR DESCRIPTION
Add approve keyword to the assertion methods pattern to support ApproveJ library
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
