### PR TITLE
SONARJAVA-6406 : Change rule S8714 maintainability to low / address leftovers comments

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S5786.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S5786.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S5786",
   "hasTruePositives": true,
-  "falseNegatives": 71,
+  "falseNegatives": 72,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S5960.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S5960.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S5960",
   "hasTruePositives": false,
-  "falseNegatives": 4,
+  "falseNegatives": 3,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8714",
   "hasTruePositives": false,
-  "falseNegatives": 32,
+  "falseNegatives": 42,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/main/java/checks/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -88,6 +88,20 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
 
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
+    nonAnnotatedFunctionFN();
+  }
+
+  private void nonAnnotatedFunctionFN() {
+    org.assertj.core.api.AssertionsForInterfaceTypes.fail("expected exception"); // FN
+  }
+
+  @org.junit.Test
+  public void junit4AnnotationDontRaise() {
+    try {
+      fail("expected exception"); // TN - junit5 assert in junit4 test
+    } catch (Exception _) {
+      // test passed
+    }
   }
 
   private static void raise() {

--- a/java-checks-test-sources/default/src/main/java/checks/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -70,6 +70,22 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
       // test passed
     }
 
+    try {
+      raise();
+      org.assertj.core.api.AssertionsForClassTypes.fail("expected exception"); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    } catch (Exception _) {
+      // test passed
+    }
+
+    try {
+      raise();
+      org.assertj.core.api.AssertionsForInterfaceTypes.fail("expected exception"); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    } catch (Exception _) {
+      // test passed
+    }
+
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
   }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -1,4 +1,4 @@
