### PR TITLE
SONARJAVA-6465 : Rule S8714 - fix quickfix indexoutofbound / NPE exception

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S1874.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S1874.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S1874",
   "hasTruePositives": true,
-  "falseNegatives": 246,
+  "falseNegatives": 257,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8714",
   "hasTruePositives": false,
-  "falseNegatives": 44,
+  "falseNegatives": 246,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8714",
-  "hasTruePositives": true,
-  "falseNegatives": 246,
+  "hasTruePositives": false,
+  "falseNegatives": 46,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8714",
   "hasTruePositives": false,
-  "falseNegatives": 46,
+  "falseNegatives": 47,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8714.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8714",
-  "hasTruePositives": false,
+  "hasTruePositives": true,
   "falseNegatives": 246,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -409,7 +409,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.23.1</version>
+      <version>3.27.7</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -119,6 +119,14 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
     // edit@qf3 [[sl=114;sc=7;el=114;ec=22]] {{}}
     // edit@qf3 [[sl=116;sc=6;el=116;ec=6]] {{, "failed");}}
 
+    // assertJ fail without argument, available since assertJ 3.26.0
+    try {
+      org.assertj.core.api.Fail.fail(); // Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    } catch (Exception e) {
+      // test pass
+    }
+
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
     nonAnnotatedFunctionFN();

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -120,7 +120,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
     // edit@qf3 [[sl=116;sc=6;el=116;ec=6]] {{, "failed");}}
     // edit@qf3 [[sl=113;sc=9;el=113;ec=10]] {{{}}
     // edit@qf3 [[sl=113;sc=67;el=113;ec=68]] {{}}
-    // edit@qf3 [[sl=113;sc=69;el=113;ec=70]] {{}}
+    // edit@qf3 [[sl=113;sc=69;el=113;ec=70]] {{;}}
 
     // assertJ fail without argument, available since assertJ 3.26.0
     try {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -109,6 +109,16 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     } finally {}
 
+    // Try with resources : no catch no finally
+    try (java.io.StringReader _ = new java.io.StringReader("data")) {
+      fail("failed");// Noncompliant {{Use assertThrows() instead of try/catch and fail() in the try block.}} [[quickfixes=qf3]]
+//    ^^^^^^^^^^^^^^
+    }
+    // fix@qf3 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
+    // edit@qf3 [[sl=113;sc=5;el=113;ec=8]] {{assertThrows(Throwable, () -> }}
+    // edit@qf3 [[sl=114;sc=7;el=114;ec=22]] {{}}
+    // edit@qf3 [[sl=116;sc=6;el=116;ec=6]] {{, "failed");}}
+
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
     nonAnnotatedFunctionFN();

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -118,6 +118,9 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
     // edit@qf3 [[sl=113;sc=5;el=113;ec=8]] {{assertThrows(Throwable.class, () -> }}
     // edit@qf3 [[sl=114;sc=7;el=114;ec=22]] {{}}
     // edit@qf3 [[sl=116;sc=6;el=116;ec=6]] {{, "failed");}}
+    // edit@qf3 [[sl=113;sc=9;el=113;ec=10]] {{{}}
+    // edit@qf3 [[sl=113;sc=67;el=113;ec=68]] {{}}
+    // edit@qf3 [[sl=113;sc=69;el=113;ec=70]] {{}}
 
     // assertJ fail without argument, available since assertJ 3.26.0
     try {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -130,6 +130,14 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
       // test pass
     }
 
+    // assertJ fail without argument, available since assertJ 3.26.0
+    try {
+      // test pass
+    } catch (Exception e) {
+      org.assertj.core.api.Fail.fail("failed"); // Noncompliant {{Use assertDoesNotThrow() instead of try/catch and fail() in the catch block.}}
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+
     assertThrows(IllegalStateException.class, AssertThrowsInsteadOfTryCatchFailCheckSample::raise); // compliant
     assertDoesNotThrow(AssertThrowsInsteadOfTryCatchFailCheckSample::dontRaise); // compliant
     nonAnnotatedFunctionFN();

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -115,7 +115,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
 //    ^^^^^^^^^^^^^^
     }
     // fix@qf3 {{Use assertThrows() instead of try/catch and fail() in the try block.}}
