### PR TITLE
SONARJAVA-6511 Decrease number of FPs for the rule S125

### DIFF
--- a/its/ruling/src/test/resources/commons-beanutils/java-S125.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S125.json
@@ -48,8 +48,7 @@
 97
 ],
 "commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/PropertyUtilsTestCase.java": [
-4295,
-4319,
+4320,
 4452
 ],
 "commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/TestResultSetMetaData.java": [

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S125.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S125.json
@@ -2,9 +2,6 @@
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java": [
 389
 ],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java": [
-1192
-],
 "org.eclipse.jetty:jetty-project:jetty-http/src/test/java/org/eclipse/jetty/http/HttpURIParseTest.java": [
 247
 ],
@@ -13,9 +10,6 @@
 129,
 161,
 204
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java": [
-758
 ],
 "org.eclipse.jetty:jetty-project:jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java": [
 171,
@@ -41,13 +35,6 @@
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/PushBuilderImpl.java": [
 187
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Response.java": [
-368,
-1066
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java": [
-648
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/AsyncRequestReadTest.java": [
 136,
 182,
@@ -63,11 +50,6 @@
 435,
 481
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/DetectorConnectionTest.java": [
-212,
-483,
-550
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java": [
 395
 ],
@@ -79,16 +61,9 @@
 1012,
 1137,
 1557,
-1568,
-1777
+1568
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpWriterTest.java": [
 245
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartParserTest.java": [
-348
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java": [
-392
 ]
 }

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S8688.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S8688.json
@@ -1,6 +1,6 @@
 {
-  "org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java": [
-    428,
-    439
-  ]
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java": [
+428,
+439
+]
 }

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S125.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S125.json
@@ -2,9 +2,6 @@
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/GZIPContentDecoder.java": [
 389
 ],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java": [
-1192
-],
 "org.eclipse.jetty:jetty-project:jetty-http/src/test/java/org/eclipse/jetty/http/HttpURIParseTest.java": [
 247
 ],
@@ -13,9 +10,6 @@
 129,
 161,
 204
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java": [
-758
 ],
 "org.eclipse.jetty:jetty-project:jetty-io/src/test/java/org/eclipse/jetty/io/IOTest.java": [
 171,
@@ -41,13 +35,6 @@
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/PushBuilderImpl.java": [
 187
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Response.java": [
-368,
-1066
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java": [
-648
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/AsyncRequestReadTest.java": [
 136,
 182,
@@ -63,11 +50,6 @@
 435,
 481
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/DetectorConnectionTest.java": [
-212,
-483,
-550
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/GracefulStopTest.java": [
 395
 ],
@@ -79,31 +61,14 @@
 1012,
 1137,
 1557,
-1568,
-1777
+1568
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpWriterTest.java": [
 245
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/MultiPartParserTest.java": [
-348
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java": [
-392
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ProxyConnectionTest.java": [
-136,
-259,
-300
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ProxyCustomizerTest.java": [
-142
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ProxyProtocolTest.java": [
-164,
 176,
-179,
-247
+179
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/RequestTest.java": [
 600,
@@ -147,7 +112,6 @@
 320
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLCloseTest.java": [
-106,
 113
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLEngineTest.java": [
@@ -158,9 +122,6 @@
 265,
 370,
 378
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLReadEOFAfterResponseTest.java": [
-137
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLSelectChannelConnectorLoadTest.java": [
 132,
@@ -184,9 +145,6 @@
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ArrayTernaryTrie.java": [
 532
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IO.java": [
-462
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java": [
 277
@@ -212,23 +170,12 @@
 "org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/RolloverFileOutputStreamTest.java": [
 54
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/SearchPatternTest.java": [
-83
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/URIUtilTest.java": [
-140,
-144
-],
 "org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/Utf8AppendableTest.java": [
 166,
 186
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/component/LifeCycleListenerTest.java": [
 107
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/ssl/SslContextFactoryTest.java": [
-94,
-116
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/statistic/SampleStatisticTest.java": [
 41

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S8688.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S8688.json
@@ -1,9 +1,9 @@
 {
-  "org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java": [
-    428,
-    439
-  ],
-  "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/EatWhatYouKill.java": [
-    484
-  ]
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java": [
+428,
+439
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/thread/strategy/EatWhatYouKill.java": [
+484
+]
 }

--- a/its/ruling/src/test/resources/guava/java-S125.json
+++ b/its/ruling/src/test/resources/guava/java-S125.json
@@ -2,9 +2,6 @@
 "com.google.guava:guava:src/com/google/common/base/Preconditions.java": [
 259
 ],
