### PR TITLE
SONARJAVA-6375 S3752: Allow explicit unsafe HTTP methods and change from hotspot to vulnerability

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S3752.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S3752.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S3752",
   "hasTruePositives": true,
-  "falseNegatives": 31,
+  "falseNegatives": 24,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/home")
 public class SpringRequestMappingMethodCheckSample {
 
-  @RequestMapping("/") // Noncompliant {{Make sure allowing safe and unsafe HTTP methods is safe here.}}
+  @RequestMapping("/") // Noncompliant {{Do not use @RequestMapping without specifying the allowed HTTP methods.}}
 // ^^^^^^^^^^^^^^
   String home() {
     return "Hello from get";
@@ -31,8 +31,7 @@ public class SpringRequestMappingMethodCheckSample {
     return "Hello from get";
   }
 
-  @RequestMapping(path = "/delete", method = {RequestMethod.GET, RequestMethod.POST}) // Noncompliant {{Make sure allowing safe and unsafe HTTP methods is safe here.}}
-//                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  @RequestMapping(path = "/delete", method = {RequestMethod.GET, RequestMethod.POST}) // Compliant - explicit methods
   String delete(@RequestParam("id") String id) {
     return "Hello from delete";
   }
@@ -47,7 +46,7 @@ public class SpringRequestMappingMethodCheckSample {
     return "unsafe";
   }
 
-  @RequestMapping(path = "/all", method = { // Noncompliant
+  @RequestMapping(path = "/all", method = { // Compliant - explicit methods
     RequestMethod.GET, RequestMethod.HEAD, RequestMethod.OPTIONS, RequestMethod.TRACE,
     RequestMethod.DELETE, RequestMethod.PATCH, RequestMethod.POST, RequestMethod.PUT
   })
@@ -64,17 +63,17 @@ public class SpringRequestMappingMethodCheckSample {
       return "Hello from get";
     }
 
-    @RequestMapping(value = "/post", method = RequestMethod.POST) // Noncompliant
+    @RequestMapping(value = "/post", method = RequestMethod.POST) // Compliant - explicit methods
     String post() {
       return "Hello from post";
     }
 
-    @RequestMapping(value = "/put", method = RequestMethod.PUT) // Noncompliant
+    @RequestMapping(value = "/put", method = RequestMethod.PUT) // Compliant - explicit methods
     String put() {
       return "Hello from put";
     }
 
-    @RequestMapping(value = "/delete", method = RequestMethod.DELETE) // Noncompliant
+    @RequestMapping(value = "/delete", method = RequestMethod.DELETE) // Compliant - explicit methods
     String delete() {
       return "Hello from delete";
     }
@@ -83,12 +82,12 @@ public class SpringRequestMappingMethodCheckSample {
   @RestController
   @RequestMapping(path = "/update", method = RequestMethod.POST)
   public static class UpdateController {
-    @RequestMapping(value = "/", method = RequestMethod.GET) // Noncompliant
+    @RequestMapping(value = "/", method = RequestMethod.GET) // Compliant - explicit methods
     String get() {
       return "Hello from get";
     }
 
-    @RequestMapping(value = "/head", method = RequestMethod.HEAD) // Noncompliant
+    @RequestMapping(value = "/head", method = RequestMethod.HEAD) // Compliant - explicit methods
     String head() {
       return "Hello from head";
     }
@@ -128,7 +127,7 @@ public class SpringRequestMappingMethodCheckSample {
 
   public static class DummyFoo implements Dummy {
 
-    @RequestMapping(path = "/other") // Noncompliant
+    @RequestMapping(path = "/other") // Noncompliant {{Do not use @RequestMapping without specifying the allowed HTTP methods.}}
     String get() {
       return "Hello from get";
     }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
@@ -1,5 +1,6 @@
 package checks.spring;
 
+import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -130,6 +131,15 @@ public class SpringRequestMappingMethodCheckSample {
     @RequestMapping(path = "/other") // Noncompliant {{Do not use @RequestMapping without specifying the allowed HTTP methods.}}
     String get() {
       return "Hello from get";
+    }
+  }
+
+  @RestController
+  public static class CustomErrorController implements ErrorController {
+
+    @RequestMapping("/error") // Compliant - ErrorController implementations are excluded
+    String error() {
+      return "error";
     }
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
@@ -136,6 +136,11 @@ public class SpringRequestMappingMethodCheckSample {
 
   @RestController
   public static class CustomErrorController implements ErrorController {
+    
+    @Override
+    public String getErrorPath() {
+      return "/error";
+    }
 
     @RequestMapping("/error") // Compliant - ErrorController implementations are excluded
     String error() {

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringRequestMappingMethodCheckSample.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/home")
 public class SpringRequestMappingMethodCheckSample {
 
-  @RequestMapping("/") // Noncompliant {{Do not use @RequestMapping without specifying the allowed HTTP methods.}}
+  @RequestMapping("/") // Noncompliant {{Explicitly specify the HTTP methods this endpoint accepts.}}
 // ^^^^^^^^^^^^^^
   String home() {
     return "Hello from get";
@@ -128,7 +128,7 @@ public class SpringRequestMappingMethodCheckSample {
 
   public static class DummyFoo implements Dummy {
 
-    @RequestMapping(path = "/other") // Noncompliant {{Do not use @RequestMapping without specifying the allowed HTTP methods.}}
+    @RequestMapping(path = "/other") // Noncompliant {{Explicitly specify the HTTP methods this endpoint accepts.}}
     String get() {
       return "Hello from get";
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringRequestMappingMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringRequestMappingMethodCheck.java
@@ -16,12 +16,9 @@
  */
 package org.sonar.java.checks.spring;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Symbol;
@@ -29,7 +26,6 @@ import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
@@ -43,12 +39,7 @@ public class SpringRequestMappingMethodCheck extends IssuableSubscriptionVisitor
   private static final String REQUEST_MAPPING_CLASS = "org.springframework.web.bind.annotation.RequestMapping";
 
   private static final String REQUEST_METHOD = "method";
-  public static final String MESSAGE = "Make sure allowing safe and unsafe HTTP methods is safe here.";
-
-  private boolean classHasSafeMethods;
-  private boolean classHasUnsafeMethods;
-  private boolean methodHasSafeMethods;
-  private boolean methodHasUnsafeMethods;
+  public static final String MESSAGE = "Do not use @RequestMapping without specifying the allowed HTTP methods.";
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -58,34 +49,17 @@ public class SpringRequestMappingMethodCheck extends IssuableSubscriptionVisitor
   @Override
   public void visitNode(Tree tree) {
     ClassTree classTree = (ClassTree) tree;
-    resetFlags();
-    findRequestMappingAnnotation(classTree.modifiers())
-      .flatMap(SpringRequestMappingMethodCheck::findRequestMethods)
-      .filter(this::mixesSafeAndUnsafeMethodsOnClass)
-      .ifPresent(methods -> reportIssue(methods, MESSAGE));
     classTree.members().stream()
       .filter(member -> member.is(Tree.Kind.METHOD))
       .forEach(member -> checkMethod((MethodTree) member, classTree.symbol()));
   }
 
   private void checkMethod(MethodTree method, Symbol.TypeSymbol classSymbol) {
-    Optional<AnnotationTree> requestMappingAnnotation = findRequestMappingAnnotation(method.modifiers());
-    Optional<ExpressionTree> requestMethods = requestMappingAnnotation
-      .flatMap(SpringRequestMappingMethodCheck::findRequestMethods);
-
-    if (requestMethods.isPresent()) {
-      Optional<ExpressionTree> expressionTree = requestMethods
-        .filter(this::mixesSafeAndUnsafeMethodsOnMethod);
-      if (expressionTree.isPresent()) {
-        reportIssue(expressionTree.get(), MESSAGE);
-      } else {
-        if ((classHasSafeMethods && methodHasUnsafeMethods) || (classHasUnsafeMethods && methodHasSafeMethods)) {
-          reportIssue(requestMethods.get(), MESSAGE);
-        }
+    findRequestMappingAnnotation(method.modifiers()).ifPresent(annotation -> {
+      if (findRequestMethods(annotation).isEmpty() && !inheritRequestMethod(classSymbol)) {
+        reportIssue(annotation.annotationType(), MESSAGE);
       }
-    } else if (requestMappingAnnotation.isPresent() && !inheritRequestMethod(classSymbol)) {
-      reportIssue(requestMappingAnnotation.get().annotationType(), MESSAGE);
-    }
+    });
   }
 
   private static Optional<AnnotationTree> findRequestMappingAnnotation(ModifiersTree modifiers) {
@@ -118,43 +92,6 @@ public class SpringRequestMappingMethodCheck extends IssuableSubscriptionVisitor
       }
     }
     return false;
-  }
-
-  private boolean mixesSafeAndUnsafeMethodsOnClass(ExpressionTree requestMethodsAssignment) {
-    HttpMethodVisitor visitor = new HttpMethodVisitor();
-    requestMethodsAssignment.accept(visitor);
-    classHasSafeMethods = visitor.hasSafeMethods;
-    classHasUnsafeMethods = visitor.hasUnsafeMethods;
-    return visitor.hasSafeMethods && visitor.hasUnsafeMethods;
-  }
-
-  private boolean mixesSafeAndUnsafeMethodsOnMethod(ExpressionTree requestMethodsAssignment) {
-    HttpMethodVisitor visitor = new HttpMethodVisitor();
-    requestMethodsAssignment.accept(visitor);
-    methodHasSafeMethods = visitor.hasSafeMethods;
-    methodHasUnsafeMethods = visitor.hasUnsafeMethods;
-    return visitor.hasSafeMethods && visitor.hasUnsafeMethods;
-  }
-
-  private void resetFlags() {
-    classHasSafeMethods = false;
-    classHasUnsafeMethods = false;
-    methodHasSafeMethods = false;
-    methodHasUnsafeMethods = false;
-  }
-
-  private static class HttpMethodVisitor extends BaseTreeVisitor {
-    private static final Set<String> SAFE_METHODS = new HashSet<>(Arrays.asList("GET", "HEAD", "OPTIONS", "TRACE"));
-    private static final Set<String> UNSAFE_METHODS = new HashSet<>(Arrays.asList("DELETE", "PATCH", "POST", "PUT"));
-
-    private boolean hasSafeMethods = false;
-    private boolean hasUnsafeMethods = false;
-
-    @Override
-    public void visitIdentifier(IdentifierTree tree) {
-      hasSafeMethods |= SAFE_METHODS.contains(tree.name());
-      hasUnsafeMethods |= UNSAFE_METHODS.contains(tree.name());
-    }
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringRequestMappingMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringRequestMappingMethodCheck.java
@@ -37,6 +37,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 public class SpringRequestMappingMethodCheck extends IssuableSubscriptionVisitor {
 
   private static final String REQUEST_MAPPING_CLASS = "org.springframework.web.bind.annotation.RequestMapping";
+  private static final String ERROR_CONTROLLER_CLASS = "org.springframework.boot.web.servlet.error.ErrorController";
 
   private static final String REQUEST_METHOD = "method";
   public static final String MESSAGE = "Do not use @RequestMapping without specifying the allowed HTTP methods.";
@@ -49,6 +50,9 @@ public class SpringRequestMappingMethodCheck extends IssuableSubscriptionVisitor
   @Override
   public void visitNode(Tree tree) {
     ClassTree classTree = (ClassTree) tree;
+    if (classTree.symbol().type().isSubtypeOf(ERROR_CONTROLLER_CLASS)) {
+      return;
+    }
     classTree.members().stream()
       .filter(member -> member.is(Tree.Kind.METHOD))
       .forEach(member -> checkMethod((MethodTree) member, classTree.symbol()));

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringRequestMappingMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringRequestMappingMethodCheck.java
@@ -40,7 +40,7 @@ public class SpringRequestMappingMethodCheck extends IssuableSubscriptionVisitor
   private static final String ERROR_CONTROLLER_CLASS = "org.springframework.boot.web.servlet.error.ErrorController";
 
   private static final String REQUEST_METHOD = "method";
-  public static final String MESSAGE = "Do not use @RequestMapping without specifying the allowed HTTP methods.";
+  public static final String MESSAGE = "Explicitly specify the HTTP methods this endpoint accepts.";
 
   @Override
   public List<Tree.Kind> nodesToVisit() {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S3752.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S3752.html
@@ -1,51 +1,49 @@
-<p>An HTTP method is safe when used to perform a read-only operation, such as retrieving information. In contrast, an unsafe HTTP method is used to
-change the state of an application, for instance to update a user’s profile on a web application.</p>
-<p>Common safe HTTP methods are GET, HEAD, or OPTIONS.</p>
-<p>Common unsafe HTTP methods are POST, PUT and DELETE.</p>
-<p>Allowing both safe and unsafe HTTP methods to perform a specific operation on a web application could impact its security, for example CSRF
-protections are most of the time only protecting operations performed by unsafe HTTP methods.</p>
-<h2>Ask Yourself Whether</h2>
+<p>HTTP routes that do not explicitly restrict which HTTP methods are allowed accept both safe (read-only) and unsafe (state-changing) methods, which
+can expose the application to CSRF attacks.</p>
+<h2>Why is this an issue?</h2>
+<p>HTTP methods are divided into safe methods (GET, HEAD, OPTIONS), which are intended for read-only operations, and unsafe methods (POST, PUT,
+DELETE), which are intended for state-changing operations. When a route does not restrict which methods it accepts, an attacker can trigger
+state-changing behavior through a safe method such as GET. CSRF protections typically only apply to unsafe methods, so a route that accepts both can
+be exploited via a crafted link or image tag without requiring the attacker to bypass CSRF defenses.</p>
+<h3>What is the potential impact?</h3>
+<h4>Cross-Site Request Forgery</h4>
+<p>An attacker can craft a malicious link or page that causes a victim’s browser to issue a state-changing HTTP request to the vulnerable route.
+Because the request originates from the victim’s authenticated session, the server processes it as legitimate, allowing the attacker to perform
+actions such as deleting records, changing account settings, or initiating transactions on behalf of the victim.</p>
+<h2>How to fix it in Spring</h2>
+<h3>Code examples</h3>
+<p>The following noncompliant example shows a route that applies no method restriction, allowing any HTTP verb to trigger state-changing behavior.
+Each compliant example restricts the route to only the methods appropriate for its purpose.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@RequestMapping("/delete_user")  // Noncompliant: by default all HTTP methods are allowed
+public String delete1(String username) {
+// state of the application will be changed here
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@RequestMapping("/delete_user", method = RequestMethod.POST)
+public String delete1(String username) {
+// state of the application will be changed here
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
 <ul>
-  <li>HTTP methods are not defined at all for a route/controller of the application.</li>
-  <li>Safe HTTP methods are defined and used for a route/controller that can change the state of an application.</li>
+  <li><a href="https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/csrf.html#csrf-use-proper-verbs">Spring Security</a> - Use proper
+  HTTP verbs (CSRF protection)</li>
 </ul>
-<p>There is a risk if you answered yes to any of those questions.</p>
-<h2>Recommended Secure Coding Practices</h2>
-<p>For all the routes/controllers of an application, the authorized HTTP methods should be explicitly defined and safe HTTP methods should only be
-used to perform read-only operations.</p>
-<h2>Sensitive Code Example</h2>
-<pre>
-@RequestMapping("/delete_user")  // Sensitive: by default all HTTP methods are allowed
-public String delete1(String username) {
-// state of the application will be changed here
-}
-
-@RequestMapping(path = "/delete_user", method = {RequestMethod.GET, RequestMethod.POST}) // Sensitive: both safe and unsafe methods are allowed
-String delete2(@RequestParam("id") String id) {
-// state of the application will be changed here
-}
-</pre>
-<h2>Compliant Solution</h2>
-<pre>
-@RequestMapping("/delete_user", method = RequestMethod.POST)  // Compliant
-public String delete1(String username) {
-// state of the application will be changed here
-}
-
-@RequestMapping(path = "/delete_user", method = RequestMethod.POST) // Compliant
-String delete2(@RequestParam("id") String id) {
-// state of the application will be changed here
-}
-</pre>
-<h2>See</h2>
+<h3>Articles &amp; blog posts</h3>
+<ul>
+  <li><a href="https://owasp.org/www-community/attacks/csrf">OWASP</a> - Cross-Site Request Forgery</li>
+</ul>
+<h3>Standards</h3>
 <ul>
   <li>OWASP - <a href="https://owasp.org/Top10/A01_2021-Broken_Access_Control/">Top 10 2021 Category A1 - Broken Access Control</a></li>
   <li>OWASP - <a href="https://owasp.org/Top10/A04_2021-Insecure_Design/">Top 10 2021 Category A4 - Insecure Design</a></li>
   <li>OWASP - <a href="https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control">Top 10 2017 Category A5 - Broken Access
   Control</a></li>
   <li>CWE - <a href="https://cwe.mitre.org/data/definitions/352">CWE-352 - Cross-Site Request Forgery (CSRF)</a></li>
-  <li><a href="https://owasp.org/www-community/attacks/csrf">OWASP: Cross-Site Request Forgery</a></li>
-  <li><a href="https://docs.spring.io/spring-security/site/docs/5.0.x/reference/html/csrf.html#csrf-use-proper-verbs">Spring Security Official
-  Documentation: Use proper HTTP verbs (CSRF protection)</a></li>
 </ul>
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S3752.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S3752.json
@@ -1,6 +1,6 @@
 {
-  "title": "Allowing both safe and unsafe HTTP methods is security-sensitive",
-  "type": "SECURITY_HOTSPOT",
+  "title": "HTTP routes should restrict allowed HTTP methods",
+  "type": "VULNERABILITY",
   "code": {
     "impacts": {
       "SECURITY": "LOW"
@@ -8,13 +8,15 @@
     "attribute": "COMPLETE"
   },
   "status": "ready",
+  "quickfix": "unknown",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "5min"
   },
   "tags": [
     "cwe",
-    "spring"
+    "spring",
+    "former-hotspot"
   ],
   "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-3752",
@@ -41,6 +43,5 @@
       "13.2.3",
       "4.2.2"
     ]
-  },
-  "quickfix": "unknown"
+  }
 }


### PR DESCRIPTION
We are converting this rule to a vulnerability. To make sure that this rule brings the most value, we decided to stop raising when HTTP verbs are explicitly allowed and only raise when implicitly all verbs are allowed for an endpoint.