### PR TITLE
SONARJAVA-6389 Implement a quickfix for rule S8694

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckImportSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckImportSample.java
@@ -1,0 +1,12 @@
+package checks;
+
+import java.time.LocalDate;
+
+public class DateEnumsCheckImportSample {
+  LocalDate date = LocalDate.of(2024, 1, 15);// Noncompliant [[quickfixes=qf1]]
+  // fix@qf1 {{Replace with Month.JANUARY.}}
+  // edit@qf1 [[sl=6;sc=39;el=6;ec=40]]{{Month.JANUARY}}
+  // edit@qf1 [[sl=3;sc=28;el=3;ec=28]]{{\nimport java.time.Month;}}
+
+}
+

--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
@@ -26,12 +26,12 @@ public class DateEnumsCheckSample {
     //                                ^
     MonthDay md = MonthDay.of(2, 16); // Noncompliant
     //                        ^
-    MonthDay monthDay = MonthDay.of(+2, 16); // Noncompliant
-    LocalDate ld = LocalDate.of(2024, -1, 15); // Noncompliant
+    MonthDay monthDay = MonthDay.of(+2, 16); // Compliant; ignored by the rule to keep it simple
+    LocalDate ld = LocalDate.of(2024, -1, 15); // Compliant; ignored by the rule to keep it simple
     DayOfWeek day = DayOfWeek.of(2); // Noncompliant {{Use a "java.time.DayOfWeek" enum constant instead of this int literal.}}
     Month month = Month.of(10); // Noncompliant {{Use a "java.time.Month" enum constant instead of this int literal.}}
-    DayOfWeek parenthesized = DayOfWeek.of((-3)); // Noncompliant {{Use a "java.time.DayOfWeek" enum constant instead of this int literal.}}
-    DayOfWeek parenthesizedOutside = DayOfWeek.of(-(3)); // Noncompliant {{Use a "java.time.DayOfWeek" enum constant instead of this int literal.}}
+    DayOfWeek parenthesized = DayOfWeek.of((-3)); // Compliant; ignored by the rule to keep it simple
+    DayOfWeek parenthesizedOutside = DayOfWeek.of(-(3)); // Compliant; ignored by the rule to keep it simple
   }
 
   void compliantDateCreation(int monthNumber) {
@@ -67,5 +67,42 @@ public class DateEnumsCheckSample {
     return day == DayOfWeek.THURSDAY;
   }
 
+
+  void quickfixDateCreation() {
+    LocalDate date = LocalDate.of(2024, 1, 15); // Noncompliant [[quickfixes=qf1]]
+    // fix@qf1 {{Replace with Month.JANUARY.}}
+    // edit@qf1 [[sc=41;ec=42]]{{Month.JANUARY}}
+
+    LocalDateTime dateTime = LocalDateTime.of(2024, 10, 15, 1, 20); // Noncompliant [[quickfixes=qf2]]
+    // fix@qf2 {{Replace with Month.OCTOBER.}}
+    // edit@qf2 [[sc=53;ec=55]]{{Month.OCTOBER}}
+
+    MonthDay monthDay = MonthDay.of(2, 16); // Noncompliant [[quickfixes=qf3]]
+    // fix@qf3 {{Replace with Month.FEBRUARY.}}
+    // edit@qf3 [[sc=37;ec=38]]{{Month.FEBRUARY}}
+
+    DayOfWeek day = DayOfWeek.of(2); // Noncompliant [[quickfixes=qf4]]
+    // fix@qf4 {{Replace with DayOfWeek.TUESDAY.}}
+    // edit@qf4 [[sc=34;ec=35]]{{DayOfWeek.TUESDAY}}
+
+    Month month = Month.of(12); // Noncompliant [[quickfixes=qf5]]
+    // fix@qf5 {{Replace with Month.DECEMBER.}}
+    // edit@qf5 [[sc=28;ec=30]]{{Month.DECEMBER}}
+  }
+
+  void quickfixDateManipulation(LocalDate date, DayOfWeek day, Month month) {
+    if (date.getMonthValue() == 9) { // Noncompliant [[quickfixes=qf6]]
+      // fix@qf6 {{Replace with date.getMonth() == Month.SEPTEMBER.}}
+      // edit@qf6 [[sc=9;ec=34]]{{date.getMonth() == Month.SEPTEMBER}}
+    }
+    if (day.getValue() != 3) { // Noncompliant [[quickfixes=qf7]]
+      // fix@qf7 {{Replace with day != DayOfWeek.WEDNESDAY.}}
+      // edit@qf7 [[sc=9;ec=28]]{{day != DayOfWeek.WEDNESDAY}}
+    }
+    if (3 == month.getValue()) { // Noncompliant [[quickfixes=qf8]]
+      // fix@qf8 {{Replace with Month.MARCH == month.}}
+      // edit@qf8 [[sc=9;ec=30]]{{Month.MARCH == month}}
+    }
+  }
 
 }

--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
@@ -103,6 +103,9 @@ public class DateEnumsCheckSample {
       // fix@qf8 {{Replace with Month.MARCH == month.}}
       // edit@qf8 [[sc=9;ec=30]]{{Month.MARCH == month}}
     }
+    boolean isSeptember = (LocalDate.now().getMonthValue() == 9); // Noncompliant [[quickfixes=qf9]]
+      // fix@qf9 {{Replace with LocalDate.now().getMonth() == Month.SEPTEMBER.}}
+      // edit@qf9 [[sc=27;ec=63]]{{LocalDate.now().getMonth() == Month.SEPTEMBER}}
   }
 
 }

