### PR TITLE
SONARJAVA-3259 Implement new rule S5673

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -2118,6 +2118,12 @@
     "falsePositives": 0
   },
   {
+    "ruleKey": "S5673",
+    "hasTruePositives": false,
+    "falseNegatives": 17,
+    "falsePositives": 0
+  },
+  {
     "ruleKey": "S5679",
     "hasTruePositives": false,
     "falseNegatives": 2,

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S5673.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S5673.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S5673",
+  "hasTruePositives": false,
+  "falseNegatives": 17,
+  "falsePositives": 0
+}

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S5673.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S5673.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S5673",
   "hasTruePositives": false,
-  "falseNegatives": 17,
+  "falseNegatives": 20,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringComponentSpecializationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringComponentSpecializationCheckSample.java
@@ -122,4 +122,34 @@ public class SpringComponentSpecializationCheckSample {
   @Component // Noncompliant {{Use @RestController instead of @Component}}
   public class apirestcontroller {
   }
+
+  // Interface patterns
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public interface UserRepository {
+  }
+
+  @Component // Noncompliant {{Use @Service instead of @Component}}
+  public interface PaymentService {
+  }
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public interface ProductDao {
+  }
+
+  // Compliant interfaces - correct annotations used
+
+  @Repository
+  public interface CategoryRepository {
+  }
+
+  @Service
+  public interface NotificationService {
+  }
+
+  // Compliant interfaces - generic names
+
+  @Component
+  public interface EventListener {
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringComponentSpecializationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringComponentSpecializationCheckSample.java
@@ -1,0 +1,125 @@
+package checks.spring;
+
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
+public class SpringComponentSpecializationCheckSample {
+
+  // Service patterns
+
+  @Component // Noncompliant {{Use @Service instead of @Component}}
+  public class CustomerServiceImpl {
+  }
+
+  @Component // Noncompliant {{Use @Service instead of @Component}}
+  public class OrderService {
+  }
+
+  @Component // Noncompliant {{Use @Service instead of @Component}}
+  public class PaymentServiceFacade {
+  }
+
+  // Repository patterns
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public class ProductRepository {
+  }
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public class UserRepositoryImpl {
+  }
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public class OrderDao {
+  }
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public class CustomerDao {
+  }
+
+  // RestController patterns
+
+  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  public class FooBarRestController {
+  }
+
+  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  public class ApiRestController {
+  }
+
+  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  public class UserRestControllerImpl {
+  }
+
+  // Controller patterns
+
+  @Component // Noncompliant {{Use @Controller instead of @Component}}
+  public class HomeController {
+  }
+
+  @Component // Noncompliant {{Use @Controller instead of @Component}}
+  public class LoginControllerImpl {
+  }
+
+  // Compliant - Correct annotations used
+
+  @Service
+  public class CustomerServiceImplCorrect {
+  }
+
+  @Repository
+  public class ProductRepositoryCorrect {
+  }
+
+  @RestController
+  public class FooBarRestControllerCorrect {
+  }
+
+  @Controller
+  public class HomeControllerCorrect {
+  }
+
+  // Generic component names
+
+  @Component
+  public class SomeOtherComponent {
+  }
+
+  @Component
+  public class UtilityHelper {
+  }
+
+  @Component
+  public class CacheManager {
+  }
+
+  @Component
+  public class DataProcessor {
+  }
+
+  // No annotation
+
+  public class PlainClass {
+  }
+
+  // Case variations
+
+  @Component // Noncompliant {{Use @Service instead of @Component}}
+  public class userservice {
+  }
+
+  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  public class USERREPOSITORY {
+  }
+
+  @Component // Noncompliant {{Use @Controller instead of @Component}}
+  public class maincontroller {
+  }
+
+  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  public class apirestcontroller {
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringComponentSpecializationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringComponentSpecializationCheckSample.java
@@ -10,57 +10,57 @@ public class SpringComponentSpecializationCheckSample {
 
   // Service patterns
 
-  @Component // Noncompliant {{Use @Service instead of @Component}}
+  @Component // Noncompliant {{Use @Service instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class CustomerServiceImpl {
   }
 
-  @Component // Noncompliant {{Use @Service instead of @Component}}
+  @Component // Noncompliant {{Use @Service instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class OrderService {
   }
 
-  @Component // Noncompliant {{Use @Service instead of @Component}}
+  @Component // Noncompliant {{Use @Service instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class PaymentServiceFacade {
   }
 
   // Repository patterns
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class ProductRepository {
   }
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class UserRepositoryImpl {
   }
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class OrderDao {
   }
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class CustomerDao {
   }
 
   // RestController patterns
 
-  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  @Component // Noncompliant {{Use @RestController instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class FooBarRestController {
   }
 
-  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  @Component // Noncompliant {{Use @RestController instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class ApiRestController {
   }
 
