### PR TITLE
SONARJAVA-6454 : Rule S8714 - implement quickfix

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8714",
   "hasTruePositives": false,
-  "falseNegatives": 42,
+  "falseNegatives": 44,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -9,11 +9,16 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   void tests() {
     try {
       raise();
-      fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]
 //    ^^^^^^
     } catch (Exception _) {
       // test passed
     }
+    // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+    // edit@qf1 [[sl=10;sc=5;el=10;ec=8]] {{assertThrows(Exception.class, () -> }}
+    // edit@qf1 [[sl=12;sc=7;el=12;ec=14]] {{}}
+    // edit@qf1 [[sl=14;sc=7;el=16;ec=6]] {{);}}
+
     try {
       dontRaise();
     } catch (Exception _) {
@@ -47,11 +52,15 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
 
     try {
       raise();
-      org.assertj.core.api.Fail.fail("expected exception"); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      org.assertj.core.api.Fail.fail("expected exception"); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}  [[quickfixes=qf2]]
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     } catch (Exception _) {
       // test passed
     }
+    // fix@qf2 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+    // edit@qf2 [[sl=53;sc=5;el=53;ec=8]] {{assertThatCode(() -> }}
+    // edit@qf2 [[sl=55;sc=7;el=55;ec=60]] {{}}
+    // edit@qf2 [[sl=57;sc=7;el=59;ec=6]] {{).withFailMessage("expected exception").isInstanceOf(Exception.class);}}
 
     try {
       raise();

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -85,6 +85,15 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
       // test passed
     }
 
