### PR TITLE
S6856: Support Spring 7 path-segment API versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           maven-args: >
             --define maven.test.skip=true
             --define sonar.skip=true
-            --projects !java-checks-test-sources/aws,!java-checks-test-sources/default,!java-checks-test-sources/java-17,!java-checks-test-sources/spring-3.2,!java-checks-test-sources/spring-web-4.0
+            --projects !java-checks-test-sources/aws,!java-checks-test-sources/default,!java-checks-test-sources/java-17,!java-checks-test-sources/spring-3.2,!java-checks-test-sources/spring-web-4.0,!java-checks-test-sources/spring-web-7.0
 
   ruling-qa:
     strategy:

--- a/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
@@ -123,7 +123,7 @@ public class AutoScanTest {
       .setProjectName(PROJECT_NAME)
       .setProjectVersion("0.1.0-SNAPSHOT")
       .setSourceEncoding("UTF-8")
-      .setSourceDirs("aws/src/main/java/,default/src/main/java/,java-17/src/main/java/,spring-3.2/src/main/java/,spring-web-4.0/src/main/java/")
+      .setSourceDirs("aws/src/main/java/,default/src/main/java/,java-17/src/main/java/,spring-3.2/src/main/java/,spring-web-4.0/src/main/java/,spring-web-7.0/src/main/java/")
       .setTestDirs("default/src/test/java/,java-17/src/test/java/,test-classpath-reader/src/test/java")
       .setProperty("sonar.java.source", "26")
       // common properties

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S6856.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S6856.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S6856",
   "hasTruePositives": false,
-  "falseNegatives": 61,
+  "falseNegatives": 65,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/README.md
+++ b/java-checks-test-sources/README.md
@@ -15,7 +15,7 @@ This is the right place when a sample:
 * needs the classpath or dependencies prepared by `java-checks-test-sources`
 * should be compiled as part of one of the dedicated test-source modules
 * is intentionally non-compiling and should live under `src/main/files/non-compiling`
-* targets a specific dedicated module such as `default`, `java-17`, `spring-3.2`, or `spring-web-4.0`
+* targets a specific dedicated module such as `default`, `java-17`, `spring-3.2`, `spring-web-4.0`, or `spring-web-7.0`
 
 Prefer `java-checks/src/test/files` only for fixtures that are not supposed to belong to one of these Maven modules,
 for example parser-only inputs or other ad hoc verifier fixtures.

--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -22,6 +22,7 @@
     <module>java-17</module>
     <module>spring-3.2</module>
     <module>spring-web-4.0</module>
+    <module>spring-web-7.0</module>
 
     <!-- should be the last module to be able to test classpath files "target/test-classpath.txt" of the previous modules -->
     <module>test-classpath-reader</module>

--- a/java-checks-test-sources/spring-web-7.0/pom.xml
+++ b/java-checks-test-sources/spring-web-7.0/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonarsource.java</groupId>
+    <artifactId>java-checks-test-sources</artifactId>
+    <version>8.35.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>spring-web-7.0</artifactId>
+  <name>SonarQube Java :: Checks Test Sources :: Spring Web 7.0</name>
+
+  <properties>
+    <spring-framework.version>7.0.8</spring-framework.version>
+    <sonar.skip>true</sonar.skip>
+    <forbiddenapis.skip>true</forbiddenapis.skip>
+    <skipTests>true</skipTests>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring-framework.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>${spring-framework.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>${spring-framework.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>analyze-tests</id>
+      <properties>
+        <sonar.skip>false</sonar.skip>
+      </properties>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.simplify4u.plugins</groupId>
+        <artifactId>sign-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>src/main/java/**</exclude>
+                <exclude>src/test/java/**</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java-checks-test-sources/spring-web-7.0/src/main/java/checks/spring/s6856/ApiVersionPathConfiguration.java
+++ b/java-checks-test-sources/spring-web-7.0/src/main/java/checks/spring/s6856/ApiVersionPathConfiguration.java
@@ -1,0 +1,20 @@
+package checks.spring.s6856;
+
+import java.util.function.Predicate;
+import org.springframework.http.server.RequestPath;
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+class ApiVersionPathConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void configureApiVersioning(ApiVersionConfigurer configurer) {
+    Predicate<RequestPath> versionedPaths = this::isVersionedPath;
+    configurer.usePathSegment(1, versionedPaths);
+  }
+
+  private boolean isVersionedPath(RequestPath requestPath) {
+    String path = requestPath.pathWithinApplication().value();
+    return path.startsWith("/api/");
+  }
+}

--- a/java-checks-test-sources/spring-web-7.0/src/main/java/checks/spring/s6856/ApiVersionPathUnconditionalConfiguration.java
+++ b/java-checks-test-sources/spring-web-7.0/src/main/java/checks/spring/s6856/ApiVersionPathUnconditionalConfiguration.java
@@ -1,0 +1,12 @@
+package checks.spring.s6856;
+
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+class ApiVersionPathUnconditionalConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void configureApiVersioning(ApiVersionConfigurer configurer) {
+    configurer.usePathSegment(1);
+  }
+}

--- a/java-checks-test-sources/spring-web-7.0/src/main/java/checks/spring/s6856/MissingPathVariableAnnotationCheck_ApiVersionPath.java
+++ b/java-checks-test-sources/spring-web-7.0/src/main/java/checks/spring/s6856/MissingPathVariableAnnotationCheck_ApiVersionPath.java
@@ -1,0 +1,51 @@
+package checks.spring.s6856;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+public class MissingPathVariableAnnotationCheck_ApiVersionPath {
+
+  static class VersionedController {
+
+    @GetMapping(value = "/api/v{apiVersion}/resource/{id}", version = "2")
+    String valid(@PathVariable String id) {
+      return id;
+    }
+
+    @GetMapping(value = "/api/v{apiVersion}/resource/{id}", version = "2") // Noncompliant {{Bind template variable "id" to a method parameter.}}
+    String missingId() {
+      return "";
+    }
+
+    @GetMapping(value = "/api/v{major}.{minor}/resource", version = "2")
+    String multipleVariablesInVersionSegment() {
+      return "";
+    }
+
+    @GetMapping("/api/v{apiVersion}/unversioned") // Noncompliant {{Bind template variable "apiVersion" to a method parameter.}}
+    String versionlessMapping() {
+      return "";
+    }
+
+    @GetMapping(value = "/api/{*apiVersion}", version = "2") // Noncompliant {{Bind template variable "apiVersion" to a method parameter.}}
+    String catchAllVariable() {
+      return "";
+    }
+
+    @GetMapping(value = {"/api/v{apiVersion}/alternative", "/{apiVersion}/alternative"}, version = "2") // Noncompliant {{Bind template variable "apiVersion" to a method parameter.}}
+    String variableAtDifferentIndices() {
+      return "";
+    }
+  }
+
+  @RequestMapping("/api")
+  static class TypeLevelPathController {
+
+    @GetMapping(value = "/v{apiVersion}/resource/{id}", version = "2")
+    String valid(@PathVariable String id) {
+      return id;
+    }
+  }
+
+}

--- a/java-checks-test-sources/test-classpath-reader/src/main/java/org/sonar/java/test/classpath/TestClasspathUtils.java
+++ b/java-checks-test-sources/test-classpath-reader/src/main/java/org/sonar/java/test/classpath/TestClasspathUtils.java
@@ -48,6 +48,7 @@ public final class TestClasspathUtils {
   public static final Module JAVA_17_MODULE = new Module("java-checks-test-sources/java-17");
   public static final Module SPRING_32_MODULE = new Module("java-checks-test-sources/spring-3.2");
   public static final Module SPRING_WEB_40_MODULE = new Module("java-checks-test-sources/spring-web-4.0");
+  public static final Module SPRING_WEB_70_MODULE = new Module("java-checks-test-sources/spring-web-7.0");
   private static final Path testJarsPath = Path.of("java-checks-test-sources/target/test-jars");
 
   public static List<File> getTestJars(List<String> jars) {

--- a/java-checks-test-sources/test-classpath-reader/src/test/java/org/sonar/java/test/classpath/TestClasspathUtilsTest.java
+++ b/java-checks-test-sources/test-classpath-reader/src/test/java/org/sonar/java/test/classpath/TestClasspathUtilsTest.java
@@ -43,6 +43,7 @@ class TestClasspathUtilsTest {
     assertThat(Path.of(TestClasspathUtils.JAVA_17_MODULE.getPath())).exists();
     assertThat(Path.of(TestClasspathUtils.SPRING_32_MODULE.getPath())).exists();
     assertThat(Path.of(TestClasspathUtils.SPRING_WEB_40_MODULE.getPath())).exists();
+    assertThat(Path.of(TestClasspathUtils.SPRING_WEB_70_MODULE.getPath())).exists();
 
     TestClasspathUtils.Module unknowModule = new TestClasspathUtils.Module("unknow");
     assertThat(unknowModule.getPath()).isNull();
@@ -60,6 +61,7 @@ class TestClasspathUtilsTest {
     assertThat(TestClasspathUtils.JAVA_17_MODULE.getClassPath()).hasSizeGreaterThan(5);
     assertThat(TestClasspathUtils.SPRING_32_MODULE.getClassPath()).hasSizeGreaterThan(15);
     assertThat(TestClasspathUtils.SPRING_WEB_40_MODULE.getClassPath()).hasSizeGreaterThan(5);
+    assertThat(TestClasspathUtils.SPRING_WEB_70_MODULE.getClassPath()).hasSizeGreaterThan(5);
 
     TestClasspathUtils.Module unknowModule = new TestClasspathUtils.Module("unknow");
     assertThat(unknowModule.getClassPath()).isEmpty();

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheck.java
@@ -27,16 +27,28 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.sonar.api.batch.fs.InputComponent;
 import org.sonar.check.Rule;
 import org.sonar.java.annotations.VisibleForTesting;
+import org.sonar.java.model.DefaultModuleScannerContext;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.java.reporting.AnalyzerMessage;
 import org.sonar.plugins.java.api.DependencyVersionAware;
+import org.sonar.plugins.java.api.InputFileScannerContext;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.ModuleScannerContext;
 import org.sonar.plugins.java.api.Version;
+import org.sonar.plugins.java.api.internal.EndOfAnalysis;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
@@ -45,12 +57,22 @@ import static org.sonar.java.checks.helpers.ExpressionsHelper.isStandardDataType
 import static org.sonar.java.checks.helpers.MethodTreeUtils.isSetterLike;
 
 @Rule(key = "S6856")
-public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
+public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware, EndOfAnalysis {
   private static final String PATH_VARIABLE_ANNOTATION = "org.springframework.web.bind.annotation.PathVariable";
   private static final String MAP = "java.util.Map";
   private static final String MODEL_ATTRIBUTE_ANNOTATION = "org.springframework.web.bind.annotation.ModelAttribute";
   private static final String REQUEST_MAPPING_ANNOTATION = "org.springframework.web.bind.annotation.RequestMapping";
+  private static final String MVC_API_VERSION_CONFIGURER = "org.springframework.web.servlet.config.annotation.ApiVersionConfigurer";
+  private static final String WEB_MVC_CONFIGURER = "org.springframework.web.servlet.config.annotation.WebMvcConfigurer";
+  private static final String WEB_MVC_CONFIGURATION_SUPPORT = "org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport";
   private static final String PROPERTY_PLACEHOLDER_PATTERN = "\\$\\{[^{}]*\\}";
+
+  private static final Set<String> AMBIGUOUS_API_VERSION_CONFIGURATION_METHODS = Set.of(
+    "useRequestHeader",
+    "useQueryParam",
+    "useMediaTypeParameter",
+    "useVersionResolver",
+    "setDefaultVersion");
 
   private static final Set<String> MAPPING_ANNOTATIONS = Set.of(
     REQUEST_MAPPING_ANNOTATION,
@@ -67,6 +89,10 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
   private static final String BIND_PARAM_ANNOTATION = "org.springframework.web.bind.annotation.BindParam";
 
   private SpringWebVersion springWebVersion;
+  private final Set<Integer> apiVersionPathSegments = new HashSet<>();
+  private boolean hasAmbiguousApiVersionConfiguration;
+  private final List<AnalyzerMessage> pendingIssues = new ArrayList<>();
+  private final List<PendingMappingIssue> pendingMappingIssues = new ArrayList<>();
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -82,12 +108,14 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
       .map(MethodTree.class::cast)
       .toList();
 
+    collectApiVersionPathSegments(methods);
+
     // request @RequestMapping can be put on top of a class, path template inside it will affect all the class methods
     var requestMappingArguments = clazzTree.symbol().metadata().valuesForAnnotation(REQUEST_MAPPING_ANNOTATION);
-    Set<String> requestMappingTemplateVariables = new HashSet<>();
+    MappingInfo classMapping = MappingInfo.empty();
     if (requestMappingArguments != null) {
       try {
-        requestMappingTemplateVariables = templateVariablesFromMapping(requestMappingArguments);
+        classMapping = mappingInfoFromMapping(requestMappingArguments);
       } catch (DoNotReport ignored) {
         return;
       }
@@ -96,7 +124,94 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
     Set<String> modelAttributeMethodParameter = extractModelAttributeMethodParameter(methods);
     modelAttributeMethodParameter.addAll(addInheritedModelAttributeMethodParameter(modelAttributeMethodParameter, clazzTree));
 
-    checkParametersAndPathTemplate(methods, modelAttributeMethodParameter, requestMappingTemplateVariables);
+    checkParametersAndPathTemplate(methods, modelAttributeMethodParameter, classMapping);
+  }
+
+  private void collectApiVersionPathSegments(List<MethodTree> methods) {
+    if (springWebVersion != SpringWebVersion.START_FROM_7_0) {
+      return;
+    }
+
+    methods.stream()
+      .filter(MissingPathVariableAnnotationCheck::isApiVersionConfigurationMethod)
+      .forEach(method -> {
+        Symbol configurerParameter = method.parameters().get(0).symbol();
+        method.accept(new BaseTreeVisitor() {
+          @Override
+          public void visitIdentifier(IdentifierTree identifier) {
+            if (configurerParameter.equals(identifier.symbol())
+              && !isConfigurerParameterDeclaration(identifier)
+              && !isDirectConfigurerReceiver(identifier)) {
+              hasAmbiguousApiVersionConfiguration = true;
+            }
+            super.visitIdentifier(identifier);
+          }
+
+          @Override
+          public void visitMethodInvocation(MethodInvocationTree invocation) {
+            collectApiVersionConfiguration(invocation, configurerParameter);
+            super.visitMethodInvocation(invocation);
+          }
+        });
+      });
+  }
+
+  private static boolean isApiVersionConfigurationMethod(MethodTree method) {
+    if (!"configureApiVersioning".equals(method.simpleName().name()) || method.parameters().size() != 1
+      || !method.parameters().get(0).type().symbolType().is(MVC_API_VERSION_CONFIGURER)) {
+      return false;
+    }
+
+    Type ownerType = method.symbol().owner().type();
+    return ownerType.isSubtypeOf(WEB_MVC_CONFIGURER) || ownerType.isSubtypeOf(WEB_MVC_CONFIGURATION_SUPPORT);
+  }
+
+  private void collectApiVersionConfiguration(MethodInvocationTree invocation, Symbol configurerParameter) {
+    Symbol.MethodSymbol method = invocation.methodSymbol();
+    if (!method.owner().type().is(MVC_API_VERSION_CONFIGURER) || !isInvokedOnParameter(invocation, configurerParameter)) {
+      return;
+    }
+
+    if ("usePathSegment".equals(method.name()) && !invocation.arguments().isEmpty()) {
+      Optional<Integer> index = invocation.arguments().get(0).asConstant(Integer.class).filter(value -> value >= 0);
+      if (index.isPresent()) {
+        apiVersionPathSegments.add(index.get());
+      } else {
+        hasAmbiguousApiVersionConfiguration = true;
+      }
+    } else if (AMBIGUOUS_API_VERSION_CONFIGURATION_METHODS.contains(method.name())
+      || isPossiblyOptionalVersionConfiguration(invocation, method)) {
+      hasAmbiguousApiVersionConfiguration = true;
+    }
+  }
+
+  private static boolean isInvokedOnParameter(MethodInvocationTree invocation, Symbol configurerParameter) {
+    if (!(invocation.methodSelect() instanceof MemberSelectExpressionTree memberSelect)) {
+      return false;
+    }
+    ExpressionTree receiver = ExpressionUtils.skipParentheses(memberSelect.expression());
+    while (receiver instanceof MethodInvocationTree receiverInvocation
+      && receiverInvocation.methodSelect() instanceof MemberSelectExpressionTree receiverMethodSelect) {
+      receiver = ExpressionUtils.skipParentheses(receiverMethodSelect.expression());
+    }
+    return receiver instanceof IdentifierTree identifier && configurerParameter.equals(identifier.symbol());
+  }
+
+  private static boolean isConfigurerParameterDeclaration(IdentifierTree identifier) {
+    return identifier.parent() instanceof VariableTree variable && variable.simpleName() == identifier;
+  }
+
+  private static boolean isDirectConfigurerReceiver(IdentifierTree identifier) {
+    return identifier.parent() instanceof MemberSelectExpressionTree memberSelect
+      && memberSelect.expression() == identifier
+      && memberSelect.parent() instanceof MethodInvocationTree invocation
+      && invocation.methodSelect() == memberSelect
+      && invocation.methodSymbol().owner().type().is(MVC_API_VERSION_CONFIGURER);
+  }
+
+  private static boolean isPossiblyOptionalVersionConfiguration(MethodInvocationTree invocation, Symbol.MethodSymbol method) {
+    return "setVersionRequired".equals(method.name())
+      && (invocation.arguments().isEmpty() || !invocation.arguments().get(0).asConstant(Boolean.class).orElse(false));
   }
 
   private static Set<String> extractModelAttributeMethodParameter(List<MethodTree> methods){
@@ -133,11 +248,11 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
     return modelAttributeMethodParameters;
   }
 
-  private void checkParametersAndPathTemplate(List<MethodTree> methods, Set<String> modelAttributeMethodParameter, Set<String> requestMappingTemplateVariables) {
+  private void checkParametersAndPathTemplate(List<MethodTree> methods, Set<String> modelAttributeMethodParameter, MappingInfo classMapping) {
     for (var method : methods) {
       if (!method.symbol().metadata().isAnnotatedWith(MODEL_ATTRIBUTE_ANNOTATION)) {
         try {
-          checkParametersAndPathTemplate(method, modelAttributeMethodParameter, requestMappingTemplateVariables);
+          checkParametersAndPathTemplate(method, modelAttributeMethodParameter, classMapping);
         } catch (DoNotReport ignored) {
           // We don't want to report when semantics is broken or we were unable to parse the path template
         }
@@ -145,7 +260,7 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
     }
   }
 
-  private void checkParametersAndPathTemplate(MethodTree method, Set<String> modelAttributeMethodParameters, Set<String> requestMappingTemplateVars) {
+  private void checkParametersAndPathTemplate(MethodTree method, Set<String> modelAttributeMethodParameters, MappingInfo classMapping) {
     // we find path variable annotations and extract the name
     // example find : @PathVariable() String id and extract id
     List<ParameterInfo> methodParameters = new ArrayList<>();
@@ -165,7 +280,7 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
 
     // we find mapping annotation and extract path
     // example find @GetMapping("/{id}") and extract "/{id}"
-    List<UriInfo<Set<String>>> templateVariables = new ArrayList<>();
+    List<UriInfo> templateVariables = new ArrayList<>();
     for (var ann : method.modifiers().annotations()) {
       if (ann.symbolType().isUnknown()) {
         throw new DoNotReport();
@@ -177,19 +292,19 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
         continue;
       }
 
-      templateVariables.add(new UriInfo<>(ann, templateVariablesFromMapping(values)));
+      templateVariables.add(new UriInfo(ann, mappingInfoFromMapping(values)));
     }
 
     // we handle the case where a path variable doesn't match to uri parameter (/{aParam}/)
     Set<String> allTemplateVariables = templateVariables.stream()
-      .flatMap(uri -> uri.value().stream())
+      .flatMap(uri -> uri.mapping().templateVariables().stream())
       .collect(Collectors.toSet());
-    allTemplateVariables.addAll(requestMappingTemplateVars);
+    allTemplateVariables.addAll(classMapping.templateVariables());
 
     methodParameters.stream()
       .filter(v -> !allTemplateVariables.contains(v.value()))
       .filter(v -> !v.parameter().symbol().type().is(MAP))
-      .forEach(v -> reportIssue(v.parameter(), String.format("Bind method parameter \"%s\" to a template variable.", v.value())));
+      .forEach(v -> addPendingIssue(v.parameter(), String.format("Bind method parameter \"%s\" to a template variable.", v.value())));
 
     if (containsTypeMapAsParameter(method)) {
       /*
@@ -209,15 +324,141 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
     allPathVariables.addAll(extractClassAndRecordProperties(method));
 
     templateVariables.stream()
-      .filter(uri -> !allPathVariables.containsAll(uri.value()))
+      .filter(uri -> !allPathVariables.containsAll(uri.mapping().templateVariables()))
       .forEach(uri -> {
-        Set<String> unbind = new HashSet<>(uri.value());
+        Set<String> unbind = new HashSet<>(uri.mapping().templateVariables());
         unbind.removeAll(allPathVariables);
-        reportIssue(
-          uri.request(),
-          "Bind template variable \"" + String.join("\", \"", unbind) + "\" to a method parameter.");
+        reportOrDeferMissingTemplateVariables(uri, classMapping, unbind);
       });
 
+  }
+
+  private void reportOrDeferMissingTemplateVariables(UriInfo uri, MappingInfo classMapping, Set<String> unboundVariables) {
+    if (springWebVersion != SpringWebVersion.START_FROM_7_0) {
+      addPendingIssue(uri.request(), missingTemplateVariablesMessage(unboundVariables));
+      return;
+    }
+
+    pendingMappingIssues.add(new PendingMappingIssue(
+      context.getInputFile(),
+      AnalyzerMessage.textSpanFor(uri.request()),
+      Set.copyOf(unboundVariables),
+      combinePaths(classMapping.paths(), uri.mapping().paths()),
+      classMapping.versioned() || uri.mapping().versioned()));
+  }
+
+  private void addPendingIssue(Tree tree, String message) {
+    pendingIssues.add(new AnalyzerMessage(this, context.getInputFile(), AnalyzerMessage.textSpanFor(tree), message, 0));
+  }
+
+  private static String missingTemplateVariablesMessage(Set<String> variables) {
+    return "Bind template variable \"" + String.join("\", \"", variables) + "\" to a method parameter.";
+  }
+
+  private static List<String> combinePaths(List<String> classPaths, List<String> methodPaths) {
+    List<String> combinedPaths = new ArrayList<>();
+    for (String classPath : classPaths) {
+      for (String methodPath : methodPaths) {
+        combinedPaths.add(combinePath(classPath, methodPath));
+      }
+    }
+    return combinedPaths;
+  }
+
+  private static String combinePath(String classPath, String methodPath) {
+    String left = classPath.replaceAll("/+$", "");
+    String right = methodPath.replaceAll("^/+", "");
+    if (left.isEmpty()) {
+      return right.isEmpty() ? "" : "/" + right;
+    }
+    return right.isEmpty() ? left : left + "/" + right;
+  }
+
+  @Override
+  public boolean scanWithoutParsing(InputFileScannerContext inputFileScannerContext) {
+    // Cross-file configuration discovery is only needed for Spring Web 7 and later.
+    return springWebVersion != SpringWebVersion.START_FROM_7_0;
+  }
+
+  @Override
+  public void endOfAnalysis(ModuleScannerContext moduleContext) {
+    DefaultModuleScannerContext defaultContext = (DefaultModuleScannerContext) moduleContext;
+    pendingIssues.forEach(defaultContext::reportIssue);
+    for (PendingMappingIssue pendingIssue : pendingMappingIssues) {
+      Set<String> unboundVariables = new HashSet<>(pendingIssue.unboundVariables());
+      if (pendingIssue.versioned() && !hasAmbiguousApiVersionConfiguration && apiVersionPathSegments.size() == 1) {
+        unboundVariables.removeIf(variable -> isReadByPathVersionResolver(variable, pendingIssue.paths(), apiVersionPathSegments));
+      }
+      if (!unboundVariables.isEmpty()) {
+        defaultContext.reportIssue(new AnalyzerMessage(
+          this,
+          pendingIssue.inputComponent(),
+          pendingIssue.textSpan(),
+          missingTemplateVariablesMessage(unboundVariables),
+          0));
+      }
+    }
+
+    apiVersionPathSegments.clear();
+    hasAmbiguousApiVersionConfiguration = false;
+    pendingIssues.clear();
+    pendingMappingIssues.clear();
+  }
+
+  private static boolean isReadByPathVersionResolver(String variable, List<String> paths, Set<Integer> configuredSegments) {
+    if (configuredSegments.isEmpty()) {
+      return false;
+    }
+
+    boolean found = false;
+    for (String path : paths) {
+      if (path.contains("${")) {
+        return false;
+      }
+      List<String> segments = pathSegments(path);
+      for (int index = 0; index < segments.size(); index++) {
+        String segment = segments.get(index);
+        if (PathPatternParser.parsePathVariables(segment).contains(variable)) {
+          found = true;
+          if (!configuredSegments.contains(index) || segment.contains("{*" + variable + "}")) {
+            return false;
+          }
+        }
+      }
+    }
+    return found;
+  }
+
+  private static List<String> pathSegments(String path) {
+    List<String> segments = new ArrayList<>();
+    int segmentStart = 0;
+    int braces = 0;
+    boolean escaped = false;
+    for (int i = 0; i < path.length(); i++) {
+      char current = path.charAt(i);
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (current == '\\') {
+        escaped = true;
+      } else if (current == '{') {
+        braces++;
+      } else if (current == '}' && braces > 0) {
+        braces--;
+      } else if (current == '/' && braces == 0) {
+        addPathSegment(path, segmentStart, i, segments);
+        segmentStart = i + 1;
+      }
+    }
+    addPathSegment(path, segmentStart, path.length(), segments);
+    return segments;
+  }
+
+  private static void addPathSegment(String path, int start, int end, List<String> segments) {
+    if (start < end) {
+      segments.add(path.substring(start, end));
+    }
   }
 
   private static boolean containsTypeMapAsParameter(MethodTree method) {
@@ -229,22 +470,23 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
       });
   }
 
-  private static Set<String> templateVariablesFromMapping(List<SymbolMetadata.AnnotationValue> values) {
+  private static MappingInfo mappingInfoFromMapping(List<SymbolMetadata.AnnotationValue> values) {
     Map<String, Object> nameToValue = values.stream()
       .collect(Collectors.toMap(SymbolMetadata.AnnotationValue::name, SymbolMetadata.AnnotationValue::value));
     List<String> path = arrayOrString(nameToValue.get("path"));
     List<String> value = arrayOrString(nameToValue.get("value"));
-
-    if (path != null || value != null) {
-      List<String> paths = path != null ? path : value;
-      return paths.stream()
-        .map(MissingPathVariableAnnotationCheck::removePropertyPlaceholder)
-        .map(PathPatternParser::parsePathVariables)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toSet());
-    } else {
-      return Set.of();
+    List<String> paths = path != null ? path : value;
+    if (paths == null || paths.isEmpty()) {
+      paths = List.of("");
     }
+
+    Set<String> templateVariables = paths.stream()
+      .map(MissingPathVariableAnnotationCheck::removePropertyPlaceholder)
+      .map(PathPatternParser::parsePathVariables)
+      .flatMap(Collection::stream)
+      .collect(Collectors.toSet());
+    boolean versioned = nameToValue.get("version") instanceof String version && !version.isBlank();
+    return new MappingInfo(List.copyOf(paths), templateVariables, versioned);
   }
 
   private static ParameterInfo extractPathMethodParameters(VariableTree parameter, List<SymbolMetadata.AnnotationValue> arguments) {
@@ -279,7 +521,22 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
 
   private record ParameterInfo(VariableTree parameter, String value) {
   }
-  private record UriInfo<A>(AnnotationTree request, A value) {
+
+  private record UriInfo(AnnotationTree request, MappingInfo mapping) {
+  }
+
+  private record MappingInfo(List<String> paths, Set<String> templateVariables, boolean versioned) {
+    private static MappingInfo empty() {
+      return new MappingInfo(List.of(""), Set.of(), false);
+    }
+  }
+
+  private record PendingMappingIssue(
+    InputComponent inputComponent,
+    AnalyzerMessage.TextSpan textSpan,
+    Set<String> unboundVariables,
+    List<String> paths,
+    boolean versioned) {
   }
 
   private static String removePropertyPlaceholder(String path){
@@ -530,11 +787,15 @@ public class MissingPathVariableAnnotationCheck extends IssuableSubscriptionVisi
   }
 
   private static SpringWebVersion getSpringWebVersion(Version springWebVersion) {
-    return  (springWebVersion.isLowerThan("5.3") ? SpringWebVersion.LESS_THAN_5_3 : SpringWebVersion.START_FROM_5_3);
+    if (springWebVersion.isLowerThan("5.3")) {
+      return SpringWebVersion.LESS_THAN_5_3;
+    }
+    return springWebVersion.isLowerThan("7.0") ? SpringWebVersion.FROM_5_3_TO_6_X : SpringWebVersion.START_FROM_7_0;
   }
 
   private enum SpringWebVersion {
     LESS_THAN_5_3,
-    START_FROM_5_3;
+    FROM_5_3_TO_6_X,
+    START_FROM_7_0;
   }
 }

--- a/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_DynamicIndex.java
+++ b/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_DynamicIndex.java
@@ -1,0 +1,29 @@
+package files.checks.spring;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class MissingPathVariableAnnotationCheck_DynamicIndex {
+
+  static class VersionedController {
+
+    @GetMapping(value = "/api/v{apiVersion}/resource", version = "2") // Noncompliant
+    String ambiguousVersionSegment() {
+      return "";
+    }
+  }
+
+  static class ApiVersionConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void configureApiVersioning(ApiVersionConfigurer configurer) {
+      configurer.usePathSegment(1);
+      configurer.usePathSegment(dynamicIndex());
+    }
+
+    private static int dynamicIndex() {
+      return 2;
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_EscapingConfiguration.java
+++ b/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_EscapingConfiguration.java
@@ -1,0 +1,29 @@
+package files.checks.spring;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class MissingPathVariableAnnotationCheck_EscapingConfiguration {
+
+  static class VersionedController {
+
+    @GetMapping(value = "/api/{ordinaryVariable}/resource", version = "2") // Noncompliant
+    String missingOrdinaryVariable() {
+      return "";
+    }
+  }
+
+  static class ApiVersionConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void configureApiVersioning(ApiVersionConfigurer configurer) {
+      configurer.usePathSegment(1, path -> path.value().startsWith("/versioned/"));
+      configureFallback(configurer);
+    }
+
+    private static void configureFallback(ApiVersionConfigurer configurer) {
+      configurer.useRequestHeader("API-Version");
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_InactiveConfiguration.java
+++ b/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_InactiveConfiguration.java
@@ -1,0 +1,23 @@
+package files.checks.spring;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class MissingPathVariableAnnotationCheck_InactiveConfiguration {
+
+  static class VersionedController {
+
+    @GetMapping(value = "/api/{ordinaryVariable}/resource", version = "2") // Noncompliant
+    String missingOrdinaryVariable() {
+      return "";
+    }
+  }
+
+  static class ApiVersionConfiguration implements WebMvcConfigurer {
+
+    void unusedHelper(ApiVersionConfigurer configurer) {
+      configurer.usePathSegment(1);
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_MultipleIndices.java
+++ b/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_MultipleIndices.java
@@ -1,0 +1,25 @@
+package files.checks.spring;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class MissingPathVariableAnnotationCheck_MultipleIndices {
+
+  static class VersionedController {
+
+    @GetMapping(value = "/api/v{apiVersion}/resource", version = "2") // Noncompliant
+    String ambiguousVersionSegment() {
+      return "";
+    }
+  }
+
+  static class ApiVersionConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void configureApiVersioning(ApiVersionConfigurer configurer) {
+      configurer.usePathSegment(0);
+      configurer.usePathSegment(1);
+    }
+  }
+}

--- a/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_NonPathApiVersion.java
+++ b/java-checks/src/test/files/checks/spring/MissingPathVariableAnnotationCheck_NonPathApiVersion.java
@@ -1,0 +1,26 @@
+package files.checks.spring;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.servlet.config.annotation.ApiVersionConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class MissingPathVariableAnnotationCheck_NonPathApiVersion {
+
+  static class VersionedController {
+
+    @GetMapping(value = "/api/{ordinaryVariable}/resource/{id}", version = "2") // Noncompliant {{Bind template variable "ordinaryVariable" to a method parameter.}}
+    String missingOrdinaryVariable(@PathVariable String id) {
+      return id;
+    }
+  }
+
+  static class ApiVersionConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void configureApiVersioning(ApiVersionConfigurer configurer) {
+      configurer.usePathSegment(1, path -> path.value().startsWith("/versioned/"));
+      configurer.useRequestHeader("API-Version");
+    }
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/MissingPathVariableAnnotationCheckTest.java
@@ -17,6 +17,7 @@
 package org.sonar.java.checks.spring;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -38,12 +39,29 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPathInModule;
 import static org.sonar.java.test.classpath.TestClasspathUtils.SPRING_32_MODULE;
+import static org.sonar.java.test.classpath.TestClasspathUtils.SPRING_WEB_70_MODULE;
 
 class MissingPathVariableAnnotationCheckTest {
   private static final String TEST_SOURCE_FILE = mainCodeSourcesPath("checks/spring/s6856/MissingPathVariableAnnotationCheck_PathVariable.java");
   private static final String TEST_SOURCE_FILE_MODEL_ATTRIBUTE = mainCodeSourcesPath("checks/spring/s6856/MissingPathVariableAnnotationCheck_ModelAttribute.java");
   private static final String SETTER_PROPERTIES_TEST_FILE = mainCodeSourcesPath("checks/spring/s6856/ExtractSetterPropertiesTestData.java");
   private static final String RECORD_COMPONENTS_TEST_FILE = mainCodeSourcesPathInModule(SPRING_32_MODULE, "checks/ExtractRecordPropertiesTestData.java");
+  private static final String API_VERSION_PATH_TEST_FILE = mainCodeSourcesPathInModule(
+    SPRING_WEB_70_MODULE, "checks/spring/s6856/MissingPathVariableAnnotationCheck_ApiVersionPath.java");
+  private static final String API_VERSION_PATH_CONFIGURATION_FILE = mainCodeSourcesPathInModule(
+    SPRING_WEB_70_MODULE, "checks/spring/s6856/ApiVersionPathConfiguration.java");
+  private static final String API_VERSION_PATH_UNCONDITIONAL_CONFIGURATION_FILE = mainCodeSourcesPathInModule(
+    SPRING_WEB_70_MODULE, "checks/spring/s6856/ApiVersionPathUnconditionalConfiguration.java");
+  private static final String NON_PATH_API_VERSION_TEST_FILE =
+    "src/test/files/checks/spring/MissingPathVariableAnnotationCheck_NonPathApiVersion.java";
+  private static final String INACTIVE_API_VERSION_CONFIGURATION_TEST_FILE =
+    "src/test/files/checks/spring/MissingPathVariableAnnotationCheck_InactiveConfiguration.java";
+  private static final String MULTIPLE_API_VERSION_INDICES_TEST_FILE =
+    "src/test/files/checks/spring/MissingPathVariableAnnotationCheck_MultipleIndices.java";
+  private static final String ESCAPING_API_VERSION_CONFIGURATION_TEST_FILE =
+    "src/test/files/checks/spring/MissingPathVariableAnnotationCheck_EscapingConfiguration.java";
+  private static final String DYNAMIC_API_VERSION_INDEX_TEST_FILE =
+    "src/test/files/checks/spring/MissingPathVariableAnnotationCheck_DynamicIndex.java";
 
   private static final JavaFileScanner check = new MissingPathVariableAnnotationCheck();
   private static final Map<String, Type> testTypes = new HashMap<>();
@@ -120,6 +138,69 @@ class MissingPathVariableAnnotationCheckTest {
       .onFile(mainCodeSourcesPathInModule(SPRING_32_MODULE, "checks/MissingPathVariableAnnotationCheck_classAndRecord.java"))
       .withCheck(check)
       .withClassPath(SPRING_32_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_path_api_version() {
+    CheckVerifier.newVerifier()
+      .onFiles(List.of(API_VERSION_PATH_TEST_FILE, API_VERSION_PATH_CONFIGURATION_FILE))
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_unconditional_path_api_version() {
+    CheckVerifier.newVerifier()
+      .onFiles(List.of(API_VERSION_PATH_TEST_FILE, API_VERSION_PATH_UNCONDITIONAL_CONFIGURATION_FILE))
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_path_api_version_with_alternative_resolver() {
+    CheckVerifier.newVerifier()
+      .onFile(NON_PATH_API_VERSION_TEST_FILE)
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_ignores_inactive_api_version_configuration() {
+    CheckVerifier.newVerifier()
+      .onFile(INACTIVE_API_VERSION_CONFIGURATION_TEST_FILE)
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_multiple_path_api_version_indices_are_ambiguous() {
+    CheckVerifier.newVerifier()
+      .onFile(MULTIPLE_API_VERSION_INDICES_TEST_FILE)
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_configurer_escape_is_ambiguous() {
+    CheckVerifier.newVerifier()
+      .onFile(ESCAPING_API_VERSION_CONFIGURATION_TEST_FILE)
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_spring_7_dynamic_path_api_version_index_is_ambiguous() {
+    CheckVerifier.newVerifier()
+      .onFile(DYNAMIC_API_VERSION_INDEX_TEST_FILE)
+      .withCheck(new MissingPathVariableAnnotationCheck())
+      .withClassPath(SPRING_WEB_70_MODULE.getClassPath())
       .verifyIssues();
   }
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6856.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6856.html
@@ -11,8 +11,12 @@ Starting with Spring Web 5.3, this binding happens automatically without requiri
 variables to properties that have setter methods (including Lombok-generated setters). For records (Spring Web 5.3+), Spring binds path variables to
 record components through their accessor methods. The <code>@BindParam</code> annotation can be used on record components to specify custom binding
 names.</p>
-<p>This rule will raise an issue if a method has a path template with a placeholder, but no corresponding <code>@PathVariable</code>, matching class
-property, or matching record component, or vice-versa.</p>
+<p>Spring Framework 7 also supports resolving an API version from a path segment. When
+<code>ApiVersionConfigurer.usePathSegment(...)</code> is configured, the API version resolver reads the raw request path segment independently of
+controller argument binding. A placeholder in an explicitly versioned mapping can therefore be structural and does not need to be exposed as a
+handler method parameter.</p>
+<p>Except for a placeholder recognized as an API-version path segment, this rule will raise an issue if a method has a path template with a
+placeholder, but no corresponding <code>@PathVariable</code>, matching class property, or matching record component, or vice-versa.</p>
 <h2>How to fix it</h2>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
@@ -133,9 +137,9 @@ public ResponseEntity&lt;String&gt; getOrder(OrderRequest request) { // Complian
   Framework API - PutMapping</a></li>
   <li><a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/DeleteMapping.html">Spring
   Framework API - DeleteMapping</a></li>
+  <li><a href="https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config/api-version.html">Spring Framework - API Version</a></li>
 </ul>
 <h3>Articles &amp; blog posts</h3>
 <ul>
   <li><a href="https://www.baeldung.com/spring-pathvariable">Baeldung - Spring @PathVariable</a></li>
 </ul>
-


### PR DESCRIPTION
## Problem

  Spring Framework 7 supports resolving an API version from a request path segment:

  ```java
  @Override
  public void configureApiVersioning(ApiVersionConfigurer configurer) {
    Predicate<RequestPath> versionedPaths = this::isVersionedPath;
    configurer.usePathSegment(1, versionedPaths);
  }

  @GetMapping(value = "/api/v{apiVersion}/resources/{id}", version = "2")
  Resource getResource(@PathVariable UUID id) {
    // ...
  }

  PathApiVersionResolver reads the raw path segment (v2 in this example) independently of controller argument binding. The {apiVersion} placeholder is structural: it makes the route match the version
  segment, but it does not need to be exposed as a controller method parameter.

  S6856 currently reports {apiVersion} as unbound. Adding an unused @PathVariable merely to satisfy the rule would make the controller signature misleading.

  ## Proposed solution

  Teach S6856 to recognize source-visible Spring MVC path-version configuration and defer its final decision until all source files in the module have been inspected.

  The exception is deliberately conservative. It applies only when:

  - Spring Web 7 or later is present;
  - usePathSegment(...) is called directly from an actual configureApiVersioning callback;
  - the segment index is a non-negative compile-time constant;
  - only one distinct path-version index is configured;
  - the controller mapping declares a nonblank version;
  - no fallback resolver, default version, optional-version configuration, dynamic index, or escaped configurer makes the configuration ambiguous; and
  - the placeholder occurs only in the configured segment and is not a catch-all variable.

  Other missing variables are still reported. For example, /api/v{apiVersion}/resources/{id} continues to report an unbound {id}.

  ## Scope

  This proposal handles direct, source-visible Spring MVC Java configuration. It intentionally does not infer WebFlux configuration, configuration supplied by dependencies or properties, delegated
  configurer mutations, or programmatic path prefixes.

  ## Tests

  This change adds a Spring Web 7.0.8 fixture module and regression coverage for:

  - both usePathSegment overloads;
  - method-reference predicates;
  - configuration declared after controller sources;
  - class-level paths;
  - ordinary missing variables;
  - versionless mappings and catch-all variables;
  - fallback resolvers;
  - inactive configuration methods;
  - multiple and dynamic indices; and
  - escaped configurers.

  Verified locally:

  - Spring Web 7 fixture module: successful
  - S6856 focused suite: 29 tests, 0 failures

  Spring API-versioning documentation:
  https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config/api-version.html