-    // edit@qf3 [[sl=113;sc=5;el=113;ec=8]] {{assertThrows(Throwable, () -> }}
+    // edit@qf3 [[sl=113;sc=5;el=113;ec=8]] {{assertThrows(Throwable.class, () -> }}
     // edit@qf3 [[sl=114;sc=7;el=114;ec=22]] {{}}
     // edit@qf3 [[sl=116;sc=6;el=116;ec=6]] {{, "failed");}}
 

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertThrowsInsteadOfTryCatchFailCheckSample.java
@@ -130,7 +130,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheckSample {
       // test pass
     }
 
-    // assertJ fail without argument, available since assertJ 3.26.0
+    // assertJ fail in the catch block
     try {
       // test pass
     } catch (Exception e) {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsCompletenessCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/AssertionsCompletenessCheckSample.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Stream;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.assertj.core.description.Description;
 import org.fest.assertions.BooleanAssert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -123,8 +124,8 @@ public class AssertionsCompletenessCheckSample {
     // BDD
     org.assertj.core.api.BDDAssertions.thenRuntimeException(); // Noncompliant
     org.assertj.core.api.BDDAssertions.thenRuntimeException().isThrownBy(() -> System.out.println("b"));
-    org.assertj.core.api.BDDAssertions.thenRuntimeException().describedAs(null); // Noncompliant
-    org.assertj.core.api.BDDAssertions.thenRuntimeException().describedAs(null).isThrownBy(() -> System.out.println("b"));
+    org.assertj.core.api.BDDAssertions.thenRuntimeException().describedAs((Description) null); // Noncompliant
+    org.assertj.core.api.BDDAssertions.thenRuntimeException().describedAs((Description) null).isThrownBy(() -> System.out.println("b"));
 
 
     Comparator customComparator = null;

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -189,7 +189,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
 
 
   private static String typeClass(@Nullable Type caughtType) {
-    if (caughtType == null) return "Throwable";
+    if (caughtType == null) return "Throwable.class";
     return caughtType.name() + ".class";
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -24,16 +24,11 @@ import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Type;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
-import org.sonar.plugins.java.api.tree.MethodInvocationTree;
-import org.sonar.plugins.java.api.tree.BlockTree;
-import org.sonar.plugins.java.api.tree.MethodTree;
-import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.TryStatementTree;
-import org.sonar.plugins.java.api.tree.Arguments;
+import org.sonar.plugins.java.api.tree.*;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 
 import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 
@@ -114,21 +109,27 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         assertJReplacement(failArguments, tryStatement, isTryBlock) :
         junitReplacement(failArguments, tryStatement, isTryBlock);
 
-      var firstCatchFinallyToken = tryStatement.catches().isEmpty() ?
-        tryStatement.finallyKeyword().firstToken() :
-        tryStatement.catches().get(0).firstToken();
-      var lastCatchFinallyToken = tryStatement.finallyBlock() != null ?
-        tryStatement.finallyBlock().lastToken() :
-        tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
+      JavaTextEdit lastEdit;
+      if (!tryStatement.catches().isEmpty()){
+        var start = tryStatement.catches().get(0).firstToken();
+        var end = tryStatement.finallyBlock() != null ?
+          tryStatement.finallyBlock().lastToken() :
+          tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
+        lastEdit = JavaTextEdit.replaceBetweenTree(start, end, replacements.replaceCatchesWith);
+      }
+      else if (tryStatement.finallyBlock() != null) {
+        var start = tryStatement.finallyBlock().firstToken();
+        var end = tryStatement.finallyBlock().lastToken();
+        lastEdit = JavaTextEdit.replaceBetweenTree(start, end, replacements.replaceCatchesWith);
+      }
+      else {
+        lastEdit = JavaTextEdit.insertAfterTree(tryStatement.block(), replacements.replaceCatchesWith);
+      }
 
       return JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
         JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
         JavaTextEdit.replaceTree(failMethodInvocation.parent(), ""),
-        JavaTextEdit.replaceBetweenTree(
-          firstCatchFinallyToken,
-          lastCatchFinallyToken,
-          replacements.replaceCatchesWith
-        )
+        lastEdit
       ).build();
     }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -115,7 +115,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         junitReplacement(failArguments, tryStatement, isTryBlock);
 
       JavaTextEdit lastEdit;
-      if (!tryStatement.catches().isEmpty()){
+      if (!tryStatement.catches().isEmpty()) {
         var start = tryStatement.catches().get(0).firstToken();
         var end = tryStatement.finallyBlock() != null ?
           tryStatement.finallyBlock().lastToken() :
@@ -129,11 +129,21 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         lastEdit = JavaTextEdit.insertAfterTree(tryStatement.block(), replacements.replaceCatchesWith);
       }
 
-      return JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
+      var result = JavaQuickFix.newQuickFix(issueMessage).addTextEdit(
         JavaTextEdit.replaceTree(tryStatement.tryKeyword(), replacements.replaceTryWith),
         JavaTextEdit.replaceTree(failMethodInvocation.parent(), ""),
         lastEdit
-      ).build();
+      );
+
+      if (!tryStatement.resourceList().isEmpty()) {
+        result.addTextEdit(
+          JavaTextEdit.replaceTree(tryStatement.openParenToken(), "{"),
+          JavaTextEdit.replaceTree(tryStatement.closeParenToken(), ""),
+          JavaTextEdit.replaceTree(tryStatement.block().openBraceToken(), "")
+        );
+      }
+
+      return result.build();
     }
 
     private Replacements junitReplacement(

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -139,7 +139,7 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         result.addTextEdit(
           JavaTextEdit.replaceTree(tryStatement.openParenToken(), "{"),
           JavaTextEdit.replaceTree(tryStatement.closeParenToken(), ""),
-          JavaTextEdit.replaceTree(tryStatement.block().openBraceToken(), "")
+          JavaTextEdit.replaceTree(tryStatement.block().openBraceToken(), ";")
         );
       }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -163,16 +163,15 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {
-      // in assertJ the failure message is mandatory
-      var failureMessage = contentFor(failArguments.get(0));
+      var failureMessagePart = failArguments.stream().findFirst().map(this::contentFor).map(".withFailMessage(%s)"::formatted).orElse("");
       return isTryBlock ?
         new Replacements(
           "assertThatCode(() -> ",
-          ").withFailMessage(%s).isInstanceOf(%s);".formatted(failureMessage, typeClass(firstCaughtTypeInTry(tryStatement)))
+          ")%s.isInstanceOf(%s);".formatted(failureMessagePart, typeClass(firstCaughtTypeInTry(tryStatement)))
         ) :
         new Replacements(
           "assertThatCode(() -> ",
-          ").withFailMessage(%s).doesNotThrowAnyException();".formatted(failureMessage)
+          ")%s.doesNotThrowAnyException();".formatted(failureMessagePart)
         );
     }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -121,13 +121,11 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
           tryStatement.finallyBlock().lastToken() :
           tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
         lastEdit = JavaTextEdit.replaceBetweenTree(start, end, replacements.replaceCatchesWith);
