### PR TITLE
SONARJAVA-6608 Adapt ITs to new behaviour of scanner engine when binaries are missing

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaClasspathTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/java/suite/JavaClasspathTest.java
@@ -155,11 +155,11 @@ public class JavaClasspathTest {
   }
 
   @Test
-  public void should_log_warnings_if_binaries_missing() {
+  public void should_log_warnings_if_libraries_missing() {
     SonarScanner scanner = ditProjectSonarScanner();
     BuildResult buildResult = ORCHESTRATOR.executeBuildQuietly(scanner);
     String logs = buildResult.getLogs();
-    assertThat(logs).contains("WARN  Missing 'sonar.java.binaries' and 'sonar.java.libraries' properties. You might end up with less precise analysis results.");
+    assertThat(logs).containsPattern("WARN  Missing .*'sonar\\.java\\.libraries' propert(y|ies)\\. You might end up with less precise analysis results\\.");
     assertThat(buildResult.isSuccess()).isTrue();
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `sonar.plugin.api.version` from `13.0.0.3026` to `13.8.0.4399` in `pom.xml`.
- **Test updates:**
  - Renamed `should_log_warnings_if_binaries_missing` to `should_log_warnings_if_libraries_missing` in `JavaClasspathTest`.
  - Updated the expected warning log message to exclude the reference to `sonar.java.binaries`.
- **CI configuration:**
  - Commented out the `exclude` logic for `DEV` version in `.github/workflows/build.yml`.

<sub>This will update automatically on new commits.</sub>