### PR TITLE
SONARJAVA-6342 Update GitHub Action to use version 7 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD Configuration:**
  - Update `release.yml` to use `SonarSource/gh-action_release` version `v7` instead of `v6`.

<sub>This will update automatically on new commits.</sub>