### PR TITLE
SONARJAVA-6440 Refactor: visit IMPORT nodes instead of scanning CompilationUnitTree

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/PseudoRandomCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/PseudoRandomCheck.java
@@ -32,10 +32,8 @@ import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
-import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.ImportClauseTree;
 import org.sonar.plugins.java.api.tree.ImportTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
@@ -103,17 +101,17 @@ public class PseudoRandomCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return Arrays.asList(Tree.Kind.NEW_CLASS, Tree.Kind.METHOD_INVOCATION);
-  }
-
-  @Override
-  public void setContext(JavaFileScannerContext context) {
-    super.setContext(context);
-    cryptoImportPresent = hasCryptoImport(context.getTree());
+    return Arrays.asList(Tree.Kind.IMPORT, Tree.Kind.NEW_CLASS, Tree.Kind.METHOD_INVOCATION);
   }
 
   @Override
   public void visitNode(Tree tree) {
+    if (tree instanceof ImportTree importTree) {
+      if (matchesCryptoPrefix(ExpressionsHelper.concatenate((ExpressionTree) importTree.qualifiedIdentifier()))) {
+        cryptoImportPresent = true;
+      }
+      return;
+    }
     if (tree instanceof MethodInvocationTree mit) {
       if (isStaticCallToInsecureRandomMethod(mit) && isInSecurityContext(mit)) {
         reportIssue(ExpressionUtils.methodName(mit), MESSAGE);
@@ -138,17 +136,6 @@ public class PseudoRandomCheck extends IssuableSubscriptionVisitor {
       && !RANDOM_STRING_UTILS_RANDOM_WITH_RANDOM_SOURCE.matches(mit)
       && !RANDOM_STRING_UTILS_SECURE_INSTANCES.matches(mit)
       && mit.methodSymbol().isStatic();
-  }
-
-  private static boolean hasCryptoImport(CompilationUnitTree cut) {
-    for (ImportClauseTree importClause : cut.imports()) {
-      if (importClause.is(Tree.Kind.IMPORT)
-        && ((ImportTree) importClause).qualifiedIdentifier() instanceof ExpressionTree exprTree
-        && matchesCryptoPrefix(ExpressionsHelper.concatenate(exprTree))) {
-        return true;
-      }
-    }
-    return false;
   }
 
   private static boolean matchesCryptoPrefix(String importName) {
@@ -200,8 +187,8 @@ public class PseudoRandomCheck extends IssuableSubscriptionVisitor {
     return null;
   }
 
-// Split on underscores first; for each part either keep it as a single lowercase word
-// when all-uppercase, or split further on capital-letter boundaries.
+  // Split on underscores first; for each part either keep it as a single lowercase word
+  // when all-uppercase, or split further on capital-letter boundaries.
   static List<String> tokenizeIdentifier(String identifier) {
     List<String> words = new ArrayList<>();
     for (String part : identifier.split("_")) {


### PR DESCRIPTION
## Summary

Suggestion from code review: instead of scanning the `CompilationUnitTree` manually in `setContext`, subscribe to `Tree.Kind.IMPORT` and let the visitor framework drive the import traversal — the same pattern used by `DateAndTimesCheck`, `WildcardImportsShouldNotBeUsedCheck`, and `UselessImportCheck`.

- Add `Tree.Kind.IMPORT` to `nodesToVisit()`
- Handle `ImportTree` in `visitNode` — set `cryptoImportPresent = true` when a crypto prefix matches
- Remove `setContext` override
- Remove `hasCryptoImport(CompilationUnitTree)` helper
- Remove now-unused `CompilationUnitTree` and `ImportClauseTree` imports
- Fix misindented comment on `tokenizeIdentifier`

No test changes — all existing tests cover this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)