-      }
-      else if (tryStatement.finallyBlock() != null) {
+      } else if (tryStatement.finallyBlock() != null) {
         var start = tryStatement.finallyBlock().firstToken();
         var end = tryStatement.finallyBlock().lastToken();
         lastEdit = JavaTextEdit.replaceBetweenTree(start, end, replacements.replaceCatchesWith);
-      }
-      else {
+      } else {
         lastEdit = JavaTextEdit.insertAfterTree(tryStatement.block(), replacements.replaceCatchesWith);
       }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -76,7 +76,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
-          var isAssertJ = failMethodInvocation.methodSymbol().signature().contains("org.assertj");
+          var isAssertJ = failMethodInvocation
+            .methodSymbol()
+            .owner()
+            .type()
+            .fullyQualifiedName()
+            .startsWith("org.assertj");
           if (hasJunitJupiterTestAnnotation || isAssertJ) {
             String issueMessage = isTryBlock ?
               "Use assertThrows() instead of try/catch and fail() in the try block." :
@@ -115,15 +120,16 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         junitReplacement(failArguments, tryStatement, isTryBlock);
 
       JavaTextEdit lastEdit;
+      @Nullable var finallyBlock = tryStatement.finallyBlock();
       if (!tryStatement.catches().isEmpty()) {
         var start = tryStatement.catches().get(0).firstToken();
-        var end = tryStatement.finallyBlock() != null ?
-          tryStatement.finallyBlock().lastToken() :
+        var end = finallyBlock != null ?
+          finallyBlock.lastToken() :
           tryStatement.catches().get(tryStatement.catches().size() - 1).block().lastToken();
         lastEdit = JavaTextEdit.replaceBetweenTree(start, end, replacements.replaceCatchesWith);
-      } else if (tryStatement.finallyBlock() != null) {
-        var start = tryStatement.finallyBlock().firstToken();
-        var end = tryStatement.finallyBlock().lastToken();
+      } else if (finallyBlock != null) {
+        var start = finallyBlock.firstToken();
+        var end = finallyBlock.lastToken();
         lastEdit = JavaTextEdit.replaceBetweenTree(start, end, replacements.replaceCatchesWith);
       } else {
         lastEdit = JavaTextEdit.insertAfterTree(tryStatement.block(), replacements.replaceCatchesWith);
@@ -177,7 +183,9 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       TryStatementTree tryStatement,
       boolean isTryBlock
     ) {
-      var failureMessagePart = failArguments.stream().findFirst().map(this::contentFor).map(".withFailMessage(%s)"::formatted).orElse("");
+      var failureMessagePart = failArguments.isEmpty() ?
+        "" :
+        ".withFailMessage(%s)".formatted(contentFor(failArguments.get(0)));
       return isTryBlock ?
         new Replacements(
           "assertThatCode(() -> ",

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -24,11 +24,16 @@ import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Type;
-import org.sonar.plugins.java.api.tree.*;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.BlockTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TryStatementTree;
+import org.sonar.plugins.java.api.tree.Arguments;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 import static org.sonar.java.checks.helpers.TryCatchUtils.getCaughtTypes;
 

--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -76,9 +76,11 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
     ) {
       UnitTestUtils.findFail(block).ifPresent(failMethodInvocation -> {
 
-          var isAssertJ = failMethodInvocation
-            .methodSymbol()
-            .owner()
+          var failOwner = failMethodInvocation.methodSymbol().owner();
+          if (failOwner == null) {
+            return;
+          }
+          var isAssertJ = failOwner
             .type()
             .fullyQualifiedName()
             .startsWith("org.assertj");


### PR DESCRIPTION
Despite [AssertJ doc pretends fail always has a string argument message](https://joel-costigliola.github.io/assertj/core/api/org/assertj/core/api/Fail.html), it is not the case in practice : causing a index out of bound exception

----
## Summary by Gitar

- **Fixed bugs:**
  - Resolved `IndexOutOfBoundsException` in `AssertThrowsInsteadOfTryCatchFailCheck` by handling `fail()` calls without arguments.
  - Added safeguard against `null` method owners during `fail()` invocation analysis.
  - Corrected `Throwable` to `Throwable.class` in expected type resolution.
- **Refactored logic:**
  - Rebuilt `JavaTextEdit` generation to handle diverse `TryStatementTree` configurations, including `try-with-resources` without `catch` or `finally`.
- **Dependencies:**
  - Updated `assertj-core` to `3.27.7` and updated test samples accordingly.


<sub>This will update automatically on new commits.</sub>