### PR TITLE
SONARJAVA-6222 Extend ProfileRegistrar to register rules for specific quality profiles

### DIFF
--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/TestProfileRegistrarContext.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/TestProfileRegistrarContext.java
@@ -17,18 +17,22 @@
 package org.sonar.java.checks.verifier;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.plugins.java.api.ProfileRegistrar;
 
 public class TestProfileRegistrarContext implements ProfileRegistrar.RegistrarContext {
 
-  public final Set<RuleKey> defaultQualityProfileRules = new HashSet<>();
+  public final Map<String, Set<RuleKey>> rulesByQualityProfile = new HashMap<>();
 
   @Override
-  public void registerDefaultQualityProfileRules(Collection<RuleKey> ruleKeys) {
-    defaultQualityProfileRules.addAll(ruleKeys);
+  public void registerRules(String qualityProfileName, Collection<RuleKey> ruleKeys) {
+    rulesByQualityProfile
+      .computeIfAbsent(qualityProfileName, k -> new HashSet<>())
+      .addAll(ruleKeys);
   }
 
 }

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/TestProfileRegistrarContextTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/TestProfileRegistrarContextTest.java
@@ -28,7 +28,10 @@ class TestProfileRegistrarContextTest {
   void store_registration() {
     TestProfileRegistrarContext context = new TestProfileRegistrarContext();
     context.registerDefaultQualityProfileRules(List.of(RuleKey.of("java", "S1234")));
-    assertThat(context.defaultQualityProfileRules).containsExactly(RuleKey.of("java", "S1234"));
+    context.registerRules("Sonar way", List.of(RuleKey.of("java", "S1235")));
+    context.registerRules("Sonar agentic AI", List.of(RuleKey.of("java", "S4321")));
+    assertThat(context.rulesByQualityProfile.get("Sonar way")).containsOnly(RuleKey.of("java", "S1234"), RuleKey.of("java", "S1235"));
+    assertThat(context.rulesByQualityProfile.get("Sonar agentic AI")).containsExactly(RuleKey.of("java", "S4321"));
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/plugins/java/api/ProfileRegistrar.java
+++ b/java-frontend/src/main/java/org/sonar/plugins/java/api/ProfileRegistrar.java
@@ -23,12 +23,13 @@ import org.sonar.java.annotations.Beta;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 /**
- * This class can be extended to provide additional rule keys in the builtin default quality profile.
+ * This class can be extended to provide additional rule keys in builtin quality profiles.
  *
  * <pre>
  *   {@code
  *     public void register(RegistrarContext registrarContext) {
  *       registrarContext.registerDefaultQualityProfileRules(ruleKeys);
+ *       registrarContext.registerRules("Sonar agentic AI", ruleKeys);
  *     }
  *   }
  * </pre>
@@ -46,16 +47,27 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
 public interface ProfileRegistrar {
 
   /**
-   * This method is called on server side and during an analysis to modify the builtin default quality profile for java.
+   * This method is called on server side and during an analysis to modify builtin quality profiles for Java.
    */
   void register(RegistrarContext registrarContext);
 
   interface RegistrarContext {
 
     /**
-     * Registers additional rules into the "Sonar Way" default quality profile for the language "java".
+     * Registers additional rules into the "Sonar way" default quality profile for the language "java".
      */
-    void registerDefaultQualityProfileRules(Collection<RuleKey> ruleKeys);
+    default void registerDefaultQualityProfileRules(Collection<RuleKey> ruleKeys) {
+      registerRules("Sonar way", ruleKeys);
+    }
+
+    /**
+     * Registers additional rules into a builtin quality profile for the language "java".
+     *
+     * <p>
+     * The profile name is expected to match the profile string coming from RSPEC metadata ({@code defaultQualityProfiles}).
+     * </p>
+     */
+    void registerRules(String qualityProfileName, Collection<RuleKey> ruleKeys);
 
   }
 

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/BuiltInJavaQualityProfile.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/BuiltInJavaQualityProfile.java
@@ -45,7 +45,10 @@ abstract class BuiltInJavaQualityProfile implements BuiltInQualityProfilesDefini
   static final String GET_REPOSITORY_KEY = "getRepositoryKey";
   static final String SECURITY_REPOSITORY_KEY = "javasecurity";
   static final String DBD_REPOSITORY_KEY = "javabugs";
+  static final String SONAR_WAY_PROFILE = "Sonar way";
+  static final String SONAR_AGENTIC_PROFILE = "Sonar agentic AI";
 
+  private static final Set<String> BUILTIN_PROFILES = Set.of(SONAR_WAY_PROFILE, SONAR_AGENTIC_PROFILE);
 
   protected final ProfileRegistrar[] profileRegistrars;
 
@@ -83,11 +86,17 @@ abstract class BuiltInJavaQualityProfile implements BuiltInQualityProfilesDefini
     profile.done();
   }
 
-  static Set<RuleKey> registerRulesFromJson(String pathToJsonProfile, @Nullable ProfileRegistrar[] profileRegistrars) {
+  Set<RuleKey> registerRulesFromJson(String pathToJsonProfile, @Nullable ProfileRegistrar[] profileRegistrars) {
     Set<RuleKey> ruleKeys = new HashSet<>(loadRuleKeys(pathToJsonProfile));
     if (profileRegistrars != null) {
       for (ProfileRegistrar profileRegistrar : profileRegistrars) {
-        profileRegistrar.register(ruleKeys::addAll);
+        profileRegistrar.register((qualityProfileName, registrarRuleKeys) -> {
+          if (qualityProfileName.equals(getProfileName())) {
+            ruleKeys.addAll(registrarRuleKeys);
+          } else if (!BUILTIN_PROFILES.contains(qualityProfileName)) {
+            LOG.debug("No builtin quality profile called '{}' was found: skipping rules registration.", qualityProfileName);
+          }
+        });
       }
     }
 

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaAgenticAIProfile.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaAgenticAIProfile.java
@@ -22,7 +22,8 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @SonarLintSide
 public class JavaAgenticAIProfile extends BuiltInJavaQualityProfile {
-  static final String PROFILE_NAME = "Sonar agentic AI";
+  static final String PROFILE_NAME = SONAR_AGENTIC_PROFILE;
+  static final String SONAR_AGENTIC_PATH = "/org/sonar/l10n/java/rules/java/Sonar_agentic_AI_profile.json";
 
   public JavaAgenticAIProfile() {
     this(null);
@@ -39,7 +40,7 @@ public class JavaAgenticAIProfile extends BuiltInJavaQualityProfile {
 
   @Override
   String getPathToJsonProfile() {
-    return "/org/sonar/l10n/java/rules/java/Sonar_agentic_AI_profile.json";
+    return SONAR_AGENTIC_PATH;
   }
 
   @Override

--- a/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSonarWayProfile.java
+++ b/sonar-java-plugin/src/main/java/org/sonar/plugins/java/JavaSonarWayProfile.java
@@ -27,6 +27,7 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
  */
 @SonarLintSide
 public class JavaSonarWayProfile extends BuiltInJavaQualityProfile {
+  static final String PROFILE_NAME = SONAR_WAY_PROFILE;
   static final String SONAR_WAY_PATH = "/org/sonar/l10n/java/rules/java/Sonar_way_profile.json";
 
   /**
@@ -42,7 +43,7 @@ public class JavaSonarWayProfile extends BuiltInJavaQualityProfile {
 
   @Override
   String getProfileName() {
-    return "Sonar way";
+    return PROFILE_NAME;
   }
 
   @Override

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaAgenticWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaAgenticWayProfileTest.java
@@ -32,7 +32,9 @@ import org.apache.commons.csv.CSVFormat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.sonar.api.rule.RuleKey;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
+import org.sonar.plugins.java.api.ProfileRegistrar;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +44,12 @@ class JavaAgenticWayProfileTest {
 
   @Test
   void profile_is_registered_as_expected() {
-    JavaAgenticAIProfile profile = new JavaAgenticAIProfile();
+    ProfileRegistrar agenticCustomRules = registrarContext ->
+      registrarContext.registerRules("Sonar agentic AI", List.of(RuleKey.of("java", "S1107")));
+    ProfileRegistrar sonarWayCustomRules = registrarContext ->
+      registrarContext.registerDefaultQualityProfileRules(List.of(RuleKey.of("java", "S1108")));
+
+    JavaAgenticAIProfile profile = new JavaAgenticAIProfile(new ProfileRegistrar[]{agenticCustomRules, sonarWayCustomRules});
     BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
     profile.define(context);
 
@@ -53,7 +60,7 @@ class JavaAgenticWayProfileTest {
     BuiltInQualityProfilesDefinition.BuiltInQualityProfile actualProfile = profilesPerLanguages.get("java").get("Sonar agentic AI");
     assertThat(actualProfile.isDefault()).isFalse();
     assertThat(actualProfile.rules())
-      .hasSize(465)
+      .hasSize(466)
       .extracting(BuiltInQualityProfilesDefinition.BuiltInActiveRule::ruleKey)
       .doesNotContainAnyElementsOf(List.of(
         "S101",
@@ -113,6 +120,7 @@ class JavaAgenticWayProfileTest {
         "S6242",
         "S6244",
         "S6246",
+        "S1108",
         "S6548",
         "S6804",
         "S6813",
@@ -125,7 +133,10 @@ class JavaAgenticWayProfileTest {
         "S8491",
         "S8692",
         "S8714"
-        ));
+      ))
+      .contains(
+        "S1107"
+      );
   }
 
 

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSonarWayProfileTest.java
@@ -50,10 +50,14 @@ class JavaSonarWayProfileTest {
       RuleKey.of("javasecurity", "S6287")));
     ProfileRegistrar barCustomRules = registrarContext -> registrarContext.registerDefaultQualityProfileRules(List.of(
       RuleKey.of("javabugs", "S6466")));
+    ProfileRegistrar bazCustomRules = registrarContext ->
+      registrarContext.registerRules("Sonar agentic AI", List.of(RuleKey.of("java", "S1107")));
 
     JavaSonarWayProfile profileDef = new JavaSonarWayProfile(new ProfileRegistrar[] {
       fooCustomRules,
-      barCustomRules});
+      barCustomRules,
+      bazCustomRules
+    });
     BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
     profileDef.define(context);
     BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile("java", "Sonar way");
@@ -72,7 +76,8 @@ class JavaSonarWayProfileTest {
       .doesNotContain(RuleKey.of("java", "S00116"))
       .contains(RuleKey.of("java", "S116"))
       .doesNotContain(RuleKey.of("java", "S6549"))
-      .doesNotContain(RuleKey.of("javasecurity", "S116"))
+      .doesNotContain(RuleKey.of("java", "S1107"))
+      .doesNotContain(RuleKey.of("javabugs", "S116"))
       .contains(RuleKey.of("javasecurity", "S6549"))
       .contains(RuleKey.of("javasecurity", "S6287"))
       .contains(RuleKey.of("javabugs", "S6466"));


### PR DESCRIPTION
----
## Summary by Gitar

- **API enhancements:**
  - Added `registerRules(String qualityProfileName, Collection<RuleKey> ruleKeys)` to `ProfileRegistrar.RegistrarContext`.
  - Updated `registerDefaultQualityProfileRules` to delegate to `registerRules` for the "Sonar way" profile.
- **Internal refactoring:**
  - Modified `BuiltInJavaQualityProfile` to filter registered rules by profile name and avoid leakage between profiles.
  - Updated `JavaAgenticAIProfile` and `JavaSonarWayProfile` to use static constants for profile names and paths.
- **Test infrastructure:**
  - Updated `TestProfileRegistrarContext` to support rule registration mapping for multiple distinct quality profiles.
  - Added verification tests in `JavaAgenticWayProfileTest` and `JavaSonarWayProfileTest` to ensure cross-profile isolation.

<sub>This will update automatically on new commits.</sub>