### PR TITLE
SONARJAVA-6406 Fix Quality Gate

### DIFF
--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/CheckVerifierTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/CheckVerifierTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.check.Rule;
@@ -35,8 +34,7 @@ import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.Tree;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CheckVerifierTest {
@@ -50,6 +48,7 @@ class CheckVerifierTest {
       return Collections.emptyList();
     }
   };
+  public static final String SHOULD_HAVE_FAILED = "Should have failed";
 
   @Test
   void verify_line_issues() {
@@ -74,24 +73,21 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssues().withIssue(4, "extra message");
     CheckVerifier verifier = CheckVerifier.newInternalVerifier().onFile(FILENAME_ISSUES).withCheck(visitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Unexpected at [4]");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Unexpected at [4]");
   }
 
   @Test
   void verify_unexpected_issue_java_verifier() {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssuesForJavaCheckVerifier().withIssue(4, "extra message");
     CheckVerifier verifier = CheckVerifier.newVerifier().onFile(FILENAME_ISSUES_JAVA_CHECK_VERIFIER).withCheck(visitor);
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessageContaining("ERROR: Expect 9 issues instead of 10. In file (CommonsJavaCheckVerifier.java:7)");
-    }
+
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage("Should have failed")
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("ERROR: Expect 9 issues instead of 10. In file (CommonsJavaCheckVerifier.java:7)");
   }
 
   @Test
@@ -99,12 +95,10 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssues().withIssue(4, "extra message").withoutIssue(1);
     CheckVerifier verifier = CheckVerifier.newInternalVerifier().onFile(FILENAME_ISSUES).withCheck(visitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Expected at [1], Unexpected at [4]");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Expected at [1], Unexpected at [4]");
   }
 
   @Test
@@ -112,12 +106,10 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssues().withoutIssue(1);
     CheckVerifier verifier = CheckVerifier.newInternalVerifier().onFile(FILENAME_ISSUES).withCheck(visitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Expected at [1]");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Expected at [1]");
   }
 
   @Test
@@ -200,12 +192,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectShift.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    try {
-      verifier.verifyNoIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Use only '@+N' or '@-N' to shifts messages.");
-    }
+    assertThatCode(verifier::verifyNoIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Use only '@+N' or '@-N' to shifts messages.");
   }
 
   @Test
@@ -214,12 +204,11 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectAttribute.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    try {
-      verifier.verifyNoIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("// Noncompliant attributes not valid: 'invalid=1'");
-    }
+
+    assertThatCode(verifier::verifyNoIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("// Noncompliant attributes not valid: 'invalid=1'");
   }
 
   @Test
@@ -228,12 +217,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectAttribute2.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    try {
-      verifier.verifyNoIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("// Noncompliant attributes not valid: 'invalid=1=2'");
-    }
+    assertThatCode(verifier::verifyNoIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("// Noncompliant attributes not valid: 'invalid=1=2'");
   }
 
   @Test
@@ -242,12 +229,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectEndLine.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    try {
-      verifier.verifyNoIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
-    }
+    assertThatCode(verifier::verifyNoIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
   }
 
   @Test
@@ -257,12 +242,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectSecondaryLocation.java")
       .withCheck(visitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Secondary locations: expected: [] unexpected: [3]. In JavaCheckVerifierIncorrectSecondaryLocation.java:10");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Secondary locations: expected: [] unexpected: [3]. In JavaCheckVerifierIncorrectSecondaryLocation.java:10");
   }
 
   @Test
@@ -272,12 +255,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectSecondaryLocation2.java")
       .withCheck(visitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Secondary locations: expected: [5] unexpected: []. In JavaCheckVerifierIncorrectSecondaryLocation2.java:10");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Secondary locations: expected: [5] unexpected: []. In JavaCheckVerifierIncorrectSecondaryLocation2.java:10");
   }
 
   @Test
@@ -327,12 +308,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierFlows.java")
       .withCheck(fakeVisitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Flow npe1 has line differences. Expected: [9, 3] but was: [6, 5]");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Flow npe1 has line differences. Expected: [9, 3] but was: [6, 5]");
   }
 
   @Test
@@ -349,12 +328,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierFlows.java")
       .withCheck(fakeVisitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Missing flows: npe1 [9,3].");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Missing flows: npe1 [9,3].");
   }
 
   @Test
@@ -407,12 +384,10 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierFlowsSuperfluous.java")
       .withCheck(fakeVisitor);
 
