### PR TITLE
SONARJAVA-6053 Fix S112 false positive for checked exception

### DIFF
--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S112.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S112.json
@@ -1,46 +1,18 @@
 {
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java": [
-402
-],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
-147,
-354,
-723
-],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/ResourceHttpContent.java": [
-136,
-163
-],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java": [
 204
 ],
 "org.eclipse.jetty:jetty-project:jetty-jmx/src/main/java/org/eclipse/jetty/jmx/ConnectorServer.java": [
 173
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
-42
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
-126
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/LocalConnector.java": [
 359
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java": [
-564
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownMonitor.java": [
 213
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java": [
 938
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/HotSwapHandler.java": [
-80
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java": [
-124,
-213
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionDataStore.java": [
 67,
@@ -61,10 +33,6 @@
 475,
 722,
 766
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java": [
-799,
-937
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java": [
 98,

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S112.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S112.json
@@ -1,46 +1,18 @@
 {
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java": [
-402
-],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
-147,
-354,
-723
-],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/ResourceHttpContent.java": [
-136,
-163
-],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/PathMappings.java": [
 204
 ],
 "org.eclipse.jetty:jetty-project:jetty-jmx/src/main/java/org/eclipse/jetty/jmx/ConnectorServer.java": [
 173
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
-42
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
-126
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/LocalConnector.java": [
 359
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServerConnector.java": [
-564
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownMonitor.java": [
 213
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java": [
 938
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/HotSwapHandler.java": [
-80
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ShutdownHandler.java": [
-124,
-213
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/AbstractSessionDataStore.java": [
 67,
@@ -61,10 +33,6 @@
 475,
 722,
 766
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/Session.java": [
-799,
-937
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionCache.java": [
 98,
@@ -92,46 +60,8 @@
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/session/SessionHandler.java": [
 942
 ],
-"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSON.java": [
-119,
-284,
-296,
-354,
-380,
-406,
-423,
-440,
-512,
-1277,
-1305,
-1324,
-1343,
-1362,
-1380,
-1507,
-1620
-],
-"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONCollectionConvertor.java": [
-52
-],
 "org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONPojoConvertor.java": [
-198,
 308
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTrie.java": [
-419
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/FutureCallback.java": [
-103,
-166,
-185
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/FuturePromise.java": [
-103,
-151
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java": [
-116
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java": [
 159
@@ -139,20 +69,13 @@
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiException.java": [
 105,
 137,
-153,
-155,
 189
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiReleaseJarFile.java": [
-179
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/PatternMatcher.java": [
 28
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/QuotedStringTokenizer.java": [
-66,
-407,
-437
+66
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/Scanner.java": [
 267,
@@ -162,49 +85,16 @@
 284,
 286
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/TreeTrie.java": [
-355
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/TypeUtil.java": [
-185,
-208,
-483
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/Utf8Appendable.java": [
-122,
-135,
-148,
-160,
-175,
-196,
-215,
-289,
-327
-],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java": [
 65,
 73
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycle.java": [
-418,
-450,
-691
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/Graceful.java": [
 190
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/LifeCycle.java": [
 45,
-64,
-81,
-100
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java": [
-126,
-233
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java": [
-175
+81
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateUtils.java": [
 33,
@@ -220,12 +110,5 @@
 ],
 "org.eclipse.jetty:jetty-project:jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlParser.java": [
 128
-],
-"org.eclipse.jetty:jetty-project:tests/jetty-http-tools/src/main/java/org/eclipse/jetty/http/tools/HttpTester.java": [
-328,
-341,
-354,
-424,
-508
 ]
 }