+
+    try {
+      raise();
+      fail(() -> "expected exception");  // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    } catch (Exception _) {
+      // test passed
+    }
+
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
     nonAnnotatedFunctionFN();

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -97,7 +97,8 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   @org.junit.Test
   public void junit4AnnotationDontRaise() {
     try {
-      fail("expected exception"); // TN - junit5 assert in junit4 test
+      fail("expected exception"); // TN - junit fail in junit4 test
+      org.junit.Assert.fail("expected exception"); // TN - junit fail in junit4 test
     } catch (Exception _) {
       // test passed
     }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -9,10 +9,13 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   void tests() {
     try {
       raise();
-      fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      fail();  // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]
 //    ^^^^^^
+      // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      // edit@qf1 [[sl=10;sc=5;el=18;ec=6]]{{ assertThrows(Exception.class, () -> {\n      raise();\n      fail();  // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]\n//    ^^^^^^\n      // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}\n      // edit@qf1 [[sl=10;sc=5;el=18;ec=6]]{{assertThrows(Exception.class, () -> {raise();});}}\n    }); }}
     } catch (Exception _) {
       // test passed
+
     }
 
     try {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -5,21 +5,14 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AssertThrowsInsteadOfTryCatchFailCheckSample {
-
-  // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
-  // edit@qf1 [[sl=15;sc=4;el=18;ec=5]]{{assertThrows(Exception.class, () -> {\n      raise();\n      fail();\n//    ^^^^^^\n    });}}
-
   @Test
   void tests() {
-    // Noncompliant@+3 {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]
     try {
       raise();
-      fail();
+      fail(); // NonCompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
 //    ^^^^^^
     } catch (Exception _) {
       // test passed
-      Runnable x  = () -> {
-        System.out.println("hgello"); };
     }
     try {
       dontRaise();

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -9,7 +9,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   void tests() {
     try {
       raise();
-      fail(); // NonCompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
 //    ^^^^^^
     } catch (Exception _) {
       // test passed

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -9,7 +9,11 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   void tests() {
     try {
       raise();
-      fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      fail(
+        "hello",
+        // this kind of exception
+        new RuntimeException("hello")
+      ); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
 //    ^^^^^^
     } catch (Exception _) {
       // test passed

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -112,8 +112,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   @org.junit.Test
   public void junit4AnnotationDontRaise() {
     try {
-      fail("expected exception"); // TN - junit fail in junit4 test
-      org.junit.Assert.fail("expected exception"); // TN - junit fail in junit4 test
+      fail("expected exception"); // TN - junit5 fail in junit4 test
+    } catch (Exception _) {
+      // test passed
+    }
+    try {
+      org.junit.Assert.fail("expected exception"); // TN - junit4 fail in junit4 test
     } catch (Exception _) {
       // test passed
     }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -9,11 +9,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
   void tests() {
     try {
       raise();
-      fail(
-        "hello",
-        // this kind of exception
-        new RuntimeException("hello")
-      ); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+      fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
 //    ^^^^^^
     } catch (Exception _) {
       // test passed

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -5,19 +5,22 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AssertThrowsInsteadOfTryCatchFailCheckSample {
+
+  // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+  // edit@qf1 [[sl=15;sc=4;el=18;ec=5]]{{assertThrows(Exception.class, () -> {\n      raise();\n      fail();\n//    ^^^^^^\n    });}}
+
   @Test
   void tests() {
+    // Noncompliant@+3 {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]
     try {
       raise();
-      fail();  // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]
+      fail();
 //    ^^^^^^
-      // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
-      // edit@qf1 [[sl=10;sc=5;el=18;ec=6]]{{ assertThrows(Exception.class, () -> {\n      raise();\n      fail();  // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf1]]\n//    ^^^^^^\n      // fix@qf1 {{Use assertThrows() instead of try/catch and fail() in the try block.}}\n      // edit@qf1 [[sl=10;sc=5;el=18;ec=6]]{{assertThrows(Exception.class, () -> {raise();});}}\n    }); }}
     } catch (Exception _) {
       // test passed
-
+      Runnable x  = () -> {
+        System.out.println("hgello"); };
     }
-
     try {
       dontRaise();
     } catch (Exception _) {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -94,6 +94,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
       // test passed
     }
 
+    try {
+      raise();
+      fail(() -> "expected exception");  // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    } finally {}
+
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
     nonAnnotatedFunctionFN();

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -17,7 +17,10 @@
 package org.sonar.java.checks;
 
 import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.UnitTestUtils;
+import org.sonar.java.reporting.JavaQuickFix;
+import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;
@@ -25,7 +28,9 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TryStatementTree;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 @Rule(key = "S8714")
 public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscriptionVisitor {
@@ -44,24 +49,53 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
   }
 
   private final class TryStatementsVisitor extends BaseTreeVisitor {
-    private final boolean isJunitJupiter;
+    private final boolean isJunit56;
 
-    public TryStatementsVisitor(boolean isJunitJupiter) {
-      this.isJunitJupiter = isJunitJupiter;
+    public TryStatementsVisitor(boolean isJunit56) {
+      this.isJunit56 = isJunit56;
     }
 
     @Override
     public void visitTryStatement(TryStatementTree tree) {
-      checkBlock(tree.block(), "Use assertThrows() instead of try/catch and fail() in the try block.");
-      tree.catches().forEach(c -> checkBlock(c.block(), "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block."));
+      checkBlock(tree.block(), tree, true, "Use assertThrows() instead of try/catch and fail() in the try block.");
+      tree.catches().forEach(c ->
+        checkBlock(c.block(), tree, false, "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
+      );
       super.visitTryStatement(tree);
     }
 
-    private void checkBlock(BlockTree block, String message) {
+    private void checkBlock(BlockTree block, TryStatementTree tryStatement, boolean isTryBlock, String message) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
-          if (isJunitJupiter || failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
-            reportIssue(failMethodInvocation, message);
+
+          @Nullable String replacement = "";
+          Optional<String> failArgument = failMethodInvocation.arguments().;
+
+          if (isJunit56) {
+            if (isTryBlock) {
+
+            } else {
+
+            }
+          } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
+            if (isTryBlock) {
+
+            } else {
+
+            }
           }
+
+          if (replacement == null) {
+            return;
+          }
+
+          var quickfix = JavaQuickFix.newQuickFix(message).addTextEdit(JavaTextEdit.replaceTree(tryStatement, replacement)).build();
+
+          QuickFixHelper
+            .newIssue(AssertThrowsInsteadOfTryCatchFailCheck.this.context)
+            .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
+            .withMessage(message)
+            .withQuickFix(() -> quickfix)
+            .onTree(failMethodInvocation);
         }
       );
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -25,6 +25,7 @@ import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -74,44 +75,61 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       boolean isTryBlock
     ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
-          String issueMessage = isTryBlock ?
-            "Use assertThrows() instead of try/catch and fail() in the try block." :
-            "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.";
-
-          Arguments failArguments = failMethodInvocation.arguments();
-
-          InternalJavaIssueBuilder issueBuilder = QuickFixHelper
-            .newIssue(context)
-            .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
-            .onTree(failMethodInvocation)
-            .withMessage(issueMessage);
 
           var isAssertJ = failMethodInvocation.methodSymbol().signature().contains("org.assertj");
           if (hasJunitJupiterTestAnnotation || isAssertJ) {
-            Replacements replacements = isAssertJ ?
-              assertJReplacement(failArguments, tryStatement, isTryBlock) :
-              junitReplacement(failArguments, tryStatement, isTryBlock);
-            var firstCatchFinallyToken = tryStatement.catches().isEmpty() ?
-              tryStatement.finallyKeyword().firstToken() :
-              tryStatement.catches().get(0).firstToken();
-            var lastCatchFinallyToken = tryStatement.finallyBlock() != null ?
-              tryStatement.finallyBlock().lastToken() :
-              tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
-            issueBuilder.withQuickFix(() ->
-              JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
-                JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
-                JavaTextEdit.replaceTree(failMethodInvocation.parent(), ""),
-                JavaTextEdit.replaceBetweenTree(
-                  firstCatchFinallyToken,
-                  lastCatchFinallyToken,
-                  replacements.replaceCatchesWith
+            String issueMessage = isTryBlock ?
+              "Use assertThrows() instead of try/catch and fail() in the try block." :
+              "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.";
+            InternalJavaIssueBuilder issueBuilder = QuickFixHelper
+              .newIssue(context)
+              .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
+              .onTree(failMethodInvocation)
+              .withMessage(issueMessage)
+              .withQuickFix(() ->
+                provideQuickFix(
+                  tryStatement,
+                  failMethodInvocation,
+                  issueMessage,
+                  isAssertJ,
+                  isTryBlock
                 )
-              ).build()
-            );
+              );
             issueBuilder.report();
           }
         }
       );
+    }
+
+    private JavaQuickFix provideQuickFix(
+      TryStatementTree tryStatement,
+      MethodInvocationTree failMethodInvocation,
+      String issueMessage,
+      boolean isAssertJ,
+      boolean isTryBlock
+    ) {
+      Arguments failArguments = failMethodInvocation.arguments();
+
+      Replacements replacements = isAssertJ ?
+        assertJReplacement(failArguments, tryStatement, isTryBlock) :
+        junitReplacement(failArguments, tryStatement, isTryBlock);
+
+      var firstCatchFinallyToken = tryStatement.catches().isEmpty() ?
+        tryStatement.finallyKeyword().firstToken() :
+        tryStatement.catches().get(0).firstToken();
+      var lastCatchFinallyToken = tryStatement.finallyBlock() != null ?
+        tryStatement.finallyBlock().lastToken() :
+        tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
+
+      return JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
+        JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
+        JavaTextEdit.replaceTree(failMethodInvocation.parent(), ""),
+        JavaTextEdit.replaceBetweenTree(
+          firstCatchFinallyToken,
+          lastCatchFinallyToken,
+          replacements.replaceCatchesWith
+        )
+      ).build();
     }
 
     private Replacements junitReplacement(

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -68,7 +68,8 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
           @Nullable String replacement = "";
-          Optional<String> failArgument = failMethodInvocation.arguments().;
+          // Optional<String> failArgument = failMethodInvocation.arguments();
+          // TODO : use QuickFixHelper.contentForTree(failMethodInvocation.arguments(), AssertThrowsInsteadOfTryCatchFailCheck.this.context)
 
           if (isJunit56) {
             if (isTryBlock) {

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -18,7 +18,6 @@ package org.sonar.java.checks;
 
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
-import org.sonar.java.checks.helpers.TryCatchUtils;
 import org.sonar.java.checks.helpers.UnitTestUtils;
 import org.sonar.java.reporting.InternalJavaIssueBuilder;
 import org.sonar.java.reporting.JavaQuickFix;
@@ -34,7 +33,6 @@ import org.sonar.plugins.java.api.tree.Arguments;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 
@@ -63,9 +61,9 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
     @Override
     public void visitTryStatement(TryStatementTree tree) {
-      checkBlock(tree.block(), tree, true, "Use assertThrows() instead of try/catch and fail() in the try block.");
+      checkBlock(tree.block(), tree, true);
       tree.catches().forEach(c ->
-        checkBlock(c.block(), tree, false, "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
+        checkBlock(c.block(), tree, false)
       );
       super.visitTryStatement(tree);
     }
@@ -73,10 +71,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private void checkBlock(
       BlockTree block,
       TryStatementTree tryStatement,
-      boolean isTryBlock,
-      String issueMessage
+      boolean isTryBlock
     ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
+          String issueMessage = isTryBlock ?
+            "Use assertThrows() instead of try/catch and fail() in the try block." :
+            "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.";
 
           Arguments failArguments = failMethodInvocation.arguments();
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -110,8 +110,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {
+
       String argumentsSuffix = failArguments.stream().findFirst().filter(argument ->
-        argument.symbolType().is("java.lang.String") // || argument.symbolType().is("java.util.function.Supplier<java.lang.String>")
+        {
+          Type symbolType = argument.symbolType();
+          return !symbolType.isUnknown() && (symbolType.is("java.lang.String") || symbolType.isSubtypeOf("java.util.function.Supplier<java.lang.String>"));
+        }
       ).map(argument ->
         ", %s".formatted(contentFor(argument))
       ).orElse("");

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -23,11 +23,7 @@ import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Type;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
-import org.sonar.plugins.java.api.tree.BlockTree;
-import org.sonar.plugins.java.api.tree.MethodTree;
-import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.TryStatementTree;
+import org.sonar.plugins.java.api.tree.*;
 
 import java.util.List;
 
@@ -73,19 +69,16 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
-          var context = AssertThrowsInsteadOfTryCatchFailCheck.this.context;
-          List<String> failArguments = failMethodInvocation.arguments().stream()
-            .map(argument -> QuickFixHelper.contentForTree(argument, context))
-            .toList();
+          Arguments failArguments = failMethodInvocation.arguments();
 
-          InternalJavaIssueBuilder result = QuickFixHelper
+          InternalJavaIssueBuilder issueBuilder = QuickFixHelper
             .newIssue(AssertThrowsInsteadOfTryCatchFailCheck.this.context)
             .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
             .withMessage(issueMessage)
             .onTree(failMethodInvocation);
 
           if (isJunit56) {
-            result = result.withQuickFix(() ->
+            issueBuilder = issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
@@ -94,7 +87,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
               ).build()
             );
           } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
-            result = result.withQuickFix(() ->
+            issueBuilder = issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
@@ -104,31 +97,39 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             );
           }
 
-          result.report();
+          issueBuilder.report();
         }
       );
     }
 
     private String junitReplacement(
-      List<String> failArguments,
+      Arguments failArguments,
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {
       String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
+      String argumentsSuffix = failArguments.stream().findFirst().filter(argument ->
+        argument.symbolType().is("") || argument.symbolType().is("")
+      ).map(argument ->
+        ", %s".formatted(QuickFixHelper.contentForTree(argument, context))
+      ).orElse("");
+
       if (isTryBlock) {
-        return "assertThrows(%s, () -> %s);".formatted(
+        return "assertThrows(%s, () -> %s%s);".formatted(
           typeClass(firstCaughtTypeInTry(tryStatement)),
-          tryBlockString
+          tryBlockString,
+          argumentsSuffix
         );
       } else {
-        return "assertDoesNotThrow(%s, %s);".formatted(
-          tryBlockString
+        return "assertDoesNotThrow(%s%s);".formatted(
+          tryBlockString,
+          argumentsSuffix
         );
       }
     }
 
     private String assertJReplacement(
-      List<String> failArguments,
+      Arguments failArguments,
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -44,15 +44,15 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
   public void visitNode(Tree tree) {
     MethodTree methodTree = (MethodTree) tree;
     tree.accept(
-      new TryStatementsVisitor(UnitTestUtils.hasJUnit56TestAnnotation(methodTree))
+      new TryStatementsVisitor(UnitTestUtils.hasJUnitJupiterAnnotation(methodTree))
     );
   }
 
   private final class TryStatementsVisitor extends BaseTreeVisitor {
-    private final boolean isJunit56;
+    private final boolean hasJunitJupiterTestAnnotation;
 
-    public TryStatementsVisitor(boolean isJunit56) {
-      this.isJunit56 = isJunit56;
+    public TryStatementsVisitor(boolean hasJunitJupiterTestAnnotation) {
+      this.hasJunitJupiterTestAnnotation = hasJunitJupiterTestAnnotation;
     }
 
     @Override
@@ -80,56 +80,41 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             .onTree(failMethodInvocation)
             .withMessage(issueMessage);
 
-          // Compute try block without tne fail method invocation
-          var filteredTryBlock = new BlockTreeImpl(
-            (InternalSyntaxToken) tryStatement.block().openBraceToken(),
-            tryStatement.block().body().stream()
-              .filter(statement ->
-                statement instanceof ExpressionStatementTree expression && expression.expression() != failMethodInvocation
-              ).toList(),
-            (InternalSyntaxToken) tryStatement.block().closeBraceToken());
-          var filteredTryBlockString = contentFor(filteredTryBlock);
-
-          if (isJunit56) {
-            issueBuilder.withQuickFix(() ->
-              /** Replace single text edit by 3 :
-               * JUNIT :
-               * 1 : Try token -> 'assertThrows({exception type}, () ->' or 'assertDoesntThrow(() ->'
-               * 2 : fail method invocation -> ""
-               * 3 : catches -> );
-               * ASSERTJ :
-               * 1 : Try token -> assertThatCode(() ->
-               * 2 : fail method invocation -> ""
-               * 3 : catches -> ').isInstanceOf({exception type});' or ').doesNotThrowAnyException();'
-               */
-
-              JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
-                JavaTextEdit.replaceTree(
-                  tryStatement,
-                  junitReplacement(failArguments, tryStatement, filteredTryBlockString, isTryBlock)
-                )
-              ).build()
-            );
-          } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
+          var isAssertJ = failMethodInvocation.methodSymbol().signature().contains("org.assertj");
+          if (hasJunitJupiterTestAnnotation || isAssertJ) {
+            Replacements replacements = isAssertJ ?
+              assertJReplacement(failArguments, tryStatement, isTryBlock) :
+              junitReplacement(failArguments, tryStatement, isTryBlock);
+            /** Replace single text edit by 3 :
+             * JUNIT :
+             * 1 : Try token -> 'assertThrows({exception type}, () ->' or 'assertDoesntThrow(() ->'
+             * 2 : fail method invocation -> ""
+             * 3 : catches -> );
+             * ASSERTJ :
+             * 1 : Try token -> assertThatCode(() ->
+             * 2 : fail method invocation -> ""
+             * 3 : catches -> ').isInstanceOf({exception type});' or ').doesNotThrowAnyException();'
+             */
             issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
-                JavaTextEdit.replaceTree(
-                  tryStatement,
-                  assertJReplacement(failArguments, tryStatement, filteredTryBlockString, isTryBlock)
+                JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
+                JavaTextEdit.replaceTree(failMethodInvocation, ""),
+                JavaTextEdit.replaceBetweenTree(
+                  tryStatement.catches().get(0).catchKeyword(),
+                  tryStatement.catches().get(tryStatement.catches().size() - 1).block().closeBraceToken(),
+                  replacements.replaceCatchesWith
                 )
               ).build()
             );
           }
-
           issueBuilder.report();
         }
       );
     }
 
-    private String junitReplacement(
+    private Replacements junitReplacement(
       Arguments failArguments,
       TryStatementTree tryStatement,
-      String filteredTryBlockString,
       boolean isTryBlock
     ) {
       String argumentsSuffix = failArguments.stream().findFirst().filter(argument ->
@@ -138,54 +123,50 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         ", %s".formatted(contentFor(argument))
       ).orElse("");
 
-      if (isTryBlock) {
-        return "assertThrows(%s, () -> %s%s);".formatted(
-          typeClass(firstCaughtTypeInTry(tryStatement)),
-          filteredTryBlockString,
-          argumentsSuffix
+      return isTryBlock ?
+        new Replacements(
+          "assertThrows(%s, () -> ".formatted(typeClass(firstCaughtTypeInTry(tryStatement))),
+          "%s);".formatted(argumentsSuffix)
+        ) :
+        new Replacements(
+          "assertDoesNotThrow(() -> ",
+          "%s);".formatted(argumentsSuffix)
         );
-      } else {
-        return "assertDoesNotThrow(() -> %s%s);".formatted(
-          filteredTryBlockString,
-          argumentsSuffix
-        );
-      }
     }
 
-    private String assertJReplacement(
+    private Replacements assertJReplacement(
       Arguments failArguments,
       TryStatementTree tryStatement,
-      String filteredTryBlockString,
       boolean isTryBlock
     ) {
       // in assertJ the failure message is mandatory
       var failureMessage = contentFor(failArguments.get(0));
-
-      if (isTryBlock) {
-        return "assertThatCode(() -> %s).withFailMessage(%s).isInstanceOf(%s);".formatted(
-          filteredTryBlockString,
-          failureMessage,
-          typeClass(firstCaughtTypeInTry(tryStatement))
+      return isTryBlock ?
+        new Replacements(
+          "assertThatCode(() -> ",
+          ").withFailMessage(%s).isInstanceOf(%s);".formatted(failureMessage, typeClass(firstCaughtTypeInTry(tryStatement)))
+        ) :
+        new Replacements(
+          "assertThatCode(() -> ",
+          ").withFailMessage(%s).doesNotThrowAnyException();".formatted(failureMessage)
         );
-      } else {
-        return "assertThatCode(() -> %s).withFailMessage(%s).doesNotThrowAnyException();".formatted(
-          filteredTryBlockString,
-          failureMessage
-        );
-      }
     }
 
     private String contentFor(Tree tree) {
       return QuickFixHelper.contentForTree(tree, context);
     }
 
-    private static String typeClass(Type caughtType) {
-      return caughtType.name() + ".class";
+    private record Replacements(String replaceTryWith, String replaceCatchesWith) {
     }
-
-    private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
-      return getCaughtTypes(tryStatement.catches().get(0)).get(0);
-    }
-
   }
+
+
+  private static String typeClass(Type caughtType) {
+    return caughtType.name() + ".class";
+  }
+
+  private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
+    return getCaughtTypes(tryStatement.catches().get(0)).get(0);
+  }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -19,6 +19,9 @@ package org.sonar.java.checks;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.UnitTestUtils;
+import org.sonar.java.model.InternalSyntaxToken;
+import org.sonar.java.model.statement.BlockTreeImpl;
+import org.sonar.java.reporting.InternalJavaIssueBuilder;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
@@ -41,7 +44,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
   public void visitNode(Tree tree) {
     MethodTree methodTree = (MethodTree) tree;
     tree.accept(
-      new TryStatementsVisitor(UnitTestUtils.hasJUnitJupiterAnnotation(methodTree))
+      new TryStatementsVisitor(UnitTestUtils.hasJUnit56TestAnnotation(methodTree))
     );
   }
 
@@ -77,12 +80,22 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             .onTree(failMethodInvocation)
             .withMessage(issueMessage);
 
+          // Compute try block without tne fail method invocation
+          var filteredTryBlock = new BlockTreeImpl(
+            (InternalSyntaxToken) tryStatement.block().openBraceToken(),
+            tryStatement.block().body().stream()
+              .filter(statement ->
+                statement instanceof ExpressionStatementTree expression && expression != failMethodInvocation
+              ).toList(),
+            (InternalSyntaxToken) tryStatement.block().closeBraceToken());
+          var filteredTryBlockString = contentFor(filteredTryBlock);
+
           if (isJunit56) {
             issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
-                  junitReplacement(failArguments, tryStatement, isTryBlock)
+                  junitReplacement(failArguments, tryStatement, filteredTryBlockString, isTryBlock)
                 )
               ).build()
             );
@@ -91,7 +104,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
-                  assertJReplacement(failArguments, tryStatement, isTryBlock)
+                  assertJReplacement(failArguments, tryStatement, filteredTryBlockString, isTryBlock)
                 )
               ).build()
             );
@@ -105,9 +118,9 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private String junitReplacement(
       Arguments failArguments,
       TryStatementTree tryStatement,
+      String filteredTryBlockString,
       boolean isTryBlock
     ) {
-      String tryBlockString = contentFor(tryStatement.block());
       String argumentsSuffix = failArguments.stream().findFirst().filter(argument ->
         argument.symbolType().is("java.lang.String") // || argument.symbolType().is("java.util.function.Supplier<java.lang.String>")
       ).map(argument ->
@@ -117,12 +130,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       if (isTryBlock) {
         return "assertThrows(%s, () -> %s%s);".formatted(
           typeClass(firstCaughtTypeInTry(tryStatement)),
-          tryBlockString,
+          filteredTryBlockString,
           argumentsSuffix
         );
       } else {
         return "assertDoesNotThrow(() -> %s%s);".formatted(
-          tryBlockString,
+          filteredTryBlockString,
           argumentsSuffix
         );
       }
@@ -131,21 +144,21 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private String assertJReplacement(
       Arguments failArguments,
       TryStatementTree tryStatement,
+      String filteredTryBlockString,
       boolean isTryBlock
     ) {
       // in assertJ the failure message is mandatory
       var failureMessage = contentFor(failArguments.get(0));
-      String tryBlockString = contentFor(tryStatement.block());
 
       if (isTryBlock) {
         return "assertThatCode(() -> %s).withFailMessage(%s).isInstanceOf(%s);".formatted(
-          tryBlockString,
+          filteredTryBlockString,
           failureMessage,
           typeClass(firstCaughtTypeInTry(tryStatement))
         );
       } else {
         return "assertThatCode(() -> %s).withFailMessage(%s).doesNotThrowAnyException();".formatted(
-          tryBlockString,
+          filteredTryBlockString,
           failureMessage
         );
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -24,7 +24,12 @@ import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Type;
-import org.sonar.plugins.java.api.tree.*;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BlockTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TryStatementTree;
+import org.sonar.plugins.java.api.tree.Arguments;
 
 import java.util.List;
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -93,9 +93,14 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
           if (isJunit56) {
             issueBuilder.withQuickFix(() ->
               /** Replace single text edit by 3 :
-               * 1 :  Try token -> assertThrows(
-               * 2 :  fail method invocation .-> ""
-               * 3 : catch -> );
+               * JUNIT :
+               * 1 : Try token -> 'assertThrows({exception type}, () ->' or 'assertDoesntThrow(() ->'
+               * 2 : fail method invocation -> ""
+               * 3 : catches -> );
+               * ASSERTJ :
+               * 1 : Try token -> assertThatCode(() ->
+               * 2 : fail method invocation -> ""
+               * 3 : catches -> ').isInstanceOf({exception type});' or ').doesNotThrowAnyException();'
                */
 
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -92,6 +92,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
           if (isJunit56) {
             issueBuilder.withQuickFix(() ->
+              /** Replace single text edit by 3 :
+               * 1 :  Try token -> assertThrows(
+               * 2 :  fail method invocation .-> ""
+               * 3 : catch -> );
+               */
+
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -74,8 +74,8 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
           InternalJavaIssueBuilder issueBuilder = QuickFixHelper
             .newIssue(AssertThrowsInsteadOfTryCatchFailCheck.this.context)
             .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
-            .withMessage(issueMessage)
-            .onTree(failMethodInvocation);
+            .onTree(failMethodInvocation)
+            .withMessage(issueMessage);
 
           if (isJunit56) {
             issueBuilder.withQuickFix(() ->
@@ -109,7 +109,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     ) {
       String tryBlockString = contentFor(tryStatement.block());
       String argumentsSuffix = failArguments.stream().findFirst().filter(argument ->
-        argument.symbolType().is("") || argument.symbolType().is("")
+        argument.symbolType().is("java.lang.String") // || argument.symbolType().is("java.util.function.Supplier<java.lang.String>")
       ).map(argument ->
         ", %s".formatted(contentFor(argument))
       ).orElse("");
@@ -134,7 +134,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       boolean isTryBlock
     ) {
       // in assertJ the failure message is mandatory
-      var failureMessage = contentFor(failArguments.getFirst());
+      var failureMessage = contentFor(failArguments.get(0));
       String tryBlockString = contentFor(tryStatement.block());
 
       if (isTryBlock) {
@@ -160,7 +160,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     }
 
     private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
-      return getCaughtTypes(tryStatement.catches().getFirst()).getFirst();
+      return getCaughtTypes(tryStatement.catches().get(0)).get(0);
     }
 
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -58,10 +58,9 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
     @Override
     public void visitTryStatement(TryStatementTree tree) {
-      var firstCaught = getCaughtTypes(tree.catches().getFirst()).getFirst();
-      checkBlock(tree.block(), tree, List.of(), "Use assertThrows() instead of try/catch and fail() in the try block.");
+      checkBlock(tree.block(), tree, true, "Use assertThrows() instead of try/catch and fail() in the try block.");
       tree.catches().forEach(c ->
-        checkBlock(c.block(), tree, getCaughtTypes(c), "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
+        checkBlock(c.block(), tree, false, "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
       );
       super.visitTryStatement(tree);
     }
@@ -69,8 +68,8 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private void checkBlock(
       BlockTree block,
       TryStatementTree tryStatement,
-      List<Type> caughtTypesInBlock,
-      String message
+      boolean isTryBlock,
+      String issueMessage
     ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
@@ -82,24 +81,24 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
           InternalJavaIssueBuilder result = QuickFixHelper
             .newIssue(AssertThrowsInsteadOfTryCatchFailCheck.this.context)
             .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
-            .withMessage(message)
+            .withMessage(issueMessage)
             .onTree(failMethodInvocation);
 
           if (isJunit56) {
             result = result.withQuickFix(() ->
-              JavaQuickFix.newQuickFix(message).addTextEdit(
+              JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
-                  junitReplacement(failArguments, tryStatement, caughtTypesInBlock)
+                  junitReplacement(failArguments, tryStatement, isTryBlock)
                 )
               ).build()
             );
           } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
             result = result.withQuickFix(() ->
-              JavaQuickFix.newQuickFix(message).addTextEdit(
+              JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
-                  assertJReplacement(failArguments, tryStatement, caughtTypesInBlock)
+                  assertJReplacement(failArguments, tryStatement, isTryBlock)
                 )
               ).build()
             );
@@ -113,17 +112,16 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private String junitReplacement(
       List<String> failArguments,
       TryStatementTree tryStatement,
-      List<Type> caughtTypesInBlock
+      boolean isTryBlock
     ) {
       String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
-      if (caughtTypesInBlock.isEmpty()) {
+      if (isTryBlock) {
         return "assertThrows(%s, () -> %s);".formatted(
           typeClass(firstCaughtTypeInTry(tryStatement)),
           tryBlockString
         );
       } else {
         return "assertDoesNotThrow(%s, %s);".formatted(
-          typeClass(caughtTypesInBlock.getFirst()),
           tryBlockString
         );
       }
@@ -132,10 +130,10 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private String assertJReplacement(
       List<String> failArguments,
       TryStatementTree tryStatement,
-      List<Type> caughtTypesInBlock
+      boolean isTryBlock
     ) {
       String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
-      if (caughtTypesInBlock.isEmpty()) {
+      if (isTryBlock) {
         return "assertThatThrownBy(() -> %s).isInstanceOf(%s);".formatted(
           tryBlockString,
           typeClass(firstCaughtTypeInTry(tryStatement))

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -75,7 +75,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
           Arguments failArguments = failMethodInvocation.arguments();
 
           InternalJavaIssueBuilder issueBuilder = QuickFixHelper
-            .newIssue(AssertThrowsInsteadOfTryCatchFailCheck.this.context)
+            .newIssue(context)
             .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
             .onTree(failMethodInvocation)
             .withMessage(issueMessage);
@@ -85,7 +85,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             (InternalSyntaxToken) tryStatement.block().openBraceToken(),
             tryStatement.block().body().stream()
               .filter(statement ->
-                statement instanceof ExpressionStatementTree expression && expression != failMethodInvocation
+                statement instanceof ExpressionStatementTree expression && expression.expression() != failMethodInvocation
               ).toList(),
             (InternalSyntaxToken) tryStatement.block().closeBraceToken());
           var filteredTryBlockString = contentFor(filteredTryBlock);

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -78,7 +78,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             .onTree(failMethodInvocation);
 
           if (isJunit56) {
-            issueBuilder = issueBuilder.withQuickFix(() ->
+            issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
@@ -87,7 +87,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
               ).build()
             );
           } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
-            issueBuilder = issueBuilder.withQuickFix(() ->
+            issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(
                   tryStatement,
@@ -107,11 +107,11 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {
-      String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
+      String tryBlockString = contentFor(tryStatement.block());
       String argumentsSuffix = failArguments.stream().findFirst().filter(argument ->
         argument.symbolType().is("") || argument.symbolType().is("")
       ).map(argument ->
-        ", %s".formatted(QuickFixHelper.contentForTree(argument, context))
+        ", %s".formatted(contentFor(argument))
       ).orElse("");
 
       if (isTryBlock) {
@@ -121,7 +121,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
           argumentsSuffix
         );
       } else {
-        return "assertDoesNotThrow(%s%s);".formatted(
+        return "assertDoesNotThrow(() -> %s%s);".formatted(
           tryBlockString,
           argumentsSuffix
         );
@@ -133,17 +133,26 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {
-      String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
+      // in assertJ the failure message is mandatory
+      var failureMessage = contentFor(failArguments.getFirst());
+      String tryBlockString = contentFor(tryStatement.block());
+
       if (isTryBlock) {
-        return "assertThatThrownBy(() -> %s).isInstanceOf(%s);".formatted(
+        return "assertThatCode(() -> %s).withFailMessage(%s).isInstanceOf(%s);".formatted(
           tryBlockString,
+          failureMessage,
           typeClass(firstCaughtTypeInTry(tryStatement))
         );
       } else {
-        return "assertThatThrownBy(() -> %s).doesNotThrowAnyException();".formatted(
-          tryBlockString
+        return "assertThatCode(() -> %s).withFailMessage(%s).doesNotThrowAnyException();".formatted(
+          tryBlockString,
+          failureMessage
         );
       }
+    }
+
+    private String contentFor(Tree tree) {
+      return QuickFixHelper.contentForTree(tree, context);
     }
 
     private static String typeClass(Type caughtType) {
@@ -153,5 +162,6 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
       return getCaughtTypes(tryStatement.catches().getFirst()).getFirst();
     }
+
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -18,6 +18,7 @@ package org.sonar.java.checks;
 
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
+import org.sonar.java.checks.helpers.TryCatchUtils;
 import org.sonar.java.checks.helpers.UnitTestUtils;
 import org.sonar.java.reporting.InternalJavaIssueBuilder;
 import org.sonar.java.reporting.JavaQuickFix;
@@ -31,7 +32,9 @@ import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TryStatementTree;
 import org.sonar.plugins.java.api.tree.Arguments;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 
@@ -88,13 +91,19 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             Replacements replacements = isAssertJ ?
               assertJReplacement(failArguments, tryStatement, isTryBlock) :
               junitReplacement(failArguments, tryStatement, isTryBlock);
+            var firstCatchFinallyToken = tryStatement.catches().isEmpty() ?
+              tryStatement.finallyKeyword().firstToken() :
+              tryStatement.catches().get(0).firstToken();
+            var lastCatchFinallyToken = tryStatement.finallyBlock() != null ?
+              tryStatement.finallyBlock().lastToken() :
+              tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
             issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
                 JavaTextEdit.replaceTree(failMethodInvocation.parent(), ""),
                 JavaTextEdit.replaceBetweenTree(
-                  tryStatement.catches().get(0).catchKeyword(),
-                  tryStatement.catches().get(tryStatement.catches().size() - 1).block().closeBraceToken(),
+                  firstCatchFinallyToken,
+                  lastCatchFinallyToken,
                   replacements.replaceCatchesWith
                 )
               ).build()
@@ -158,12 +167,17 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
   }
 
 
-  private static String typeClass(Type caughtType) {
+  private static String typeClass(@Nullable Type caughtType) {
+    if (caughtType == null) return "Throwable";
     return caughtType.name() + ".class";
   }
 
+  @Nullable
   private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
-    return getCaughtTypes(tryStatement.catches().get(0)).get(0);
+    if (tryStatement.catches().size() > 0) {
+      return getCaughtTypes(tryStatement.catches().get(0)).get(0);
+    }
+    return null;
   }
 
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -174,7 +174,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
   @Nullable
   private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
-    if (tryStatement.catches().size() > 0) {
+    if (!tryStatement.catches().isEmpty()) {
       return getCaughtTypes(tryStatement.catches().get(0)).get(0);
     }
     return null;

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -98,7 +98,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
-                JavaTextEdit.replaceTree(failMethodInvocation, ""),
+                JavaTextEdit.replaceTree(failMethodInvocation.parent(), ""),
                 JavaTextEdit.replaceBetweenTree(
                   tryStatement.catches().get(0).catchKeyword(),
                   tryStatement.catches().get(tryStatement.catches().size() - 1).block().closeBraceToken(),

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -29,9 +29,7 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TryStatementTree;
 
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 
@@ -60,6 +58,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
     @Override
     public void visitTryStatement(TryStatementTree tree) {
+      var firstCaught = getCaughtTypes(tree.catches().getFirst()).getFirst();
       checkBlock(tree.block(), tree, List.of(), "Use assertThrows() instead of try/catch and fail() in the try block.");
       tree.catches().forEach(c ->
         checkBlock(c.block(), tree, getCaughtTypes(c), "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
@@ -67,11 +66,16 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       super.visitTryStatement(tree);
     }
 
-    private void checkBlock(BlockTree block, TryStatementTree tryStatement, List<Type> caughtTypes, String message) {
+    private void checkBlock(
+      BlockTree block,
+      TryStatementTree tryStatement,
+      List<Type> caughtTypesInBlock,
+      String message
+    ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
           var context = AssertThrowsInsteadOfTryCatchFailCheck.this.context;
-          List<String> arguments = failMethodInvocation.arguments().stream()
+          List<String> failArguments = failMethodInvocation.arguments().stream()
             .map(argument -> QuickFixHelper.contentForTree(argument, context))
             .toList();
 
@@ -83,11 +87,21 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
           if (isJunit56) {
             result = result.withQuickFix(() ->
-              JavaQuickFix.newQuickFix(message).addTextEdit(JavaTextEdit.replaceTree(tryStatement, junitReplacement(arguments, caughtTypes, message))).build()
+              JavaQuickFix.newQuickFix(message).addTextEdit(
+                JavaTextEdit.replaceTree(
+                  tryStatement,
+                  junitReplacement(failArguments, tryStatement, caughtTypesInBlock)
+                )
+              ).build()
             );
           } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
             result = result.withQuickFix(() ->
-              JavaQuickFix.newQuickFix(message).addTextEdit(JavaTextEdit.replaceTree(tryStatement, assertJReplacement(arguments, caughtTypes, message))).build()
+              JavaQuickFix.newQuickFix(message).addTextEdit(
+                JavaTextEdit.replaceTree(
+                  tryStatement,
+                  assertJReplacement(failArguments, tryStatement, caughtTypesInBlock)
+                )
+              ).build()
             );
           }
 
@@ -96,24 +110,49 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       );
     }
 
-    private static String junitReplacement(List<String> arguments, List<Type> caughtTypes, String message) {
-      boolean isTryBlock = caughtTypes.isEmpty();
-      if (isTryBlock) {
-
+    private String junitReplacement(
+      List<String> failArguments,
+      TryStatementTree tryStatement,
+      List<Type> caughtTypesInBlock
+    ) {
+      String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
+      if (caughtTypesInBlock.isEmpty()) {
+        return "assertThrows(%s, () -> %s);".formatted(
+          typeClass(firstCaughtTypeInTry(tryStatement)),
+          tryBlockString
+        );
       } else {
-
+        return "assertDoesNotThrow(%s, %s);".formatted(
+          typeClass(caughtTypesInBlock.getFirst()),
+          tryBlockString
+        );
       }
-      return "";
     }
 
-    private static String assertJReplacement(List<String> arguments, List<Type> caughtTypes, String message) {
-      boolean isTryBlock = caughtTypes.isEmpty();
-      if (isTryBlock) {
-
+    private String assertJReplacement(
+      List<String> failArguments,
+      TryStatementTree tryStatement,
+      List<Type> caughtTypesInBlock
+    ) {
+      String tryBlockString = QuickFixHelper.contentForTree(tryStatement.block(), AssertThrowsInsteadOfTryCatchFailCheck.this.context);
+      if (caughtTypesInBlock.isEmpty()) {
+        return "assertThatThrownBy(() -> %s).isInstanceOf(%s);".formatted(
+          tryBlockString,
+          typeClass(firstCaughtTypeInTry(tryStatement))
+        );
       } else {
-
+        return "assertThatThrownBy(() -> %s).doesNotThrowAnyException();".formatted(
+          tryBlockString
+        );
       }
-      return "";
+    }
+
+    private static String typeClass(Type caughtType) {
+      return caughtType.name() + ".class";
+    }
+
+    private static Type firstCaughtTypeInTry(TryStatementTree tryStatement) {
+      return getCaughtTypes(tryStatement.catches().getFirst()).getFirst();
     }
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -22,6 +22,7 @@ import org.sonar.java.checks.helpers.UnitTestUtils;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
@@ -31,6 +32,8 @@ import org.sonar.plugins.java.api.tree.TryStatementTree;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
+
+import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 
 @Rule(key = "S8714")
 public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscriptionVisitor {
@@ -57,48 +60,60 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
     @Override
     public void visitTryStatement(TryStatementTree tree) {
-      checkBlock(tree.block(), tree, true, "Use assertThrows() instead of try/catch and fail() in the try block.");
+      checkBlock(tree.block(), tree, List.of(), "Use assertThrows() instead of try/catch and fail() in the try block.");
       tree.catches().forEach(c ->
-        checkBlock(c.block(), tree, false, "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
+        checkBlock(c.block(), tree, getCaughtTypes(c), "Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.")
       );
       super.visitTryStatement(tree);
     }
 
-    private void checkBlock(BlockTree block, TryStatementTree tryStatement, boolean isTryBlock, String message) {
+    private void checkBlock(BlockTree block, TryStatementTree tryStatement, List<Type> caughtTypes, String message) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
-          @Nullable String replacement = "";
-          // Optional<String> failArgument = failMethodInvocation.arguments();
-          // TODO : use QuickFixHelper.contentForTree(failMethodInvocation.arguments(), AssertThrowsInsteadOfTryCatchFailCheck.this.context)
+          var context = AssertThrowsInsteadOfTryCatchFailCheck.this.context;
+          List<String> arguments = failMethodInvocation.arguments().stream()
+            .map(argument -> QuickFixHelper.contentForTree(argument, context))
+            .toList();
 
-          if (isJunit56) {
-            if (isTryBlock) {
-
-            } else {
-
-            }
-          } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
-            if (isTryBlock) {
-
-            } else {
-
-            }
-          }
-
-          if (replacement == null) {
-            return;
-          }
-
-          var quickfix = JavaQuickFix.newQuickFix(message).addTextEdit(JavaTextEdit.replaceTree(tryStatement, replacement)).build();
-
-          QuickFixHelper
+          InternalJavaIssueBuilder result = QuickFixHelper
             .newIssue(AssertThrowsInsteadOfTryCatchFailCheck.this.context)
             .forRule(AssertThrowsInsteadOfTryCatchFailCheck.this)
             .withMessage(message)
-            .withQuickFix(() -> quickfix)
             .onTree(failMethodInvocation);
+
+          if (isJunit56) {
+            result = result.withQuickFix(() ->
+              JavaQuickFix.newQuickFix(message).addTextEdit(JavaTextEdit.replaceTree(tryStatement, junitReplacement(arguments, caughtTypes, message))).build()
+            );
+          } else if (failMethodInvocation.methodSymbol().signature().contains("org.assertj")) {
+            result = result.withQuickFix(() ->
+              JavaQuickFix.newQuickFix(message).addTextEdit(JavaTextEdit.replaceTree(tryStatement, assertJReplacement(arguments, caughtTypes, message))).build()
+            );
+          }
+
+          result.report();
         }
       );
+    }
+
+    private static String junitReplacement(List<String> arguments, List<Type> caughtTypes, String message) {
+      boolean isTryBlock = caughtTypes.isEmpty();
+      if (isTryBlock) {
+
+      } else {
+
+      }
+      return "";
+    }
+
+    private static String assertJReplacement(List<String> arguments, List<Type> caughtTypes, String message) {
+      boolean isTryBlock = caughtTypes.isEmpty();
+      if (isTryBlock) {
+
+      } else {
+
+      }
+      return "";
     }
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -19,8 +19,6 @@ package org.sonar.java.checks;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.UnitTestUtils;
-import org.sonar.java.model.InternalSyntaxToken;
-import org.sonar.java.model.statement.BlockTreeImpl;
 import org.sonar.java.reporting.InternalJavaIssueBuilder;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
@@ -85,16 +83,6 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
             Replacements replacements = isAssertJ ?
               assertJReplacement(failArguments, tryStatement, isTryBlock) :
               junitReplacement(failArguments, tryStatement, isTryBlock);
-            /** Replace single text edit by 3 :
-             * JUNIT :
-             * 1 : Try token -> 'assertThrows({exception type}, () ->' or 'assertDoesntThrow(() ->'
-             * 2 : fail method invocation -> ""
-             * 3 : catches -> );
-             * ASSERTJ :
-             * 1 : Try token -> assertThatCode(() ->
-             * 2 : fail method invocation -> ""
-             * 3 : catches -> ').isInstanceOf({exception type});' or ').doesNotThrowAnyException();'
-             */
             issueBuilder.withQuickFix(() ->
               JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
                 JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
@@ -106,8 +94,8 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
                 )
               ).build()
             );
+            issueBuilder.report();
           }
-          issueBuilder.report();
         }
       );
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/InterruptedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/InterruptedExceptionCheck.java
@@ -42,10 +42,9 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.ThrowStatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TryStatementTree;
-import org.sonar.plugins.java.api.tree.TypeTree;
-import org.sonar.plugins.java.api.tree.UnionTypeTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
+import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 import static org.sonar.java.model.ExpressionUtils.extractIdentifierSymbol;
 
 @Rule(key = "S2142")
@@ -85,7 +84,7 @@ public class InterruptedExceptionCheck extends IssuableSubscriptionVisitor {
 
     for (CatchTree catchTree : tryStatementTree.catches()) {
       VariableTree catchParameter = catchTree.parameter();
-      List<Type> caughtTypes = getCaughtTypes(catchParameter);
+      List<Type> caughtTypes = getCaughtTypes(catchTree);
 
       Optional<Type> interruptType = caughtTypes.stream().filter(INTERRUPTING_TYPE_PREDICATE).findFirst();
       if (interruptType.isPresent()) {
@@ -119,15 +118,6 @@ public class InterruptedExceptionCheck extends IssuableSubscriptionVisitor {
     BlockVisitor blockVisitor = new BlockVisitor(tree -> isRethrowingCaughtException(tree, caughtSymbol));
     catchTree.block().accept(blockVisitor);
     return !blockVisitor.threadInterrupted && !isWithinInterruptingFinally();
-  }
-
-  private static List<Type> getCaughtTypes(VariableTree parameter) {
-    if (parameter.type().is(Tree.Kind.UNION_TYPE)) {
-      return ((UnionTypeTree) parameter.type()).typeAlternatives().stream()
-        .map(TypeTree::symbolType)
-        .toList();
-    }
-    return Collections.singletonList(parameter.symbol().type());
   }
 
   private boolean isWithinInterruptingFinally() {
@@ -173,7 +163,7 @@ public class InterruptedExceptionCheck extends IssuableSubscriptionVisitor {
       // interruptions thrown there must be handled within the scope of the outer try.
 
       boolean isCatchingAnyInterruptingTypes = tryStatementTree.catches().stream()
-        .anyMatch(catchTree -> getCaughtTypes(catchTree.parameter()).stream().anyMatch(INTERRUPTING_TYPE_PREDICATE));
+        .anyMatch(catchTree -> getCaughtTypes(catchTree).stream().anyMatch(INTERRUPTING_TYPE_PREDICATE));
 
       scan(tryStatementTree.resourceList());
       if (!isCatchingAnyInterruptingTypes) {

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
@@ -17,7 +17,11 @@
 package org.sonar.java.checks.helpers;
 
 import org.sonar.plugins.java.api.semantic.Type;
-import org.sonar.plugins.java.api.tree.*;
+import org.sonar.plugins.java.api.tree.CatchTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.UnionTypeTree;
+import org.sonar.plugins.java.api.tree.TypeTree;
+import org.sonar.plugins.java.api.tree.VariableTree;
 
 import java.util.*;
 

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
@@ -1,0 +1,38 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.helpers;
+
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.*;
+
+import java.util.*;
+
+public final class TryCatchUtils {
+  private TryCatchUtils() {
+    /* This utility class should not be instantiated */
+  }
+
+  public static List<Type> getCaughtTypes(CatchTree tree) {
+    VariableTree parameter = tree.parameter();
+    if (parameter.type().is(Tree.Kind.UNION_TYPE)) {
+      return ((UnionTypeTree) parameter.type()).typeAlternatives().stream()
+        .map(TypeTree::symbolType)
+        .toList();
+    }
+    return Collections.singletonList(parameter.symbol().type());
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
@@ -22,8 +22,8 @@ import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.UnionTypeTree;
 import org.sonar.plugins.java.api.tree.TypeTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
-
-import java.util.*;
+import java.util.List;
+import java.util.Collections;
 
 public final class TryCatchUtils {
   private TryCatchUtils() {

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/TryCatchUtils.java
@@ -18,12 +18,11 @@ package org.sonar.java.checks.helpers;
 
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.CatchTree;
-import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.UnionTypeTree;
 import org.sonar.plugins.java.api.tree.TypeTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
+
 import java.util.List;
-import java.util.Collections;
 
 public final class TryCatchUtils {
   private TryCatchUtils() {
@@ -32,11 +31,11 @@ public final class TryCatchUtils {
 
   public static List<Type> getCaughtTypes(CatchTree tree) {
     VariableTree parameter = tree.parameter();
-    if (parameter.type().is(Tree.Kind.UNION_TYPE)) {
-      return ((UnionTypeTree) parameter.type()).typeAlternatives().stream()
+    if (parameter.type() instanceof UnionTypeTree unionTypeTree) {
+      return unionTypeTree.typeAlternatives().stream()
         .map(TypeTree::symbolType)
         .toList();
     }
-    return Collections.singletonList(parameter.symbol().type());
+    return List.of(parameter.symbol().type());
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/TryCatchUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/TryCatchUtilsTest.java
@@ -36,7 +36,6 @@ class TryCatchUtilsTest {
 
   private TryStatementTree parseTry(String code) {
     CompilationUnitTree compilationUnitTree = JParserTestUtils.parse("void main() { %s }".formatted(code));
-    System.out.println(compilationUnitTree);
     ClassTree classTree = (ClassTree) compilationUnitTree.types().get(0);
     MethodTree methodTree = (MethodTree) classTree.members().get(0);
     return (TryStatementTree) methodTree.block().body().get(0);

--- a/java-checks/src/test/java/org/sonar/java/checks/helpers/TryCatchUtilsTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/helpers/TryCatchUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.helpers;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.TryStatementTree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class TryCatchUtilsTest {
+
+  @Test
+  void testGetCaughtTypes() {
+    assertThat(TryCatchUtils.getCaughtTypes(
+      parseTry("try {} catch (ExceptionABCD e) {} ").catches().get(0)
+    )).first().matches(type -> type.name().equals("ExceptionABCD"));
+  }
+
+  private TryStatementTree parseTry(String code) {
+    CompilationUnitTree compilationUnitTree = JParserTestUtils.parse("void main() { %s }".formatted(code));
+    System.out.println(compilationUnitTree);
+    ClassTree classTree = (ClassTree) compilationUnitTree.types().get(0);
+    MethodTree methodTree = (MethodTree) classTree.members().get(0);
+    return (TryStatementTree) methodTree.block().body().get(0);
+  }
+}
+


### PR DESCRIPTION
----
## Summary by Gitar

- **New implementation:**
  - Added quickfix support for `AssertThrowsInsteadOfTryCatchFailCheck` for both JUnit and AssertJ.
  - Implemented `TryCatchUtils` helper to centralize catch block type extraction logic.
- **Refactoring:**
  - Migrated `getCaughtTypes` logic from `InterruptedExceptionCheck` to the new shared `TryCatchUtils` helper.
- **Test updates:**
  - Updated `AssertThrowsInsteadOfTryCatchFailCheckSample` to correctly categorize JUnit failure cases and add new test coverage.
  - Added `TryCatchUtilsTest` to verify catch block type resolution.
- **Quickfix features:**
  - Introduced `Replacements` record to handle automated code transformations for JUnit `assertThrows` and AssertJ `assertThatCode` patterns.

<sub>This will update automatically on new commits.</sub>