### PR TITLE
SONARJAVA-6470 ToggleLockBranch: Add additional-message

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -2,6 +2,10 @@ name: Toggle lock branch
 
 on:
   workflow_dispatch:    # Triggered manually from the GitHub UI / Actions
+    inputs:
+      additional-message:
+        description: 'Additional Slack message text'
+        required: false
 
 jobs:
   ToggleLockBranch_job:
@@ -20,4 +24,5 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
+          additional-message: ${{ github.event.inputs.additional-message }}
           slack-channel: squad-jvm-notifs


### PR DESCRIPTION
This new parameter will be appended to the Slack message. It removes the need to go to Slack and explain why it's being locked