### PR TITLE
SONARJAVA-6523 Don't raise S2092 on Cookie subtype self-instantiation

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
@@ -199,6 +199,12 @@ class SecureCookieCheckSampleB extends Cookie {
     setSecure(true);
     return; // code coverage
   }
+  public Object clone() {
+    return new SecureCookieCheckSampleB("name", "value"); // self-instantiation, compliant
+  }
+  Cookie cloneDifferentType() {
+    return new Cookie("name", "value"); // Noncompliant
+  }
   Date codeCoverage(Cookie cookie) {
     SecureCookieCheckSample a = new SecureCookieCheckSample();
     a.foo(cookie);

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -16,7 +16,9 @@
  */
 package org.sonar.java.checks.security;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -32,6 +34,7 @@ import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.Arguments;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
@@ -113,6 +116,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
 
   private final Map<Symbol.VariableSymbol, NewClassTree> unsecuredCookies = new HashMap<>();
   private final Set<NewClassTree> cookieConstructors = new HashSet<>();
+  private final Deque<Symbol.TypeSymbol> enclosingClass = new ArrayDeque<>();
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -120,13 +124,15 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       Tree.Kind.VARIABLE,
       Tree.Kind.ASSIGNMENT,
       Tree.Kind.METHOD_INVOCATION,
-      Tree.Kind.NEW_CLASS);
+      Tree.Kind.NEW_CLASS,
+      Tree.Kind.CLASS);
   }
 
   @Override
   public void setContext(JavaFileScannerContext context) {
     unsecuredCookies.clear();
     cookieConstructors.clear();
+    enclosingClass.clear();
     super.setContext(context);
   }
 
@@ -143,8 +149,17 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       addToUnsecuredCookies((AssignmentExpressionTree) tree);
     } else if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
       checkSecureCall((MethodInvocationTree) tree);
+    } else if (tree.is(Tree.Kind.CLASS)) {
+      enclosingClass.push(((ClassTree) tree).symbol());
     } else {
       checkConstructor((NewClassTree) tree);
+    }
+  }
+
+  @Override
+  public void leaveNode(Tree tree) {
+    if (tree.is(Tree.Kind.CLASS)) {
+      enclosingClass.pop();
     }
   }
 
@@ -190,9 +205,14 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   }
 
   private void checkConstructor(NewClassTree tree) {
-    if (isCookieClass(tree.symbolType()) && isSecureParamFalse(tree)) {
+    if (isCookieClass(tree.symbolType()) && isSecureParamFalse(tree) && !isSelfInstantiation(tree)) {
       cookieConstructors.add(tree);
     }
+  }
+
+  private boolean isSelfInstantiation(NewClassTree tree) {
+    Symbol.TypeSymbol enclosing = enclosingClass.peek();
+    return enclosing != null && !tree.symbolType().isUnknown() && tree.symbolType().equals(enclosing.type());
   }
 
   private static boolean isSecureParamFalse(NewClassTree newClassTree) {


### PR DESCRIPTION
## Problem

`S2092` (`SecureCookieCheck`) flags cookie construction that lacks an explicit `secure` flag. It has a high false-positive rate on bridge/wrapper classes: a `Cookie` subtype that instantiates itself inside one of its own methods (typically `clone()`) purely to delegate cookie behavior — including `setSecure` — to an inner wrapped cookie. The rule fires on that self-instantiation as if it were a "naked" `new Cookie(...)`, even though the secure flag is actually managed by the delegate cookie, not by this constructor call.

[SONARJAVA-6523](https://sonarsource.atlassian.net/browse/SONARJAVA-6523)

## Approach

Guiding principle: favor fewer false positives — the new suppression must fail safe, i.e. if either the instantiated type or the enclosing class's type can't be resolved, don't suppress (preserve prior reporting behavior).

| Question | Decision |
|---|---|
| How to detect self-instantiation? | Track the lexically enclosing class via a `Deque<Symbol.TypeSymbol>`, pushed/popped on `Tree.Kind.CLASS` (mirrors the existing pattern in `DebugFeatureEnabledCheck` in the same package). In `checkConstructor`, skip adding to `cookieConstructors` when the `NewClassTree`'s resolved type equals the enclosing class's type. |
| FQN string comparison or `Type.equals(Type)`? | `Type.equals(Type)` — matches the existing idiom used elsewhere in this codebase (e.g. `SingletonUsageCheck`) for comparing two resolved types, and avoids unnecessary string materialization. |
| Does `isSelfInstantiation` also need to check that the enclosing class is itself a tracked Cookie subtype? | No — redundant. `checkConstructor` already gates on `isCookieClass(tree.symbolType())`; if the instantiated type equals the enclosing class's type, the enclosing class is necessarily that same cookie subtype too. |
| Risk: `Type.UNKNOWN` is a shared singleton with default (reference) `equals()`, so two unrelated unresolved types would compare as "equal" | Added an explicit `!tree.symbolType().isUnknown()` guard so unresolved types never trigger suppression. This directly encodes the fail-safe requirement rather than relying on the upstream `isCookieClass` gate as an implicit (and less obvious) invariant. |
| Scope: should sibling Cookie subtypes (not the enclosing class) also be suppressed? | No — out of scope per the ticket. `Type.equals()` (exact type identity), not `isSubtypeOf()`, so a different Cookie subtype instantiated inside another Cookie subtype still raises. |

## Implementation

`SecureCookieCheck.java`: added `Tree.Kind.CLASS` to `nodesToVisit()`, a `Deque<Symbol.TypeSymbol> enclosingClass` field maintained via `visitNode`/`leaveNode`, and a new `isSelfInstantiation` guard in `checkConstructor`. No new abstractions or dependencies beyond what's needed.

## Tests

Extended the existing `SecureCookieCheckSampleB` class (already `extends Cookie` with a matching constructor) in `SecureCookieCheckSample.java`:
- A `clone()`-style method returning `new SecureCookieCheckSampleB(...)` — self-instantiation, compliant (no issue).
- A sibling method returning `new Cookie(...)` from within the same class — different type than the enclosing class, still `// Noncompliant` (pins the out-of-scope carve-out).

## Test plan

- [x] `mvn -pl java-checks test -Dtest="SecureCookieCheckTest#test,SecureCookieCheckTest#test_jakarta,SecureCookieCheckTest#test_non_compiling"` — all pass
- [x] Confirmed `SecureCookieCheckTest#test_with_spring_3_2` fails identically on unmodified `master` (pre-existing, unrelated to this change)
- [x] Ran the full `org.sonar.java.checks.security.*Test` suite on both `master` and this branch — identical set of 14 pre-existing unrelated failures (Android/WebView checks) on both; no new regressions introduced

[SONARJAVA-6523]: https://sonarsource.atlassian.net/browse/SONARJAVA-6523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