### PR TITLE
SONARJAVA-4926 Implement new rule S8989

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8989.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8989.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8989",
   "hasTruePositives": false,
-  "falseNegatives": 11,
+  "falseNegatives": 12,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8989.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8989.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S8989",
+  "hasTruePositives": false,
+  "falseNegatives": 11,
+  "falsePositives": 0
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/spring/TransactionalMethodCheckedExceptionCheckSampleNonCompiling.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/spring/TransactionalMethodCheckedExceptionCheckSampleNonCompiling.java
@@ -1,0 +1,15 @@
+package checks.spring;
+
+import org.springframework.transaction.annotation.Transactional;
+
+class TransactionalMethodCheckedExceptionCheckSampleNonCompiling {
+
+  // Test unknown/unresolved exception type
+  @Transactional
+  public void unknownException() throws UnresolvedCheckedException { // No issue - type is unknown
+  }
+
+  @Transactional // Noncompliant
+  public void knownException() throws java.io.IOException {
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -12,22 +12,27 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
   @Transactional
   public void processOrder(Order order) throws IOException, SQLException { // Noncompliant {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes.}}
+//            ^^^^^^^^^^^^
   }
 
   @Transactional
   public void importData() throws Exception { // Noncompliant
+//            ^^^^^^^^^^
   }
 
   @Transactional(timeout = 30)
   public void withOtherAttributes() throws SQLException { // Noncompliant
+//            ^^^^^^^^^^^^^^^^^^^
   }
 
   @Transactional
   public void customException() throws CustomCheckedException { // Noncompliant
+//            ^^^^^^^^^^^^^^^
   }
 
   @Transactional
   public void mixedExceptions() throws IOException, RuntimeException { // Noncompliant
+//            ^^^^^^^^^^^^^^^
   }
 
   @Transactional(rollbackFor = IOException.class)
@@ -78,6 +83,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @Transactional
   static class ClassLevelNoConfig {
     public void noConfig() throws IOException { // Noncompliant
+//              ^^^^^^^^
     }
 
     @Transactional(rollbackFor = IOException.class)
@@ -91,6 +97,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
   @org.springframework.transaction.annotation.Transactional
   public void fullyQualified() throws IOException { // Noncompliant
+//            ^^^^^^^^^^^^^^
   }
 
   @Transactional(rollbackFor = IOException.class)

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -127,4 +127,9 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @Transactional(rollbackFor = IOException.class)
   public void partialConfig() throws SQLException {
   }
+
+  @Transactional(value = "txManager") // Noncompliant
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  public void withValueAttribute() throws IOException {
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -10,29 +10,45 @@ class CustomCheckedException extends Exception {}
 
 public class TransactionalMethodCheckedExceptionCheckSample {
 
-  @Transactional
-  public void processOrder(Order order) throws IOException, SQLException { // Noncompliant {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes.}}
-//            ^^^^^^^^^^^^
+  @Transactional // Noncompliant {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes.}} [[quickfixes=qf1,qf2]]
+//^^^^^^^^^^^^^^
+  // fix@qf1 {{Add rollbackFor attribute}}
+  // edit@qf1 [[sc=3;ec=17]] {{@Transactional(rollbackFor = {IOException.class, SQLException.class})}}
+  // fix@qf2 {{Add rollbackFor = Exception.class}}
+  // edit@qf2 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  public void processOrder(Order order) throws IOException, SQLException {
   }
 
-  @Transactional
-  public void importData() throws Exception { // Noncompliant
-//            ^^^^^^^^^^
+  @Transactional // Noncompliant [[quickfixes=qf3,qf4]]
+//^^^^^^^^^^^^^^
+  // fix@qf3 {{Add rollbackFor attribute}}
+  // edit@qf3 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  // fix@qf4 {{Add rollbackFor = Exception.class}}
+  // edit@qf4 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  public void importData() throws Exception {
   }
 
-  @Transactional(timeout = 30)
-  public void withOtherAttributes() throws SQLException { // Noncompliant
-//            ^^^^^^^^^^^^^^^^^^^
+  @Transactional(timeout = 30) // Noncompliant
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  public void withOtherAttributes() throws SQLException {
   }
 
-  @Transactional
-  public void customException() throws CustomCheckedException { // Noncompliant
-//            ^^^^^^^^^^^^^^^
+  @Transactional // Noncompliant [[quickfixes=qf7,qf8]]
+//^^^^^^^^^^^^^^
+  // fix@qf7 {{Add rollbackFor attribute}}
+  // edit@qf7 [[sc=3;ec=17]] {{@Transactional(rollbackFor = CustomCheckedException.class)}}
+  // fix@qf8 {{Add rollbackFor = Exception.class}}
+  // edit@qf8 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  public void customException() throws CustomCheckedException {
   }
 
-  @Transactional
-  public void mixedExceptions() throws IOException, RuntimeException { // Noncompliant
-//            ^^^^^^^^^^^^^^^
+  @Transactional // Noncompliant [[quickfixes=qf9,qf10]]
+//^^^^^^^^^^^^^^
+  // fix@qf9 {{Add rollbackFor attribute}}
+  // edit@qf9 [[sc=3;ec=17]] {{@Transactional(rollbackFor = IOException.class)}}
+  // fix@qf10 {{Add rollbackFor = Exception.class}}
+  // edit@qf10 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  public void mixedExceptions() throws IOException, RuntimeException {
   }
 
   @Transactional(rollbackFor = IOException.class)
@@ -80,10 +96,14 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     }
   }
 
-  @Transactional
+  @Transactional // Noncompliant [[quickfixes=qf11,qf12]]
+//^^^^^^^^^^^^^^
+  // fix@qf11 {{Add rollbackFor attribute}}
+  // edit@qf11 [[sc=3;ec=17]] {{@Transactional(rollbackFor = IOException.class)}}
+  // fix@qf12 {{Add rollbackFor = Exception.class}}
+  // edit@qf12 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
   static class ClassLevelNoConfig {
-    public void noConfig() throws IOException { // Noncompliant
-//              ^^^^^^^^
+    public void noConfig() throws IOException {
     }
 
     @Transactional(rollbackFor = IOException.class)
@@ -95,9 +115,13 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   public void errorNotChecked() throws Error {
   }
 
-  @org.springframework.transaction.annotation.Transactional
-  public void fullyQualified() throws IOException { // Noncompliant
-//            ^^^^^^^^^^^^^^
+  @org.springframework.transaction.annotation.Transactional // Noncompliant [[quickfixes=qf13,qf14]]
+//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>^^^^^^^^^^^^^^^^^^^^^^^^
+  // fix@qf13 {{Add rollbackFor attribute}}
+  // edit@qf13 [[sc=3;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = IOException.class)}}
+  // fix@qf14 {{Add rollbackFor = Exception.class}}
+  // edit@qf14 [[sc=3;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = Exception.class)}}
+  public void fullyQualified() throws IOException {
   }
 
   @Transactional(rollbackFor = IOException.class)

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -164,13 +164,6 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   public void metaAnnotated() throws IOException {
   }
 
-  // Test unknown type (unresolved exception) - line 168 coverage
-  @Transactional
-  public void unknownException() throws UnresolvedCheckedException {
-    // UnresolvedCheckedException is not imported/defined, so type.isUnknown() returns true
-    // Should not raise an issue since we can't determine if it's a checked exception
-  }
-
   // Test annotation with value attribute (transaction manager name)
   @Transactional("txManager") // Noncompliant
   public void valueShorthand() throws IOException {

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -132,4 +132,24 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   public void withValueAttribute() throws IOException {
   }
+
+  // Test nested structure to ensure parent traversal works
+  static class OuterClass {
+    @Transactional // Noncompliant
+    static class InnerClassWithAnnotation {
+      public void nestedMethod() throws IOException {
+      }
+    }
+
+    static class InnerClassNoAnnotation {
+      public void nestedMethodNoAnnotation() throws IOException {
+        // No @Transactional at any level, so no issue
+      }
+    }
+  }
+
+  @Transactional // Noncompliant
+  interface TransactionalInterface {
+    void interfaceMethod() throws IOException;
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -1,0 +1,99 @@
+package checks.spring;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import org.springframework.transaction.annotation.Transactional;
+
+class Order {}
+class NotificationException extends Exception {}
+class CustomCheckedException extends Exception {}
+
+public class TransactionalMethodCheckedExceptionCheckSample {
+
+  @Transactional
+  public void processOrder(Order order) throws IOException, SQLException { // Noncompliant {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes.}}
+  }
+
+  @Transactional
+  public void importData() throws Exception { // Noncompliant
+  }
+
+  @Transactional(timeout = 30)
+  public void withOtherAttributes() throws SQLException { // Noncompliant
+  }
+
+  @Transactional
+  public void customException() throws CustomCheckedException { // Noncompliant
+  }
+
+  @Transactional
+  public void mixedExceptions() throws IOException, RuntimeException { // Noncompliant
+  }
+
+  @Transactional(rollbackFor = IOException.class)
+  public void withRollbackFor() throws IOException {
+  }
+
+  @Transactional(rollbackFor = {IOException.class, SQLException.class})
+  public void withMultipleRollbackFor() throws IOException, SQLException {
+  }
+
+  @Transactional(rollbackFor = Exception.class)
+  public void rollbackForAll() throws Exception {
+  }
+
+  @Transactional(noRollbackFor = NotificationException.class)
+  public void withNoRollbackFor() throws NotificationException {
+  }
+
+  @Transactional(rollbackFor = Exception.class, noRollbackFor = NotificationException.class)
+  public void withBoth() throws Exception {
+  }
+
+  @Transactional(rollbackForClassName = "java.io.IOException")
+  public void rollbackForClassName() throws IOException {
+  }
+
+  @Transactional(noRollbackForClassName = "checks.spring.NotificationException")
+  public void noRollbackForClassName() throws NotificationException {
+  }
+
+  @Transactional
+  public void noExceptions() {
+  }
+
+  @Transactional
+  public void uncheckedOnly() throws RuntimeException {
+  }
+
+  public void noAnnotation() throws IOException {
+  }
+
+  @Transactional(rollbackFor = Exception.class)
+  static class ClassLevelConfig {
+    public void inherited() throws IOException {
+    }
+  }
+
+  @Transactional
+  static class ClassLevelNoConfig {
+    public void noConfig() throws IOException { // Noncompliant
+    }
+
+    @Transactional(rollbackFor = IOException.class)
+    public void methodOverrides() throws IOException {
+    }
+  }
+
+  @Transactional
+  public void errorNotChecked() throws Error {
+  }
+
+  @org.springframework.transaction.annotation.Transactional
+  public void fullyQualified() throws IOException { // Noncompliant
+  }
+
+  @Transactional(rollbackFor = IOException.class)
+  public void partialConfig() throws SQLException {
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -2,7 +2,15 @@ package checks.spring;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import org.springframework.transaction.annotation.Transactional;
+
+// Composed/meta-annotation for testing
+@Retention(RetentionPolicy.RUNTIME)
+@Transactional
+@interface MyTransactional {
+}
 
 class Order {}
 class NotificationException extends Exception {}
@@ -13,18 +21,16 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @Transactional // Noncompliant {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes.}} [[quickfixes=qf1,qf2]]
 //^^^^^^^^^^^^^^
   // fix@qf1 {{Add rollbackFor attribute}}
-  // edit@qf1 [[sc=3;ec=17]] {{@Transactional(rollbackFor = {IOException.class, SQLException.class})}}
+  // edit@qf1 [[sc=3;ec=17]] {{@Transactional(rollbackFor = {java.io.IOException.class, java.sql.SQLException.class})}}
   // fix@qf2 {{Add rollbackFor = Exception.class}}
-  // edit@qf2 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  // edit@qf2 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.lang.Exception.class)}}
   public void processOrder(Order order) throws IOException, SQLException {
   }
 
-  @Transactional // Noncompliant [[quickfixes=qf3,qf4]]
+  @Transactional // Noncompliant [[quickfixes=qf3]]
 //^^^^^^^^^^^^^^
-  // fix@qf3 {{Add rollbackFor attribute}}
-  // edit@qf3 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
-  // fix@qf4 {{Add rollbackFor = Exception.class}}
-  // edit@qf4 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  // fix@qf3 {{Add rollbackFor = Exception.class}}
+  // edit@qf3 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.lang.Exception.class)}}
   public void importData() throws Exception {
   }
 
@@ -36,18 +42,18 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @Transactional // Noncompliant [[quickfixes=qf7,qf8]]
 //^^^^^^^^^^^^^^
   // fix@qf7 {{Add rollbackFor attribute}}
-  // edit@qf7 [[sc=3;ec=17]] {{@Transactional(rollbackFor = CustomCheckedException.class)}}
+  // edit@qf7 [[sc=3;ec=17]] {{@Transactional(rollbackFor = checks.spring.CustomCheckedException.class)}}
   // fix@qf8 {{Add rollbackFor = Exception.class}}
-  // edit@qf8 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  // edit@qf8 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.lang.Exception.class)}}
   public void customException() throws CustomCheckedException {
   }
 
   @Transactional // Noncompliant [[quickfixes=qf9,qf10]]
 //^^^^^^^^^^^^^^
   // fix@qf9 {{Add rollbackFor attribute}}
-  // edit@qf9 [[sc=3;ec=17]] {{@Transactional(rollbackFor = IOException.class)}}
+  // edit@qf9 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.io.IOException.class)}}
   // fix@qf10 {{Add rollbackFor = Exception.class}}
-  // edit@qf10 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  // edit@qf10 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.lang.Exception.class)}}
   public void mixedExceptions() throws IOException, RuntimeException {
   }
 
@@ -99,9 +105,9 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @Transactional // Noncompliant [[quickfixes=qf11,qf12]]
 //^^^^^^^^^^^^^^
   // fix@qf11 {{Add rollbackFor attribute}}
-  // edit@qf11 [[sc=3;ec=17]] {{@Transactional(rollbackFor = IOException.class)}}
+  // edit@qf11 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.io.IOException.class)}}
   // fix@qf12 {{Add rollbackFor = Exception.class}}
-  // edit@qf12 [[sc=3;ec=17]] {{@Transactional(rollbackFor = Exception.class)}}
+  // edit@qf12 [[sc=3;ec=17]] {{@Transactional(rollbackFor = java.lang.Exception.class)}}
   static class ClassLevelNoConfig {
     public void noConfig() throws IOException {
     }
@@ -118,9 +124,9 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @org.springframework.transaction.annotation.Transactional // Noncompliant [[quickfixes=qf13,qf14]]
 //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>^^^^^^^^^^^^^^^^^^^^^^^^
   // fix@qf13 {{Add rollbackFor attribute}}
-  // edit@qf13 [[sc=3;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = IOException.class)}}
+  // edit@qf13 [[sc=3;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = java.io.IOException.class)}}
   // fix@qf14 {{Add rollbackFor = Exception.class}}
-  // edit@qf14 [[sc=3;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = Exception.class)}}
+  // edit@qf14 [[sc=3;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = java.lang.Exception.class)}}
   public void fullyQualified() throws IOException {
   }
 
@@ -151,5 +157,10 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @Transactional // Noncompliant
   interface TransactionalInterface {
     void interfaceMethod() throws IOException;
+  }
+
+  // Test meta-annotated (composed) annotation
+  @MyTransactional // Noncompliant
+  public void metaAnnotated() throws IOException {
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -163,4 +163,17 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   @MyTransactional // Noncompliant
   public void metaAnnotated() throws IOException {
   }
+
+  // Test unknown type (unresolved exception) - line 168 coverage
+  @Transactional
+  public void unknownException() throws UnresolvedCheckedException {
+    // UnresolvedCheckedException is not imported/defined, so type.isUnknown() returns true
+    // Should not raise an issue since we can't determine if it's a checked exception
+  }
+
+  // Test annotation with value attribute (transaction manager name)
+  @Transactional("txManager") // Noncompliant
+  public void valueShorthand() throws IOException {
+    // Has value attribute but no rollback configuration
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -117,9 +117,9 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
       .map(name -> name + ".class")
       .collect(Collectors.joining(", "));
 
-    String rollbackForAttribute = checkedExceptions.size() == 1
-      ? "rollbackFor = " + exceptionsList
-      : "rollbackFor = {" + exceptionsList + "}";
+    String rollbackForAttribute = (checkedExceptions.size() == 1)
+      ? ("rollbackFor = " + exceptionsList)
+      : ("rollbackFor = {" + exceptionsList + "}");
 
     quickFixes.add(createQuickFix(annotation, rollbackForAttribute, "Add rollbackFor attribute"));
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -30,8 +30,6 @@ import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.DependencyVersionAware;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.Version;
-import org.sonar.plugins.java.api.semantic.Symbol;
-import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.Arguments;
@@ -60,7 +58,7 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
 
     List<Type> checkedExceptions = throwsClauses.stream()
       .map(TypeTree::symbolType)
-      .filter(this::isCheckedException)
+      .filter(TransactionalMethodCheckedExceptionCheck::isCheckedException)
       .toList();
 
     if (checkedExceptions.isEmpty()) {
@@ -150,7 +148,7 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
     }
   }
 
-  private boolean isCheckedException(Type type) {
+  private static boolean isCheckedException(Type type) {
     if (type.isUnknown()) {
       return false;
     }
@@ -173,19 +171,6 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
         }
         return false;
       });
-  }
-
-  private boolean hasRollbackConfiguration(SymbolMetadata metadata) {
-    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(SpringUtils.TRANSACTIONAL_ANNOTATION);
-    if (values == null) {
-      return false;
-    }
-
-    return values.stream()
-      .anyMatch(av -> "rollbackFor".equals(av.name())
-        || "rollbackForClassName".equals(av.name())
-        || "noRollbackFor".equals(av.name())
-        || "noRollbackForClassName".equals(av.name()));
   }
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -16,20 +16,28 @@
  */
 package org.sonar.java.checks.spring;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.SpringUtils;
+import org.sonar.java.reporting.JavaQuickFix;
+import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.DependencyVersionAware;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.Version;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.Arguments;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TypeTree;
 
@@ -45,51 +53,101 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
   public void visitNode(Tree tree) {
     MethodTree method = (MethodTree) tree;
 
-    SymbolMetadata effectiveAnnotation = getEffectiveTransactionalAnnotation(method);
-    if (effectiveAnnotation == null) {
-      return;
-    }
-
     List<TypeTree> throwsClauses = method.throwsClauses();
     if (throwsClauses.isEmpty()) {
       return;
     }
 
-    boolean hasCheckedExceptions = throwsClauses.stream()
+    List<Type> checkedExceptions = throwsClauses.stream()
       .map(TypeTree::symbolType)
-      .anyMatch(this::isCheckedException);
+      .filter(this::isCheckedException)
+      .toList();
 
-    if (!hasCheckedExceptions) {
+    if (checkedExceptions.isEmpty()) {
       return;
     }
 
-    if (hasRollbackConfiguration(effectiveAnnotation)) {
+    AnnotationTree transactionalAnnotation = getTransactionalAnnotation(method);
+    if (transactionalAnnotation == null) {
       return;
     }
 
-    reportIssue(
-      method.simpleName(),
-      "Specify rollback behavior for checked exceptions using \"rollbackFor\" or \"noRollbackFor\" attributes."
-    );
+    // Check if the annotation tree itself has rollback configuration
+    if (hasRollbackConfiguration(transactionalAnnotation)) {
+      return;
+    }
+
+    QuickFixHelper.newIssue(context)
+      .forRule(this)
+      .onTree(transactionalAnnotation)
+      .withMessage("Specify rollback behavior for checked exceptions using \"rollbackFor\" or \"noRollbackFor\" attributes.")
+      .withQuickFixes(() -> computeQuickFixes(transactionalAnnotation, checkedExceptions))
+      .report();
   }
 
-  private SymbolMetadata getEffectiveTransactionalAnnotation(MethodTree method) {
-    Symbol.MethodSymbol methodSymbol = method.symbol();
-    SymbolMetadata methodMetadata = methodSymbol.metadata();
-
-    if (methodMetadata.isAnnotatedWith(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
-      return methodMetadata;
+  private static AnnotationTree getTransactionalAnnotation(MethodTree method) {
+    // Check method-level annotation first
+    for (AnnotationTree annotation : method.modifiers().annotations()) {
+      if (annotation.symbolType().is(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+        return annotation;
+      }
     }
 
-    Symbol.TypeSymbol classSymbol = methodSymbol.enclosingClass();
-    if (classSymbol != null) {
-      SymbolMetadata classMetadata = classSymbol.metadata();
-      if (classMetadata.isAnnotatedWith(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
-        return classMetadata;
+    // Check class-level annotation
+    Tree parent = method.parent();
+    while (parent != null && !parent.is(Tree.Kind.CLASS, Tree.Kind.INTERFACE, Tree.Kind.ENUM, Tree.Kind.RECORD)) {
+      parent = parent.parent();
+    }
+
+    if (parent instanceof ClassTree classTree) {
+      for (AnnotationTree annotation : classTree.modifiers().annotations()) {
+        if (annotation.symbolType().is(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+          return annotation;
+        }
       }
     }
 
     return null;
+  }
+
+  private List<JavaQuickFix> computeQuickFixes(AnnotationTree annotation, List<Type> checkedExceptions) {
+    List<JavaQuickFix> quickFixes = new ArrayList<>();
+
+    // Quick fix 1: Add rollbackFor with all checked exceptions
+    String exceptionsList = checkedExceptions.stream()
+      .map(Type::name)
+      .map(name -> name + ".class")
+      .collect(Collectors.joining(", "));
+
+    String rollbackForAttribute = checkedExceptions.size() == 1
+      ? "rollbackFor = " + exceptionsList
+      : "rollbackFor = {" + exceptionsList + "}";
+
+    quickFixes.add(createQuickFix(annotation, rollbackForAttribute, "Add rollbackFor attribute"));
+
+    // Quick fix 2: Add rollbackFor = Exception.class (covers all checked exceptions)
+    quickFixes.add(createQuickFix(annotation, "rollbackFor = Exception.class", "Add rollbackFor = Exception.class"));
+
+    return quickFixes;
+  }
+
+  private JavaQuickFix createQuickFix(AnnotationTree annotation, String attribute, String description) {
+    Arguments arguments = annotation.arguments();
+
+    if (arguments.isEmpty()) {
+      // @Transactional -> @Transactional(rollbackFor = ...)
+      String annotationTypeName = QuickFixHelper.contentForTree(annotation.annotationType(), context);
+      String replacement = annotationTypeName + "(" + attribute + ")";
+      return JavaQuickFix.newQuickFix(description)
+        .addTextEdit(JavaTextEdit.replaceTree(annotation, "@" + replacement))
+        .build();
+    } else {
+      // @Transactional(timeout = 30) -> @Transactional(timeout = 30, rollbackFor = ...)
+      SyntaxToken closeParenToken = arguments.closeParenToken();
+      return JavaQuickFix.newQuickFix(description)
+        .addTextEdit(JavaTextEdit.insertBeforeTree(closeParenToken, ", " + attribute))
+        .build();
+    }
   }
 
   private boolean isCheckedException(Type type) {
@@ -100,6 +158,21 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
     return type.isSubtypeOf("java.lang.Exception")
       && !type.isSubtypeOf("java.lang.RuntimeException")
       && !type.isSubtypeOf("java.lang.Error");
+  }
+
+  private static boolean hasRollbackConfiguration(AnnotationTree annotation) {
+    return annotation.arguments().stream()
+      .anyMatch(arg -> {
+        if (arg.is(Tree.Kind.ASSIGNMENT)) {
+          var assignment = (org.sonar.plugins.java.api.tree.AssignmentExpressionTree) arg;
+          String name = ((org.sonar.plugins.java.api.tree.IdentifierTree) assignment.variable()).name();
+          return "rollbackFor".equals(name)
+            || "rollbackForClassName".equals(name)
+            || "noRollbackFor".equals(name)
+            || "noRollbackForClassName".equals(name);
+        }
+        return false;
+      });
   }
 
   private boolean hasRollbackConfiguration(SymbolMetadata metadata) {

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -84,9 +84,9 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
   }
 
   private static AnnotationTree getTransactionalAnnotation(MethodTree method) {
-    // Check method-level annotation first
+    // Check method-level annotation first (including meta-annotations)
     for (AnnotationTree annotation : method.modifiers().annotations()) {
-      if (annotation.symbolType().is(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+      if (isTransactionalAnnotation(annotation)) {
         return annotation;
       }
     }
@@ -99,7 +99,7 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
 
     if (parent instanceof ClassTree classTree) {
       for (AnnotationTree annotation : classTree.modifiers().annotations()) {
-        if (annotation.symbolType().is(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+        if (isTransactionalAnnotation(annotation)) {
           return annotation;
         }
       }
@@ -108,12 +108,21 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
     return null;
   }
 
+  private static boolean isTransactionalAnnotation(AnnotationTree annotation) {
+    // Check if the annotation itself is @Transactional
+    if (annotation.symbolType().is(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+      return true;
+    }
+    // Check if the annotation is meta-annotated with @Transactional (composed annotation)
+    return annotation.symbolType().symbol().metadata().isAnnotatedWith(SpringUtils.TRANSACTIONAL_ANNOTATION);
+  }
+
   private List<JavaQuickFix> computeQuickFixes(AnnotationTree annotation, List<Type> checkedExceptions) {
     List<JavaQuickFix> quickFixes = new ArrayList<>();
 
-    // Quick fix 1: Add rollbackFor with all checked exceptions
+    // Quick fix 1: Add rollbackFor with all checked exceptions (using fully qualified names)
     String exceptionsList = checkedExceptions.stream()
-      .map(Type::name)
+      .map(Type::fullyQualifiedName)
       .map(name -> name + ".class")
       .collect(Collectors.joining(", "));
 
@@ -121,10 +130,16 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
       ? ("rollbackFor = " + exceptionsList)
       : ("rollbackFor = {" + exceptionsList + "}");
 
-    quickFixes.add(createQuickFix(annotation, rollbackForAttribute, "Add rollbackFor attribute"));
+    // Only add the specific exceptions quick fix if it's different from Exception.class
+    boolean isAlreadyExceptionClass = checkedExceptions.size() == 1
+      && "java.lang.Exception".equals(checkedExceptions.get(0).fullyQualifiedName());
+
+    if (!isAlreadyExceptionClass) {
+      quickFixes.add(createQuickFix(annotation, rollbackForAttribute, "Add rollbackFor attribute"));
+    }
 
     // Quick fix 2: Add rollbackFor = Exception.class (covers all checked exceptions)
-    quickFixes.add(createQuickFix(annotation, "rollbackFor = Exception.class", "Add rollbackFor = Exception.class"));
+    quickFixes.add(createQuickFix(annotation, "rollbackFor = java.lang.Exception.class", "Add rollbackFor = Exception.class"));
 
     return quickFixes;
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -1,0 +1,124 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.spring;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.SpringUtils;
+import org.sonar.plugins.java.api.DependencyVersionAware;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.Version;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TypeTree;
+
+@Rule(key = "S8989")
+public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    MethodTree method = (MethodTree) tree;
+
+    SymbolMetadata effectiveAnnotation = getEffectiveTransactionalAnnotation(method);
+    if (effectiveAnnotation == null) {
+      return;
+    }
+
+    List<TypeTree> throwsClauses = method.throwsClauses();
+    if (throwsClauses.isEmpty()) {
+      return;
+    }
+
+    boolean hasCheckedExceptions = throwsClauses.stream()
+      .map(TypeTree::symbolType)
+      .anyMatch(this::isCheckedException);
+
+    if (!hasCheckedExceptions) {
+      return;
+    }
+
+    if (hasRollbackConfiguration(effectiveAnnotation)) {
+      return;
+    }
+
+    reportIssue(
+      method.simpleName(),
+      "Specify rollback behavior for checked exceptions using \"rollbackFor\" or \"noRollbackFor\" attributes."
+    );
+  }
+
+  private SymbolMetadata getEffectiveTransactionalAnnotation(MethodTree method) {
+    Symbol.MethodSymbol methodSymbol = method.symbol();
+    SymbolMetadata methodMetadata = methodSymbol.metadata();
+
+    if (methodMetadata.isAnnotatedWith(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+      return methodMetadata;
+    }
+
+    Symbol.TypeSymbol classSymbol = methodSymbol.enclosingClass();
+    if (classSymbol != null) {
+      SymbolMetadata classMetadata = classSymbol.metadata();
+      if (classMetadata.isAnnotatedWith(SpringUtils.TRANSACTIONAL_ANNOTATION)) {
+        return classMetadata;
+      }
+    }
+
+    return null;
+  }
+
+  private boolean isCheckedException(Type type) {
+    if (type.isUnknown()) {
+      return false;
+    }
+
+    return type.isSubtypeOf("java.lang.Exception")
+      && !type.isSubtypeOf("java.lang.RuntimeException")
+      && !type.isSubtypeOf("java.lang.Error");
+  }
+
+  private boolean hasRollbackConfiguration(SymbolMetadata metadata) {
+    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(SpringUtils.TRANSACTIONAL_ANNOTATION);
+    if (values == null) {
+      return false;
+    }
+
+    return values.stream()
+      .anyMatch(av -> "rollbackFor".equals(av.name())
+        || "rollbackForClassName".equals(av.name())
+        || "noRollbackFor".equals(av.name())
+        || "noRollbackForClassName".equals(av.name()));
+  }
+
+  @Override
+  public boolean isCompatibleWithDependencies(Function<String, Optional<Version>> dependencyFinder) {
+    Optional<Version> springContextVersion = dependencyFinder.apply("spring-context");
+    Optional<Version> springTxVersion = dependencyFinder.apply("spring-tx");
+    return springTxVersion.isPresent() || springContextVersion.isPresent();
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheckTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 
 class TransactionalMethodCheckedExceptionCheckTest {
 
@@ -39,5 +40,13 @@ class TransactionalMethodCheckedExceptionCheckTest {
       .withCheck(new TransactionalMethodCheckedExceptionCheck())
       .withClassPath(Collections.emptyList())
       .verifyNoIssues();
+  }
+
+  @Test
+  void test_nonCompiling() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/spring/TransactionalMethodCheckedExceptionCheckSampleNonCompiling.java"))
+      .withCheck(new TransactionalMethodCheckedExceptionCheck())
+      .verifyIssues();
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheckTest.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.spring;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class TransactionalMethodCheckedExceptionCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/TransactionalMethodCheckedExceptionCheckSample.java"))
+      .withCheck(new TransactionalMethodCheckedExceptionCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_noDependencies() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/TransactionalMethodCheckedExceptionCheckSample.java"))
+      .withCheck(new TransactionalMethodCheckedExceptionCheck())
+      .withClassPath(Collections.emptyList())
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.html
@@ -1,0 +1,113 @@
+<h2>Why is this an issue?</h2>
+<p>In Spring Framework, the <code>@Transactional</code> annotation controls database transactions. By default:</p>
+<ul>
+  <li><strong>Unchecked exceptions</strong> (subclasses of <code>RuntimeException</code> or <code>Error</code>) automatically trigger a transaction rollback</li>
+  <li><strong>Checked exceptions</strong> do NOT trigger a rollback - the transaction commits even when these exceptions are thrown</li>
+</ul>
+<p>When you declare a checked exception in your method signature but don't specify the rollback behavior, Spring will commit the transaction even if that exception occurs. This often leads to data being saved in an inconsistent state.</p>
+<p>When a method throws a checked exception, it typically signals that something went wrong during execution. In the context of database transactions, you usually want to roll back the transaction when errors occur to maintain data integrity.</p>
+<p>This default behavior creates a dangerous mismatch between intent and outcome:</p>
+<ul>
+  <li>Your code throws an exception to signal an error</li>
+  <li>The calling code catches the exception and treats it as a failure</li>
+  <li>But the database transaction has already committed, saving partial or incorrect data</li>
+</ul>
+<p>This silent failure mode is particularly problematic because:</p>
+<ul>
+  <li>It's not obvious from the code that checked exceptions won't trigger rollback</li>
+  <li>The behavior differs from what most developers expect</li>
+  <li>Partial transaction commits can leave your database in an inconsistent state</li>
+</ul>
+<p>By explicitly specifying <code>rollbackFor</code> or <code>noRollbackFor</code>, you make the intended behavior clear and prevent unexpected transaction commits.</p>
+
+<h3>What is the potential impact?</h3>
+<p>When checked exceptions don't trigger rollbacks as expected, the consequences can be severe:</p>
+
+<h4>Data Corruption</h4>
+<p>Partial transactions commit to the database, leaving data in an inconsistent state. For example, if an order processing method saves an order but fails when creating the invoice, you end up with an order record but no corresponding invoice.</p>
+
+<h4>Silent Failures</h4>
+<p>The application throws an exception indicating failure, but the database changes persist anyway. Error handling code may log the error or show a failure message to users, while the "failed" operation actually modified the database.</p>
+
+<h4>Business Logic Violations</h4>
+<p>Multi-step operations that should be atomic (all-or-nothing) can partially complete. This violates business rules that depend on data consistency, such as:</p>
+<ul>
+  <li>Account balances not matching transaction history</li>
+  <li>Inventory counts becoming incorrect</li>
+  <li>Orphaned records without their required relationships</li>
+</ul>
+
+<h4>Difficult Debugging</h4>
+<p>Because the transaction commits silently, these bugs are hard to diagnose. The code appears to handle errors correctly (it throws and catches exceptions), but the database state doesn't match expectations.</p>
+
+<h2>How to fix it in Spring</h2>
+<p>Explicitly specify <code>rollbackFor</code> to include the checked exceptions that should trigger a rollback. This is the most common fix, as most checked exceptions represent error conditions that should prevent the transaction from committing.</p>
+
+<h3>Code examples</h3>
+
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@Transactional
+public void processOrder(Order order) throws IOException, SQLException { // Noncompliant
+    orderRepository.save(order);
+    notificationService.sendConfirmation(order); // May throw IOException
+}
+</pre>
+
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@Transactional(rollbackFor = {IOException.class, SQLException.class})
+public void processOrder(Order order) throws IOException, SQLException {
+    orderRepository.save(order);
+    notificationService.sendConfirmation(order); // May throw IOException
+}
+</pre>
+
+<p>If you want to roll back on all exceptions (both checked and unchecked), you can specify <code>Exception.class</code> as the rollback trigger. This is a safe default when you're unsure which specific exceptions to list.</p>
+
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+@Transactional
+public void importData(File file) throws Exception { // Noncompliant
+    List&lt;Record&gt; records = parser.parse(file);
+    recordRepository.saveAll(records);
+}
+</pre>
+
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+@Transactional(rollbackFor = Exception.class)
+public void importData(File file) throws Exception {
+    List&lt;Record&gt; records = parser.parse(file);
+    recordRepository.saveAll(records);
+}
+</pre>
+
+<p>In rare cases where you intentionally want the transaction to commit even when a checked exception is thrown, use <code>noRollbackFor</code> to document this decision explicitly. This makes it clear the behavior is intentional, not an oversight.</p>
+
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="3" data-diff-type="noncompliant">
+@Transactional
+public void processWithNotification(Order order) throws NotificationException { // Noncompliant
+    orderRepository.save(order);
+    // We want order saved even if notification fails
+    notificationService.sendEmail(order);
+}
+</pre>
+
+<h4>Compliant solution</h4>
+<pre data-diff-id="3" data-diff-type="compliant">
+@Transactional(noRollbackFor = NotificationException.class)
+public void processWithNotification(Order order) throws NotificationException {
+    orderRepository.save(order);
+    // We want order saved even if notification fails
+    notificationService.sendEmail(order);
+}
+</pre>
+
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li><a href="https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html">Spring Framework Documentation - Transaction Management</a> - Official Spring documentation explaining the @Transactional annotation and its rollback behavior</li>
+  <li><a href="https://www.baeldung.com/spring-transactional-rollback">Baeldung - Spring @Transactional Rollback</a> - Practical guide to configuring transaction rollback in Spring applications</li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.html
@@ -1,11 +1,18 @@
-<h2>Why is this an issue?</h2>
+<p>This is an issue when a method is annotated with <code>@Transactional</code> and declares one or more checked exceptions in its <code>throws</code>
+clause, but does not explicitly configure how the transaction should behave when those exceptions occur.</p>
 <p>In Spring Framework, the <code>@Transactional</code> annotation controls database transactions. By default:</p>
 <ul>
-  <li><strong>Unchecked exceptions</strong> (subclasses of <code>RuntimeException</code> or <code>Error</code>) automatically trigger a transaction rollback</li>
+  <li><strong>Unchecked exceptions</strong> (subclasses of <code>RuntimeException</code> or <code>Error</code>) automatically trigger a transaction
+  rollback</li>
   <li><strong>Checked exceptions</strong> do NOT trigger a rollback - the transaction commits even when these exceptions are thrown</li>
 </ul>
-<p>When you declare a checked exception in your method signature but don't specify the rollback behavior, Spring will commit the transaction even if that exception occurs. This often leads to data being saved in an inconsistent state.</p>
-<p>When a method throws a checked exception, it typically signals that something went wrong during execution. In the context of database transactions, you usually want to roll back the transaction when errors occur to maintain data integrity.</p>
+<p>When you declare a checked exception in your method signature but don’t specify the rollback behavior, Spring will commit the transaction even if
+that exception occurs. This often leads to data being saved in an inconsistent state.</p>
+<h2>Why is this an issue?</h2>
+<p>When a method throws a checked exception, it typically signals that something went wrong during execution. In the context of database transactions,
+you usually want to roll back the transaction when errors occur to maintain data integrity.</p>
+<p>However, Spring’s <code>@Transactional</code> annotation only rolls back transactions automatically for unchecked exceptions (like
+<code>RuntimeException</code>). For checked exceptions, the transaction commits by default - even when the exception indicates a failure.</p>
 <p>This default behavior creates a dangerous mismatch between intent and outcome:</p>
 <ul>
   <li>Your code throws an exception to signal an error</li>
@@ -14,37 +21,35 @@
 </ul>
 <p>This silent failure mode is particularly problematic because:</p>
 <ul>
-  <li>It's not obvious from the code that checked exceptions won't trigger rollback</li>
+  <li>It’s not obvious from the code that checked exceptions won’t trigger rollback</li>
   <li>The behavior differs from what most developers expect</li>
   <li>Partial transaction commits can leave your database in an inconsistent state</li>
 </ul>
-<p>By explicitly specifying <code>rollbackFor</code> or <code>noRollbackFor</code>, you make the intended behavior clear and prevent unexpected transaction commits.</p>
-
+<p>By explicitly specifying <code>rollbackFor</code> or <code>noRollbackFor</code>, you make the intended behavior clear and prevent unexpected
+transaction commits.</p>
 <h3>What is the potential impact?</h3>
-<p>When checked exceptions don't trigger rollbacks as expected, the consequences can be severe:</p>
-
-<h4>Data Corruption</h4>
-<p>Partial transactions commit to the database, leaving data in an inconsistent state. For example, if an order processing method saves an order but fails when creating the invoice, you end up with an order record but no corresponding invoice.</p>
-
-<h4>Silent Failures</h4>
-<p>The application throws an exception indicating failure, but the database changes persist anyway. Error handling code may log the error or show a failure message to users, while the "failed" operation actually modified the database.</p>
-
-<h4>Business Logic Violations</h4>
-<p>Multi-step operations that should be atomic (all-or-nothing) can partially complete. This violates business rules that depend on data consistency, such as:</p>
+<p>When checked exceptions don’t trigger rollbacks as expected, the consequences can be severe:</p>
+<h3>Data Corruption</h3>
+<p>Partial transactions commit to the database, leaving data in an inconsistent state. For example, if an order processing method saves an order but
+fails when creating the invoice, you end up with an order record but no corresponding invoice.</p>
+<h3>Silent Failures</h3>
+<p>The application throws an exception indicating failure, but the database changes persist anyway. Error handling code may log the error or show a
+failure message to users, while the "failed" operation actually modified the database.</p>
+<h3>Business Logic Violations</h3>
+<p>Multi-step operations that should be atomic (all-or-nothing) can partially complete. This violates business rules that depend on data consistency,
+such as:</p>
 <ul>
   <li>Account balances not matching transaction history</li>
   <li>Inventory counts becoming incorrect</li>
   <li>Orphaned records without their required relationships</li>
 </ul>
-
-<h4>Difficult Debugging</h4>
-<p>Because the transaction commits silently, these bugs are hard to diagnose. The code appears to handle errors correctly (it throws and catches exceptions), but the database state doesn't match expectations.</p>
-
+<h3>Difficult Debugging</h3>
+<p>Because the transaction commits silently, these bugs are hard to diagnose. The code appears to handle errors correctly (it throws and catches
+exceptions), but the database state doesn’t match expectations.</p>
 <h2>How to fix it in Spring</h2>
-<p>Explicitly specify <code>rollbackFor</code> to include the checked exceptions that should trigger a rollback. This is the most common fix, as most checked exceptions represent error conditions that should prevent the transaction from committing.</p>
-
+<p>Explicitly specify <code>rollbackFor</code> to include the checked exceptions that should trigger a rollback. This is the most common fix, as most
+checked exceptions represent error conditions that should prevent the transaction from committing.</p>
 <h3>Code examples</h3>
-
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 @Transactional
@@ -53,7 +58,6 @@ public void processOrder(Order order) throws IOException, SQLException { // Nonc
     notificationService.sendConfirmation(order); // May throw IOException
 }
 </pre>
-
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
 @Transactional(rollbackFor = {IOException.class, SQLException.class})
@@ -62,9 +66,8 @@ public void processOrder(Order order) throws IOException, SQLException {
     notificationService.sendConfirmation(order); // May throw IOException
 }
 </pre>
-
-<p>If you want to roll back on all exceptions (both checked and unchecked), you can specify <code>Exception.class</code> as the rollback trigger. This is a safe default when you're unsure which specific exceptions to list.</p>
-
+<p>If you want to roll back on all exceptions (both checked and unchecked), you can specify <code>Exception.class</code> as the rollback trigger. This
+is a safe default when you’re unsure which specific exceptions to list.</p>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="2" data-diff-type="noncompliant">
 @Transactional
@@ -73,7 +76,6 @@ public void importData(File file) throws Exception { // Noncompliant
     recordRepository.saveAll(records);
 }
 </pre>
-
 <h4>Compliant solution</h4>
 <pre data-diff-id="2" data-diff-type="compliant">
 @Transactional(rollbackFor = Exception.class)
@@ -82,9 +84,8 @@ public void importData(File file) throws Exception {
     recordRepository.saveAll(records);
 }
 </pre>
-
-<p>In rare cases where you intentionally want the transaction to commit even when a checked exception is thrown, use <code>noRollbackFor</code> to document this decision explicitly. This makes it clear the behavior is intentional, not an oversight.</p>
-
+<p>In rare cases where you intentionally want the transaction to commit even when a checked exception is thrown, use <code>noRollbackFor</code> to
+document this decision explicitly. This makes it clear the behavior is intentional, not an oversight.</p>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="3" data-diff-type="noncompliant">
 @Transactional
@@ -94,7 +95,6 @@ public void processWithNotification(Order order) throws NotificationException { 
     notificationService.sendEmail(order);
 }
 </pre>
-
 <h4>Compliant solution</h4>
 <pre data-diff-id="3" data-diff-type="compliant">
 @Transactional(noRollbackFor = NotificationException.class)
@@ -104,10 +104,13 @@ public void processWithNotification(Order order) throws NotificationException {
     notificationService.sendEmail(order);
 }
 </pre>
-
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
-  <li><a href="https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html">Spring Framework Documentation - Transaction Management</a> - Official Spring documentation explaining the @Transactional annotation and its rollback behavior</li>
-  <li><a href="https://www.baeldung.com/spring-transactional-rollback">Baeldung - Spring @Transactional Rollback</a> - Practical guide to configuring transaction rollback in Spring applications</li>
+  <li>Spring Framework Documentation - Transaction Management - <a
+  href="https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html">Official Spring documentation
+  explaining the @Transactional annotation and its rollback behavior</a></li>
+  <li>Baeldung - Spring @Transactional Rollback - <a href="https://www.baeldung.com/spring-transactional-rollback">Practical guide to configuring
+  transaction rollback in Spring applications</a></li>
 </ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.json
@@ -1,0 +1,23 @@
+{
+  "title": "Methods with \"@Transactional\" should specify rollback behavior for checked exceptions",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "spring"
+  ],
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "HIGH"
+    },
+    "attribute": "CLEAR"
+  },
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-8989",
+  "sqKey": "S8989",
+  "scope": "Main",
+  "quickfix": "unknown"
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.json
@@ -3,21 +3,24 @@
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {
-    "func": "Constant/Issue",
-    "constantCost": "5min"
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
   },
   "tags": [
-    "spring"
+    "spring",
+    "transaction",
+    "pitfall"
   ],
-  "code": {
-    "impacts": {
-      "MAINTAINABILITY": "HIGH"
-    },
-    "attribute": "CLEAR"
-  },
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-8989",
   "sqKey": "S8989",
   "scope": "Main",
-  "quickfix": "unknown"
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "MEDIUM",
+      "MAINTAINABILITY": "HIGH"
+    },
+    "attribute": "COMPLETE"
+  }
 }


### PR DESCRIPTION
This rule detects methods annotated with @Transactional from Spring Framework that declare checked exceptions but do not explicitly configure rollback behavior using rollbackFor or noRollbackFor attributes. By default, Spring only rolls back transactions for unchecked exceptions, which can lead to silent data corruption when checked exceptions are thrown but the transaction commits anyway. The rule helps prevent this by requiring explicit rollback configuration for all transactional methods that throw checked exceptions.

[RSPEC PR](https://github.com/SonarSource/rspec/pull/7353)