### PR TITLE
SONARJAVA-6536 Make sonar-java required for Kotlin

### DIFF
--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -153,7 +153,7 @@
           <pluginName>Java Code Quality and Security</pluginName>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <pluginClass>org.sonar.plugins.java.JavaPlugin</pluginClass>
-          <requiredForLanguages>java,jsp</requiredForLanguages>
+          <requiredForLanguages>java,jsp,kotlin</requiredForLanguages>
           <sonarLintSupported>true</sonarLintSupported>
           <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
           <jreMinVersion>17</jreMinVersion>


### PR DESCRIPTION
Part of SONARKT-765

----
## Summary by Gitar

- **Build configuration:**
  - Updated `requiredForLanguages` in `sonar-java-plugin/pom.xml` to include `kotlin` as a required language.

<sub>This will update automatically on new commits.</sub>