-package checks;
+package checks.tests;
 
 import org.junit.jupiter.api.Test;
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -39,15 +39,15 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
   public void visitNode(Tree tree) {
     MethodTree methodTree = (MethodTree) tree;
     tree.accept(
-      new TryStatementsVisitor(UnitTestUtils.hasJUnit56TestAnnotation(methodTree))
+      new TryStatementsVisitor(UnitTestUtils.hasJUnitJupiterAnnotation(methodTree))
     );
   }
 
   private final class TryStatementsVisitor extends BaseTreeVisitor {
-    private final boolean isJunit56;
+    private final boolean isJunitJupiter;
 
-    public TryStatementsVisitor(boolean isJunit56) {
-      this.isJunit56 = isJunit56;
+    public TryStatementsVisitor(boolean isJunitJupiter) {
+      this.isJunitJupiter = isJunitJupiter;
     }
 
     @Override
@@ -59,7 +59,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
     private void checkBlock(BlockTree block, String message) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
-          if (isJunit56 || failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
+          if (isJunitJupiter || failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
             reportIssue(failMethodInvocation, message);
           }
         }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -16,13 +16,10 @@
  */
 package org.sonar.java.checks.helpers;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import org.sonar.java.annotations.VisibleForTesting;
@@ -43,7 +40,11 @@ import org.sonar.plugins.java.api.tree.Tree;
 import static java.util.Arrays.asList;
 
 public final class UnitTestUtils {
-  private static final String ORG_ASSERTJ_CORE_API_ASSERTIONS = "org.assertj.core.api.Assertions";
+  private static final List<String> ORG_ASSERTJ_CORE_API_ASSERTIONS = List.of(
+    "org.assertj.core.api.Assertions",
+    "org.assertj.core.api.AssertionsForClassTypes",
+    "org.assertj.core.api.AssertionsForInterfaceTypes"
+  );
   private static final String ORG_JUNIT_TEST = "org.junit.Test";
   public static final Pattern ASSERTION_METHODS_PATTERN = Pattern.compile(
     "(assert|verify|fail|should|check|expect|validate|andExpect|approve).*" +
@@ -98,21 +99,25 @@ public final class UnitTestUtils {
 
   public static final MethodMatchers FAIL_METHOD_MATCHER = MethodMatchers.or(
     MethodMatchers.create().ofTypes(
-        // JUnit 5
-        "org.junit.jupiter.api.Assertions",
-        // JUnit 4
-        "org.junit.Assert",
-        // JUnit 3
-        "junit.framework.Assert",
-        // Fest assert
-        "org.fest.assertions.Fail",
-        // AssertJ
-        "org.assertj.core.api.Fail",
-        ORG_ASSERTJ_CORE_API_ASSERTIONS)
+        Stream.concat(
+          Stream.of(// JUnit 5
+            "org.junit.jupiter.api.Assertions",
+            // JUnit 4
+            "org.junit.Assert",
+            // JUnit 3
+            "junit.framework.Assert",
+            // Fest assert
+            "org.fest.assertions.Fail",
+            // AssertJ
+            "org.assertj.core.api.Fail"
+          ),
+          ORG_ASSERTJ_CORE_API_ASSERTIONS.stream()
+        ).toArray(String[]::new))
       .names("fail").withAnyParameters().build(),
     MethodMatchers.create().ofTypes(
         // AssertJ
-        ORG_ASSERTJ_CORE_API_ASSERTIONS)
+        ORG_ASSERTJ_CORE_API_ASSERTIONS.toArray(String[]::new)
+      )
       .names("failBecauseExceptionWasNotThrown").withAnyParameters().build());
 
   public static final MethodMatchers ASSERTIONS_METHOD_MATCHER = MethodMatchers.or(
@@ -124,7 +129,7 @@ public final class UnitTestUtils {
       .build(),
     // Fest assert and AssertJ
     MethodMatchers.create()
-      .ofTypes(ORG_ASSERTJ_CORE_API_ASSERTIONS, "org.fest.assertions.Assertions")
+      .ofTypes(Stream.concat(ORG_ASSERTJ_CORE_API_ASSERTIONS.stream(), Stream.of("org.fest.assertions.Assertions")).toArray(String[]::new))
       .names("assertThat")
       .withAnyParameters()
       .build());

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -16,7 +16,11 @@
  */
 package org.sonar.java.checks.helpers;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -104,7 +104,8 @@ public final class UnitTestUtils {
   public static final MethodMatchers FAIL_METHOD_MATCHER = MethodMatchers.or(
     MethodMatchers.create().ofTypes(
         Stream.concat(
-          Stream.of(// JUnit 5
+          Stream.of(
+            // JUnit 5
             "org.junit.jupiter.api.Assertions",
             // JUnit 4
             "org.junit.Assert",

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -171,14 +171,14 @@ public final class UnitTestUtils {
 
   public static boolean hasTestAnnotation(MethodTree tree) {
     SymbolMetadata symbolMetadata = tree.symbol().metadata();
-    return TEST_ANNOTATIONS.stream().anyMatch(symbolMetadata::isAnnotatedWith) || hasJUnit56TestAnnotation(symbolMetadata);
+    return TEST_ANNOTATIONS.stream().anyMatch(symbolMetadata::isAnnotatedWith) || hasJUnitJupiterAnnotation(symbolMetadata);
   }
 
-  public static boolean hasJUnit56TestAnnotation(MethodTree tree) {
-    return hasJUnit56TestAnnotation(tree.symbol().metadata());
+  public static boolean hasJUnitJupiterAnnotation(MethodTree tree) {
+    return hasJUnitJupiterAnnotation(tree.symbol().metadata());
   }
 
-  private static boolean hasJUnit56TestAnnotation(SymbolMetadata symbolMetadata) {
+  private static boolean hasJUnitJupiterAnnotation(SymbolMetadata symbolMetadata) {
     return JUNIT5_TEST_ANNOTATIONS.stream().anyMatch(symbolMetadata::isAnnotatedWith);
   }
 
@@ -206,7 +206,7 @@ public final class UnitTestUtils {
       return true;
     }
 
-    if (hasJUnit56TestAnnotation(methodTree)) {
+    if (hasJUnitJupiterAnnotation(methodTree)) {
       // contrary to JUnit 4, JUnit 5 Test annotations are not inherited when method is overridden, so no need to check overridden symbols
       return true;
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/AbstractJUnit5NotCompliantModifierChecker.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/AbstractJUnit5NotCompliantModifierChecker.java
@@ -82,7 +82,7 @@ public abstract class AbstractJUnit5NotCompliantModifierChecker extends Issuable
       .filter(member -> member.is(Tree.Kind.METHOD))
       .map(MethodTree.class::cast)
       .forEach(method -> {
-        if (UnitTestUtils.hasJUnit56TestAnnotation(method) || UnitTestUtils.hasJUnit5InstanceLifecycleAnnotation(method)) {
+        if (UnitTestUtils.hasJUnitJupiterAnnotation(method) || UnitTestUtils.hasJUnit5InstanceLifecycleAnnotation(method)) {
           if (isNotOverriding(method)) {
             junit5InstanceMethods.add(method);
           }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit45MethodAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit45MethodAnnotationCheck.java
@@ -76,7 +76,7 @@ public class JUnit45MethodAnnotationCheck extends IssuableSubscriptionVisitor {
     for (MethodTree methodTree : methods) {
       SymbolMetadata metadata = methodTree.symbol().metadata();
       containsJUnit4Tests |= metadata.isAnnotatedWith("org.junit.Test");
-      if (UnitTestUtils.hasJUnit56TestAnnotation(methodTree)) {
+      if (UnitTestUtils.hasJUnitJupiterAnnotation(methodTree)) {
         // While migrating from JUnit4 to JUnit5, classes might end up in mixed state of having tests using both versions.
         // If it's the case, we consider the test classes as ultimately targeting 5
         return 5;

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JunitNestedAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JunitNestedAnnotationCheck.java
@@ -58,7 +58,7 @@ public class JunitNestedAnnotationCheck extends IssuableSubscriptionVisitor {
     return classTree.members().stream()
       .filter(member -> member.is(Tree.Kind.METHOD))
       .map(MethodTree.class::cast)
-      .anyMatch(UnitTestUtils::hasJUnit56TestAnnotation);
+      .anyMatch(UnitTestUtils::hasJUnitJupiterAnnotation);
   }
 
   private static boolean isNestedClass(Symbol.TypeSymbol classSymbol) {

--- a/java-checks/src/test/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheckTest.java
@@ -19,14 +19,14 @@ package org.sonar.java.checks;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
 
 class AssertThrowsInsteadOfTryCatchFailCheckTest {
 
   @Test
   void detected() {
     CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/AssertThrowsInsteadOfTryCatchFailCheckSample.java"))
+      .onFile(testCodeSourcesPath("checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java"))
       .withCheck(new AssertThrowsInsteadOfTryCatchFailCheck())
       .verifyIssues();
   }
@@ -34,7 +34,7 @@ class AssertThrowsInsteadOfTryCatchFailCheckTest {
   @Test
   void undetected() {
     CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/AssertThrowsInsteadOfTryCatchFailCheckSample.java"))
+      .onFile(testCodeSourcesPath("checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java"))
       .withCheck(new AssertThrowsInsteadOfTryCatchFailCheck())
       .withoutSemantic()
       .verifyNoIssues();

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8714.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8714.json
@@ -16,7 +16,7 @@
   "quickfix": "unknown",
   "code": {
     "impacts": {
-      "MAINTAINABILITY": "MEDIUM"
+      "MAINTAINABILITY": "LOW"
     },
     "attribute": "CONVENTIONAL"
   }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8714.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8714.json
@@ -9,7 +9,7 @@
   "tags": [
     "tests"
   ],
-  "defaultSeverity": "Major",
+  "defaultSeverity": "Minor",
   "ruleSpecification": "RSPEC-8714",
   "sqKey": "S8714",
   "scope": "Tests",


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule configuration:**
  - Update `MAINTAINABILITY` impact from `MEDIUM` to `LOW` and `defaultSeverity` from `Major` to `Minor` for rule `S8714` in `S8714.json`.
- **Refactoring:**
  - Expand `ORG_ASSERTJ_CORE_API_ASSERTIONS` in `UnitTestUtils.java` to include `AssertionsForClassTypes` and `AssertionsForInterfaceTypes`.
  - Rename `hasJUnit56TestAnnotation` to `hasJUnitJupiterAnnotation` and update related references in checkers.
  - Update `FAIL_METHOD_MATCHER` and `ASSERTIONS_METHOD_MATCHER` to use the updated, exhaustive list of AssertJ API classes.
- **Testing:**
  - Add test cases in `AssertThrowsInsteadOfTryCatchFailCheckSample.java` to verify detection using additional AssertJ API classes.

<sub>This will update automatically on new commits.</sub>