### PR TITLE
SONARJAVA-6436 S2970 Add missing AssertJ classes to fix FNs

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2970.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2970.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2970",
   "hasTruePositives": false,
-  "falseNegatives": 65,
+  "falseNegatives": 68,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsCompletenessCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsCompletenessCheckSample.java
@@ -115,6 +115,11 @@ public class AssertionsCompletenessCheckSample {
     org.assertj.core.api.Assertions.assertThatIllegalStateException(); // Noncompliant
     org.assertj.core.api.Assertions.assertThatIllegalStateException().isThrownBy(() -> {});
 
+    org.assertj.core.api.AssertionsForClassTypes.assertThat(1); // Noncompliant
+    org.assertj.core.api.AssertionsForClassTypes.assertThat(1).isGreaterThan(0);
+    org.assertj.core.api.AssertionsForInterfaceTypes.assertThat(1); // Noncompliant
+    org.assertj.core.api.AssertionsForInterfaceTypes.assertThat(1).isGreaterThan(0);
+
     // BDD
     org.assertj.core.api.BDDAssertions.thenRuntimeException(); // Noncompliant
     org.assertj.core.api.BDDAssertions.thenRuntimeException().isThrownBy(() -> System.out.println("b"));

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/AssertionsCompletenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/AssertionsCompletenessCheck.java
@@ -81,6 +81,8 @@ public class AssertionsCompletenessCheck extends BaseTreeVisitor implements Java
         "org.assertj.core.api.AbstractSoftAssertions",
         // AssertJ 2.X
         "org.assertj.core.api.Assertions",
+        "org.assertj.core.api.AssertionsForClassTypes",
+        "org.assertj.core.api.AssertionsForInterfaceTypes",
         "org.assertj.core.api.Java6Assertions",
         "org.assertj.core.api.AbstractStandardSoftAssertions",
         JAVA6_ABSTRACT_SOFT_ASSERT,


### PR DESCRIPTION
----
## Summary by Gitar

- **Check updates:**
  - Added `AssertionsForClassTypes` and `AssertionsForInterfaceTypes` to `AssertionsCompletenessCheck` to ensure better coverage.
- **Test updates:**
  - Added test cases in `AssertionsCompletenessCheckSample` to verify assertion completeness for the new classes.

<sub>This will update automatically on new commits.</sub>