--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
@@ -1,6 +1,7 @@
 package checks;
 
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -18,10 +19,6 @@ public class DateEnumsCheckSample {
     //                                  ^
     LocalDateTime dateTime = LocalDateTime.of(2024, 10, 15, 1, 20); // Noncompliant {{Use a "java.time.Month" enum constant instead of this int literal.}}
     //                                              ^^
-    OffsetDateTime offsetDateTime = OffsetDateTime.of(2025, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC); // Noncompliant
-    //                                                      ^
-    ZonedDateTime zdt = ZonedDateTime.of(2026, 12, 21, 3, 33, 33, 4, ZoneId.of("Europe/Paris")); // Noncompliant
-    //                                         ^^
     YearMonth ym = YearMonth.of(2025, 3); // Noncompliant
     //                                ^
     MonthDay md = MonthDay.of(2, 16); // Noncompliant
@@ -30,15 +27,18 @@ public class DateEnumsCheckSample {
     LocalDate ld = LocalDate.of(2024, -1, 15); // Compliant; ignored by the rule to keep it simple
     DayOfWeek day = DayOfWeek.of(2); // Noncompliant {{Use a "java.time.DayOfWeek" enum constant instead of this int literal.}}
     Month month = Month.of(10); // Noncompliant {{Use a "java.time.Month" enum constant instead of this int literal.}}
-    DayOfWeek parenthesized = DayOfWeek.of((-3)); // Compliant; ignored by the rule to keep it simple
-    DayOfWeek parenthesizedOutside = DayOfWeek.of(-(3)); // Compliant; ignored by the rule to keep it simple
   }
 
   void compliantDateCreation(int monthNumber) {
     LocalDate date = LocalDate.of(2024, Month.JANUARY, 15);
     LocalDateTime dateTime = LocalDateTime.of(2024, Month.DECEMBER, 25, 10, 30);
     YearMonth yearMonth = YearMonth.of(2024, Month.JUNE);
+    MonthDay monthDay = MonthDay.of(Month.FEBRUARY, 16);
     LocalDateTime dateTimeWithVariable = LocalDateTime.of(2024, monthNumber, 25, 10, 30);
+    OffsetDateTime offsetDateTime = OffsetDateTime.of(2025, 1, 1, 1, 1, 1, 1, ZoneOffset.UTC); // Compliant; no "of" method available with a Month enum
+    ZonedDateTime zdt = ZonedDateTime.of(2026, 12, 21, 3, 33, 33, 4, ZoneId.of("Europe/Paris")); // Compliant; no "of" method available with a Month enum
+    DayOfWeek parenthesized = DayOfWeek.of((-3)); // Compliant; ignored by the rule to keep it simple
+    DayOfWeek parenthesizedOutside = DayOfWeek.of(-(3)); // Compliant; ignored by the rule to keep it simple
   }
 
   boolean noncompliantDateManipulation(LocalDate date, DayOfWeek day, Month month) {
@@ -83,11 +83,11 @@ public class DateEnumsCheckSample {
 
     DayOfWeek day = DayOfWeek.of(2); // Noncompliant [[quickfixes=qf4]]
     // fix@qf4 {{Replace with DayOfWeek.TUESDAY.}}
-    // edit@qf4 [[sc=34;ec=35]]{{DayOfWeek.TUESDAY}}
+    // edit@qf4 [[sc=21;ec=36]]{{DayOfWeek.TUESDAY}}
 
     Month month = Month.of(12); // Noncompliant [[quickfixes=qf5]]
     // fix@qf5 {{Replace with Month.DECEMBER.}}
-    // edit@qf5 [[sc=28;ec=30]]{{Month.DECEMBER}}
+    // edit@qf5 [[sc=19;ec=31]]{{Month.DECEMBER}}
   }
 
   void quickfixDateManipulation(LocalDate date, DayOfWeek day, Month month) {

--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
@@ -27,6 +27,7 @@ public class DateEnumsCheckSample {
     LocalDate ld = LocalDate.of(2024, -1, 15); // Compliant; ignored by the rule to keep it simple
     DayOfWeek day = DayOfWeek.of(2); // Noncompliant {{Use a "java.time.DayOfWeek" enum constant instead of this int literal.}}
     Month month = Month.of(10); // Noncompliant {{Use a "java.time.Month" enum constant instead of this int literal.}}
+    //            ^^^^^^^^^^^^
   }
 
   void compliantDateCreation(int monthNumber) {
@@ -86,6 +87,7 @@ public class DateEnumsCheckSample {
     // edit@qf4 [[sc=21;ec=36]]{{DayOfWeek.TUESDAY}}
 
     Month month = Month.of(12); // Noncompliant [[quickfixes=qf5]]
+    int i = month.getValue();
     // fix@qf5 {{Replace with Month.DECEMBER.}}
     // edit@qf5 [[sc=19;ec=31]]{{Month.DECEMBER}}
   }

--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
@@ -1,7 +1,6 @@
 package checks;
 
 import java.time.DayOfWeek;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;

--- a/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DateEnumsCheckSample.java
@@ -104,8 +104,8 @@ public class DateEnumsCheckSample {
       // edit@qf8 [[sc=9;ec=30]]{{Month.MARCH == month}}
     }
     boolean isSeptember = (LocalDate.now().getMonthValue() == 9); // Noncompliant [[quickfixes=qf9]]
-      // fix@qf9 {{Replace with LocalDate.now().getMonth() == Month.SEPTEMBER.}}
-      // edit@qf9 [[sc=27;ec=63]]{{LocalDate.now().getMonth() == Month.SEPTEMBER}}
+    // fix@qf9 {{Replace with LocalDate.now().getMonth() == Month.SEPTEMBER.}}
+    // edit@qf9 [[sc=28;ec=64]]{{LocalDate.now().getMonth() == Month.SEPTEMBER}}
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -168,10 +168,10 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     return "Month." + monthNames[month - 1];
   }
 
-  private static String getDayOfWeekEnumName(int month) {
+  private static String getDayOfWeekEnumName(int day) {
     String[] dayOfWeekNames = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY",
       "SUNDAY"};
-    return "DayOfWeek." + dayOfWeekNames[month - 1];
+    return "DayOfWeek." + dayOfWeekNames[day - 1];
   }
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -192,18 +192,18 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       ExpressionTree rightOperand = binaryExpressionTree.rightOperand();
       // Check if left is method call and right is literal
       if (leftOperand instanceof MethodInvocationTree mit) {
-        checkComparison(binaryExpressionTree, mit, rightOperand);
+        checkComparison(binaryExpressionTree, mit, rightOperand, false);
         return;
       }
       // Check if right is method call and left is literal
       if (rightOperand instanceof MethodInvocationTree mit) {
-        checkComparison(binaryExpressionTree, mit, leftOperand);
+        checkComparison(binaryExpressionTree, mit, leftOperand, true);
       }
     }
   }
 
   private void checkComparison(BinaryExpressionTree binaryExpressionTree,
-    MethodInvocationTree methodInvocationSide, ExpressionTree literalSide) {
+    MethodInvocationTree methodInvocationSide, ExpressionTree literalSide, boolean isReversed) {
     int intLiteral = getIntLiteral(literalSide);
     if (intLiteral != -1) {
       if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide)) {
@@ -212,7 +212,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
           .onTree(binaryExpressionTree)
           .withMessage(MONTH_ISSUE_MESSAGE)
           .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
-            getMonthValueReplacement(methodInvocationSide, binaryExpressionTree, intLiteral)))
+            getMonthValueReplacement(methodInvocationSide, binaryExpressionTree, intLiteral, isReversed)))
           .report();
         return;
       }
