### PR TITLE
SONARJAVA-6330 Use a fixed clock in ExecutionTimeReportTest

### DIFF
--- a/java-frontend/src/test/java/org/sonar/java/ExecutionTimeReportTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ExecutionTimeReportTest.java
@@ -246,7 +246,7 @@ class ExecutionTimeReportTest {
     private Instant instant;
 
     public UnitTestClock() {
-      this.instant = Instant.now();
+      this.instant = Instant.now(Clock.fixed(Instant.parse("2026-05-26T00:00:00Z"), ZoneId.of("UTC")));
     }
 
     public void addMilliseconds(long millisToAdd) {

--- a/java-frontend/src/test/java/org/sonar/java/ExecutionTimeReportTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ExecutionTimeReportTest.java
@@ -246,7 +246,7 @@ class ExecutionTimeReportTest {
     private Instant instant;
 
     public UnitTestClock() {
-      this.instant = Instant.now(Clock.fixed(Instant.parse("2026-05-26T00:00:00Z"), ZoneId.of("UTC")));
+      this.instant = Instant.parse("2026-05-26T00:00:00Z");
     }
 
     public void addMilliseconds(long millisToAdd) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Test stability:**
  - Update `UnitTestClock` in `ExecutionTimeReportTest` to use a fixed `Clock` initialized to May 26, 2026.

<sub>This will update automatically on new commits.</sub>