### PR TITLE
SONARJAVA-6425 Support records in S1068

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/unused/UnusedPrivateFieldCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/unused/UnusedPrivateFieldCheck.java
@@ -198,5 +198,12 @@ record MyRecord(int a) {
   private static final int XXX = 3; // Noncompliant
 //                         ^^^
 
-  static final int YYY = 4; // Compliant
+  // Non-private fields should not be reported.
+  static final int YYY = 4;
+
+  private static final int USED = 5;
+
+  int sum() {
+    return a + USED;
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/unused/UnusedPrivateFieldCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/unused/UnusedPrivateFieldCheck.java
@@ -195,6 +195,8 @@ class UnusedPrivateFieldCheckQuickfix {
 }
 
 record MyRecord(int a) {
-  private static final int XYZ = 3; // Noncompliant
+  private static final int XXX = 3; // Noncompliant
 //                         ^^^
+
+  static final int YYY = 4; // Compliant
 }

--- a/java-checks-test-sources/default/src/main/java/checks/unused/UnusedPrivateFieldCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/unused/UnusedPrivateFieldCheck.java
@@ -194,3 +194,7 @@ class UnusedPrivateFieldCheckQuickfix {
   }
 }
 
+record MyRecord(int a) {
+  private static final int XYZ = 3; // Noncompliant
+//                         ^^^
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedPrivateFieldCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/unused/UnusedPrivateFieldCheck.java
@@ -99,7 +99,7 @@ public class UnusedPrivateFieldCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return Arrays.asList(Tree.Kind.CLASS, Tree.Kind.METHOD, Tree.Kind.EXPRESSION_STATEMENT, Tree.Kind.IDENTIFIER);
+    return Arrays.asList(Tree.Kind.CLASS, Tree.Kind.RECORD, Tree.Kind.METHOD, Tree.Kind.EXPRESSION_STATEMENT, Tree.Kind.IDENTIFIER);
   }
 
   @Override
@@ -129,7 +129,7 @@ public class UnusedPrivateFieldCheck extends IssuableSubscriptionVisitor {
       case METHOD:
         checkIfNativeMethod((MethodTree) tree);
         break;
-      case CLASS:
+      case CLASS, RECORD:
         classes.add((ClassTree) tree);
         break;
       case EXPRESSION_STATEMENT:


### PR DESCRIPTION
----
## Summary by Gitar

- **Check logic:**
  - Updated `UnusedPrivateFieldCheck` to include `Tree.Kind.RECORD` in `nodesToVisit` and switch case.
- **Test updates:**
  - Added test case for record private field usage in `UnusedPrivateFieldCheck.java` test sources.

<sub>This will update automatically on new commits.</sub>