@@ -222,7 +222,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
           .onTree(binaryExpressionTree)
           .withMessage(MONTH_ISSUE_MESSAGE)
           .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
-            getValueReplacement(methodInvocationSide, binaryExpressionTree, getMonthEnumName(intLiteral))))
+            getValueReplacement(methodInvocationSide, binaryExpressionTree, getMonthEnumName(intLiteral), isReversed)))
           .report();
         return;
       }
@@ -232,20 +232,25 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
           .onTree(binaryExpressionTree)
           .withMessage(DAY_ISSUE_MESSAGE)
           .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
-            getValueReplacement(methodInvocationSide, binaryExpressionTree, getDayOfWeekEnumName(intLiteral))))
+            getValueReplacement(methodInvocationSide, binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed)))
           .report();
       }
     }
   }
 
-  private String getMonthValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, int literal) {
+  private String getMonthValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, int literal, boolean isReversed) {
     String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
-    return variableName + ".getMonth() " + binaryExpressionTree.operatorToken().text() + " " + getMonthEnumName(literal);
+    String enumName = getMonthEnumName(literal);
+    String comparisonOperator = binaryExpressionTree.operatorToken().text();
+    return isReversed ? enumName + " " + comparisonOperator + " " + variableName + ".getMonth()"
+      : variableName + ".getMonth() " + comparisonOperator + " " + enumName;
   }
 
-  private String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName) {
+  private String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName, boolean  isReversed) {
     String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
-    return variableName + " " + binaryExpressionTree.operatorToken().text() + " " + enumName;
+    String comparisonOperator = binaryExpressionTree.operatorToken().text();
+    return isReversed ? enumName + " " + comparisonOperator + " " + variableName
+      : variableName + " " + comparisonOperator + " " + enumName;
   }
 
   private int getIntLiteral(ExpressionTree arg) {

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -18,9 +18,11 @@ package org.sonar.java.checks;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
+import org.sonar.java.model.LiteralUtils;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.JavaVersion;
@@ -247,12 +249,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
 
   private static int getIntLiteral(ExpressionTree arg) {
     if (arg.is(Tree.Kind.INT_LITERAL)) {
-      String literalValue = ((LiteralTree) arg).value();
-      try {
-        return Integer.parseInt(literalValue);
-      } catch (NumberFormatException e) {
-        return -1;
-      }
+      return Objects.requireNonNull(LiteralUtils.intLiteralValue(arg));
     }
     return -1;
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -198,15 +198,18 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     int intLiteral = getIntLiteral(literalSide);
     if (intLiteral != -1) {
       if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide) && isValidMonth(intLiteral)) {
-        reportAndCreateQuickfix(binaryExpressionTree, getMonthValueReplacement(methodInvocationSide, binaryExpressionTree, intLiteral, isReversed), MONTH_ISSUE_MESSAGE);
+        reportAndCreateQuickfix(binaryExpressionTree, getMonthValueReplacement(methodInvocationSide,
+          binaryExpressionTree, intLiteral, isReversed), MONTH_ISSUE_MESSAGE);
         return;
       }
       if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidMonth(intLiteral)) {
-        reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide, binaryExpressionTree, getMonthEnumName(intLiteral), isReversed), MONTH_ISSUE_MESSAGE);
+        reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide,
+          binaryExpressionTree, getMonthEnumName(intLiteral), isReversed), MONTH_ISSUE_MESSAGE);
         return;
       }
       if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidDay(intLiteral)) {
-        reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide, binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed), DAY_ISSUE_MESSAGE);
+        reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide,
+          binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed), DAY_ISSUE_MESSAGE);
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -22,6 +22,7 @@ import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
 import org.sonar.java.reporting.JavaQuickFix;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.JavaVersionAwareVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
