### PR TITLE
SONARJAVA-6378 Update tomcat-embed-jasper to 9.0.118

### DIFF
--- a/java-jsp/pom.xml
+++ b/java-jsp/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-jasper</artifactId>
-      <version>9.0.112</version>
+      <version>9.0.118</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jdt</groupId>


### PR DESCRIPTION
## Summary
- Bumps `org.apache.tomcat.embed:tomcat-embed-jasper` in `java-jsp` from `9.0.112` to `9.0.118` (patch-level only, staying on the 9.0.x line).
- Picks up the latest cumulative fixes from Apache Tomcat 9.0.x.

## Test plan
- [ ] CI build passes
- [ ] `java-jsp` module compiles and tests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)