### PR TITLE
BUILD-10835 Replace sonar-m-docker with warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   dogfood_merge:
-    runs-on: sonar-m-docker
+    runs-on: warp-custom-ubuntu-24-04
     name: Update dogfood branch
     permissions:
       id-token: write # required for SonarSource/vault-action-wrapper


### PR DESCRIPTION
BUILD-10835

## Purpose

Replace `sonar-m-docker` with `warp-custom-ubuntu-24-04` for the dogfood workflow, following the platform WarpBuild Ubuntu runner policy (Docker available natively on the WarpBuild image).

## Scope

- `.github/workflows/dogfood.yml` (1 job)

No other workflows in this repository reference `sonar-m-docker` on current `master`.