### PR TITLE
SONARJAVA-6450 Fix QG: only one @BeforeAll is allowed

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
@@ -55,7 +55,13 @@ class MissingPathVariableAnnotationCheckTest {
     scanRecordTestFile();
   }
 
-  static void scanTestFile() {
+  @BeforeAll
+  static void scanTestFiles() {
+    scanTestFile();
+    scanRecordTestFile();
+  }
+
+  static void scanClassTestFile() {
     IssuableSubscriptionVisitor typeCollector = new IssuableSubscriptionVisitor() {
       @Override
       public java.util.List<Tree.Kind> nodesToVisit() {

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
@@ -50,6 +50,11 @@ class MissingPathVariableAnnotationCheckTest {
   private static final Map<String, Type> testRecords = new HashMap<>();
 
   @BeforeAll
+  static void scanFiles() {
+    scanTestFile();
+    scanRecordTestFile();
+  }
+
   static void scanTestFile() {
     IssuableSubscriptionVisitor typeCollector = new IssuableSubscriptionVisitor() {
       @Override
@@ -71,7 +76,6 @@ class MissingPathVariableAnnotationCheckTest {
       .verifyNoIssues();
   }
 
-  @BeforeAll
   static void scanRecordTestFile() {
     IssuableSubscriptionVisitor recordCollector = new IssuableSubscriptionVisitor() {
       @Override

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
@@ -50,14 +50,8 @@ class MissingPathVariableAnnotationCheckTest {
   private static final Map<String, Type> testRecords = new HashMap<>();
 
   @BeforeAll
-  static void scanFiles() {
-    scanTestFile();
-    scanRecordTestFile();
-  }
-
-  @BeforeAll
   static void scanTestFiles() {
-    scanTestFile();
+    scanClassTestFile();
     scanRecordTestFile();
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Test refactoring:**
  - Consolidated duplicate `@BeforeAll` methods into a single `scanFiles` method in `MissingPathVariableAnnotationCheckTest`.
  - Adjusted `MissingPathVariableAnnotationCheckTest` to comply with JUnit 5 requirements by removing multiple `@BeforeAll` annotations.

<sub>This will update automatically on new commits.</sub>