### PR TITLE
SONARJAVA-6187 S4605: improve scanning detection

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/SpringBootApp5.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/SpringBootApp5.java
@@ -1,0 +1,9 @@
+package checks.spring.s4605.springBootApplication.fifthApp;
+
+import checks.spring.s4605.springBootApplication.fifthApp.service.ServiceMarker;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(
+  scanBasePackages = "checks.spring.s4605.springBootApplication.fifthApp.extra",
+  scanBasePackageClasses = ServiceMarker.class)
+public class SpringBootApp5 {}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/controller/MyController.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/controller/MyController.java
@@ -1,0 +1,7 @@
+package checks.spring.s4605.springBootApplication.fifthApp.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MyController {} // Noncompliant {{'MyController' is not reachable by @ComponentScan or @SpringBootApplication. Either move it to a package configured in @ComponentScan or update your @ComponentScan configuration.}}
+//           ^^^^^^^^^^^^

--- a/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/extra/ExtraService.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/extra/ExtraService.java
@@ -1,0 +1,6 @@
+package checks.spring.s4605.springBootApplication.fifthApp.extra;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExtraService {} // Compliant - in the package referenced by scanBasePackages

--- a/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/service/MyService.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/service/MyService.java
@@ -1,0 +1,6 @@
+package checks.spring.s4605.springBootApplication.fifthApp.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MyService {} // Compliant - in the package referenced by scanBasePackageClasses

--- a/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/service/ServiceMarker.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/s4605/springBootApplication/fifthApp/service/ServiceMarker.java
@@ -1,0 +1,3 @@
+package checks.spring.s4605.springBootApplication.fifthApp.service;
+
+public class ServiceMarker {}

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringBeansShouldBeAccessibleCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringBeansShouldBeAccessibleCheck.java
@@ -66,6 +66,7 @@ public class SpringBeansShouldBeAccessibleCheck extends IssuableSubscriptionVisi
 
   private static final String COMPONENT_SCAN_ANNOTATION = "org.springframework.context.annotation.ComponentScan";
   private static final Set<String> COMPONENT_SCAN_BASE_ARGUMENTS = SetUtils.immutableSetOf("basePackages", "basePackageClasses", "value");
+  private static final Set<String> SCAN_BASE_ANNOTATIONS = SetUtils.immutableSetOf("scanBasePackages", "scanBasePackageClasses");
 
   private static final String CACHE_KEY_PREFIX = "java:S4605:targeted:";
 
@@ -187,25 +188,24 @@ public class SpringBeansShouldBeAccessibleCheck extends IssuableSubscriptionVisi
 
   private static List<String> targetedPackages(String classPackageName, SymbolMetadata classSymbolMetadata) {
     // annotation is necessarily there already
-    return Objects.requireNonNull(classSymbolMetadata.valuesForAnnotation(SpringUtils.SPRING_BOOT_APP_ANNOTATION))
-      .stream()
-      .filter(v -> "scanBasePackages".equals(v.name()))
-      .map(SymbolMetadata.AnnotationValue::value)
-      .findFirst()
-      // list of packages to scan
-      .filter(Object[].class::isInstance)
-      .map(Object[].class::cast)
-      .map(SpringBeansShouldBeAccessibleCheck::asStringList)
-      // Using this annotation without arguments tells Spring to scan the current package and all of its sub-packages.
-      .orElse(Collections.singletonList(classPackageName));
-  }
-
-  private static List<String> asStringList(Object[] array) {
-    return Arrays.asList(array)
-      .stream()
-      .filter(String.class::isInstance)
-      .map(String.class::cast)
+    var scanBaseValues = Objects.requireNonNull(classSymbolMetadata.valuesForAnnotation(SpringUtils.SPRING_BOOT_APP_ANNOTATION)).stream()
+      .filter(v -> SCAN_BASE_ANNOTATIONS.contains(v.name()) && v.value() instanceof Object[])
       .toList();
+
+    List<String> packages = new ArrayList<>();
+    for (SymbolMetadata.AnnotationValue value : scanBaseValues) {
+      boolean isClassBased = "scanBasePackageClasses".equals(value.name());
+      for (Object element : (Object[]) value.value()) {
+        if (!isClassBased && element instanceof String s) {
+          packages.add(s);
+        } else if (isClassBased && element instanceof Symbol s) {
+          packages.add(packageNameOf(s));
+        }
+      }
+    }
+
+    // Using this annotation without arguments tells Spring to scan the current package and all of its sub-packages.
+    return scanBaseValues.isEmpty() ? Collections.singletonList(classPackageName) : packages;
   }
 
   private void addMessageToMap(String classPackageName, IdentifierTree classNameTree) {

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/SpringBeansShouldBeAccessibleCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/SpringBeansShouldBeAccessibleCheckTest.java
@@ -131,7 +131,8 @@ class SpringBeansShouldBeAccessibleCheckTest {
   }
 
   @Test
-  void testSpringBootApplicationWithAnnotation() {
+  void testSpringBootApplicationWithScanBasePackages() {
+    //test case when using explicit package names
     final String testFolderThirdApp = BASE_PATH + "springBootApplication/thirdApp/";
     List<String> thirdAppTestFiles = Arrays.asList(
       mainCodeSourcesPath(testFolderThirdApp + "SpringBootApp3.java"),
@@ -143,6 +144,7 @@ class SpringBeansShouldBeAccessibleCheckTest {
       .withCheck(new SpringBeansShouldBeAccessibleCheck())
       .verifyIssues();
 
+    //test case when using string constants for package names
     final String testFolderFourthApp = BASE_PATH + "springBootApplication/fourthApp/";
     List<String> fourthAppTestFiles = Arrays.asList(
       mainCodeSourcesPath(testFolderFourthApp + "SpringBootApp4.java"),
@@ -153,6 +155,22 @@ class SpringBeansShouldBeAccessibleCheckTest {
 
     CheckVerifier.newVerifier()
       .onFiles(fourthAppTestFiles)
+      .withCheck(new SpringBeansShouldBeAccessibleCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void testSpringBootApplicationWithMixedScanBasePackageAttributes() {
+    final String testFolder = BASE_PATH + "springBootApplication/fifthApp/";
+    List<String> files = List.of(
+      mainCodeSourcesPath(testFolder + "SpringBootApp5.java"),
+      mainCodeSourcesPath(testFolder + "service/ServiceMarker.java"),
+      mainCodeSourcesPath(testFolder + "service/MyService.java"),
+      mainCodeSourcesPath(testFolder + "extra/ExtraService.java"),
+      mainCodeSourcesPath(testFolder + "controller/MyController.java"));
+
+    CheckVerifier.newVerifier()
+      .onFiles(files)
       .withCheck(new SpringBeansShouldBeAccessibleCheck())
       .verifyIssues();
   }


### PR DESCRIPTION
Add support for the type-safe `scanBasePackageClasses` attribute on `@SpringBootApplication`, which was previously ignored, causing false positives for beans reachable via class-based package references.

