### PR TITLE
SONARJAVA-6269 S1451: Rollback to empty default headerFormat

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FileHeaderCheck.java
@@ -31,13 +31,7 @@ import java.util.regex.Pattern;
 @Rule(key = "S1451")
 public class FileHeaderCheck extends IssuableSubscriptionVisitor {
 
-  private static final String DEFAULT_HEADER_FORMAT = """
-    /*
-     * <Your-Product-Name>
-     * Copyright (c) <Year-From>-<Year-To> <Your-Company-Name>
-     *
-     * Please configure this header in your SonarCloud/SonarQube quality profile.
-     */""";
+  private static final String DEFAULT_HEADER_FORMAT = "";
   private static final String MESSAGE = "Add or update the header of this file.";
 
   @RuleProperty(

--- a/java-checks/src/test/java/org/sonar/java/checks/FileHeaderCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FileHeaderCheckTest.java
@@ -100,14 +100,12 @@ class FileHeaderCheckTest {
       .verifyNoIssues();
 
     check = new FileHeaderCheck();
-    check.headerFormat = "";
     CheckVerifier.newVerifier()
       .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/ClassBlankLine.java"))
       .withCheck(check)
       .verifyNoIssues();
 
     check = new FileHeaderCheck();
-    check.headerFormat = "";
     CheckVerifier.newVerifier()
       .onFile(mainCodeSourcesPath("checks/FileHeaderCheck/ClassNoBlankLine.java"))
       .withCheck(check)


### PR DESCRIPTION
Replace the template header with an empty string to allow setting an empty header in SQ quality profile.
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
