### PR TITLE
SONARJAVA-6447 Use Surefire 3.5.6 in java-custom-rules-example to fix broken build

### DIFF
--- a/docs/java-custom-rules-example/pom_SQ_10_6_LATEST.xml
+++ b/docs/java-custom-rules-example/pom_SQ_10_6_LATEST.xml
@@ -145,6 +145,12 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.6</version>
+      </plugin>
+
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco.version}</version>


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
  - Added `maven-surefire-plugin` version `3.5.6` to `docs/java-custom-rules-example/pom_SQ_10_6_LATEST.xml` to resolve build issues.

<sub>This will update automatically on new commits.</sub>