### PR TITLE
SONARJAVA-6197 S1451 should not fail at analysis time when an empty headerFormat rule property marked as a regular expression is provided

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Class4.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Class4.java
@@ -3,5 +3,5 @@ package checks.FileHeaderCheck;
 
 public class Class4 {
 }
-// Noncompliant {{Add or update the header of this file.}}
+// Compliant
 

--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Class4.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Class4.java
@@ -1,0 +1,7 @@
+
+package checks.FileHeaderCheck;
+
+public class Class4 {
+}
+// Noncompliant {{Add or update the header of this file.}}
+

--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Class5.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Class5.java
@@ -1,0 +1,5 @@
+package checks.FileHeaderCheck;
+
+public class Class5 {
+}
+// Compliant

--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex5.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex5.java
@@ -1,4 +1,6 @@
+
 package checks.FileHeaderCheck;
 
 public class Regex5 {
 }
+// Compliant

--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex5.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex5.java
@@ -1,0 +1,4 @@
+package checks.FileHeaderCheck;
+
+public class Regex5 {
+}

--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex6.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex6.java
@@ -2,3 +2,4 @@ package checks.FileHeaderCheck;
 
 public class Regex6 {
 }
+// Compliant

--- a/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex6.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FileHeaderCheck/Regex6.java
@@ -1,0 +1,4 @@
+package checks.FileHeaderCheck;
+
+public class Regex6 {
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
@@ -67,7 +67,9 @@ public class FileHeaderCheck extends IssuableSubscriptionVisitor {
         }
       }
     } else {
-      expectedLines = headerFormat.split("(?:\r)?\n|\r");
+      if (headerFormat.isEmpty()) {
+        expectedLines = new String[]{};
+      } else {expectedLines = headerFormat.split("(?:\r)?\n|\r");}
     }
     visitFile();
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.checks;
 
-import java.util.Arrays;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;

--- a/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.checks;
 
+import java.util.Arrays;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
@@ -58,18 +59,21 @@ public class FileHeaderCheck extends IssuableSubscriptionVisitor {
   @Override
   public void setContext(JavaFileScannerContext context) {
     super.context = context;
-    if (isRegularExpression) {
-      if (searchPattern == null) {
-        try {
-          searchPattern = Pattern.compile(getHeaderFormat(), Pattern.DOTALL);
-        } catch (IllegalArgumentException e) {
-          throw new IllegalArgumentException("[" + getClass().getSimpleName() + "] Unable to compile the regular expression: " + headerFormat, e);
-        }
-      }
+    if (headerFormat.isEmpty()) {
+      expectedLines = new String[]{};
+      isRegularExpression = false;
     } else {
-      if (headerFormat.isEmpty()) {
-        expectedLines = new String[]{};
-      } else {expectedLines = headerFormat.split("(?:\r)?\n|\r");}
+      if (isRegularExpression) {
+        if (searchPattern == null) {
+          try {
+            searchPattern = Pattern.compile(getHeaderFormat(), Pattern.DOTALL);
+          } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("[" + getClass().getSimpleName() + "] Unable to compile the regular expression: " + headerFormat, e);
+          }
+        }
+      } else {
+        expectedLines = headerFormat.split("(?:\r)?\n|\r");
+      }
     }
     visitFile();
   }
@@ -116,7 +120,6 @@ public class FileHeaderCheck extends IssuableSubscriptionVisitor {
     } else {
       result = false;
     }
-
     return result;
   }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/FileHeaderCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FileHeaderCheckTest.java
@@ -151,6 +151,20 @@ class FileHeaderCheckTest {
       .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/Regex4.java"))
       .withCheck(check)
       .verifyIssues();
+
+    check = new FileHeaderCheck();
+    check.isRegularExpression = true;
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/Regex5.java"))
+      .withCheck(check)
+      .verifyNoIssues();
+
+    check = new FileHeaderCheck();
+    check.isRegularExpression = true;
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/Regex6.java"))
+      .withCheck(check)
+      .verifyNoIssues();
   }
 
   @Test

--- a/java-checks/src/test/java/org/sonar/java/checks/FileHeaderCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FileHeaderCheckTest.java
@@ -98,6 +98,18 @@ class FileHeaderCheckTest {
       .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/Class3.java"))
       .withCheck(check)
       .verifyNoIssues();
+
+    check = new FileHeaderCheck();
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/Class4.java"))
+      .withCheck(check)
+      .verifyNoIssues();
+
+    check = new FileHeaderCheck();
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/Class5.java"))
+      .withCheck(check)
+      .verifyNoIssues();
   }
 
   @Test


### PR DESCRIPTION
Modify S1451 to handle empty header separately whether or not it is marked as a regular expression.
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