@@ -35,6 +36,8 @@ import org.sonar.java.reporting.JavaTextEdit;
 
 @Rule(key = "S8694")
 public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersionAwareVisitor {
+  private static final String JAVA_TIME_MONTH = "java.time.Month";
+  private static final String JAVA_TIME_DAY_OF_WEEK = "java.time.DayOfWeek";
 
   private static final MethodMatchers METHOD_WITH_MONTH_AS_SECOND_ARGUMENT = MethodMatchers.or(
     MethodMatchers.create()
@@ -62,13 +65,13 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     .build();
 
   private static final MethodMatchers MONTH_OF_MATCHER = MethodMatchers.create()
-    .ofTypes("java.time.Month")
+    .ofTypes(JAVA_TIME_MONTH)
     .names("of")
     .addParametersMatcher("int")
     .build();
 
   private static final MethodMatchers DAY_OF_WEEK_OF_MATCHER = MethodMatchers.create()
-    .ofTypes("java.time.DayOfWeek")
+    .ofTypes(JAVA_TIME_DAY_OF_WEEK)
     .names("of")
     .addParametersMatcher("int")
     .build();
@@ -81,19 +84,32 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     .build();
 
   private static final MethodMatchers MONTH_GET_VALUE_MATCHER = MethodMatchers.create()
-    .ofTypes("java.time.Month")
+    .ofTypes(JAVA_TIME_MONTH)
     .names("getValue")
     .addWithoutParametersMatcher()
     .build();
 
   private static final MethodMatchers DAY_OF_WEEK_GET_VALUE_MATCHER = MethodMatchers.create()
-    .ofTypes("java.time.DayOfWeek")
+    .ofTypes(JAVA_TIME_DAY_OF_WEEK)
     .names("getValue")
     .addWithoutParametersMatcher()
     .build();
 
   private static final String MONTH_ISSUE_MESSAGE = "Use a \"java.time.Month\" enum constant instead of this int literal.";
   private static final String DAY_ISSUE_MESSAGE = "Use a \"java.time.DayOfWeek\" enum constant instead of this int literal.";
+
+  private QuickFixHelper.ImportSupplier importSupplier;
+
+  @Override
+  public void setContext(JavaFileScannerContext context) {
+    super.setContext(context);
+    importSupplier = null;
+  }
+
+  @Override
+  public void leaveFile(JavaFileScannerContext context) {
+    importSupplier = null;
+  }
 
   @Override
   public boolean isCompatibleWithJavaVersion(JavaVersion version) {
@@ -119,7 +135,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       ExpressionTree secondArgument = mit.arguments().get(1);
       int secondArgumentLiteral = getIntLiteral(secondArgument);
       if (isValidMonth(secondArgumentLiteral)) {
-        reportAndCreateQuickfix(secondArgument, getMonthEnumName(secondArgumentLiteral), MONTH_ISSUE_MESSAGE);
+        reportAndCreateQuickfix(secondArgument, getMonthEnumName(secondArgumentLiteral), MONTH_ISSUE_MESSAGE, JAVA_TIME_MONTH);
         return;
       }
     }
@@ -127,33 +143,37 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     int firstArgumentLiteral = getIntLiteral(firstArgument);
     if (DAY_OF_WEEK_OF_MATCHER.matches(mit)
       && isValidDay(firstArgumentLiteral)) {
-      reportAndCreateQuickfix(mit, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE);
+      reportAndCreateQuickfix(mit, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE, JAVA_TIME_DAY_OF_WEEK);
       return;
     }
     if (MONTH_OF_MATCHER.matches(mit)
       && isValidMonth(firstArgumentLiteral)) {
-      reportAndCreateQuickfix(mit, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
+      reportAndCreateQuickfix(mit, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE, JAVA_TIME_MONTH);
       return;
     }
     if (MONTH_DAY_OF_MATCHER.matches(mit)
       && isValidMonth(firstArgumentLiteral)) {
-      reportAndCreateQuickfix(firstArgument, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
+      reportAndCreateQuickfix(firstArgument, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE, JAVA_TIME_MONTH);
     }
   }
 
-  private void reportAndCreateQuickfix(ExpressionTree arg, String replacement, String issueMessage) {
+  private void reportAndCreateQuickfix(ExpressionTree arg, String replacement, String issueMessage, String importName) {
     QuickFixHelper.newIssue(context)
       .forRule(this)
       .onTree(arg)
       .withMessage(issueMessage)
-      .withQuickFix(() -> computeQuickfix(arg, replacement))
+      .withQuickFix(() -> computeQuickfix(arg, replacement, importName))
       .report();
   }
 
-  private static JavaQuickFix computeQuickfix(Tree replacedTree, String replacement) {
-    return JavaQuickFix.newQuickFix(String.format("Replace with %s.", replacement))
-      .addTextEdit(JavaTextEdit.replaceTree(replacedTree, replacement))
-      .build();
+  private JavaQuickFix computeQuickfix(Tree replacedTree, String replacement, String importName) {
+    JavaQuickFix.Builder builder = JavaQuickFix.newQuickFix(String.format("Replace with %s.", replacement))
+      .addTextEdit(JavaTextEdit.replaceTree(replacedTree, replacement));
+    if (importSupplier == null) {
+      importSupplier = QuickFixHelper.newImportSupplier(context);
+    }
+    importSupplier.newImportEdit(importName).ifPresent(builder::addTextEdit);
+    return builder.build();
   }
 
   private static String getMonthEnumName(int month) {
@@ -193,17 +213,17 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     if (intLiteral != -1) {
       if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide) && isValidMonth(intLiteral)) {
         reportAndCreateQuickfix(binaryExpressionTree, getMonthValueReplacement(methodInvocationSide,
-          binaryExpressionTree, intLiteral, isReversed), MONTH_ISSUE_MESSAGE);
+          binaryExpressionTree, intLiteral, isReversed), MONTH_ISSUE_MESSAGE, JAVA_TIME_MONTH);
         return;
       }
       if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide) && isValidMonth(intLiteral)) {
         reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide,
-          binaryExpressionTree, getMonthEnumName(intLiteral), isReversed), MONTH_ISSUE_MESSAGE);
+          binaryExpressionTree, getMonthEnumName(intLiteral), isReversed), MONTH_ISSUE_MESSAGE, JAVA_TIME_MONTH);
         return;
       }
       if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide) && isValidDay(intLiteral)) {
         reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide,
-          binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed), DAY_ISSUE_MESSAGE);
+          binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed), DAY_ISSUE_MESSAGE, JAVA_TIME_DAY_OF_WEEK);
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -18,7 +18,6 @@ package org.sonar.java.checks;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
@@ -206,7 +205,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     MethodInvocationTree methodInvocationSide, ExpressionTree literalSide, boolean isReversed) {
     int intLiteral = getIntLiteral(literalSide);
     if (intLiteral != -1) {
-      if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide)) {
+      if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide) && isValidMonth(intLiteral)) {
         QuickFixHelper.newIssue(context)
           .forRule(this)
           .onTree(binaryExpressionTree)
@@ -216,7 +215,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
           .report();
         return;
       }
-      if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide)) {
+      if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidMonth(intLiteral)) {
         QuickFixHelper.newIssue(context)
           .forRule(this)
           .onTree(binaryExpressionTree)
@@ -226,7 +225,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
           .report();
         return;
       }
