### PR TITLE
SONARJAVA-6434 S1186 Do not report on annotated compact constructors in records

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/EmptyMethodsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyMethodsCheckSample.java
@@ -4,6 +4,24 @@ import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.junit.jupiter.api.Test;
 
+class Records {
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.CONSTRUCTOR)
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+  public @interface QueryProjection {}
+
+  public record MyRecord2(int a, int b) {
+    @QueryProjection
+    public MyRecord2 {
+    }
+  }
+
+  public record MyRecord3(int a, int b) {
+    // Noncompliant@+1
+    public MyRecord3 {
+    }
+  }
+}
+
 // missing @SpringBootTest annotation
 class NonSpringBootTests {
   // Noncompliant@+2

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyMethodsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyMethodsCheck.java
@@ -95,7 +95,7 @@ public class EmptyMethodsCheck extends IssuableSubscriptionVisitor {
       .filter(member -> member.is(Tree.Kind.CONSTRUCTOR))
       .map(MethodTree.class::cast)
       .toList();
-    if (constructors.size() == 1 && isPublicNoArgConstructor(constructors.get(0))) {
+    if (constructors.size() == 1 && isPublicNoArgConstructor(constructors.get(0)) && !isAnnotatedCompactConstructor(constructors.get(0))) {
       // In case that there is only a single public default constructor with empty body, we raise an issue, as this is equivalent to not
       // defining a constructor at all and hence redundant.
       checkMethod(constructors.get(0));
@@ -110,6 +110,10 @@ public class EmptyMethodsCheck extends IssuableSubscriptionVisitor {
 
   private static boolean isPublicNoArgConstructor(MethodTree constructor) {
     return ModifiersUtils.hasModifier(constructor.modifiers(), Modifier.PUBLIC) && constructor.parameters().isEmpty();
+  }
+
+  private static boolean isAnnotatedCompactConstructor(MethodTree constructor) {
+    return constructor.closeParenToken() == null && !constructor.modifiers().annotations().isEmpty();
   }
 
   private void checkMethod(MethodTree methodTree) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
  - Modified `EmptyMethodsCheck` to ignore annotated compact constructors in Java records.
  - Added `isAnnotatedCompactConstructor` helper to verify constructor annotations and record syntax.

<sub>This will update automatically on new commits.</sub>