-"com.google.guava:guava:src/com/google/common/base/Suppliers.java": [
-202
-],
 "com.google.guava:guava:src/com/google/common/base/Utf8.java": [
 92,
 187
@@ -26,22 +23,17 @@
 2676
 ],
 "com.google.guava:guava:src/com/google/common/collect/Maps.java": [
-335
+336
 ],
 "com.google.guava:guava:src/com/google/common/collect/Ordering.java": [
-371,
 382,
-393,
-472
+393
 ],
 "com.google.guava:guava:src/com/google/common/collect/TreeRangeSet.java": [
 170,
 173,
 216,
 231
-],
-"com.google.guava:guava:src/com/google/common/io/FileBackedOutputStream.java": [
-198
 ],
 "com.google.guava:guava:src/com/google/common/math/IntMath.java": [
 53
@@ -61,9 +53,6 @@
 "com.google.guava:guava:src/com/google/common/reflect/TypeToken.java": [
 1061
 ],
-"com.google.guava:guava:src/com/google/common/reflect/TypeVisitor.java": [
-72
-],
 "com.google.guava:guava:src/com/google/common/util/concurrent/AbstractFuture.java": [
 346
 ],
@@ -79,7 +68,7 @@
 114
 ],
 "com.google.guava:guava:src/com/google/common/util/concurrent/Monitor.java": [
-209,
+210,
 950,
 953,
 1003

--- a/its/ruling/src/test/resources/jboss-ejb3-tutorial/java-S125.json
+++ b/its/ruling/src/test/resources/jboss-ejb3-tutorial/java-S125.json
@@ -2,9 +2,6 @@
 "jboss-ejb3-tutorial:composite/src/org/jboss/tutorial/composite/bean/Flight.java": [
 78
 ],
-"jboss-ejb3-tutorial:extended_pc/src/org/jboss/tutorial/extended/client/Client.java": [
-29
-],
 "jboss-ejb3-tutorial:relationships/src/org/jboss/tutorial/relationships/bean/Flight.java": [
 84
 ]

--- a/its/ruling/src/test/resources/sonar-server/java-S125.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S125.json
@@ -24,10 +24,6 @@
 "org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/rule/RegisterRulesMediumTest.java": [
 252
 ],
-"org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/rule/index/RuleIndexTest.java": [
-648,
-651
-],
 "org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/rule/ws/SearchActionMediumTest.java": [
 27
 ]

--- a/its/ruling/src/test/resources/sonar-server/java-S3706.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S3706.json
@@ -1,12 +1,12 @@
 {
-  "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/permission/ws/template/SearchTemplatesDataLoader.java": [
-    96
-  ],
-  "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/rule/ws/ShowAction.java": [
-    140
-  ],
-  "org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/qualityprofile/RuleActivatorTest.java": [
-    863,
-    898
-  ]
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/permission/ws/template/SearchTemplatesDataLoader.java": [
+96
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/rule/ws/ShowAction.java": [
+140
+],
+"org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/qualityprofile/RuleActivatorTest.java": [
+863,
+898
+]
 }

--- a/java-checks-test-sources/default/src/main/java/checks/CommentedCode.java
+++ b/java-checks-test-sources/default/src/main/java/checks/CommentedCode.java
@@ -110,6 +110,24 @@ public class CommentedCode {
      * }
      */
     int a;
+
+    // This is a legal comment that ends with semi-colon;
+
+// Noncompliant@+2
+    // uses System/.out/.println
+    // System.out.println("testit");
+
+// Noncompliant@+2
+    // uses System/.err/.println
+    // System.err.println("err");
+
+// Noncompliant@+2
+    // ends by ';' and uses CamelCase
+    // assertEquals(a, "smth");
+
+// Noncompliant@+2
+    // ends by ';' and uses int keyword
+    // int i = 1;
   }
 
   // TODo

--- a/java-checks/src/main/java/org/sonar/java/checks/JavaFootprint.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/JavaFootprint.java
@@ -30,12 +30,14 @@ public final class JavaFootprint implements LanguageFootprint {
   private final Set<Detector> detectors = new HashSet<>();
 
   public JavaFootprint() {
-    detectors.add(new EndWithDetector(0.95, '}', ';', '{'));
+    detectors.add(new EndWithDetector(0.95, '}', '{'));
+    // add detection of ';' at the end of a line, it is less than a threshold used in the detector to avoid false positives
+    detectors.add(new EndWithDetector(0.87, ';'));
     detectors.add(new KeywordsDetector(0.7, "++", "||", "&&"));
     detectors.add(new KeywordsDetector(0.3, "public", "abstract", "class", "implements", "extends", "return", "throw",
         "private", "protected", "enum", "continue", "assert", "package", "synchronized", "boolean", "this", "double", "instanceof",
         "final", "interface", "static", "void", "long", "int", "float", "super", "true", "case:"));
-    detectors.add(new ContainsDetector(0.95, "for(", "if(", "while(", "catch(", "switch(", "try{", "else{"));
+    detectors.add(new ContainsDetector(0.95, "for(", "if(", "while(", "catch(", "switch(", "try{", "else{", "System.out.print", "System.err.print"));
     detectors.add(new CamelCaseDetector(0.5));
   }
 


### PR DESCRIPTION
Semicolons in the end of comment's lines can be punctuation marks and not code indicators. We have a lot of user feedback pointing on it.

This PR removes FPs for comments where **the only** sign of code is that line ends with ';'. Comments that additionally have some indicators like CamelCase or keywords are still recognized as code.
This change unavoidably adds some amount of FNs. To reduce them the pattern is tuned to react on typical Java commented messages like System.out(err).print.