-      if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide)) {
+      if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidDay(intLiteral)) {
         QuickFixHelper.newIssue(context)
           .forRule(this)
           .onTree(binaryExpressionTree)
@@ -239,18 +238,20 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
   }
 
   private String getMonthValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, int literal, boolean isReversed) {
-    String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
+    ExpressionTree receiver = ((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression();
+    String receiverText = QuickFixHelper.contentForTree(receiver, context);
     String enumName = getMonthEnumName(literal);
     String comparisonOperator = binaryExpressionTree.operatorToken().text();
-    return isReversed ? (enumName + " " + comparisonOperator + " " + variableName + ".getMonth()")
-      : (variableName + ".getMonth() " + comparisonOperator + " " + enumName);
+    return isReversed ? (enumName + " " + comparisonOperator + " " + receiverText + ".getMonth()")
+      : (receiverText + ".getMonth() " + comparisonOperator + " " + enumName);
   }
 
-  private static String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName, boolean  isReversed) {
-    String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
+  private String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName, boolean isReversed) {
+    ExpressionTree receiver = ((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression();
+    String receiverText = QuickFixHelper.contentForTree(receiver, context);
     String comparisonOperator = binaryExpressionTree.operatorToken().text();
-    return isReversed ? (enumName + " " + comparisonOperator + " " + variableName)
-      : (variableName + " " + comparisonOperator + " " + enumName);
+    return isReversed ? (enumName + " " + comparisonOperator + " " + receiverText)
+      : (receiverText + " " + comparisonOperator + " " + enumName);
   }
 
   private static int getIntLiteral(ExpressionTree arg) {

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -50,32 +50,22 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       .addParametersMatcher("int", "int", "int", "int", "int", "int", "int")
       .build(),
     MethodMatchers.create()
-      .ofTypes("java.time.OffsetDateTime")
-      .names("of")
-      .addParametersMatcher("int", "int", "int", "int", "int", "int", "int", "java.time.ZoneOffset")
-      .build(),
-    MethodMatchers.create()
-      .ofTypes("java.time.ZonedDateTime")
-      .names("of")
-      .addParametersMatcher("int", "int", "int", "int", "int", "int", "int", "java.time.ZoneId")
-      .build(),
-    MethodMatchers.create()
       .ofTypes("java.time.YearMonth")
       .names("of")
       .addParametersMatcher("int", "int")
       .build());
 
-  private static final MethodMatchers METHOD_WITH_MONTH_AS_FIRST_ARGUMENT = MethodMatchers.or(
-    MethodMatchers.create()
-      .ofTypes("java.time.MonthDay")
-      .names("of")
-      .addParametersMatcher("int", "int")
-      .build(),
-    MethodMatchers.create()
-      .ofTypes("java.time.Month")
-      .names("of")
-      .addParametersMatcher("int")
-      .build());
+  private static final MethodMatchers MONTH_DAY_OF_MATCHER = MethodMatchers.create()
+    .ofTypes("java.time.MonthDay")
+    .names("of")
+    .addParametersMatcher("int", "int")
+    .build();
+
+  private static final MethodMatchers MONTH_OF_MATCHER = MethodMatchers.create()
+    .ofTypes("java.time.Month")
+    .names("of")
+    .addParametersMatcher("int")
+    .build();
 
   private static final MethodMatchers DAY_OF_WEEK_OF_MATCHER = MethodMatchers.create()
     .ofTypes("java.time.DayOfWeek")
@@ -84,17 +74,17 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     .build();
 
   private static final MethodMatchers GET_MONTH_VALUE_MATCHER = MethodMatchers.create()
-      .ofTypes("java.time.LocalDate", "java.time.LocalDateTime", "java.time.OffsetDateTime", "java.time.ZonedDateTime",
-        "java.time.YearMonth", "java.time.MonthDay")
-      .names("getMonthValue")
-      .addWithoutParametersMatcher()
-      .build();
+    .ofTypes("java.time.LocalDate", "java.time.LocalDateTime", "java.time.OffsetDateTime", "java.time.ZonedDateTime",
+      "java.time.YearMonth", "java.time.MonthDay")
+    .names("getMonthValue")
+    .addWithoutParametersMatcher()
+    .build();
 
   private static final MethodMatchers MONTH_GET_VALUE_MATCHER = MethodMatchers.create()
-      .ofTypes("java.time.Month")
-      .names("getValue")
-      .addWithoutParametersMatcher()
-      .build();
+    .ofTypes("java.time.Month")
+    .names("getValue")
+    .addWithoutParametersMatcher()
+    .build();
 
   private static final MethodMatchers DAY_OF_WEEK_GET_VALUE_MATCHER = MethodMatchers.create()
     .ofTypes("java.time.DayOfWeek")
@@ -112,7 +102,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
 
   @Override
   protected MethodMatchers getMethodInvocationMatchers() {
-    return MethodMatchers.or(METHOD_WITH_MONTH_AS_SECOND_ARGUMENT, METHOD_WITH_MONTH_AS_FIRST_ARGUMENT, DAY_OF_WEEK_OF_MATCHER);
+    return MethodMatchers.or(METHOD_WITH_MONTH_AS_SECOND_ARGUMENT, MONTH_OF_MATCHER, MONTH_DAY_OF_MATCHER, DAY_OF_WEEK_OF_MATCHER);
   }
 
   @Override
@@ -137,10 +127,15 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     int firstArgumentLiteral = getIntLiteral(firstArgument);
     if (DAY_OF_WEEK_OF_MATCHER.matches(mit)
       && isValidDay(firstArgumentLiteral)) {
-      reportAndCreateQuickfix(firstArgument, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE);
+      reportAndCreateQuickfix(mit, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE);
       return;
     }
-    if (METHOD_WITH_MONTH_AS_FIRST_ARGUMENT.matches(mit)
+    if (MONTH_OF_MATCHER.matches(mit)
+      && isValidMonth(firstArgumentLiteral)) {
+      reportAndCreateQuickfix(mit, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
+      return;
+    }
+    if (MONTH_DAY_OF_MATCHER.matches(mit)
       && isValidMonth(firstArgumentLiteral)) {
       reportAndCreateQuickfix(firstArgument, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
     }
@@ -151,8 +146,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       .forRule(this)
       .onTree(arg)
       .withMessage(issueMessage)
-      .withQuickFix(() -> computeQuickfix(arg,
-        replacement))
+      .withQuickFix(() -> computeQuickfix(arg, replacement))
       .report();
   }
 
@@ -202,12 +196,12 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
           binaryExpressionTree, intLiteral, isReversed), MONTH_ISSUE_MESSAGE);
         return;
       }
-      if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidMonth(intLiteral)) {
+      if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide) && isValidMonth(intLiteral)) {
         reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide,
           binaryExpressionTree, getMonthEnumName(intLiteral), isReversed), MONTH_ISSUE_MESSAGE);
         return;
       }
-      if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidDay(intLiteral)) {
+      if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide) && isValidDay(intLiteral)) {
         reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide,
           binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed), DAY_ISSUE_MESSAGE);
       }
