### PR TITLE
SONARJAVA-6487 Bump sonar-java-jdt to 1.9.0.1840

### DIFF
--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jdt-package</artifactId>
-      <version>1.8.0.1483</version>
+      <version>1.9.0.1840</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Updates the jdt to [the version i just released](https://github.com/SonarSource/sonar-java-jdt/releases/tag/1.9.0.1840).The equivalent changes were tested on peachee via a dogfood branch targeting [this PR](https://github.com/SonarSource/sonar-java/pull/5666).