### PR TITLE
SONARJAVA-6446 Refactor merging list of arguments to MethodMatchers

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
@@ -17,6 +17,10 @@
 package org.sonar.java.checks.helpers;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public class StringUtils {
   private StringUtils() {}
@@ -40,5 +44,31 @@ public class StringUtils {
     }
 
     return count;
+  }
+
+  /**
+   * Build String[] by concatenating Strings, arrays of Strings, and Collections of Strings.
+   * Nested collections and arrays are not supported, and will throw an IllegalArgumentException if encountered.
+   */
+  public static String[] stringArgs(Object ... args) {
+    List<String> result = new ArrayList<>();
+    for (Object arg : args) {
+      if (arg instanceof String s) {
+        result.add(s);
+      } else if (arg instanceof String[] arr) {
+        Collections.addAll(result, arr);
+      } else if (arg instanceof Collection<?> col) {
+        for (Object o : col) {
+          if (o instanceof String s) {
+            result.add(s);
+          } else {
+            throw new IllegalArgumentException("Unsupported collection element type: " + o.getClass());
+          }
+        }
+      } else {
+        throw new IllegalArgumentException("Unsupported argument type: " + arg.getClass());
+      }
+    }
+    return result.toArray(new String[0]);
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
@@ -53,8 +53,9 @@ public class StringUtils {
    *   <li>java.lang.String[]</li>
    *   <li>java.util.Collection<java.lang.strings></li>
    * </ol> 
-   * Nested collections and arrays are not supported, and will throw an IllegalArgumentException if encountered.
-   * @throws  IllegalArgumentException If one of the argument is not of the supported types
+   * Nested collections and arrays are not supported, and will throw an ArrayStoreException if encountered.
+   * @throws IllegalArgumentException If one of the argument is not of the supported types.
+   * @throws ArrayStoreException If a collection passed as argument contains an element that is not a String.
    */
   public static String[] flatten(Object ... args) {
     List<String> result = new ArrayList<>();

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
@@ -56,16 +56,15 @@ public class StringUtils {
    * Nested collections and arrays are not supported, and will throw an IllegalArgumentException if encountered.
    * @throws  IllegalArgumentException If one of the argument is not of the supported types
    */
-  public static String[] stringArgs(Object ... args) {
+  public static String[] flatten(Object ... args) {
     List<String> result = new ArrayList<>();
     for (Object arg : args) {
       if (arg instanceof String s) {
         result.add(s);
       } else if (arg instanceof String[] arr) {
         Collections.addAll(result, arr);
-      } else if (arg instanceof Collection<String> col) {
-          result.addAll(col);
-        }
+      } else if (arg instanceof Collection<?> col) {
+        result.addAll((Collection<String>) col);
       } else {
         throw new IllegalArgumentException("Unsupported argument type: " + arg.getClass());
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
@@ -63,13 +63,8 @@ public class StringUtils {
         result.add(s);
       } else if (arg instanceof String[] arr) {
         Collections.addAll(result, arr);
-      } else if (arg instanceof Collection<?> col) {
-        for (Object o : col) {
-          if (o instanceof String s) {
-            result.add(s);
-          } else {
-            throw new IllegalArgumentException("Unsupported collection element type: " + o.getClass());
-          }
+      } else if (arg instanceof Collection<String> col) {
+          result.addAll(col);
         }
       } else {
         throw new IllegalArgumentException("Unsupported argument type: " + arg.getClass());

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/StringUtils.java
@@ -47,8 +47,14 @@ public class StringUtils {
   }
 
   /**
-   * Build String[] by concatenating Strings, arrays of Strings, and Collections of Strings.
+   * Build String[] by concatenating arguments of types:
+   * <ol>
+   *   <li>java.lang.String</li>
+   *   <li>java.lang.String[]</li>
+   *   <li>java.util.Collection<java.lang.strings></li>
+   * </ol> 
    * Nested collections and arrays are not supported, and will throw an IllegalArgumentException if encountered.
+   * @throws  IllegalArgumentException If one of the argument is not of the supported types
    */
   public static String[] stringArgs(Object ... args) {
     List<String> result = new ArrayList<>();

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -41,7 +41,7 @@ import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static java.util.Arrays.asList;
-import static org.sonar.java.checks.helpers.StringUtils.stringArgs;
+import static org.sonar.java.checks.helpers.StringUtils.flatten;
 
 public final class UnitTestUtils {
   private static final List<String> ORG_ASSERTJ_CORE_API_ASSERTIONS = List.of(
@@ -103,7 +103,7 @@ public final class UnitTestUtils {
 
   public static final MethodMatchers FAIL_METHOD_MATCHER = MethodMatchers.or(
     MethodMatchers.create().ofTypes(
-        stringArgs(
+        flatten(
             // JUnit 5
             "org.junit.jupiter.api.Assertions",
             // JUnit 4
@@ -119,7 +119,7 @@ public final class UnitTestUtils {
       .names("fail").withAnyParameters().build(),
     MethodMatchers.create().ofTypes(
         // AssertJ
-        stringArgs(ORG_ASSERTJ_CORE_API_ASSERTIONS)
+        flatten(ORG_ASSERTJ_CORE_API_ASSERTIONS)
       )
       .names("failBecauseExceptionWasNotThrown").withAnyParameters().build());
 
@@ -132,7 +132,7 @@ public final class UnitTestUtils {
       .build(),
     // Fest assert and AssertJ
     MethodMatchers.create()
-      .ofTypes(stringArgs(ORG_ASSERTJ_CORE_API_ASSERTIONS, "org.fest.assertions.Assertions"))
+      .ofTypes(flatten(ORG_ASSERTJ_CORE_API_ASSERTIONS, "org.fest.assertions.Assertions"))
       .names("assertThat")
       .withAnyParameters()
       .build());

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/UnitTestUtils.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 import org.sonar.java.annotations.VisibleForTesting;
@@ -42,6 +41,7 @@ import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static java.util.Arrays.asList;
+import static org.sonar.java.checks.helpers.StringUtils.stringArgs;
 
 public final class UnitTestUtils {
   private static final List<String> ORG_ASSERTJ_CORE_API_ASSERTIONS = List.of(
@@ -103,8 +103,7 @@ public final class UnitTestUtils {
 
   public static final MethodMatchers FAIL_METHOD_MATCHER = MethodMatchers.or(
     MethodMatchers.create().ofTypes(
-        Stream.concat(
-          Stream.of(
+        stringArgs(
             // JUnit 5
             "org.junit.jupiter.api.Assertions",
             // JUnit 4
@@ -114,14 +113,13 @@ public final class UnitTestUtils {
             // Fest assert
             "org.fest.assertions.Fail",
             // AssertJ
-            "org.assertj.core.api.Fail"
-          ),
-          ORG_ASSERTJ_CORE_API_ASSERTIONS.stream()
-        ).toArray(String[]::new))
+            "org.assertj.core.api.Fail",
+            ORG_ASSERTJ_CORE_API_ASSERTIONS
+        ))
       .names("fail").withAnyParameters().build(),
     MethodMatchers.create().ofTypes(
         // AssertJ
-        ORG_ASSERTJ_CORE_API_ASSERTIONS.toArray(String[]::new)
+        stringArgs(ORG_ASSERTJ_CORE_API_ASSERTIONS)
       )
       .names("failBecauseExceptionWasNotThrown").withAnyParameters().build());
 
@@ -134,7 +132,7 @@ public final class UnitTestUtils {
       .build(),
     // Fest assert and AssertJ
     MethodMatchers.create()
-      .ofTypes(Stream.concat(ORG_ASSERTJ_CORE_API_ASSERTIONS.stream(), Stream.of("org.fest.assertions.Assertions")).toArray(String[]::new))
+      .ofTypes(stringArgs(ORG_ASSERTJ_CORE_API_ASSERTIONS, "org.fest.assertions.Assertions"))
       .names("assertThat")
       .withAnyParameters()
       .build());

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/StringUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/StringUtilsTest.java
@@ -18,7 +18,10 @@ package org.sonar.java.checks.helpers;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 class StringUtilsTest {
   @Test
@@ -41,5 +44,33 @@ class StringUtilsTest {
 
     assertThat(StringUtils.countMatches("abaTaba", "aba")).isEqualTo(2);
     assertThat(StringUtils.countMatches("abababa", "aba")).isEqualTo(2);
+  }
+
+  @Test
+  void testStringArgs() {
+    assertThat(StringUtils.stringArgs()).isEmpty();
+    assertThat(StringUtils.stringArgs("a", "b", "c")).containsExactly("a", "b", "c");
+
+    assertThat(StringUtils.stringArgs(new String[] {"a", "b"}, "c")).containsExactly("a", "b", "c");
+    assertThat(StringUtils.stringArgs("a", new String[] {"b", "c"})).containsExactly("a", "b", "c");
+
+    assertThat(StringUtils.stringArgs(List.of("A", "B"), "a", new String[] {"b", "c"}))
+      .containsExactly("A", "B", "a", "b", "c");
+  }
+
+  @Test
+  void testStringArgs_exceptions() {
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> StringUtils.stringArgs("a", 2))
+      .withMessageContaining("Unsupported argument type:");
+
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> StringUtils.stringArgs(new int[]{4, 5}))
+      .withMessageContaining("Unsupported argument type:");
+
+    var list = List.of("b", List.of("c", "d"));
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> StringUtils.stringArgs("a", list))
+      .withMessageContaining("Unsupported collection element type:");
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/StringUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/StringUtilsTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StringUtilsTest {
   @Test
@@ -47,30 +48,29 @@ class StringUtilsTest {
   }
 
   @Test
-  void testStringArgs() {
-    assertThat(StringUtils.stringArgs()).isEmpty();
-    assertThat(StringUtils.stringArgs("a", "b", "c")).containsExactly("a", "b", "c");
+  void testFlatten() {
+    assertThat(StringUtils.flatten()).isEmpty();
+    assertThat(StringUtils.flatten("a", "b", "c")).containsExactly("a", "b", "c");
 
-    assertThat(StringUtils.stringArgs(new String[] {"a", "b"}, "c")).containsExactly("a", "b", "c");
-    assertThat(StringUtils.stringArgs("a", new String[] {"b", "c"})).containsExactly("a", "b", "c");
+    assertThat(StringUtils.flatten(new String[] {"a", "b"}, "c")).containsExactly("a", "b", "c");
+    assertThat(StringUtils.flatten("a", new String[] {"b", "c"})).containsExactly("a", "b", "c");
 
-    assertThat(StringUtils.stringArgs(List.of("A", "B"), "a", new String[] {"b", "c"}))
+    assertThat(StringUtils.flatten(List.of("A", "B"), "a", new String[] {"b", "c"}))
       .containsExactly("A", "B", "a", "b", "c");
   }
 
   @Test
-  void testStringArgs_exceptions() {
+  void testFlatten_exceptions() {
     assertThatIllegalArgumentException()
-      .isThrownBy(() -> StringUtils.stringArgs("a", 2))
+      .isThrownBy(() -> StringUtils.flatten("a", 2))
       .withMessageContaining("Unsupported argument type:");
 
     assertThatIllegalArgumentException()
-      .isThrownBy(() -> StringUtils.stringArgs(new int[]{4, 5}))
+      .isThrownBy(() -> StringUtils.flatten(new int[]{4, 5}))
       .withMessageContaining("Unsupported argument type:");
 
     var list = List.of("b", List.of("c", "d"));
-    assertThatIllegalArgumentException()
-      .isThrownBy(() -> StringUtils.stringArgs("a", list))
-      .withMessageContaining("Unsupported collection element type:");
+    assertThatThrownBy(() -> StringUtils.flatten("a", list))
+      .isInstanceOf(ArrayStoreException.class);
   }
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **New utility method:**
  - Added `StringUtils.flatten` to concatenate `String`, `String[]`, and `Collection<String>` arguments into a single `String[]` array.
- **Refactoring:**
  - Simplified `MethodMatchers` definitions in `UnitTestUtils` by replacing complex `Stream.concat` logic with the new `flatten` helper.
- **Testing:**
  - Added `StringUtilsTest.testFlatten` to verify argument merging and exception handling for unsupported types.

<sub>This will update automatically on new commits.</sub>