@@ -234,7 +228,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
   private static int getIntLiteral(ExpressionTree arg) {
     if (arg.is(Tree.Kind.INT_LITERAL)) {
       String literalValue = ((LiteralTree) arg).value();
-      try  {
+      try {
         return Integer.parseInt(literalValue);
       } catch (NumberFormatException e) {
         return -1;

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -18,17 +18,23 @@ package org.sonar.java.checks;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
 import org.sonar.java.model.ExpressionUtils;
+import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.JavaVersionAwareVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.java.reporting.JavaTextEdit;
 
 @Rule(key = "S8694")
 public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersionAwareVisitor {
@@ -80,18 +86,18 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     .addParametersMatcher("int")
     .build();
 
-  private static final MethodMatchers METHOD_TO_GET_MONTH_VALUE_AS_INT = MethodMatchers.or(
-    MethodMatchers.create()
+  private static final MethodMatchers GET_MONTH_VALUE_MATCHER = MethodMatchers.create()
       .ofTypes("java.time.LocalDate", "java.time.LocalDateTime", "java.time.OffsetDateTime", "java.time.ZonedDateTime",
         "java.time.YearMonth", "java.time.MonthDay")
       .names("getMonthValue")
       .addWithoutParametersMatcher()
-      .build(),
-    MethodMatchers.create()
+      .build();
+
+  private static final MethodMatchers MONTH_GET_VALUE_MATCHER = MethodMatchers.create()
       .ofTypes("java.time.Month")
       .names("getValue")
       .addWithoutParametersMatcher()
-      .build());
+      .build();
 
   private static final MethodMatchers DAY_OF_WEEK_GET_VALUE_MATCHER = MethodMatchers.create()
     .ofTypes("java.time.DayOfWeek")
@@ -124,21 +130,59 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
   protected void onMethodInvocationFound(MethodInvocationTree mit) {
     if (METHOD_WITH_MONTH_AS_SECOND_ARGUMENT.matches(mit)) {
       ExpressionTree secondArgument = mit.arguments().get(1);
-      if (isIntLiteral(secondArgument)) {
-        reportIssue(secondArgument, MONTH_ISSUE_MESSAGE);
+      int secondArgumentLiteral = getIntLiteral(secondArgument);
+      if (isValidMonth(secondArgumentLiteral)) {
+        QuickFixHelper.newIssue(context)
+          .forRule(this)
+          .onTree(secondArgument)
+          .withMessage(MONTH_ISSUE_MESSAGE)
+          .withQuickFix(() -> computeQuickfix(secondArgument,
+            getMonthEnumName(secondArgumentLiteral)))
+          .report();
         return;
       }
     }
     ExpressionTree firstArgument = mit.arguments().get(0);
+    int firstArgumentLiteral = getIntLiteral(firstArgument);
     if (DAY_OF_WEEK_OF_MATCHER.matches(mit)
-      && isIntLiteral(firstArgument)) {
-      reportIssue(firstArgument, DAY_ISSUE_MESSAGE);
+      && isValidDay(firstArgumentLiteral)) {
+      QuickFixHelper.newIssue(context)
+        .forRule(this)
+        .onTree(firstArgument)
+        .withMessage(DAY_ISSUE_MESSAGE)
+        .withQuickFix(() -> computeQuickfix(firstArgument,
+          getDayOfWeekEnumName(firstArgumentLiteral)))
+        .report();
       return;
     }
     if (METHOD_WITH_MONTH_AS_FIRST_ARGUMENT.matches(mit)
-      && isIntLiteral(firstArgument)) {
-      reportIssue(firstArgument, MONTH_ISSUE_MESSAGE);
+      && isValidMonth(firstArgumentLiteral)) {
+      QuickFixHelper.newIssue(context)
+        .forRule(this)
+        .onTree(firstArgument)
+        .withMessage(MONTH_ISSUE_MESSAGE)
+        .withQuickFix(() -> computeQuickfix(firstArgument,
+          getMonthEnumName(firstArgumentLiteral)))
+        .report();
     }
+  }
+
+  private static JavaQuickFix computeQuickfix(Tree replacedTree, String replacement) {
+    return JavaQuickFix.newQuickFix(String.format("Replace with %s.", replacement))
+      .addTextEdit(JavaTextEdit.replaceTree(replacedTree, replacement))
+      .build();
+  }
+
+  private String getMonthEnumName(int month) {
+    String[] monthNames = {"JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE",
+      "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"};
+    return "Month." + monthNames[month - 1];
+  }
+
+  private String getDayOfWeekEnumName(int month) {
+    String[] dayOfWeekNames = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY",
+      "SUNDAY"};
+    return "DayOfWeek." + dayOfWeekNames[month - 1];
   }
 
   @Override
@@ -160,16 +204,50 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     }
   }
 
-  private void checkComparison(BinaryExpressionTree binaryExpressionTree, MethodInvocationTree methodInvocationSide, ExpressionTree literalSide) {
-    if (isIntLiteral(literalSide)) {
-      if (METHOD_TO_GET_MONTH_VALUE_AS_INT.matches(methodInvocationSide)) {
-        reportIssue(binaryExpressionTree, MONTH_ISSUE_MESSAGE);
+  private void checkComparison(BinaryExpressionTree binaryExpressionTree,
+    MethodInvocationTree methodInvocationSide, ExpressionTree literalSide) {
+    int intLiteral = getIntLiteral(literalSide);
+    if (intLiteral != -1) {
+      if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide)) {
+        QuickFixHelper.newIssue(context)
+          .forRule(this)
+          .onTree(binaryExpressionTree)
+          .withMessage(MONTH_ISSUE_MESSAGE)
+          .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
+            getMonthValueReplacement(methodInvocationSide, binaryExpressionTree, intLiteral)))
+          .report();
+        return;
+      }
+      if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide)) {
+        QuickFixHelper.newIssue(context)
+          .forRule(this)
+          .onTree(binaryExpressionTree)
+          .withMessage(MONTH_ISSUE_MESSAGE)
+          .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
+            getValueReplacement(methodInvocationSide, binaryExpressionTree, getMonthEnumName(intLiteral))))
+          .report();
         return;
       }
       if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide)) {
-        reportIssue(binaryExpressionTree, DAY_ISSUE_MESSAGE);
+        QuickFixHelper.newIssue(context)
+          .forRule(this)
+          .onTree(binaryExpressionTree)
+          .withMessage(DAY_ISSUE_MESSAGE)
+          .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
+            getValueReplacement(methodInvocationSide, binaryExpressionTree, getDayOfWeekEnumName(intLiteral))))
+          .report();
       }
     }
