### PR TITLE
SONARJAVA-5719 S1176 Should have a separate message for undocumented type parameters.

### DIFF
--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/api/undocumentedAPI/UndocumentedApi.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/api/undocumentedAPI/UndocumentedApi.java
@@ -331,6 +331,13 @@ class A {
 
 }
 
+/**
+ * Description.
+ */
+public record MyRecord<U>(U a, int b) { // Noncompliant {{Document the type parameter(s): <U>}}
+  //          ^^^^^^^^
+}
+
 @interface MyAnnotation {}
 
 class UsesVisibleForTesting {

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/api/undocumentedAPI/UndocumentedApi.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/api/undocumentedAPI/UndocumentedApi.java
@@ -67,7 +67,7 @@ public class AClass { // Noncompliant {{Document this public class by adding an 
 /**
  * This is a Javadoc comment
  */
-public class MyClass<T> implements Runnable { // Noncompliant {{Document the parameter(s): <T>}}
+public class MyClass<T> implements Runnable { // Noncompliant {{Document the type parameter(s): <T>}}
 
  private int status;                            // Compliant - not public
 

--- a/java-checks-test-sources/default/src/main/java/checks/api/undocumentedAPI/UndocumentedApiJava23.java
+++ b/java-checks-test-sources/default/src/main/java/checks/api/undocumentedAPI/UndocumentedApiJava23.java
@@ -51,7 +51,7 @@ public class UndocumentedApiJava23 {
   }
 
   /// Documented, but not the type.
-  public class SomethingGenericBad<T> { // Noncompliant {{Document the parameter(s): <T>}}
+  public class SomethingGenericBad<T> { // Noncompliant {{Document the type parameter(s): <T>}}
   }
 
   /// Documented.

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -155,7 +155,7 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
   }
 
   private static String getParamLabel(Tree tree) {
-    return (tree.is(Kind.CLASS) || tree.is(Kind.INTERFACE)) ? "type parameter(s): " : "parameter(s): ";
+    return (tree.is(Kind.CLASS) || tree.is(Kind.INTERFACE) || tree.is(Kind.RECORD)) ? "type parameter(s): " : "parameter(s): ";
   }
 
   private static String getType(Tree tree) {
@@ -168,10 +168,7 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
         return "field";
       case ANNOTATION_TYPE:
         return "annotation";
-      case CLASS,
-        INTERFACE,
-        ENUM,
-        RECORD:
+      case CLASS, INTERFACE, ENUM, RECORD:
         return ((ClassTree) tree).declarationKeyword().text();
       default:
         return "";

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -20,7 +20,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.utils.WildcardPattern;
 import org.sonar.check.Rule;
@@ -130,14 +129,14 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
         Set<String> undocumentedParameters = javadoc.undocumentedParameters();
         if (!undocumentedParameters.isEmpty()) {
           String label = getParamLabel(tree);
-          context.reportIssue(this, reportTree, "Document the " + label + undocumentedParameters.stream().collect(Collectors.joining(", ")));
+          context.reportIssue(this, reportTree, "Document the " + label + String.join(", ", undocumentedParameters));
         }
         if (hasNonVoidReturnType(tree) && javadoc.noReturnDescription()) {
           context.reportIssue(this, reportTree, "Document this method return value.");
         }
         Set<String> undocumentedExceptions = javadoc.undocumentedThrownExceptions();
         if (!undocumentedExceptions.isEmpty()) {
-          context.reportIssue(this, reportTree, "Document this method thrown exception(s): " + undocumentedExceptions.stream().collect(Collectors.joining(", ")));
+          context.reportIssue(this, reportTree, "Document this method thrown exception(s): " + String.join(", ", undocumentedExceptions));
         }
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UndocumentedApiCheck.java
@@ -129,7 +129,8 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
       } else {
         Set<String> undocumentedParameters = javadoc.undocumentedParameters();
         if (!undocumentedParameters.isEmpty()) {
-          context.reportIssue(this, reportTree, "Document the parameter(s): " + undocumentedParameters.stream().collect(Collectors.joining(", ")));
+          String label = getParamLabel(tree);
+          context.reportIssue(this, reportTree, "Document the " + label + undocumentedParameters.stream().collect(Collectors.joining(", ")));
         }
         if (hasNonVoidReturnType(tree) && javadoc.noReturnDescription()) {
           context.reportIssue(this, reportTree, "Document this method return value.");
@@ -151,6 +152,10 @@ public class UndocumentedApiCheck extends BaseTreeVisitor implements JavaFileSca
       && ((MethodTree) tree).parameters().isEmpty()
       // if return description is there, then it will be validated later
       && !javadoc.noReturnDescription();
+  }
+
+  private static String getParamLabel(Tree tree) {
+    return (tree.is(Kind.CLASS) || tree.is(Kind.INTERFACE)) ? "type parameter(s): " : "parameter(s): ";
   }
 
   private static String getType(Tree tree) {


### PR DESCRIPTION
Add separate message for type parameters in rule S1176.
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
