### PR TITLE
SONARJAVA-6558 Add package-info.java for quarkus checks package

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/package-info.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.java.checks.quarkus;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
## Summary
- Adds a `package-info.java` file to the `org.sonar.java.checks.quarkus` package with `@ParametersAreNonnullByDefault` annotation, following the convention used by other check sub-packages (spring, security, serialization, etc.)

## Test plan
- [ ] Verify the file follows the same structure as other `package-info.java` files in sibling packages
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)