+  }
+
+  private String getMonthValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, int literal) {
+    String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
+    return variableName + ".getMonth() " + binaryExpressionTree.operatorToken().text() + " " + getMonthEnumName(literal);
+  }
+
+  private String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName) {
+    String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
+    return variableName + " " + binaryExpressionTree.operatorToken().text() + " " + enumName;
   }
 
   private static boolean isIntLiteral(ExpressionTree arg) {
@@ -182,5 +260,21 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       return expressionWithoutParentheses.is(Tree.Kind.INT_LITERAL);
     }
     return false;
+  }
+
+  private int getIntLiteral(ExpressionTree arg) {
+    if (arg.is(Tree.Kind.INT_LITERAL)) {
+      String literalValue = ((LiteralTree) arg).value();
+      return Integer.parseInt(literalValue);
+    }
+    return -1;
+  }
+
+  private boolean isValidMonth(int month) {
+    return month >= 1 && month <= 12;
+  }
+
+  private boolean isValidDay(int day) {
+    return day >= 1 && day <= 7;
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.methods.AbstractMethodDetection;
-import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.JavaVersionAwareVisitor;
@@ -32,7 +31,6 @@ import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
-import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.java.reporting.JavaTextEdit;
 
@@ -248,18 +246,6 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
   private String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName) {
     String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
     return variableName + " " + binaryExpressionTree.operatorToken().text() + " " + enumName;
-  }
-
-  private static boolean isIntLiteral(ExpressionTree arg) {
-    ExpressionTree argWithoutParentheses = ExpressionUtils.skipParentheses(arg);
-    if (argWithoutParentheses.is(Tree.Kind.INT_LITERAL)) {
-      return true;
-    }
-    if (argWithoutParentheses.is(Tree.Kind.UNARY_MINUS, Tree.Kind.UNARY_PLUS)) {
-      ExpressionTree expressionWithoutParentheses = ExpressionUtils.skipParentheses(((UnaryExpressionTree) argWithoutParentheses).expression());
-      return expressionWithoutParentheses.is(Tree.Kind.INT_LITERAL);
-    }
-    return false;
   }
 
   private int getIntLiteral(ExpressionTree arg) {

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -129,13 +129,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       ExpressionTree secondArgument = mit.arguments().get(1);
       int secondArgumentLiteral = getIntLiteral(secondArgument);
       if (isValidMonth(secondArgumentLiteral)) {
-        QuickFixHelper.newIssue(context)
-          .forRule(this)
-          .onTree(secondArgument)
-          .withMessage(MONTH_ISSUE_MESSAGE)
-          .withQuickFix(() -> computeQuickfix(secondArgument,
-            getMonthEnumName(secondArgumentLiteral)))
-          .report();
+        reportComparisonIssue(secondArgument, getMonthEnumName(secondArgumentLiteral), MONTH_ISSUE_MESSAGE);
         return;
       }
     }
@@ -143,25 +137,23 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     int firstArgumentLiteral = getIntLiteral(firstArgument);
     if (DAY_OF_WEEK_OF_MATCHER.matches(mit)
       && isValidDay(firstArgumentLiteral)) {
-      QuickFixHelper.newIssue(context)
-        .forRule(this)
-        .onTree(firstArgument)
-        .withMessage(DAY_ISSUE_MESSAGE)
-        .withQuickFix(() -> computeQuickfix(firstArgument,
-          getDayOfWeekEnumName(firstArgumentLiteral)))
-        .report();
+      reportComparisonIssue(firstArgument, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE);
       return;
     }
     if (METHOD_WITH_MONTH_AS_FIRST_ARGUMENT.matches(mit)
       && isValidMonth(firstArgumentLiteral)) {
-      QuickFixHelper.newIssue(context)
-        .forRule(this)
-        .onTree(firstArgument)
-        .withMessage(MONTH_ISSUE_MESSAGE)
-        .withQuickFix(() -> computeQuickfix(firstArgument,
-          getMonthEnumName(firstArgumentLiteral)))
-        .report();
+      reportComparisonIssue(firstArgument, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
     }
+  }
+
+  private void reportComparisonIssue(ExpressionTree arg, String replacement, String issueMessage) {
+    QuickFixHelper.newIssue(context)
+      .forRule(this)
+      .onTree(arg)
+      .withMessage(issueMessage)
+      .withQuickFix(() -> computeQuickfix(arg,
+        replacement))
+      .report();
   }
 
   private static JavaQuickFix computeQuickfix(Tree replacedTree, String replacement) {

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -30,7 +30,6 @@ import org.sonar.plugins.java.api.JavaVersionAwareVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
-import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -231,7 +231,11 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
   private static int getIntLiteral(ExpressionTree arg) {
     if (arg.is(Tree.Kind.INT_LITERAL)) {
       String literalValue = ((LiteralTree) arg).value();
-      return Integer.parseInt(literalValue);
+      try  {
+        return Integer.parseInt(literalValue);
+      } catch (NumberFormatException e) {
+        return -1;
+      }
     }
     return -1;
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -129,7 +129,7 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       ExpressionTree secondArgument = mit.arguments().get(1);
       int secondArgumentLiteral = getIntLiteral(secondArgument);
       if (isValidMonth(secondArgumentLiteral)) {
-        reportComparisonIssue(secondArgument, getMonthEnumName(secondArgumentLiteral), MONTH_ISSUE_MESSAGE);
+        reportAndCreateQuickfix(secondArgument, getMonthEnumName(secondArgumentLiteral), MONTH_ISSUE_MESSAGE);
         return;
       }
     }
@@ -137,16 +137,16 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     int firstArgumentLiteral = getIntLiteral(firstArgument);
     if (DAY_OF_WEEK_OF_MATCHER.matches(mit)
       && isValidDay(firstArgumentLiteral)) {
-      reportComparisonIssue(firstArgument, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE);
+      reportAndCreateQuickfix(firstArgument, getDayOfWeekEnumName(firstArgumentLiteral), DAY_ISSUE_MESSAGE);
       return;
     }
     if (METHOD_WITH_MONTH_AS_FIRST_ARGUMENT.matches(mit)
       && isValidMonth(firstArgumentLiteral)) {
-      reportComparisonIssue(firstArgument, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
+      reportAndCreateQuickfix(firstArgument, getMonthEnumName(firstArgumentLiteral), MONTH_ISSUE_MESSAGE);
     }
   }
 
-  private void reportComparisonIssue(ExpressionTree arg, String replacement, String issueMessage) {
+  private void reportAndCreateQuickfix(ExpressionTree arg, String replacement, String issueMessage) {
     QuickFixHelper.newIssue(context)
       .forRule(this)
       .onTree(arg)

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -198,33 +198,15 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     int intLiteral = getIntLiteral(literalSide);
     if (intLiteral != -1) {
       if (GET_MONTH_VALUE_MATCHER.matches(methodInvocationSide) && isValidMonth(intLiteral)) {
-        QuickFixHelper.newIssue(context)
-          .forRule(this)
-          .onTree(binaryExpressionTree)
-          .withMessage(MONTH_ISSUE_MESSAGE)
-          .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
-            getMonthValueReplacement(methodInvocationSide, binaryExpressionTree, intLiteral, isReversed)))
-          .report();
+        reportAndCreateQuickfix(binaryExpressionTree, getMonthValueReplacement(methodInvocationSide, binaryExpressionTree, intLiteral, isReversed), MONTH_ISSUE_MESSAGE);
         return;
       }
       if (MONTH_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidMonth(intLiteral)) {
-        QuickFixHelper.newIssue(context)
-          .forRule(this)
-          .onTree(binaryExpressionTree)
-          .withMessage(MONTH_ISSUE_MESSAGE)
-          .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
-            getValueReplacement(methodInvocationSide, binaryExpressionTree, getMonthEnumName(intLiteral), isReversed)))
-          .report();
+        reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide, binaryExpressionTree, getMonthEnumName(intLiteral), isReversed), MONTH_ISSUE_MESSAGE);
         return;
       }
       if (DAY_OF_WEEK_GET_VALUE_MATCHER.matches(methodInvocationSide)  && isValidDay(intLiteral)) {
-        QuickFixHelper.newIssue(context)
-          .forRule(this)
-          .onTree(binaryExpressionTree)
-          .withMessage(DAY_ISSUE_MESSAGE)
-          .withQuickFix(() -> computeQuickfix(binaryExpressionTree,
-            getValueReplacement(methodInvocationSide, binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed)))
-          .report();
+        reportAndCreateQuickfix(binaryExpressionTree, getValueReplacement(methodInvocationSide, binaryExpressionTree, getDayOfWeekEnumName(intLiteral), isReversed), DAY_ISSUE_MESSAGE);
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DateEnumsCheck.java
@@ -171,13 +171,13 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
       .build();
   }
 