-  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  @Component // Noncompliant {{Use @RestController instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class UserRestControllerImpl {
   }
 
   // Controller patterns
 
-  @Component // Noncompliant {{Use @Controller instead of @Component}}
+  @Component // Noncompliant {{Use @Controller instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class HomeController {
   }
 
-  @Component // Noncompliant {{Use @Controller instead of @Component}}
+  @Component // Noncompliant {{Use @Controller instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class LoginControllerImpl {
   }
 
@@ -107,33 +107,33 @@ public class SpringComponentSpecializationCheckSample {
 
   // Case variations
 
-  @Component // Noncompliant {{Use @Service instead of @Component}}
+  @Component // Noncompliant {{Use @Service instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class userservice {
   }
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class USERREPOSITORY {
   }
 
-  @Component // Noncompliant {{Use @Controller instead of @Component}}
+  @Component // Noncompliant {{Use @Controller instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class maincontroller {
   }
 
-  @Component // Noncompliant {{Use @RestController instead of @Component}}
+  @Component // Noncompliant {{Use @RestController instead of @Component, or rename this type if the @Component annotation is intentional}}
   public class apirestcontroller {
   }
 
   // Interface patterns
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public interface UserRepository {
   }
 
-  @Component // Noncompliant {{Use @Service instead of @Component}}
+  @Component // Noncompliant {{Use @Service instead of @Component, or rename this type if the @Component annotation is intentional}}
   public interface PaymentService {
   }
 
-  @Component // Noncompliant {{Use @Repository instead of @Component}}
+  @Component // Noncompliant {{Use @Repository instead of @Component, or rename this type if the @Component annotation is intentional}}
   public interface ProductDao {
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
@@ -31,7 +31,7 @@ public class SpringComponentSpecializationCheck extends IssuableSubscriptionVisi
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return List.of(Tree.Kind.CLASS);
+    return List.of(Tree.Kind.CLASS, Tree.Kind.INTERFACE);
   }
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
@@ -50,7 +50,7 @@ public class SpringComponentSpecializationCheck extends IssuableSubscriptionVisi
     String suggestedAnnotation = getSuggestedAnnotation(className);
 
     if (suggestedAnnotation != null) {
-      reportIssue(componentAnnotation.get(), String.format("Use @%s instead of @Component", suggestedAnnotation));
+      reportIssue(componentAnnotation.get(), String.format("Use @%s instead of @Component, or rename this type if the @Component annotation is intentional", suggestedAnnotation));
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
@@ -17,6 +17,7 @@
 package org.sonar.java.checks.spring;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import javax.annotation.CheckForNull;
 import org.sonar.check.Rule;
@@ -88,6 +89,6 @@ public class SpringComponentSpecializationCheck extends IssuableSubscriptionVisi
   }
 
   private static boolean containsIgnoreCase(String str, String substring) {
-    return str.toLowerCase().contains(substring.toLowerCase());
+    return str.toLowerCase(Locale.ROOT).contains(substring.toLowerCase(Locale.ROOT));
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
@@ -1,0 +1,93 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.spring;
+
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.CheckForNull;
+import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.SpringUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S5673")
+public class SpringComponentSpecializationCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    var classTree = (ClassTree) tree;
+
+    Optional<AnnotationTree> componentAnnotation = classTree.modifiers().annotations().stream()
+      .filter(a -> SpringUtils.COMPONENT_ANNOTATION.equals(a.annotationType().symbolType().fullyQualifiedName()))
+      .findFirst();
+
+    if (componentAnnotation.isEmpty()) {
+      return;
+    }
+
+    String className = classTree.simpleName().name();
+    String suggestedAnnotation = getSuggestedAnnotation(className);
+
+    if (suggestedAnnotation != null) {
+      reportIssue(componentAnnotation.get(), String.format("Use @%s instead of @Component", suggestedAnnotation));
+    }
+  }
+
+  @CheckForNull
+  private static String getSuggestedAnnotation(String className) {
+    // Check RestController first to avoid false matches with Controller
+    if (endsWithIgnoreCase(className, "RestController") || endsWithIgnoreCase(className, "RestControllerImpl")) {
+      return "RestController";
+    }
+
+    if (endsWithIgnoreCase(className, "Controller") || endsWithIgnoreCase(className, "ControllerImpl")) {
+      return "Controller";
+    }
+
+    if (endsWithIgnoreCase(className, "Service") ||
+        endsWithIgnoreCase(className, "ServiceImpl") ||
+        containsIgnoreCase(className, "ServiceFacade")) {
+      return "Service";
+    }
+
+    if (endsWithIgnoreCase(className, "Repository") ||
+        endsWithIgnoreCase(className, "RepositoryImpl") ||
+        endsWithIgnoreCase(className, "Dao")) {
+      return "Repository";
+    }
+
+    return null;
+  }
+
+  private static boolean endsWithIgnoreCase(String str, String suffix) {
+    if (str.length() < suffix.length()) {
+      return false;
+    }
+    return str.substring(str.length() - suffix.length()).equalsIgnoreCase(suffix);
+  }
+
+  private static boolean containsIgnoreCase(String str, String substring) {
+    return str.toLowerCase().contains(substring.toLowerCase());
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheck.java
@@ -17,7 +17,6 @@
 package org.sonar.java.checks.spring;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import javax.annotation.CheckForNull;
 import org.sonar.check.Rule;
@@ -68,7 +67,7 @@ public class SpringComponentSpecializationCheck extends IssuableSubscriptionVisi
 
     if (endsWithIgnoreCase(className, "Service") ||
         endsWithIgnoreCase(className, "ServiceImpl") ||
-        containsIgnoreCase(className, "ServiceFacade")) {
+        endsWithIgnoreCase(className, "ServiceFacade")) {
       return "Service";
     }
 
@@ -88,7 +87,4 @@ public class SpringComponentSpecializationCheck extends IssuableSubscriptionVisi
     return str.substring(str.length() - suffix.length()).equalsIgnoreCase(suffix);
   }
 
