### PR TITLE
SONARJAVA-6512 Enable analysis of Java 26

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/model/JavaVersionImpl.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JavaVersionImpl.java
@@ -45,7 +45,8 @@ public class JavaVersionImpl implements JavaVersion {
   private static final int JAVA_23 = 23;
   private static final int JAVA_24 = 24;
   private static final int JAVA_25 = 25;
-  public static final int MAX_SUPPORTED = JAVA_25;
+  private static final int JAVA_26 = 26;
+  public static final int MAX_SUPPORTED = JAVA_26;
 
   private final int javaVersion;
   private final boolean previewFeaturesEnabled;
@@ -171,6 +172,11 @@ public class JavaVersionImpl implements JavaVersion {
   @Override
   public boolean isJava25Compatible() {
     return JAVA_25 <= javaVersion;
+  }
+
+  @Override
+  public boolean isJava26Compatible() {
+    return JAVA_26 <= javaVersion;
   }
 
   private boolean notSetOrAtLeast(int requiredJavaVersion) {

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaVersion.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaVersion.java
@@ -177,7 +177,7 @@ public interface JavaVersion {
    * Test if java version of the project is greater than or equal to 26.
    * Remark - Contrary to other isJava*Compatible methods, this one will NOT return true if version is not set
    * @return true if java version used is >= 26
-   * @since SonarJava 8.32: Support of Java 26
+   * @since SonarJava 8.34: Support of Java 26
    */
   boolean isJava26Compatible();
 

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaVersion.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/JavaVersion.java
@@ -174,6 +174,14 @@ public interface JavaVersion {
   boolean isJava25Compatible();
 
   /**
+   * Test if java version of the project is greater than or equal to 26.
+   * Remark - Contrary to other isJava*Compatible methods, this one will NOT return true if version is not set
+   * @return true if java version used is >= 26
+   * @since SonarJava 8.32: Support of Java 26
+   */
+  boolean isJava26Compatible();
+
+  /**
    * get java version as integer
    * @return an int representing the java version
    */

--- a/java-frontend/src/test/java/org/sonar/java/model/JavaVersionImplTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JavaVersionImplTest.java
@@ -54,11 +54,12 @@ class JavaVersionImplTest {
     assertThat(version.isJava23Compatible()).isFalse();
     assertThat(version.isJava24Compatible()).isFalse();
     assertThat(version.isJava25Compatible()).isFalse();
+    assertThat(version.isJava26Compatible()).isFalse();
     assertThat(version.asInt()).isEqualTo(-1);
   }
 
   @ParameterizedTest(name = "JavaVersion: \"{0}\"")
-  @ValueSource(ints = {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 42})
+  @ValueSource(ints = {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 42})
   void java_versions(int javaVersionAsInt) {
     JavaVersion version = new JavaVersionImpl(javaVersionAsInt);
     assertThat(version.isSet()).isTrue();
@@ -81,6 +82,7 @@ class JavaVersionImplTest {
     assertThat(version.isJava23Compatible()).isEqualTo(javaVersionAsInt >= 23);
     assertThat(version.isJava24Compatible()).isEqualTo(javaVersionAsInt >= 24);
     assertThat(version.isJava25Compatible()).isEqualTo(javaVersionAsInt >= 25);
+    assertThat(version.isJava26Compatible()).isEqualTo(javaVersionAsInt >= 26);
 
     assertThat(version.asInt()).isEqualTo(javaVersionAsInt);
   }
@@ -101,9 +103,9 @@ class JavaVersionImplTest {
 
   @Test
   void test_effective_java_version() {
-    assertThat(new JavaVersionImpl().effectiveJavaVersionAsString()).isEqualTo("25");
+    assertThat(new JavaVersionImpl().effectiveJavaVersionAsString()).isEqualTo("26");
     assertThat(new JavaVersionImpl(10).effectiveJavaVersionAsString()).isEqualTo("10");
-    assertThat(new JavaVersionImpl(-1).effectiveJavaVersionAsString()).isEqualTo("25");
+    assertThat(new JavaVersionImpl(-1).effectiveJavaVersionAsString()).isEqualTo("26");
   }
 
   @Test


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Java 26 support:**
  - Updated `JavaVersionImpl` and `JavaVersion` to support Java 26 as the maximum supported version.
  - Added `isJava26Compatible` predicate to check for Java 26 compatibility.
  - Updated `JavaVersionImplTest` to include validation for Java 26 and updated default effective version to 26.

<sub>This will update automatically on new commits.</sub>