-  private String getMonthEnumName(int month) {
+  private static String getMonthEnumName(int month) {
     String[] monthNames = {"JANUARY", "FEBRUARY", "MARCH", "APRIL", "MAY", "JUNE",
       "JULY", "AUGUST", "SEPTEMBER", "OCTOBER", "NOVEMBER", "DECEMBER"};
     return "Month." + monthNames[month - 1];
   }
 
-  private String getDayOfWeekEnumName(int month) {
+  private static String getDayOfWeekEnumName(int month) {
     String[] dayOfWeekNames = {"MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY",
       "SUNDAY"};
     return "DayOfWeek." + dayOfWeekNames[month - 1];
@@ -242,18 +242,18 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
     String enumName = getMonthEnumName(literal);
     String comparisonOperator = binaryExpressionTree.operatorToken().text();
-    return isReversed ? enumName + " " + comparisonOperator + " " + variableName + ".getMonth()"
-      : variableName + ".getMonth() " + comparisonOperator + " " + enumName;
+    return isReversed ? (enumName + " " + comparisonOperator + " " + variableName + ".getMonth()")
+      : (variableName + ".getMonth() " + comparisonOperator + " " + enumName);
   }
 
-  private String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName, boolean  isReversed) {
+  private static String getValueReplacement(MethodInvocationTree methodInvocationSide, BinaryExpressionTree binaryExpressionTree, String enumName, boolean  isReversed) {
     String variableName = Objects.requireNonNull(((MemberSelectExpressionTree) methodInvocationSide.methodSelect()).expression().firstToken()).text();
     String comparisonOperator = binaryExpressionTree.operatorToken().text();
-    return isReversed ? enumName + " " + comparisonOperator + " " + variableName
-      : variableName + " " + comparisonOperator + " " + enumName;
+    return isReversed ? (enumName + " " + comparisonOperator + " " + variableName)
+      : (variableName + " " + comparisonOperator + " " + enumName);
   }
 
-  private int getIntLiteral(ExpressionTree arg) {
+  private static int getIntLiteral(ExpressionTree arg) {
     if (arg.is(Tree.Kind.INT_LITERAL)) {
       String literalValue = ((LiteralTree) arg).value();
       return Integer.parseInt(literalValue);
@@ -261,11 +261,11 @@ public class DateEnumsCheck extends AbstractMethodDetection implements JavaVersi
     return -1;
   }
 
-  private boolean isValidMonth(int month) {
+  private static boolean isValidMonth(int month) {
     return month >= 1 && month <= 12;
   }
 
-  private boolean isValidDay(int day) {
+  private static boolean isValidDay(int day) {
     return day >= 1 && day <= 7;
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/DateEnumsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/DateEnumsCheckTest.java
@@ -29,4 +29,12 @@ class DateEnumsCheckTest {
       .withCheck(new DateEnumsCheck())
       .verifyIssues();
   }
+
+  @Test
+  void test_quickfix_import() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/DateEnumsCheckImportSample.java"))
+      .withCheck(new DateEnumsCheck())
+      .verifyIssues();
+  }
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8694.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8694.json
@@ -15,7 +15,7 @@
   "ruleSpecification": "RSPEC-8694",
   "sqKey": "S8694",
   "scope": "All",
-  "quickfix": "targeted",
+  "quickfix": "covered",
   "code": {
     "impacts": {
       "MAINTAINABILITY": "LOW"


### PR DESCRIPTION

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Quickfix implementation for S8694:**
  - Added quickfix to replace int literals with `Month` and `DayOfWeek` enum constants in date/time methods
  - Quickfix automatically adds necessary imports (`java.time.Month`, `java.time.DayOfWeek`) when replacing literals
- **Code improvements:**
  - Extracted type names to constants `JAVA_TIME_MONTH` and `JAVA_TIME_DAY_OF_WEEK`
  - Added `ImportSupplier` for managing import additions across quickfix invocations
  - Added lifecycle methods (`setContext`, `leaveFile`) to reset import supplier state
- **Tests:**
  - Added test case `DateEnumsCheckImportSample.java` verifying quickfix includes proper import statements

<sub>This will update automatically on new commits.</sub>