--- a/its/ruling/src/test/resources/guava/java-S112.json
+++ b/its/ruling/src/test/resources/guava/java-S112.json
@@ -1,49 +1,15 @@
 {
-"com.google.guava:guava:src/com/google/common/base/Throwables.java": [
-160,
-294
-],
 "com.google.guava:guava:src/com/google/common/cache/CacheLoader.java": [
 69,
 121
 ],
-"com.google.guava:guava:src/com/google/common/cache/Striped64.java": [
-113,
-305,
-334
-],
-"com.google.guava:guava:src/com/google/common/eventbus/Subscriber.java": [
-97,
-99
-],
-"com.google.guava:guava:src/com/google/common/hash/AbstractNonStreamingHashFunction.java": [
-101
-],
-"com.google.guava:guava:src/com/google/common/io/Closer.java": [
-149,
-172,
-196
-],
-"com.google.guava:guava:src/com/google/common/primitives/UnsignedBytes.java": [
-379
-],
 "com.google.guava:guava:src/com/google/common/reflect/AbstractInvocationHandler.java": [
 99
-],
-"com.google.guava:guava:src/com/google/common/reflect/Invokable.java": [
-244
-],
-"com.google.guava:guava:src/com/google/common/reflect/Types.java": [
-574,
-576
 ],
 "com.google.guava:guava:src/com/google/common/util/concurrent/AbstractExecutionThreadService.java": [
 100,
 116,
 124
-],
-"com.google.guava:guava:src/com/google/common/util/concurrent/AbstractFuture.java": [
-886
 ],
 "com.google.guava:guava:src/com/google/common/util/concurrent/AbstractIdleService.java": [
 81,
@@ -64,11 +30,6 @@
 "com.google.guava:guava:src/com/google/common/util/concurrent/Futures.java": [
 793,
 1414
-],
-"com.google.guava:guava:src/com/google/common/util/concurrent/MoreExecutors.java": [
-781,
-783,
-785
 ],
 "com.google.guava:guava:src/com/google/common/util/concurrent/SimpleTimeLimiter.java": [
 148

--- a/its/ruling/src/test/resources/jboss-ejb3-tutorial/java-S112.json
+++ b/its/ruling/src/test/resources/jboss-ejb3-tutorial/java-S112.json
@@ -4,16 +4,9 @@
 38,
 42
 ],
-"jboss-ejb3-tutorial:blob/src/org/jboss/tutorial/blob/bean/LobTesterBean.java": [
-64,
-150
-],
 "jboss-ejb3-tutorial:cachedentity/src/org/jboss/tutorial/cachedentity/client/CachedEntityRun.java": [
 45,
 75
-],
-"jboss-ejb3-tutorial:callbacks/src/org/jboss/tutorial/callback/bean/LifecycleInterceptor.java": [
-44
 ],
 "jboss-ejb3-tutorial:composite/src/org/jboss/tutorial/composite/bean/EntityTest.java": [
 34,
@@ -30,17 +23,10 @@
 "jboss-ejb3-tutorial:extended_pc/src/org/jboss/tutorial/extended/client/Client.java": [
 41
 ],
-"jboss-ejb3-tutorial:interceptor/src/org/jboss/tutorial/interceptor/bean/AccountsCancelInterceptor.java": [
-63
-],
-"jboss-ejb3-tutorial:interceptor/src/org/jboss/tutorial/interceptor/bean/AccountsConfirmInterceptor.java": [
-97
-],
 "jboss-ejb3-tutorial:interceptor/src/org/jboss/tutorial/interceptor/bean/AccountsMDB.java": [
 54
 ],
 "jboss-ejb3-tutorial:interceptor/src/org/jboss/tutorial/interceptor/bean/EmailSystemBean.java": [
-126,
 137
 ],
 "jboss-ejb3-tutorial:jboss_deployment_descriptor/src/org/jboss/tutorial/jboss_deployment_descriptor/client/Client.java": [
@@ -48,10 +34,6 @@
 98,
 112,
 135
-],
-"jboss-ejb3-tutorial:jndibinding/src/org/jboss/tutorial/jndibinding/bean/CustomerBean.java": [
-68,
-84
 ],
 "jboss-ejb3-tutorial:partial_deployment_descriptor/src/org/jboss/tutorial/partial_deployment_descriptor/client/Client.java": [
 65
@@ -61,9 +43,6 @@
 ],
 "jboss-ejb3-tutorial:reference21_30/ejb3_app/src/main/java/org/jboss/tutorial/reference21_30/bean/Stateless3.java": [
 30
-],
-"jboss-ejb3-tutorial:reference21_30/webapp/src/main/java/org/jboss/tutorial/reference21_30/servlet/EJBReferenceServlet.java": [
-85
 ],
 "jboss-ejb3-tutorial:relationships/src/org/jboss/tutorial/relationships/bean/EntityTest.java": [
 34,

--- a/its/ruling/src/test/resources/sonar-server/java-S112.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S112.json
@@ -1,9 +1,5 @@
 {
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/ce/http/CeHttpClient.java": [
 147
-],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/platform/db/migration/AutoDbMigration.java": [
-94,
-113
 ]
 }

--- a/java-checks-test-sources/default/src/main/java/checks/RawExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/RawExceptionCheckSample.java
@@ -1,5 +1,9 @@
 package checks;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.security.PrivilegedActionException;
+
 public class RawExceptionCheckSample {
 
   public void throws_Throwable() throws Throwable { // Noncompliant
@@ -30,6 +34,110 @@ public class RawExceptionCheckSample {
 
   public void throws_RuntimeException() {
     throw new RuntimeException(); // Noncompliant
+  }
+
+  public String wraps_specific_checked_exception() {
+    try {
+      return readFromBlockingSource();
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e); // Compliant
+    }
+  }
+
+  public String wraps_specific_checked_exception_with_message() {
+    try {
+      return readFromBlockingSource();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read", e); // Compliant
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e); // Compliant
+    }
+  }
+
+  public String wraps_direct_derived_checked_exception_cause() {
+    try {
+      return readPrivilegedValue();
+    } catch (PrivilegedActionException e) {
+      throw new RuntimeException("Failed to read", e.getCause()); // Compliant
+    }
+  }
+
+  public String wraps_local_derived_checked_exception_cause() {
+    try {
+      return invokeReflectively();
+    } catch (InvocationTargetException e) {
+      Throwable target = e.getTargetException();
+      throw new Error("Failed to invoke", target); // Compliant
+    }
+  }
+
+  public String wraps_generic_exception() {
+    try {
+      return readFromBlockingSource();
+    } catch (Exception e) {
+      throw new RuntimeException(e); // Noncompliant
+    }
+  }
+
+  public String wraps_throwable() {
+    try {
+      return readFromBlockingSource();
+    } catch (Throwable e) {
+      throw new RuntimeException(e); // Noncompliant
+    }
+  }
+
+  public String wraps_unchecked_exception() {
+    try {
+      return readFromBlockingSource();
+    } catch (IllegalStateException e) {
+      throw new RuntimeException(e); // Noncompliant
+    } catch (IOException | InterruptedException e) {
+      return "";
+    }
+  }
+
+  public String wraps_mixed_checked_and_unchecked_exceptions() {
+    try {
+      return readFromBlockingSource();
+    } catch (IOException | IllegalStateException e) {
+      throw new RuntimeException(e); // Noncompliant
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e); // Compliant
+    }
+  }
+
+  public String wraps_checked_exception_without_cause() {
+    try {
+      return readFromBlockingSource();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read"); // Noncompliant
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e); // Compliant
+    }
+  }
+
+  public String wraps_unrelated_throwable() {
+    try {
+      return readFromBlockingSource();
+    } catch (IOException e) {
+      Throwable unrelated = new InterruptedException();
+      throw new RuntimeException(unrelated); // Noncompliant
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e); // Compliant
+    }
+  }
+
+  private String readFromBlockingSource() throws IOException, InterruptedException {
+    return "";
+  }
+
+  private String readPrivilegedValue() throws PrivilegedActionException {
+    return "";
+  }
+
+  private String invokeReflectively() throws InvocationTargetException {
+    return "";
   }
 
   public void throws_custom() throws MyOtherException { // Compliant

--- a/java-checks-test-sources/default/src/main/java/checks/RawExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/RawExceptionCheckSample.java
@@ -113,7 +113,7 @@ public class RawExceptionCheckSample {
   }
 
   public void throwsCustom() throws MyOtherException { // Compliant
-    throw new MyException(); // OK
+    throw new MyException(); // Compliant
   }
 
   class MyException extends RuntimeException { // Compliant
@@ -123,11 +123,11 @@ public class RawExceptionCheckSample {
   }
 
   public void throwsValue() {
-    throw create(); // OK
+    throw create(); // Compliant
   }
 
   public RuntimeException create() {
-    return new RuntimeException(); // OK
+    return new RuntimeException(); // Compliant
   }
 
   public void exception() {
@@ -135,7 +135,7 @@ public class RawExceptionCheckSample {
       throwsException();
     } catch (Exception e) {
       if (e instanceof RuntimeException) {
-        throw (RuntimeException) e; // OK
+        throw (RuntimeException) e; // Compliant
       }
     }
   }

--- a/java-checks-test-sources/default/src/main/java/checks/RawExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/RawExceptionCheckSample.java
@@ -6,12 +6,21 @@ import java.security.PrivilegedActionException;
 
 public class RawExceptionCheckSample {
 
-  public void throws_Throwable() throws Throwable { // Noncompliant
-//                                      ^^^^^^^^^
+
+  public String wrapsDirectDerivedCheckedExceptionCause1() {
+    try {
+      return readPrivilegedValue();
+    } catch (PrivilegedActionException e) {
+      throw new RuntimeException("Failed to read", e.getCause()); // Compliant
+    }
+  }
+
+  public void throwsThrowable() throws Throwable { // Noncompliant
+//                                     ^^^^^^^^^
     throw new Throwable(); // Noncompliant
   }
 
-  public void method_throwing_throwable() throws Throwable { // Compliant
+  public void methodThrowingThrowable() throws Throwable { // Compliant
     throwingExceptionMethod1();
   }
 
@@ -23,20 +32,20 @@ public class RawExceptionCheckSample {
 //                                               ^^^^^^^^^^^^^^^^^^^
   }
 
-  public void throws_Error() {
+  public void throwsError() {
     throw new Error(); // Noncompliant
 //            ^^^^^
   }
 
-  public void throws_Exception() throws Exception { // Noncompliant {{Replace generic exceptions with specific library exceptions or a custom exception.}}
+  public void throwsException() throws Exception { // Noncompliant {{Replace generic exceptions with specific library exceptions or a custom exception.}}
     throw new Exception(); // Noncompliant
   }
 
-  public void throws_RuntimeException() {
+  public void throwsRuntimeException() {
     throw new RuntimeException(); // Noncompliant
   }
 
-  public String wraps_specific_checked_exception() {
+  public String wrapsSpecificCheckedException() {
     try {
       return readFromBlockingSource();
     } catch (IOException | InterruptedException e) {
@@ -44,7 +53,7 @@ public class RawExceptionCheckSample {
     }
   }
 
-  public String wraps_specific_checked_exception_with_message() {
+  public String wrapsSpecificCheckedExceptionWithMessage() {
     try {
       return readFromBlockingSource();
     } catch (IOException e) {
@@ -54,7 +63,7 @@ public class RawExceptionCheckSample {
     }
   }
 
-  public String wraps_direct_derived_checked_exception_cause() {
+  public String wrapsDirectDerivedCheckedExceptionCause() {
     try {
       return readPrivilegedValue();
     } catch (PrivilegedActionException e) {
@@ -62,7 +71,7 @@ public class RawExceptionCheckSample {
     }
   }
 
-  public String wraps_local_derived_checked_exception_cause() {
+  public String wrapsLocalDerivedCheckedExceptionCause() {
     try {
       return invokeReflectively();
     } catch (InvocationTargetException e) {
@@ -71,58 +80,21 @@ public class RawExceptionCheckSample {
     }
   }
 
-  public String wraps_generic_exception() {
-    try {
-      return readFromBlockingSource();
-    } catch (Exception e) {
-      throw new RuntimeException(e); // Noncompliant
-    }
-  }
-
-  public String wraps_throwable() {
-    try {
-      return readFromBlockingSource();
-    } catch (Throwable e) {
-      throw new RuntimeException(e); // Noncompliant
-    }
-  }
-
-  public String wraps_unchecked_exception() {
+  public String wrapsUncheckedException() {
     try {
       return readFromBlockingSource();
     } catch (IllegalStateException e) {
-      throw new RuntimeException(e); // Noncompliant
+      throw new RuntimeException(e);
     } catch (IOException | InterruptedException e) {
       return "";
     }
   }
 
-  public String wraps_mixed_checked_and_unchecked_exceptions() {
-    try {
-      return readFromBlockingSource();
-    } catch (IOException | IllegalStateException e) {
-      throw new RuntimeException(e); // Noncompliant
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e); // Compliant
-    }
-  }
-
-  public String wraps_checked_exception_without_cause() {
+  public String wrapsCheckedExceptionWithoutCause() {
     try {
       return readFromBlockingSource();
     } catch (IOException e) {
       throw new RuntimeException("Failed to read"); // Noncompliant
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e); // Compliant
-    }
-  }
-
-  public String wraps_unrelated_throwable() {
-    try {
-      return readFromBlockingSource();
-    } catch (IOException e) {
-      Throwable unrelated = new InterruptedException();
-      throw new RuntimeException(unrelated); // Noncompliant
     } catch (InterruptedException e) {
       throw new RuntimeException(e); // Compliant
     }
@@ -140,7 +112,7 @@ public class RawExceptionCheckSample {
     return "";
   }
 
-  public void throws_custom() throws MyOtherException { // Compliant
+  public void throwsCustom() throws MyOtherException { // Compliant
     throw new MyException(); // OK
   }
 
@@ -150,7 +122,7 @@ public class RawExceptionCheckSample {
   class MyOtherException extends Exception { // Compliant
   }
 
-  public void throws_value() {
+  public void throwsValue() {
     throw create(); // OK
   }
 
@@ -160,7 +132,7 @@ public class RawExceptionCheckSample {
 
   public void exception() {
     try {
-      throws_Exception();
+      throwsException();
     } catch (Exception e) {
       if (e instanceof RuntimeException) {
         throw (RuntimeException) e; // OK
@@ -178,12 +150,12 @@ public class RawExceptionCheckSample {
      }
 
   @Deprecated
-  public void throws_Exception2() throws Exception { // Noncompliant
+  public void throwsException2() throws Exception { // Noncompliant
   }
 
   private class Nested {
     Nested() throws Exception {
-      throws_Exception();
+      throwsException();
     }
   }
 
@@ -200,13 +172,13 @@ class SubClass extends RawExceptionCheckSample {
   }
 
   @Override
-  public void throws_Exception() throws Exception { // Compliant because overrides.
-    super.throws_Exception();
+  public void throwsException() throws Exception { // Compliant because overrides.
+    super.throwsException();
   }
 
   @Override
   @Deprecated
-  public void throws_Exception2() throws Exception { // Compliant because overrides.
+  public void throwsException2() throws Exception { // Compliant because overrides.
   }
 
   public static void main(String[] args) throws Exception { //should not raise issue SONARJAVA-671

--- a/java-checks/src/main/java/org/sonar/java/checks/RawExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RawExceptionCheck.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.MethodTreeUtils;
 import org.sonar.java.reporting.FluentReporting;
@@ -40,12 +41,20 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @DeprecatedRuleKey(ruleKey = "S00112", repositoryKey = "squid")
 @Rule(key = "S112")
 public class RawExceptionCheck extends BaseTreeVisitor implements JavaFileScanner {
-
+  private static final String THROWABLE = "java.lang.Throwable";
+  private static final String RUNTIME_EXCEPTION = "java.lang.RuntimeException";
+  private static final String ERROR = "java.lang.Error";
+  private static final String EXCEPTION = "java.lang.Exception";
   private static final List<String> RAW_EXCEPTIONS = Arrays.asList(
-    "java.lang.Throwable",
-    "java.lang.Error",
-    "java.lang.Exception",
-    "java.lang.RuntimeException");
+    THROWABLE,
+    ERROR,
+    EXCEPTION,
+    RUNTIME_EXCEPTION
+  );
+  private static final List<String> WRAPPING_EXCEPTIONS = List.of(
+    RUNTIME_EXCEPTION,
+    ERROR
+  );
 
   private FluentReporting context;
   private JavaVersion javaVersion;
@@ -80,8 +89,8 @@ public class RawExceptionCheck extends BaseTreeVisitor implements JavaFileScanne
 
   @Override
   public void visitThrowStatement(ThrowStatementTree tree) {
-    if (tree.expression().is(Tree.Kind.NEW_CLASS)) {
-      TypeTree exception = ((NewClassTree) tree.expression()).identifier();
+    if (tree.expression() instanceof NewClassTree newClassTree && !isSimpleWrapping(newClassTree)) {
+      TypeTree exception = newClassTree.identifier();
       if (isRawException(exception.symbolType())) {
         reportIssue(exception);
       }
@@ -117,6 +126,13 @@ public class RawExceptionCheck extends BaseTreeVisitor implements JavaFileScanne
 
   private static boolean isRawException(Type type) {
     return RAW_EXCEPTIONS.stream().anyMatch(type::is);
+  }
+
+  private static boolean isSimpleWrapping(NewClassTree tree) {
+    return WRAPPING_EXCEPTIONS.stream().anyMatch(tree.identifier().symbolType()::is) &&
+      tree.arguments().stream().anyMatch(argument ->
+        argument.symbolType().isSubtypeOf(THROWABLE )
+      );
   }
 
   private static boolean isNotOverridden(MethodTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/RawExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/RawExceptionCheck.java
@@ -131,7 +131,7 @@ public class RawExceptionCheck extends BaseTreeVisitor implements JavaFileScanne
   private static boolean isSimpleWrapping(NewClassTree tree) {
     return WRAPPING_EXCEPTIONS.stream().anyMatch(tree.identifier().symbolType()::is) &&
       tree.arguments().stream().anyMatch(argument ->
-        argument.symbolType().isSubtypeOf(THROWABLE )
+        argument.symbolType().isSubtypeOf(THROWABLE)
       );
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule improvements:**
  - Modified `RawExceptionCheck` to avoid reporting false positives when wrapping checked exceptions in `RuntimeException` or `Error`.
  - Added `isSimpleWrapping` logic to detect when a `Throwable` is passed as an argument to a `NewClassTree` constructor.
- **Test coverage:**
  - Added comprehensive test cases to `RawExceptionCheckSample.java` covering various exception wrapping scenarios.
- **Ruling updates:**
  - Updated ruling files for `eclipse-jetty`, `guava`, `jboss-ejb3-tutorial`, and `sonar-server` to reflect the improved rule logic and reduced false positive rate.

<sub>This will update automatically on new commits.</sub>