-  private static boolean containsIgnoreCase(String str, String substring) {
-    return str.toLowerCase(Locale.ROOT).contains(substring.toLowerCase(Locale.ROOT));
-  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/SpringComponentSpecializationCheckTest.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.spring;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class SpringComponentSpecializationCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/SpringComponentSpecializationCheckSample.java"))
+      .withCheck(new SpringComponentSpecializationCheck())
+      .verifyIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5673.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5673.html
@@ -1,0 +1,45 @@
+<p>The Spring Framework provides several specializations of the generic <code>@Component</code> stereotype annotation which better express the programmer's intent. Using them should be preferred.</p>
+<h2>Why is this an issue?</h2>
+<p>Spring provides specialized stereotype annotations (<code>@Service</code>, <code>@Repository</code>, <code>@Controller</code>, and <code>@RestController</code>) that make code more expressive and provide additional semantics. When a class name suggests it should use one of these specialized annotations but uses <code>@Component</code> instead, it reduces code clarity.</p>
+<h2>How to fix it</h2>
+<p>Replace <code>@Component</code> with the appropriate specialized annotation based on the class's role in the application.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@Component // Noncompliant
+public class CustomerServiceImpl {
+  // ...
+}
+
+@Component // Noncompliant
+public class ProductRepository {
+    // ...
+}
+
+@Component // Noncompliant
+public class FooBarRestController {
+    // ...
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@Service // Compliant
+public class CustomerServiceImpl {
+  // ...
+}
+
+@Repository // Compliant
+public class ProductRepository {
+    // ...
+}
+
+@RestController // Compliant
+public class FooBarRestController {
+    // ...
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li><a href="https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/core.html#beans-stereotype-annotations">Spring documentation - @Component and Further Stereotype Annotations</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5673.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5673.json
@@ -1,0 +1,23 @@
+{
+  "title": "Spring components should use specialized annotations",
+  "type": "CODE_SMELL",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW"
+    },
+    "attribute": "CLEAR"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    "spring"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-5673",
+  "sqKey": "S5673",
+  "scope": "All",
+  "quickfix": "unknown"
+}


### PR DESCRIPTION
This rule detects classes and interfaces annotated with `@Component` whose names suggest they should use specialized Spring stereotype annotations (`@Service`, `@Repository`, `@Controller`, or `@RestController`) instead.

The rule also covers interfaces, which is relevant for Spring Data repository interfaces — where Spring generates the implementation at runtime, but `@Repository` is still the appropriate stereotype.