### PR TITLE
SONARJAVA-6579 Implement S8975: The return value of "EntityManager.merge()" should be used

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8975.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8975.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S8975",
+  "hasTruePositives": false,
+  "falseNegatives": 2,
+  "falsePositives": 0
+}

--- a/java-checks-test-sources/default/src/main/java/checks/EntityManagerMergeUnusedResultCheckSampleJakarta.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EntityManagerMergeUnusedResultCheckSampleJakarta.java
@@ -1,0 +1,27 @@
+package checks;
+
+import jakarta.persistence.EntityManager;
+
+class EntityManagerMergeUnusedResultCheckSampleJakarta {
+
+  void noncompliant(EntityManager em, Object entity) {
+    em.merge(entity); // Noncompliant {{Use the return value of "merge()".}}
+    // ^^^^^
+  }
+
+  void compliant(EntityManager em, Object entity) {
+    Object managed = em.merge(entity); // Compliant
+    return_merge(em, entity); // Compliant
+  }
+
+  Object return_merge(EntityManager em, Object entity) {
+    return em.merge(entity); // Compliant
+  }
+
+  void pass_as_arg(EntityManager em, Object entity) {
+    process(em.merge(entity)); // Compliant
+  }
+
+  void process(Object o) {
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/EntityManagerMergeUnusedResultCheckSampleJavax.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EntityManagerMergeUnusedResultCheckSampleJavax.java
@@ -1,0 +1,27 @@
+package checks;
+
+import javax.persistence.EntityManager;
+
+class EntityManagerMergeUnusedResultCheckSampleJavax {
+
+  void noncompliant(EntityManager em, Object entity) {
+    em.merge(entity); // Noncompliant {{Use the return value of "merge()".}}
+    // ^^^^^
+  }
+
+  void compliant(EntityManager em, Object entity) {
+    Object managed = em.merge(entity); // Compliant
+    return_merge(em, entity); // Compliant
+  }
+
+  Object return_merge(EntityManager em, Object entity) {
+    return em.merge(entity); // Compliant
+  }
+
+  void pass_as_arg(EntityManager em, Object entity) {
+    process(em.merge(entity)); // Compliant
+  }
+
+  void process(Object o) {
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/EntityManagerMergeUnusedResultCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EntityManagerMergeUnusedResultCheck.java
@@ -1,0 +1,62 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S8975")
+public class EntityManagerMergeUnusedResultCheck extends IssuableSubscriptionVisitor {
+
+  private static final String MESSAGE = "Use the return value of \"merge()\".";
+
+  private static final MethodMatchers MERGE_MATCHER = MethodMatchers.or(
+    MethodMatchers.create()
+      .ofTypes("javax.persistence.EntityManager")
+      .names("merge")
+      .withAnyParameters()
+      .build(),
+    MethodMatchers.create()
+      .ofTypes("jakarta.persistence.EntityManager")
+      .names("merge")
+      .withAnyParameters()
+      .build());
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.EXPRESSION_STATEMENT);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ExpressionTree expression = ((ExpressionStatementTree) tree).expression();
+    ExpressionTree unwrapped = ExpressionUtils.skipParentheses(expression);
+    if (unwrapped.is(Tree.Kind.METHOD_INVOCATION)) {
+      MethodInvocationTree mit = (MethodInvocationTree) unwrapped;
+      if (MERGE_MATCHER.matches(mit)) {
+        reportIssue(ExpressionUtils.methodName(mit), MESSAGE);
+      }
+    }
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/EntityManagerMergeUnusedResultCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/EntityManagerMergeUnusedResultCheckTest.java
@@ -1,0 +1,41 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class EntityManagerMergeUnusedResultCheckTest {
+
+  @Test
+  void testWithJakarta() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/EntityManagerMergeUnusedResultCheckSampleJakarta.java"))
+      .withCheck(new EntityManagerMergeUnusedResultCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void testWithJavax() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/EntityManagerMergeUnusedResultCheckSampleJavax.java"))
+      .withCheck(new EntityManagerMergeUnusedResultCheck())
+      .verifyIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8975.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8975.html
@@ -1,0 +1,59 @@
+<p>An issue is raised when the return value of an entity merge operation is discarded.</p>
+<h2>Why is this an issue?</h2>
+<p>In ORM (Object-Relational Mapping) frameworks, entities can be in different states within the tracking context:</p>
+<ul>
+  <li><strong>Tracked</strong>: The entity is associated with an ORM session. Changes to the entity are automatically tracked and synchronized to the
+  database.</li>
+  <li><strong>Detached</strong>: The entity was previously tracked but is no longer associated with an ORM session. Changes are not tracked.</li>
+  <li><strong>Transient</strong>: The entity has never been associated with an ORM session.</li>
+</ul>
+<p>State merging operations are used to copy the state of a detached or transient entity into a tracked entity within the current ORM session.
+Importantly, ORM specifications typically state that:</p>
+<ul>
+  <li>The entity instance passed as an argument remains in its original state (detached or transient).</li>
+  <li>The operation returns a <strong>different</strong> entity instance that is tracked by the ORM session.</li>
+</ul>
+<p>If you discard the return value and continue using the original entity instance, any modifications you make will not be tracked by the ORM session.
+These changes will not be synchronized to the database during the transaction commit, leading to data loss.</p>
+<p>The only safe way to use state merging operations is to capture the return value and use that tracked instance for all subsequent operations.</p>
+<p>In JPA specifically, this refers to the <code>EntityManager.merge()</code> method operating on the persistence context. The entity states are
+called managed (rather than tracked), and the association is with a persistence context (rather than an ORM session).</p>
+<h3>What is the potential impact?</h3>
+<p>Data loss can occur when changes made to the entity are not persisted to the database. This can lead to:</p>
+<ul>
+  <li>Inconsistent application state where in-memory objects differ from database records</li>
+  <li>Silent failures where updates appear successful but are never saved</li>
+  <li>Difficult-to-diagnose bugs, especially in complex transactions with multiple entity operations</li>
+</ul>
+<p>In business-critical applications, this can result in lost customer data, incorrect financial records, or corrupted application state.</p>
+<h2>How to fix it</h2>
+<p>Capture the return value of <code>merge()</code> and use the returned managed entity for all subsequent operations. Stop using the original
+detached entity after the merge.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+public void updateEntity(MyEntity detachedEntity) {
+    EntityManager em = getEntityManager();
+    em.merge(detachedEntity); // Noncompliant; changes are NOT persisted
+    detachedEntity.setName("Updated Name");
+    detachedEntity.setValue(42);
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+public void updateEntity(MyEntity detachedEntity) {
+    EntityManager em = getEntityManager();
+    MyEntity managedEntity = em.merge(detachedEntity);  // Compliant; changes ARE persisted
+    managedEntity.setName("Updated Name");
+    managedEntity.setValue(42);
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>JPA Specification - <a href="https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3.0.html#a1060">Entity
+  Operations</a></li>
+  <li>Hibernate ORM - Persistence context - <a href="https://docs.hibernate.org/orm/current/userguide/html_single/#pc-detach">Working with detached
+  data</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8975.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8975.json
@@ -1,0 +1,27 @@
+{
+  "title": "The return value of \"EntityManager.merge()\" should be used",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "jpa",
+    "jakarta",
+    "hibernate",
+    "pitfall"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-8975",
+  "sqKey": "S8975",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH",
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "LOGICAL"
+  }
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **New inspection:**
  - Added `EntityManagerMergeUnusedResultCheck` to flag ignored return values of `merge()` methods.
- **Rule support:**
  - Implemented rule `S8975` for both `jakarta.persistence` and `javax.persistence` APIs.
- **Test coverage:**
  - Added verification tests with dedicated samples for `Jakarta` and `Javax` environments.
- **Documentation:**
  - Provided rule metadata and comprehensive documentation explaining the risks of discarding merge results.


<sub>This will update automatically on new commits.</sub>