-    try {
-      verifier.verifyIssues();
-      Fail.fail("Should have failed");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("Following flow comments were observed, but not referenced by any issue: {superfluous=8,6,4, npe2=7}");
-    }
+    assertThatCode(verifier::verifyIssues)
+      .withFailMessage(SHOULD_HAVE_FAILED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Following flow comments were observed, but not referenced by any issue: {superfluous=8,6,4, npe2=7}");
   }
 
   @Test

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/CheckVerifierTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/CheckVerifierTest.java
@@ -34,7 +34,9 @@ import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.Tree;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CheckVerifierTest {

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/CheckVerifierTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/CheckVerifierTest.java
@@ -36,7 +36,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CheckVerifierTest {
@@ -50,7 +50,6 @@ class CheckVerifierTest {
       return Collections.emptyList();
     }
   };
-  public static final String SHOULD_HAVE_FAILED = "Should have failed";
 
   @Test
   void verify_line_issues() {
@@ -75,8 +74,7 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssues().withIssue(4, "extra message");
     CheckVerifier verifier = CheckVerifier.newInternalVerifier().onFile(FILENAME_ISSUES).withCheck(visitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Unexpected at [4]");
   }
@@ -86,8 +84,7 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssuesForJavaCheckVerifier().withIssue(4, "extra message");
     CheckVerifier verifier = CheckVerifier.newVerifier().onFile(FILENAME_ISSUES_JAVA_CHECK_VERIFIER).withCheck(visitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage("Should have failed")
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessageContaining("ERROR: Expect 9 issues instead of 10. In file (CommonsJavaCheckVerifier.java:7)");
   }
@@ -97,8 +94,7 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssues().withIssue(4, "extra message").withoutIssue(1);
     CheckVerifier verifier = CheckVerifier.newInternalVerifier().onFile(FILENAME_ISSUES).withCheck(visitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Expected at [1], Unexpected at [4]");
   }
@@ -108,8 +104,7 @@ class CheckVerifierTest {
     IssuableSubscriptionVisitor visitor = new FakeVisitor().withDefaultIssues().withoutIssue(1);
     CheckVerifier verifier = CheckVerifier.newInternalVerifier().onFile(FILENAME_ISSUES).withCheck(visitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Expected at [1]");
   }
@@ -194,8 +189,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectShift.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    assertThatCode(verifier::verifyNoIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyNoIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Use only '@+N' or '@-N' to shifts messages.");
   }
@@ -207,8 +201,7 @@ class CheckVerifierTest {
       .withCheck(NO_EFFECT_VISITOR);
 
 
-    assertThatCode(verifier::verifyNoIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyNoIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("// Noncompliant attributes not valid: 'invalid=1'");
   }
@@ -219,8 +212,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectAttribute2.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    assertThatCode(verifier::verifyNoIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyNoIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("// Noncompliant attributes not valid: 'invalid=1=2'");
   }
@@ -231,8 +223,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectEndLine.java")
       .withCheck(NO_EFFECT_VISITOR);
 
-    assertThatCode(verifier::verifyNoIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyNoIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
   }
@@ -244,8 +235,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectSecondaryLocation.java")
       .withCheck(visitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Secondary locations: expected: [] unexpected: [3]. In JavaCheckVerifierIncorrectSecondaryLocation.java:10");
   }
@@ -257,8 +247,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierIncorrectSecondaryLocation2.java")
       .withCheck(visitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Secondary locations: expected: [5] unexpected: []. In JavaCheckVerifierIncorrectSecondaryLocation2.java:10");
   }
@@ -310,8 +299,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierFlows.java")
       .withCheck(fakeVisitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Flow npe1 has line differences. Expected: [9, 3] but was: [6, 5]");
   }
@@ -330,8 +318,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierFlows.java")
       .withCheck(fakeVisitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Missing flows: npe1 [9,3].");
   }
@@ -386,8 +373,7 @@ class CheckVerifierTest {
       .onFile("src/test/files/JavaCheckVerifierFlowsSuperfluous.java")
       .withCheck(fakeVisitor);
 
-    assertThatCode(verifier::verifyIssues)
-      .withFailMessage(SHOULD_HAVE_FAILED)
+    assertThatThrownBy(verifier::verifyIssues)
       .isInstanceOf(AssertionError.class)
       .hasMessage("Following flow comments were observed, but not referenced by any issue: {superfluous=8,6,4, npe2=7}");
   }

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
@@ -29,7 +29,9 @@ import org.sonar.java.reporting.AnalyzerMessage.TextSpan;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.END_COLUMN;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.END_LINE;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.FLOWS;

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
@@ -31,7 +31,6 @@ import org.sonar.java.reporting.JavaTextEdit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.END_COLUMN;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.END_LINE;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.FLOWS;

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,8 +29,7 @@ import org.sonar.java.reporting.AnalyzerMessage.TextSpan;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.END_COLUMN;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.END_LINE;
 import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribute.FLOWS;
@@ -44,6 +42,7 @@ import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribut
 class ExpectationsTest {
 
   private static final int TEST_LINE = 42;
+  public static final String EXCEPTION_EXPECTED = "exception expected";
 
   @Test
   void issue_without_details() {
@@ -85,12 +84,10 @@ class ExpectationsTest {
   @Test
   void invalid_attribute_name() {
     Expectations.Parser parser = new Expectations().parser();
-    try {
-      parser.parseIssue("// Noncompliant [[invalid]]", TEST_LINE);
-      Fail.fail("exception expected");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("// Noncompliant attributes not valid: 'invalid'");
-    }
+    assertThatCode(() -> parser.parseIssue("// Noncompliant [[invalid]]", TEST_LINE))
+      .withFailMessage(EXCEPTION_EXPECTED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("// Noncompliant attributes not valid: 'invalid'");
   }
 
   @Test
@@ -113,12 +110,11 @@ class ExpectationsTest {
   @Test
   void end_line_attribute() {
     Expectations.Parser parser = new Expectations().parser();
-    try {
-      parser.parseIssue("// Noncompliant [[endLine=-1]] {{message}}", 0);
-      Fail.fail("exception expected");
-    } catch (AssertionError e) {
-      assertThat(e).hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
-    }
+
+    assertThatCode(() -> parser.parseIssue("// Noncompliant [[endLine=-1]] {{message}}", 0))
+      .withFailMessage(EXCEPTION_EXPECTED)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
   }
 
   @Test

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/ExpectationsTest.java
@@ -44,7 +44,6 @@ import static org.sonar.java.checks.verifier.internal.Expectations.IssueAttribut
 class ExpectationsTest {
 
   private static final int TEST_LINE = 42;
-  public static final String EXCEPTION_EXPECTED = "exception expected";
 
   @Test
   void issue_without_details() {
@@ -86,8 +85,7 @@ class ExpectationsTest {
   @Test
   void invalid_attribute_name() {
     Expectations.Parser parser = new Expectations().parser();
-    assertThatCode(() -> parser.parseIssue("// Noncompliant [[invalid]]", TEST_LINE))
-      .withFailMessage(EXCEPTION_EXPECTED)
+    assertThatThrownBy(() -> parser.parseIssue("// Noncompliant [[invalid]]", TEST_LINE))
       .isInstanceOf(AssertionError.class)
       .hasMessage("// Noncompliant attributes not valid: 'invalid'");
   }
@@ -113,8 +111,7 @@ class ExpectationsTest {
   void end_line_attribute() {
     Expectations.Parser parser = new Expectations().parser();
 
-    assertThatCode(() -> parser.parseIssue("// Noncompliant [[endLine=-1]] {{message}}", 0))
-      .withFailMessage(EXCEPTION_EXPECTED)
+    assertThatThrownBy(() -> parser.parseIssue("// Noncompliant [[endLine=-1]] {{message}}", 0))
       .isInstanceOf(AssertionError.class)
       .hasMessage("endLine attribute should be relative to the line and must be +N with N integer");
   }

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalReadCacheTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalReadCacheTest.java
@@ -21,7 +21,9 @@ import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class InternalReadCacheTest {
 

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalReadCacheTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalReadCacheTest.java
@@ -16,14 +16,12 @@
  */
 package org.sonar.java.checks.verifier.internal;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 class InternalReadCacheTest {
 
@@ -33,11 +31,13 @@ class InternalReadCacheTest {
     String key = "a convenient key";
     byte[] data = "Some data".getBytes(StandardCharsets.UTF_8);
     cache.put(key, data);
-    try (InputStream read = cache.read(key)) {
-      assertThat(read).hasBinaryContent(data);
-    } catch (IOException e) {
-      fail("This is not expected");
-    }
+
+    assertThatCode(() -> {
+      try (InputStream read = cache.read(key)) {
+        assertThat(read).hasBinaryContent(data);
+      }
+    }).withFailMessage("This is not expected")
+      .doesNotThrowAnyException();
   }
 
   @Test

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalReadCacheTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/InternalReadCacheTest.java
@@ -38,8 +38,7 @@ class InternalReadCacheTest {
       try (InputStream read = cache.read(key)) {
         assertThat(read).hasBinaryContent(data);
       }
-    }).withFailMessage("This is not expected")
-      .doesNotThrowAnyException();
+    }).doesNotThrowAnyException();
   }
 
   @Test

--- a/java-checks/src/test/java/org/sonar/java/filters/FilterVerifier.java
+++ b/java-checks/src/test/java/org/sonar/java/filters/FilterVerifier.java
@@ -17,6 +17,7 @@
 package org.sonar.java.filters;
 
 import com.sonar.sslr.api.RecognitionException;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.assertj.core.api.Fail;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
@@ -49,6 +51,7 @@ import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sonar.java.test.classpath.TestClasspathUtils.DEFAULT_MODULE;
@@ -139,11 +142,9 @@ public class FilterVerifier {
   private static Set<JavaCheck> instantiateRules(Set<Class<? extends JavaCheck>> filteredRules) {
     Set<JavaCheck> rules = new HashSet<>();
     for (Class<? extends JavaCheck> rule : filteredRules) {
-      try {
-        rules.add(rule.newInstance());
-      } catch (InstantiationException | IllegalAccessException e) {
-        Fail.fail("Unable to instantiate rule " + rule.getCanonicalName());
-      }
+      assertThatCode(() -> rules.add(rule.newInstance()))
+        .withFailMessage("Unable to instantiate rule " + rule.getCanonicalName())
+        .doesNotThrowAnyException();
     }
     return rules;
   }

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -700,13 +700,12 @@ class SonarComponentsTest {
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null, null);
     sonarComponents.setSensorContext(specificContext);
 
-    assertThatCode(() -> sonarComponents.inputFileContents(unknownInputFile))
-      .withFailMessage("reading file content should have failed")
+    assertThatThrownBy(() -> sonarComponents.inputFileContents(unknownInputFile))
       .isInstanceOf(AnalysisException.class)
       .hasMessage("Unable to read file 'unknown_file.java'")
       .hasCauseInstanceOf(NoSuchFileException.class);
 
-    assertThatCode(() -> sonarComponents.fileLines(unknownInputFile))
+    assertThatThrownBy(() -> sonarComponents.fileLines(unknownInputFile))
       .withFailMessage("reading file lines should have failed")
       .isInstanceOf(AnalysisException.class)
       .hasMessage("Unable to read file 'unknown_file.java'")

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -17,6 +17,7 @@
 package org.sonar.java;
 
 import com.sonar.sslr.api.RecognitionException;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -90,9 +92,7 @@ import org.sonar.plugins.java.api.JspCodeVisitor;
 import org.sonar.plugins.java.api.caching.SonarLintCache;
 import org.sonarsource.sonarlint.core.plugin.commons.sonarapi.SonarLintRuntimeImpl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -698,22 +698,17 @@ class SonarComponentsTest {
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null, null);
     sonarComponents.setSensorContext(specificContext);
 
-    try {
-      sonarComponents.inputFileContents(unknownInputFile);
-      fail("reading file content should have failed");
-    } catch (AnalysisException e) {
-      assertThat(e).hasMessage("Unable to read file 'unknown_file.java'").hasCauseInstanceOf(NoSuchFileException.class);
-    } catch (Exception e) {
-      fail("reading file content should have failed", e);
-    }
-    try {
-      sonarComponents.fileLines(unknownInputFile);
-      fail("reading file lines should have failed");
-    } catch (AnalysisException e) {
-      assertThat(e).hasMessage("Unable to read file 'unknown_file.java'").hasCauseInstanceOf(NoSuchFileException.class);
-    } catch (Exception e) {
-      fail("reading file content should have failed");
-    }
+    assertThatCode(() -> sonarComponents.inputFileContents(unknownInputFile))
+      .withFailMessage("reading file content should have failed")
+      .isInstanceOf(AnalysisException.class)
+      .hasMessage("Unable to read file 'unknown_file.java'")
+      .hasCauseInstanceOf(NoSuchFileException.class);
+
+    assertThatCode(() -> sonarComponents.fileLines(unknownInputFile))
+      .withFailMessage("reading file lines should have failed")
+      .isInstanceOf(AnalysisException.class)
+      .hasMessage("Unable to read file 'unknown_file.java'")
+      .hasCauseInstanceOf(NoSuchFileException.class);
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -94,7 +94,6 @@ import org.sonarsource.sonarlint.core.plugin.commons.sonarapi.SonarLintRuntimeIm
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -92,7 +92,9 @@ import org.sonar.plugins.java.api.JspCodeVisitor;
 import org.sonar.plugins.java.api.caching.SonarLintCache;
 import org.sonarsource.sonarlint.core.plugin.commons.sonarapi.SonarLintRuntimeImpl;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -87,7 +87,6 @@ class JavaAstScannerTest {
   public static final JavaFileScanner PROBLEMATIC_VISITOR = ctx -> {
     throw new StackOverflowError();
   };
-  public static final String SHOULD_NOT_HAVE_FAILED = "Should not have failed";
 
   @RegisterExtension
   public ThreadLocalLogTester logTester = new ThreadLocalLogTester().setLevel(Level.DEBUG);
@@ -136,7 +135,6 @@ class JavaAstScannerTest {
     InputFile inputFile = TestUtils.emptyInputFile("!!dummy");
     VisitorsBridge visitorsBridge = new VisitorsBridge(null);
     assertThatCode(() -> JavaAstScanner.scanSingleFileForTests(inputFile, visitorsBridge))
-      .withFailMessage(SHOULD_NOT_HAVE_FAILED)
       .doesNotThrowAnyException();
   }
 
@@ -144,7 +142,6 @@ class JavaAstScannerTest {
   void scan_single_file_with_dumb_file_should_not_fail_when_not_fail_fast() {
     InputFile inputFile = TestUtils.emptyInputFile("!!dummy");
     assertThatCode(() -> scanSingleFile(inputFile, false))
-      .withFailMessage(SHOULD_NOT_HAVE_FAILED)
       .doesNotThrowAnyException();
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -67,7 +67,7 @@ import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,6 +87,7 @@ class JavaAstScannerTest {
   public static final JavaFileScanner PROBLEMATIC_VISITOR = ctx -> {
     throw new StackOverflowError();
   };
+  public static final String SHOULD_NOT_HAVE_FAILED = "Should not have failed";
 
   @RegisterExtension
   public ThreadLocalLogTester logTester = new ThreadLocalLogTester().setLevel(Level.DEBUG);
@@ -134,21 +135,17 @@ class JavaAstScannerTest {
   void scan_single_file_with_dumb_file_should_not_fail() {
     InputFile inputFile = TestUtils.emptyInputFile("!!dummy");
     VisitorsBridge visitorsBridge = new VisitorsBridge(null);
-    try {
-      JavaAstScanner.scanSingleFileForTests(inputFile, visitorsBridge);
-    } catch (Exception e) {
-      fail("Should not have failed", e);
-    }
+    assertThatCode(() -> JavaAstScanner.scanSingleFileForTests(inputFile, visitorsBridge))
+      .withFailMessage(SHOULD_NOT_HAVE_FAILED)
+      .doesNotThrowAnyException();
   }
 
   @Test
   void scan_single_file_with_dumb_file_should_not_fail_when_not_fail_fast() {
     InputFile inputFile = TestUtils.emptyInputFile("!!dummy");
-    try {
-      scanSingleFile(inputFile, false);
-    } catch (Exception e) {
-      fail("Should not have failed", e);
-    }
+    assertThatCode(() -> scanSingleFile(inputFile, false))
+      .withFailMessage(SHOULD_NOT_HAVE_FAILED)
+      .doesNotThrowAnyException();
   }
 
   @Test
@@ -302,17 +299,16 @@ class JavaAstScannerTest {
     JavaAstScanner scanner = new JavaAstScanner(null, new NoOpTelemetry(), TelemetryKey.JAVA_ANALYSIS_MAIN);
     scanner.setVisitorBridge(new VisitorsBridge(new CheckThrowingSOError()));
     List<InputFile> files = Collections.singletonList(TestUtils.inputFile("src/test/resources/AstScannerNoParseError.txt"));
-    try {
-      scanner.scan(files);
-      fail("Should have triggered a StackOverflowError and not reach this point.");
-    } catch (Error e) {
-      assertThat(e)
-        .isInstanceOf(StackOverflowError.class)
-        .hasMessage("boom");
-      List<String> errorLogs = logTester.logs(Level.ERROR);
-      assertThat(errorLogs).hasSize(1);
-      assertThat(errorLogs.get(0)).startsWith("A stack overflow error occurred while analyzing file");
-    }
+
+    assertThatCode(() -> scanner.scan(files))
+      .withFailMessage("Should have triggered a StackOverflowError and not reach this point.")
+      .isInstanceOf(StackOverflowError.class)
+      .hasMessage("boom");
+
+    assertThat(logTester.logs(Level.ERROR))
+      .hasSize(12)
+      .first().asString()
+      .startsWith("A stack overflow error occurred while analyzing file");
   }
 
   @Test
@@ -592,6 +588,7 @@ class JavaAstScannerTest {
       throw new StackOverflowError("boom");
     }
   }
+
   private static class CheckThrowingException implements JavaFileScanner {
 
     private final RuntimeException exception;

--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -306,7 +306,7 @@ class JavaAstScannerTest {
       .hasMessage("boom");
 
     assertThat(logTester.logs(Level.ERROR))
-      .hasSize(12)
+      .hasSize(1)
       .first().asString()
       .startsWith("A stack overflow error occurred while analyzing file");
   }

--- a/java-frontend/src/test/java/org/sonar/java/caching/JavaReadCacheImplTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/caching/JavaReadCacheImplTest.java
@@ -25,7 +25,7 @@ import org.sonar.api.batch.sensor.cache.ReadCache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -44,11 +44,12 @@ class JavaReadCacheImplTest {
     doReturn(true).when(readCache).contains(key);
 
     JavaReadCacheImpl cache = new JavaReadCacheImpl(readCache);
-    try (InputStream read = cache.read(key)) {
-      assertThat(read).hasBinaryContent(data);
-    } catch (IOException e) {
-      fail("This is not expected");
-    }
+    assertThatCode(() -> {
+      try (InputStream read = cache.read(key)) {
+        assertThat(read).hasBinaryContent(data);
+      }
+    }).withFailMessage("This is not expected")
+      .doesNotThrowAnyException();
 
     doReturn(new ByteArrayInputStream(data)).when(readCache).read(key);
     assertThat(cache.readBytes(key)).isEqualTo(data);

--- a/java-frontend/src/test/java/org/sonar/java/caching/JavaReadCacheImplTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/caching/JavaReadCacheImplTest.java
@@ -48,8 +48,7 @@ class JavaReadCacheImplTest {
       try (InputStream read = cache.read(key)) {
         assertThat(read).hasBinaryContent(data);
       }
-    }).withFailMessage("This is not expected")
-      .doesNotThrowAnyException();
+    }).doesNotThrowAnyException();
 
     doReturn(new ByteArrayInputStream(data)).when(readCache).read(key);
     assertThat(cache.readBytes(key)).isEqualTo(data);

--- a/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
@@ -413,7 +413,7 @@ class ClasspathForMainTest {
       javaClasspath = new ClasspathForMainForSonarLint(settings.asConfig(), fs);
       javaClasspath.getElements();
     })
-      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+      .withFailMessage("Analysis exception was raised but analysis should not fail")
       .doesNotThrowAnyException();
 
     assertThat(logTester.logs(Level.WARN))

--- a/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
@@ -37,7 +37,7 @@ import org.sonar.java.TestUtils;
 import org.sonar.java.testing.ThreadLocalLogTester;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 class ClasspathForMainTest {
 
+  public static final String EXCEPTION_SHOULD_HAVE_BEEN_RAISED = "Exception should have been raised";
   private MapSettings settings;
   private DefaultFileSystem fs;
   private AnalysisWarningsWrapper analysisWarnings;
@@ -341,14 +342,12 @@ class ClasspathForMainTest {
     settings.setProperty("sonar.binaries", "bin");
     settings.setProperty("sonar.libraries", "hello.jar");
     javaClasspath = createJavaClasspath();
-    try {
-      javaClasspath.getElements();
-      fail("Exception should have been raised");
-    } catch (AnalysisException ise) {
-      assertThat(ise.getMessage())
-        .isEqualTo(
-          "sonar.binaries and sonar.libraries are not supported since version 4.0 of the SonarSource Java Analyzer, please use sonar.java.binaries and sonar.java.libraries instead");
-    }
+    assertThatCode(javaClasspath::getElements)
+      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+      .isInstanceOf(AnalysisException.class)
+      .hasMessage(
+        "sonar.binaries and sonar.libraries are not supported since version 4.0 of the SonarSource Java Analyzer, please use sonar.java.binaries and sonar.java.libraries instead"
+      );
   }
 
   @Test
@@ -383,41 +382,42 @@ class ClasspathForMainTest {
   void empty_binaries_on_project_with_more_than_one_source_should_fail() {
     createTwoFilesInFileSystem();
     javaClasspath = createJavaClasspath();
-    try {
-      javaClasspath.getElements();
-      fail("Exception should have been raised");
-    } catch (AnalysisException ise) {
-      assertThat(ise.getMessage())
-        .isEqualTo("Your project contains .java files, please provide compiled classes with sonar.java.binaries property,"
-          + " or exclude them from the analysis with sonar.exclusions property.");
-    }
+    assertThatCode(javaClasspath::getElements)
+      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+      .isInstanceOf(AnalysisException.class)
+      .hasMessage(
+        "Your project contains .java files, please provide compiled classes with sonar.java.binaries property,"
+        + " or exclude them from the analysis with sonar.exclusions property."
+      );
   }
 
   @Test
   void empty_binaries_on_project_with_more_than_one_source_should_fail_on_sonarqube() {
     createTwoFilesInFileSystem();
     javaClasspath = createJavaClasspath();
-    try {
-      javaClasspath.getElements();
-      fail("Exception should have been raised");
-    } catch (AnalysisException ise) {
-      assertThat(ise.getMessage())
-        .isEqualTo("Your project contains .java files, please provide compiled classes with sonar.java.binaries property,"
-          + " or exclude them from the analysis with sonar.exclusions property.");
-    }
+
+    assertThatCode(javaClasspath::getElements)
+      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+      .isInstanceOf(AnalysisException.class)
+      .hasMessage(
+        "Your project contains .java files, please provide compiled classes with sonar.java.binaries property,"
+          + " or exclude them from the analysis with sonar.exclusions property."
+      );
   }
 
   @Test
   void empty_binaries_on_project_with_more_than_one_source_should_not_fail_on_sonarlint() {
     createTwoFilesInFileSystem();
-    try {
+
+    assertThatCode(() -> {
       javaClasspath = new ClasspathForMainForSonarLint(settings.asConfig(), fs);
       javaClasspath.getElements();
+    })
+      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+      .doesNotThrowAnyException();
 
-      logTester.logs(Level.WARN).contains("sonar.java.binaries is empty, please double check your configuration");
-    } catch (AnalysisException ise) {
-      fail("Analysis exception was raised but analysis should not fail");
-    }
+    assertThat(logTester.logs(Level.WARN))
+      .contains("sonar.java.binaries is empty, please double check your configuration");
   }
 
   private void createTwoFilesInFileSystem() {
@@ -537,12 +537,11 @@ class ClasspathForMainTest {
 
   private void checkIllegalStateException(String message) {
     javaClasspath = createJavaClasspath();
-    try {
-      javaClasspath.getElements();
-      fail("Exception should have been raised");
-    } catch (IllegalStateException ise) {
-      assertThat(ise.getMessage()).isEqualTo(message);
-    }
+
+    assertThatCode(javaClasspath::getElements)
+      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage(message);
   }
 
   private ClasspathForMain createJavaClasspath() {

--- a/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
@@ -38,6 +38,7 @@ import org.sonar.java.testing.ThreadLocalLogTester;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -46,7 +47,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 class ClasspathForMainTest {
 
-  public static final String EXCEPTION_SHOULD_HAVE_BEEN_RAISED = "Exception should have been raised";
   private MapSettings settings;
   private DefaultFileSystem fs;
   private AnalysisWarningsWrapper analysisWarnings;
@@ -342,8 +342,7 @@ class ClasspathForMainTest {
     settings.setProperty("sonar.binaries", "bin");
     settings.setProperty("sonar.libraries", "hello.jar");
     javaClasspath = createJavaClasspath();
-    assertThatCode(javaClasspath::getElements)
-      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+    assertThatThrownBy(javaClasspath::getElements)
       .isInstanceOf(AnalysisException.class)
       .hasMessage(
         "sonar.binaries and sonar.libraries are not supported since version 4.0 of the SonarSource Java Analyzer, please use sonar.java.binaries and sonar.java.libraries instead"
@@ -382,8 +381,7 @@ class ClasspathForMainTest {
   void empty_binaries_on_project_with_more_than_one_source_should_fail() {
     createTwoFilesInFileSystem();
     javaClasspath = createJavaClasspath();
-    assertThatCode(javaClasspath::getElements)
-      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+    assertThatThrownBy(javaClasspath::getElements)
       .isInstanceOf(AnalysisException.class)
       .hasMessage(
         "Your project contains .java files, please provide compiled classes with sonar.java.binaries property,"
@@ -396,8 +394,7 @@ class ClasspathForMainTest {
     createTwoFilesInFileSystem();
     javaClasspath = createJavaClasspath();
 
-    assertThatCode(javaClasspath::getElements)
-      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+    assertThatThrownBy(javaClasspath::getElements)
       .isInstanceOf(AnalysisException.class)
       .hasMessage(
         "Your project contains .java files, please provide compiled classes with sonar.java.binaries property,"
@@ -538,8 +535,7 @@ class ClasspathForMainTest {
   private void checkIllegalStateException(String message) {
     javaClasspath = createJavaClasspath();
 
-    assertThatCode(javaClasspath::getElements)
-      .withFailMessage(EXCEPTION_SHOULD_HAVE_BEEN_RAISED)
+    assertThatThrownBy(javaClasspath::getElements)
       .isInstanceOf(IllegalStateException.class)
       .hasMessage(message);
   }

--- a/java-frontend/src/test/java/org/sonar/java/matcher/MethodMatcherFactoryTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/matcher/MethodMatcherFactoryTest.java
@@ -39,45 +39,43 @@ import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class MethodMatcherFactoryTest {
 
+  public static final String ARGUMENT_SHOULD_NOT_BE_ACCEPTED = "Argument should not be accepted.";
+
   @Test
   void fail_arg() {
-    try {
-      MethodMatcherFactory.methodMatchers("org.sonar.test.Test$match");
-      fail("Argument should not be accepted.");
-    } catch (IllegalArgumentException iae) {
-      assertThat(iae.getMessage()).contains("method");
-    }
+    assertThatCode(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test$match"))
+      .withFailMessage("Argument should not be accepted.")
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("method");
 
-    try {
-      MethodMatcherFactory.constructorMatcher("   %");
-      fail("Argument should not be accepted.");
-    } catch (IllegalArgumentException iae) {
-      assertThat(iae.getMessage()).contains("constructor");
-    }
 
-    try {
-      MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String;int)");
-      fail("Argument should not be accepted.");
-    } catch (IllegalArgumentException iae) {
-      assertThat(iae.getMessage()).contains("constructor").contains("method");
-    }
 
-    try {
-      MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String,int)followed by anything");
-      fail("Argument should not be accepted.");
-    } catch (IllegalArgumentException iae) {
-      assertThat(iae.getMessage()).contains("constructor").contains("method");
-    }
-    try {
-      MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match this is an error");
-      fail("Argument should not be accepted.");
-    } catch (IllegalArgumentException iae) {
-      assertThat(iae.getMessage()).contains("method");
-    }
+    assertThatCode(() ->  MethodMatcherFactory.constructorMatcher("   %"))
+      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("constructor");
+
+    assertThatCode(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String;int)"))
+      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("constructor")
+      .hasMessageContaining("method");
+
+    assertThatCode(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String,int)followed by anything"))
+      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("constructor")
+      .hasMessageContaining("method");
+
+    assertThatCode(() ->  MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match this is an error"))
+      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("constructor")
+      .hasMessageContaining("method");
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/matcher/MethodMatcherFactoryTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/matcher/MethodMatcherFactoryTest.java
@@ -39,40 +39,32 @@ import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MethodMatcherFactoryTest {
 
-  public static final String ARGUMENT_SHOULD_NOT_BE_ACCEPTED = "Argument should not be accepted.";
 
   @Test
   void fail_arg() {
-    assertThatCode(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test$match"))
-      .withFailMessage("Argument should not be accepted.")
+    assertThatThrownBy(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test$match"))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("method");
 
-
-
-    assertThatCode(() ->  MethodMatcherFactory.constructorMatcher("   %"))
-      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+    assertThatThrownBy(() ->  MethodMatcherFactory.constructorMatcher("   %"))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("constructor");
 
-    assertThatCode(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String;int)"))
-      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+    assertThatThrownBy(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String;int)"))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("constructor")
       .hasMessageContaining("method");
 
-    assertThatCode(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String,int)followed by anything"))
-      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+    assertThatThrownBy(() -> MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match(java.lang.String,int)followed by anything"))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("constructor")
       .hasMessageContaining("method");
 
-    assertThatCode(() ->  MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match this is an error"))
-      .withFailMessage(ARGUMENT_SHOULD_NOT_BE_ACCEPTED)
+    assertThatThrownBy(() ->  MethodMatcherFactory.methodMatchers("org.sonar.test.Test#match this is an error"))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("constructor")
       .hasMessageContaining("method");

--- a/java-frontend/src/test/java/org/sonar/java/model/JMethodSymbolTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JMethodSymbolTest.java
@@ -45,10 +45,10 @@ import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -161,7 +161,7 @@ class JMethodSymbolTest {
       .parse(inputFiles, () -> false, new AnalysisProgress(inputFiles.size()), (inputFile, result) -> {
         processed.add(inputFile.filename());
         if (inputFile.filename().equals("Main.java")) {
-          try {
+          assertThatCode(() -> {
             ClassTreeImpl classA = (ClassTreeImpl) result.get().types().get(0);
             MethodTreeImpl methodM = (MethodTreeImpl) classA.members().get(0);
             List<StatementTree> body = methodM.block().body();
@@ -180,9 +180,7 @@ class JMethodSymbolTest {
             Symbol genericDependencyParamDeclaration = genericDependencyInvocation.methodSymbol().declarationParameters().get(0);
             assertThat(genericDependencyParamDeclaration.owner().owner().name()).isEqualTo("GenericDependency");
             assertThat(genericDependencyParamDeclaration.metadata().isAnnotatedWith("semantic.Nullable")).isTrue();
-          } catch (Exception e) {
-            fail(e);
-          }
+          }).doesNotThrowAnyException();
         }
       });
     assertThat(processed).containsExactly("Main.java", "Dependency.java", "GenericDependency.java", "Nullable.java");

--- a/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
@@ -61,7 +61,10 @@ import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 
-import static org.assertj.core.api.Assertions.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;

--- a/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import org.assertj.core.api.Fail;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -61,8 +61,7 @@ import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -88,16 +87,14 @@ class VisitorsBridgeTest {
   @Test
   void rethrow_exception_when_hidden_property_set_to_true_with_JavaFileScanner() {
     VisitorsBridge visitorsBridge = visitorsBridge(new JFS_ThrowingNPEJavaFileScanner(), true);
-    try {
-      visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false);
-      Fail.fail("scanning of file should have raise an exception");
-    } catch (AnalysisException e) {
-      assertThat(e.getMessage()).contains("Failing check");
-      assertThat(e.getCause()).isInstanceOf(CheckFailureException.class);
-      assertThat(e.getCause().getCause()).isSameAs(NPE);
-    } catch (Exception e) {
-      Fail.fail("Should have been an AnalysisException");
-    }
+
+    assertThatCode(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
+      .isInstanceOf(AnalysisException.class)
+      .withFailMessage("scanning of file should have raise an AnalysisException")
+      .hasMessageContaining("Failing check")
+      .hasCauseInstanceOf(CheckFailureException.class)
+      .hasRootCause(NPE);
+
     assertThat(logTester.logs(Level.ERROR)).hasSize(1);
     assertThat(logTester.logs(Level.ERROR).stream().map(VisitorsBridgeTest::ruleKeyFromErrorLog))
       .containsExactlyInAnyOrder("JFS_ThrowingNPEJavaFileScanner - JFS");
@@ -105,13 +102,13 @@ class VisitorsBridgeTest {
 
   @Test
   void swallow_exception_when_hidden_property_set_to_false_with_JavaFileScanner() {
-    try {
+    assertThatCode(() ->
       visitorsBridge(new JFS_ThrowingNPEJavaFileScanner(), false)
-        .visitFile(COMPILATION_UNIT_TREE, false);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Fail.fail("Exception should be swallowed when property is not set");
-    }
+        .visitFile(COMPILATION_UNIT_TREE, false)
+    )
+      .withFailMessage("Exception should be swallowed when property is not set")
+      .doesNotThrowAnyException();
+
     assertThat(logTester.logs(Level.ERROR)).hasSize(1);
     assertThat(logTester.logs(Level.ERROR).stream().map(VisitorsBridgeTest::ruleKeyFromErrorLog))
       .containsExactlyInAnyOrder("JFS_ThrowingNPEJavaFileScanner - JFS");
@@ -120,16 +117,14 @@ class VisitorsBridgeTest {
   @Test
   void rethrow_exception_when_hidden_property_set_to_true_with_SubscriptionVisitor() {
     VisitorsBridge visitorsBridge = visitorsBridge(new SV1_ThrowingNPEVisitingClass(), true);
-    try {
-      visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false);
-      Fail.fail("scanning of file should have raise an exception");
-    } catch (AnalysisException e) {
-      assertThat(e.getMessage()).contains("Failing check");
-      assertThat(e.getCause()).isInstanceOf(CheckFailureException.class);
-      assertThat(e.getCause().getCause()).isSameAs(NPE);
-    } catch (Exception e) {
-      Fail.fail("Should have been an AnalysisException");
-    }
+
+    assertThatCode(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
+      .isInstanceOf(AnalysisException.class)
+      .withFailMessage("scanning of file should have raise an AnalysisException")
+      .hasMessageContaining("Failing check")
+      .hasCauseInstanceOf(CheckFailureException.class)
+      .hasRootCause(NPE);
+
     assertThat(logTester.logs(Level.ERROR)).hasSize(1);
     assertThat(logTester.logs(Level.ERROR).stream().map(VisitorsBridgeTest::ruleKeyFromErrorLog))
       .containsExactlyInAnyOrder("SV1_ThrowingNPEVisitingClass - SV1");
@@ -137,18 +132,18 @@ class VisitorsBridgeTest {
 
   @Test
   void swallow_exception_when_hidden_property_set_to_false_with_SubscriptionVisitor() {
-    try {
+    assertThatCode(() -> {
       visitorsBridge(Arrays.asList(
-        new SV1_ThrowingNPEVisitingClass(),
-        new SV2_ThrowingNPELeavingClass(),
-        new SV3_ThrowingNPEVisitingToken(),
-        new SV4_ThrowingNPEVisitingTrivia()),
+          new SV1_ThrowingNPEVisitingClass(),
+          new SV2_ThrowingNPELeavingClass(),
+          new SV3_ThrowingNPEVisitingToken(),
+          new SV4_ThrowingNPEVisitingTrivia()),
         false)
         .visitFile(COMPILATION_UNIT_TREE, false);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Fail.fail("Exceptions should be swallowed when property is not set");
-    }
+    })
+      .withFailMessage("Exceptions should be swallowed when property is not set")
+      .doesNotThrowAnyException();
+
     assertThat(logTester.logs(Level.ERROR)).hasSize(4);
     assertThat(logTester.logs(Level.ERROR).stream().map(VisitorsBridgeTest::ruleKeyFromErrorLog))
       .containsExactlyInAnyOrder(
@@ -160,16 +155,16 @@ class VisitorsBridgeTest {
 
   @Test
   void swallow_exception_when_hidden_property_set_to_false_with_IssuableSubscriptionVisitor() {
-    try {
+    assertThatCode(() -> {
       visitorsBridge(Arrays.asList(
-        new IV1_ThrowingNPEVisitingClass(),
-        new IV2_ThrowingNPELeavingClass()),
+          new IV1_ThrowingNPEVisitingClass(),
+          new IV2_ThrowingNPELeavingClass()),
         false)
         .visitFile(COMPILATION_UNIT_TREE, false);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Fail.fail("Exceptions should be swallowed when property is not set");
-    }
+    })
+      .withFailMessage("Exceptions should be swallowed when property is not set")
+      .doesNotThrowAnyException();
+
     assertThat(logTester.logs(Level.ERROR)).hasSize(1);
     assertThat(logTester.logs(Level.ERROR).stream().map(VisitorsBridgeTest::ruleKeyFromErrorLog))
       .containsOnly("IV1_ThrowingNPEVisitingClass - IV1");
@@ -177,16 +172,16 @@ class VisitorsBridgeTest {
 
   @Test
   void swallow_exception_when_hidden_property_set_to_false_with_all_kinds_of_visisitors() {
-    try {
+    assertThatCode(() -> {
       visitorsBridge(Arrays.asList(
-        new SV1_ThrowingNPEVisitingClass(),
-        new IV1_ThrowingNPEVisitingClass()),
+          new SV1_ThrowingNPEVisitingClass(),
+          new IV1_ThrowingNPEVisitingClass()),
         false)
         .visitFile(COMPILATION_UNIT_TREE, false);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Fail.fail("Exceptions should be swallowed when property is not set");
-    }
+    })
+      .withFailMessage("Exceptions should be swallowed when property is not set")
+      .doesNotThrowAnyException();
+
     assertThat(logTester.logs(Level.ERROR)).hasSize(2);
     assertThat(logTester.logs(Level.ERROR).stream().map(VisitorsBridgeTest::ruleKeyFromErrorLog))
       .containsExactlyInAnyOrder(
@@ -197,13 +192,8 @@ class VisitorsBridgeTest {
   @Test
   void no_log_when_filter_execute_fine() {
     VisitorsBridge visitorsBridge = visitorsBridge(Arrays.asList(), true);
-    try {
-      visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false);
-    } catch (Exception e) {
-      e.printStackTrace();
-      Fail.fail("No exception should be raised");
-    }
-    assertThat(logTester.logs(Level.ERROR)).isEmpty();
+    assertThatCode(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
+      .doesNotThrowAnyException();
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
@@ -91,9 +91,8 @@ class VisitorsBridgeTest {
   void rethrow_exception_when_hidden_property_set_to_true_with_JavaFileScanner() {
     VisitorsBridge visitorsBridge = visitorsBridge(new JFS_ThrowingNPEJavaFileScanner(), true);
 
-    assertThatCode(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
+    assertThatThrownBy(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
       .isInstanceOf(AnalysisException.class)
-      .withFailMessage("scanning of file should have raise an AnalysisException")
       .hasMessageContaining("Failing check")
       .hasCauseInstanceOf(CheckFailureException.class)
       .hasRootCause(NPE);
@@ -121,9 +120,8 @@ class VisitorsBridgeTest {
   void rethrow_exception_when_hidden_property_set_to_true_with_SubscriptionVisitor() {
     VisitorsBridge visitorsBridge = visitorsBridge(new SV1_ThrowingNPEVisitingClass(), true);
 
-    assertThatCode(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
+    assertThatThrownBy(() -> visitorsBridge.visitFile(COMPILATION_UNIT_TREE, false))
       .isInstanceOf(AnalysisException.class)
-      .withFailMessage("scanning of file should have raise an AnalysisException")
       .hasMessageContaining("Failing check")
       .hasCauseInstanceOf(CheckFailureException.class)
       .hasRootCause(NPE);

--- a/java-frontend/src/test/java/org/sonar/java/reporting/AnalyzerMessageTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/reporting/AnalyzerMessageTest.java
@@ -35,7 +35,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 class AnalyzerMessageTest {
@@ -192,8 +192,7 @@ class AnalyzerMessageTest {
   void shouldFailOnEmptySpans() {
     CompilationUnitTree cut = JParserTestUtils.parse("class A {\n}\n");
     SyntaxToken eofToken = cut.eofToken();
-    assertThatCode(() ->  AnalyzerMessage.textSpanFor(eofToken))
-      .withFailMessage("Should have failed on empty issue location")
+    assertThatThrownBy(() ->  AnalyzerMessage.textSpanFor(eofToken))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Invalid issue location: Text span is empty when trying reporting on (l:3, c:1).");
   }
@@ -201,8 +200,7 @@ class AnalyzerMessageTest {
   @Test
   void shouldFailOnTreeWithoutParents() {
     InferedTypeTree itt = new InferedTypeTree();
-    assertThatCode(() -> AnalyzerMessage.textSpanFor(itt))
-      .withFailMessage("Should have failed on empty issue location")
+    assertThatThrownBy(() -> AnalyzerMessage.textSpanFor(itt))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Trying to report on an empty tree with no parent");
   }

--- a/java-frontend/src/test/java/org/sonar/java/reporting/AnalyzerMessageTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/reporting/AnalyzerMessageTest.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.reporting;
 
-import org.assertj.core.api.Fail;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.java.TestUtils;
@@ -33,8 +32,10 @@ import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.TypeTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
+import org.sonar.plugins.java.api.tree.SyntaxToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 
 class AnalyzerMessageTest {
@@ -190,28 +191,20 @@ class AnalyzerMessageTest {
   @Test
   void shouldFailOnEmptySpans() {
     CompilationUnitTree cut = JParserTestUtils.parse("class A {\n}\n");
-
-    try {
-      AnalyzerMessage.textSpanFor(cut.eofToken());
-      Fail.fail("Should have failed on empty issue location");
-    } catch (Exception e) {
-      assertThat(e)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Invalid issue location: Text span is empty when trying reporting on (l:3, c:1).");
-    }
+    SyntaxToken eofToken = cut.eofToken();
+    assertThatCode(() ->  AnalyzerMessage.textSpanFor(eofToken))
+      .withFailMessage("Should have failed on empty issue location")
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Invalid issue location: Text span is empty when trying reporting on (l:3, c:1).");
   }
 
   @Test
   void shouldFailOnTreeWithoutParents() {
     InferedTypeTree itt = new InferedTypeTree();
-    try {
-      AnalyzerMessage.textSpanFor(itt);
-      Fail.fail("Should have failed on empty issue location");
-    } catch (Exception e) {
-      assertThat(e)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Trying to report on an empty tree with no parent");
-    }
+    assertThatCode(() -> AnalyzerMessage.textSpanFor(itt))
+      .withFailMessage("Should have failed on empty issue location")
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Trying to report on an empty tree with no parent");
   }
 
   @Test

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/GeneratedCheckListTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/GeneratedCheckListTest.java
@@ -38,7 +38,7 @@ import org.sonar.plugins.java.api.JavaCheck;
 import org.sonarsource.analyzer.commons.collections.SetUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.fail;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class GeneratedCheckListTest {
 
@@ -93,13 +93,12 @@ class GeneratedCheckListTest {
       new RulesDefinitionAnnotationLoader().load(repository, checks.toArray(new Class[checks.size()]));
 
       for (NewRule rule : repository.rules()) {
-        try {
+        assertThatCode(() -> {
           rule.setName("Artificial Name (set via JSON files, no need to test it)");
           rule.setMarkdownDescription(ARTIFICIAL_DESCRIPTION);
-        } catch (IllegalStateException e) {
-          // it means that the html description was already set in Rule annotation
-          fail("Description of " + rule.key() + " should be in separate file");
-        }
+        })
+          .withFailMessage("Description of " + rule.key() + " should be in separate file")
+          .doesNotThrowAnyException();
       }
       repository.done();
     }

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/SanityTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/SanityTest.java
@@ -60,6 +60,7 @@ import org.sonar.plugins.java.api.JavaVersion;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPathInModule;
@@ -105,7 +106,7 @@ class SanityTest {
 
   /**
    * Verifies that playing all the checks on all the test files does not trigger any exceptions.
-   *
+   * <p>
    * This relies on the fact that a lot of tricky cases are covered in unit tests, on a rule by rule and case by case basis.
    * It does not prevent other rules to fail if similar construct of the language, but not yet encountered.
    */
@@ -134,11 +135,11 @@ class SanityTest {
       .allMatch(SanityTest::isParseError)
       .map(LogAndArguments::getFormattedMsg)
       .allMatch(log ->
-      // ECJ error message
-      log.startsWith("Parse error at line ")
-        // analyzer error message mentioning the file
-        || log.contains("RestrictedIdentifiersUsageCheckSample")
-        || log.contains("EmptyStatementsInImportsBug"));
+        // ECJ error message
+        log.startsWith("Parse error at line ")
+          // analyzer error message mentioning the file
+          || log.contains("RestrictedIdentifiersUsageCheckSample")
+          || log.contains("EmptyStatementsInImportsBug"));
   }
 
   @Test
@@ -203,11 +204,9 @@ class SanityTest {
       if (TEMPLATE_RULES_KEYS.contains(ruleKey) || EXCLUDED_RULES.contains(ruleKey)) {
         // FIXME initialize a new template rule with some default parameter ?!
       } else {
-        try {
-          javaChecks.add(checkClass.getConstructor().newInstance());
-        } catch (Exception e) {
-          fail(String.format("Unable to initialize rule %s", ruleKey), e);
-        }
+        assertThatCode(() -> javaChecks.add(checkClass.getConstructor().newInstance()))
+          .withFailMessage(String.format("Unable to initialize rule %s", ruleKey))
+          .doesNotThrowAnyException();
       }
     }
     assertThat(javaChecks).hasSizeGreaterThan(400);
@@ -245,7 +244,8 @@ class SanityTest {
       .create(javaVersion, classpath, true)
       .parse(inputFiles, () -> false, analysisProgress, (input, result) -> {
         try {
-          scanner.simpleScan(input, result, ast -> {});
+          scanner.simpleScan(input, result, ast -> {
+          });
         } catch (Throwable e) {
           exceptions.add(new SanityCheckException(input, e));
         }


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored test assertions:**
  - Migrated numerous tests across `java-checks-testkit`, `java-frontend`, and `sonar-java-plugin` to use AssertJ `assertThatCode` and `assertThatThrownBy` instead of manual `try-catch` blocks and `fail()` calls.
  - Standardized error handling and improved test readability by removing boilerplate `try-catch` and redundant message shadowing.
- **Cleaned up test imports:**
  - Removed unnecessary manual `Fail.fail` and JUnit `fail` imports, replacing them with standard AssertJ static imports.

<sub>This will update automatically on new commits.</sub>