### PR TITLE
SONARJAVA-6605 Implement S9017: Mockito stubbing chains should be complete

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S1481.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S1481.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S1481",
   "hasTruePositives": true,
-  "falseNegatives": 8,
+  "falseNegatives": 9,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2699",
   "hasTruePositives": true,
-  "falseNegatives": 170,
+  "falseNegatives": 171,
   "falsePositives": 1
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2699.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2699",
   "hasTruePositives": true,
-  "falseNegatives": 164,
+  "falseNegatives": 170,
   "falsePositives": 1
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S3577.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S3577.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S3577",
   "hasTruePositives": true,
-  "falseNegatives": 49,
+  "falseNegatives": 50,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S5778.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S5778.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S5778",
   "hasTruePositives": false,
-  "falseNegatives": 44,
+  "falseNegatives": 46,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9017.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9017.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S9017",
   "hasTruePositives": false,
-  "falseNegatives": 7,
+  "falseNegatives": 8,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9017.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9017.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9017",
+  "hasTruePositives": false,
+  "falseNegatives": 7,
+  "falsePositives": 0
+}

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStubbingChainCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStubbingChainCheckSample.java
@@ -51,7 +51,8 @@ class MockitoStubbingChainCheckSample {
   @Test
   void incompleteDoChainMissingMethodCall() {
     UserRepository repo = mock(UserRepository.class);
-    doThrow(new RuntimeException()).when(repo); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}}
+    doThrow(new RuntimeException()).when(repo); // Noncompliant {{Complete this stubbing by adding the method to stub.}}
+  //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   }
 
   @Test
@@ -67,8 +68,32 @@ class MockitoStubbingChainCheckSample {
   @Test
   void whenStoredInVariable() {
     UserRepository repo = mock(UserRepository.class);
-    OngoingStubbing<User> stub = when(repo.findUser(42)); // Compliant - variable assignment skipped
+    OngoingStubbing<User> stub = when(repo.findUser(42)); // Compliant - variable declaration skipped
     stub.thenReturn(new User("Alice"));
+  }
+
+  @Test
+  void whenStoredViaAssignment() {
+    UserRepository repo = mock(UserRepository.class);
+    OngoingStubbing<User> stub;
+    stub = when(repo.findUser(42)); // Compliant - assignment expression skipped
+    stub.thenReturn(new User("Alice"));
+  }
+
+  @Test
+  void incompleteWhenInsideLambda() {
+    UserRepository repo = mock(UserRepository.class);
+    org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+      when(repo.findUser(1)); // Noncompliant {{Complete this stubbing by adding "thenReturn()", "thenThrow()", "thenAnswer()", or "thenCallRealMethod()".}}
+    });
+  }
+
+  @Test
+  void completeWhenInsideLambda() {
+    UserRepository repo = mock(UserRepository.class);
+    org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class, () -> {
+      when(repo.findUser(1)).thenReturn(new User("Alice")); // Compliant
+    });
   }
 
   OngoingStubbing<User> helperMethod(UserRepository repo) {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStubbingChainCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStubbingChainCheckSample.java
@@ -1,0 +1,78 @@
+package checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.OngoingStubbing;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MockitoStubbingChainCheckSample {
+
+  interface UserRepository {
+    User findUser(long id);
+    void deleteUser(long id);
+    User saveUser(User user);
+  }
+
+  record User(String name) {}
+
+  @Test
+  void incompleteWhen() {
+    UserRepository repo = mock(UserRepository.class);
+    when(repo.findUser(42)); // Noncompliant {{Complete this stubbing by adding "thenReturn()", "thenThrow()", "thenAnswer()", or "thenCallRealMethod()".}}
+  //^^^^^^^^^^^^^^^^^^^^^^^
+  }
+
+  @Test
+  void completeWhen() {
+    UserRepository repo = mock(UserRepository.class);
+    when(repo.findUser(42)).thenReturn(new User("Alice")); // Compliant
+    when(repo.findUser(43)).thenThrow(new RuntimeException()); // Compliant
+    when(repo.findUser(44)).thenAnswer(inv -> new User("Bob")); // Compliant
+    when(repo.findUser(45)).thenCallRealMethod(); // Compliant
+  }
+
+  @Test
+  void incompleteDoMethods() {
+    UserRepository repo = mock(UserRepository.class);
+    doReturn(new User("Alice")); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}}
+  //^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    doThrow(new RuntimeException()); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}} [[sc=5;ec=36]]
+    doAnswer(inv -> null); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}}
+    doNothing(); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}}
+    doCallRealMethod(); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}}
+  }
+
+  @Test
+  void incompleteDoChainMissingMethodCall() {
+    UserRepository repo = mock(UserRepository.class);
+    doThrow(new RuntimeException()).when(repo); // Noncompliant {{Complete this stubbing by adding ".when(mock).method()".}}
+  }
+
+  @Test
+  void completeDoMethods() {
+    UserRepository repo = mock(UserRepository.class);
+    doReturn(new User("Alice")).when(repo).findUser(42); // Compliant
+    doThrow(new RuntimeException()).when(repo).deleteUser(99); // Compliant
+    doAnswer(inv -> new User("Bob")).when(repo).saveUser(new User("Bob")); // Compliant
+    doNothing().when(repo).deleteUser(1); // Compliant
+    doCallRealMethod().when(repo).findUser(1); // Compliant
+  }
+
+  @Test
+  void whenStoredInVariable() {
+    UserRepository repo = mock(UserRepository.class);
+    OngoingStubbing<User> stub = when(repo.findUser(42)); // Compliant - variable assignment skipped
+    stub.thenReturn(new User("Alice"));
+  }
+
+  OngoingStubbing<User> helperMethod(UserRepository repo) {
+    return when(repo.findUser(42)); // Compliant - return statement skipped
+  }
+}
+

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
@@ -95,7 +95,7 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
   }
 
   private void visitMethodInvocation(MethodInvocationTree mit, boolean isChained) {
-    if (!isChained && isIncompleteStubbing(mit, isChained)) {
+    if (!isChained && isIncompleteStubbing(mit)) {
       return;
     }
     if (mit.methodSelect() instanceof MemberSelectExpressionTree mset
@@ -104,10 +104,7 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
     }
   }
 
-  private boolean isIncompleteStubbing(MethodInvocationTree mit, boolean isChained) {
-    if (isChained) {
-      return false;
-    }
+  private boolean isIncompleteStubbing(MethodInvocationTree mit) {
     if (MOCKITO_WHEN.matches(mit)) {
       context.reportIssue(this, mit, WHEN_MESSAGE);
       return true;

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
@@ -1,0 +1,101 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.ReturnStatementTree;
+import org.sonar.plugins.java.api.tree.VariableTree;
+
+@Rule(key = "S9017")
+public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFileScanner {
+
+  private static final String WHEN_MESSAGE = "Complete this stubbing by adding \"thenReturn()\", \"thenThrow()\", \"thenAnswer()\", or \"thenCallRealMethod()\".";
+  private static final String DO_MESSAGE = "Complete this stubbing by adding \".when(mock).method()\".";
+
+  private static final MethodMatchers MOCKITO_WHEN = MethodMatchers.create()
+    .ofTypes("org.mockito.Mockito")
+    .names("when")
+    .withAnyParameters()
+    .build();
+
+  private static final MethodMatchers MOCKITO_DO_METHODS = MethodMatchers.create()
+    .ofTypes("org.mockito.Mockito")
+    .names("doReturn", "doThrow", "doAnswer", "doNothing", "doCallRealMethod")
+    .withAnyParameters()
+    .build();
+
+  // Detects do*().when(mock) that is not followed by a method call on the mock
+  private static final MethodMatchers STUBBER_WHEN = MethodMatchers.create()
+    .ofSubTypes("org.mockito.stubbing.Stubber")
+    .names("when")
+    .withAnyParameters()
+    .build();
+
+  private Boolean isChained = null;
+  private JavaFileScannerContext context;
+
+  @Override
+  public void scanFile(JavaFileScannerContext context) {
+    if (context.getSemanticModel() == null) {
+      return;
+    }
+    this.context = context;
+    scan(context.getTree());
+  }
+
+  @Override
+  public void visitVariable(VariableTree tree) {
+    // skip: the stub may be stored in a variable and completed later
+  }
+
+  @Override
+  public void visitReturnStatement(ReturnStatementTree tree) {
+    // skip: returning a partial stub is valid (e.g. helper methods)
+  }
+
+  @Override
+  public void visitMethodInvocation(MethodInvocationTree mit) {
+    if (isIncompleteStubbing(mit)) {
+      return;
+    }
+    Boolean previous = isChained;
+    isChained = true;
+    scan(mit.methodSelect());
+    // arguments are intentionally not scanned
+    isChained = previous;
+  }
+
+  private boolean isIncompleteStubbing(MethodInvocationTree mit) {
+    if (Boolean.TRUE.equals(isChained)) {
+      return false;
+    }
+    if (MOCKITO_WHEN.matches(mit)) {
+      context.reportIssue(this, mit, WHEN_MESSAGE);
+      return true;
+    }
+    if (MOCKITO_DO_METHODS.matches(mit) || STUBBER_WHEN.matches(mit)) {
+      context.reportIssue(this, mit, DO_MESSAGE);
+      return true;
+    }
+    return false;
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
@@ -22,10 +22,12 @@ import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.ReturnStatementTree;
-import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9017")
@@ -54,7 +56,6 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
     .withAnyParameters()
     .build();
 
-  private Boolean isChained = null;
   private JavaFileScannerContext context;
 
   @Override
@@ -83,25 +84,28 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
 
   @Override
   public void visitMethodInvocation(MethodInvocationTree mit) {
-    if (isIncompleteStubbing(mit)) {
-      return;
-    }
-    Boolean previous = isChained;
-    isChained = true;
-    scan(mit.methodSelect());
-    // Scan lambda/anonymous-class arguments as independent chains (reset isChained so
-    // incomplete stubs inside their bodies are detected, but they are not part of this chain)
-    isChained = null;
+    visitMethodInvocation(mit, false);
+    // also check stubs inside block-bodied lambda arguments (e.g. assertThrows(() -> { when(...); }))
     for (ExpressionTree arg : mit.arguments()) {
-      if (arg.is(Tree.Kind.LAMBDA_EXPRESSION, Tree.Kind.NEW_CLASS)) {
-        scan(arg);
+      if (arg instanceof LambdaExpressionTree lambda
+        && lambda.body() instanceof BlockTree block) {
+        visitBlock(block);
       }
     }
-    isChained = previous;
   }
 
-  private boolean isIncompleteStubbing(MethodInvocationTree mit) {
-    if (Boolean.TRUE.equals(isChained)) {
+  private void visitMethodInvocation(MethodInvocationTree mit, boolean isChained) {
+    if (!isChained && isIncompleteStubbing(mit, isChained)) {
+      return;
+    }
+    if (mit.methodSelect() instanceof MemberSelectExpressionTree mset
+      && mset.expression() instanceof MethodInvocationTree innerMit) {
+      visitMethodInvocation(innerMit, true);
+    }
+  }
+
+  private boolean isIncompleteStubbing(MethodInvocationTree mit, boolean isChained) {
+    if (isChained) {
       return false;
     }
     if (MOCKITO_WHEN.matches(mit)) {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStubbingChainCheck.java
@@ -20,9 +20,12 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.ReturnStatementTree;
+import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9017")
@@ -30,6 +33,7 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
 
   private static final String WHEN_MESSAGE = "Complete this stubbing by adding \"thenReturn()\", \"thenThrow()\", \"thenAnswer()\", or \"thenCallRealMethod()\".";
   private static final String DO_MESSAGE = "Complete this stubbing by adding \".when(mock).method()\".";
+  private static final String STUBBER_WHEN_MESSAGE = "Complete this stubbing by adding the method to stub.";
 
   private static final MethodMatchers MOCKITO_WHEN = MethodMatchers.create()
     .ofTypes("org.mockito.Mockito")
@@ -68,6 +72,11 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
   }
 
   @Override
+  public void visitAssignmentExpression(AssignmentExpressionTree tree) {
+    // skip: the stub may be stored in a pre-declared variable and completed later
+  }
+
+  @Override
   public void visitReturnStatement(ReturnStatementTree tree) {
     // skip: returning a partial stub is valid (e.g. helper methods)
   }
@@ -80,7 +89,14 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
     Boolean previous = isChained;
     isChained = true;
     scan(mit.methodSelect());
-    // arguments are intentionally not scanned
+    // Scan lambda/anonymous-class arguments as independent chains (reset isChained so
+    // incomplete stubs inside their bodies are detected, but they are not part of this chain)
+    isChained = null;
+    for (ExpressionTree arg : mit.arguments()) {
+      if (arg.is(Tree.Kind.LAMBDA_EXPRESSION, Tree.Kind.NEW_CLASS)) {
+        scan(arg);
+      }
+    }
     isChained = previous;
   }
 
@@ -92,8 +108,12 @@ public class MockitoStubbingChainCheck extends BaseTreeVisitor implements JavaFi
       context.reportIssue(this, mit, WHEN_MESSAGE);
       return true;
     }
-    if (MOCKITO_DO_METHODS.matches(mit) || STUBBER_WHEN.matches(mit)) {
+    if (MOCKITO_DO_METHODS.matches(mit)) {
       context.reportIssue(this, mit, DO_MESSAGE);
+      return true;
+    }
+    if (STUBBER_WHEN.matches(mit)) {
+      context.reportIssue(this, mit, STUBBER_WHEN_MESSAGE);
       return true;
     }
     return false;

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoStubbingChainCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoStubbingChainCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
+
+class MockitoStubbingChainCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/MockitoStubbingChainCheckSample.java"))
+      .withCheck(new MockitoStubbingChainCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void testWithoutSemantics() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/MockitoStubbingChainCheckSample.java"))
+      .withCheck(new MockitoStubbingChainCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.html
@@ -1,0 +1,96 @@
+<p>This rule raises an issue when test mock stubbing is syntactically incomplete:</p>
+<ul>
+  <li>A method that begins configuring a mock’s behavior by specifying which method call to intercept is not followed by a specification of what value
+  to return, what exception to throw, what custom logic to execute, or whether to call the real implementation</li>
+  <li>A method that specifies what action to take (return a value, throw an exception, execute custom logic, do nothing, or call the real
+  implementation) is not followed by the specification of which mock object and method the action applies to</li>
+</ul>
+<p>In Mockito specifically, this means: a <code>when()</code> call must be followed by <code>thenReturn()</code>, <code>thenThrow()</code>,
+<code>thenAnswer()</code>, or <code>thenCallRealMethod()</code>; and a <code>doReturn()</code>, <code>doThrow()</code>, <code>doAnswer()</code>,
+<code>doNothing()</code>, or <code>doCallRealMethod()</code> call must be followed by <code>.when(mock).method()</code>.</p>
+<h2>Why is this an issue?</h2>
+<p>Test double frameworks allow you to configure behavior through chained API calls. These chains must be syntactically complete to take effect.</p>
+<p>When you write the first part of a stub configuration (specifying which method call to intercept) without completing the chain with a behavior
+specification (what value to return or action to take), the configuration is discarded. The method continues to return its default value (null for
+objects, 0 for numbers, false for booleans).</p>
+<p>Similarly, when you write the behavior specification first (what to return) without completing it with the method specification (which method to
+stub), the configured behavior is never attached to any method. It is silently dropped.</p>
+<p>Both patterns compile and run without errors in lenient testing frameworks. This makes them hard to spot during code review or testing. The test
+may pass because it never actually exercises the intended stub, or it may fail with a confusing error message that doesn’t point to the incomplete
+stubbing.</p>
+<p>The incomplete stub creates a gap between what you intended to test and what the test actually verifies. This undermines the reliability of your
+test suite.</p>
+<h3>What is the potential impact?</h3>
+<p>Incomplete mock object stubs can cause:</p>
+<ul>
+  <li><strong>False passes</strong>: Tests pass because they’re checking the wrong behavior (default return values from unconfigured mock methods
+  instead of your intended stub behavior)</li>
+  <li><strong>Misleading failures</strong>: Tests fail with null pointer exceptions or assertion errors that don’t indicate the real problem</li>
+  <li><strong>Maintenance burden</strong>: Developers waste time debugging test failures that stem from incomplete mock configurations rather than
+  actual code issues</li>
+  <li><strong>Reduced confidence</strong>: The test suite becomes less trustworthy when tests don’t verify what they appear to verify</li>
+</ul>
+<h2>How to fix it in Mockito</h2>
+<p>Complete the <code>when()</code> chain by adding a behavior method such as <code>thenReturn()</code>, <code>thenThrow()</code>,
+<code>thenAnswer()</code>, or <code>thenCallRealMethod()</code>.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@Test
+void testFindUser() {
+  UserRepository mock = mock(UserRepository.class);
+  when(mock.findUser(42)); // Noncompliant
+
+  User user = service.getUser(42);
+  assertNotNull(user); // Will fail - findUser returns null
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@Test
+void testFindUser() {
+  UserRepository mock = mock(UserRepository.class);
+  when(mock.findUser(42)).thenReturn(new User("Alice"));
+
+  User user = service.getUser(42);
+  assertNotNull(user); // Now passes correctly
+}
+</pre>
+<p>Complete the <code>do*()</code> chain by adding <code>.when(mock).method()</code> to specify which method should have the configured behavior.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+@Test
+void testDeleteUser() {
+  UserRepository mock = mock(UserRepository.class);
+  doThrow(new RuntimeException()); // Noncompliant
+
+  assertThrows(RuntimeException.class, () -&gt; {
+    service.deleteUser(42);
+  }); // Will fail - no exception is thrown
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+@Test
+void testDeleteUser() {
+  UserRepository mock = mock(UserRepository.class);
+  doThrow(new RuntimeException()).when(mock).deleteUser(42);
+
+  assertThrows(RuntimeException.class, () -&gt; {
+    service.deleteUser(42);
+  }); // Now passes correctly
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Mockito Documentation - <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#stubbing">Mockito framework
+  site - Stubbing</a></li>
+  <li>Mockito Documentation - <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#12">Mockito framework site -
+  Stubbing void methods</a></li>
+</ul>
+<h3>Related rules</h3>
+<ul>
+  <li>{rule:java:S2970} - Assertions should be complete - similar pattern of incomplete test code</li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.html
@@ -1,11 +1,5 @@
-<p>This rule raises an issue when test mock stubbing is syntactically incomplete:</p>
-<ul>
-  <li>A method that begins configuring a mock’s behavior by specifying which method call to intercept is not followed by a specification of what value
-  to return, what exception to throw, what custom logic to execute, or whether to call the real implementation</li>
-  <li>A method that specifies what action to take (return a value, throw an exception, execute custom logic, do nothing, or call the real
-  implementation) is not followed by the specification of which mock object and method the action applies to</li>
-</ul>
-<p>In Mockito specifically, this means: a <code>when()</code> call must be followed by <code>thenReturn()</code>, <code>thenThrow()</code>,
+<p>This rule raises an issue when test mock stubbing is syntactically incomplete.</p>
+<p>In Mockito, this means: a <code>when()</code> call must be followed by <code>thenReturn()</code>, <code>thenThrow()</code>,
 <code>thenAnswer()</code>, or <code>thenCallRealMethod()</code>; and a <code>doReturn()</code>, <code>doThrow()</code>, <code>doAnswer()</code>,
 <code>doNothing()</code>, or <code>doCallRealMethod()</code> call must be followed by <code>.when(mock).method()</code>.</p>
 <h2>Why is this an issue?</h2>
@@ -84,10 +78,14 @@ void testDeleteUser() {
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
-  <li>Mockito Documentation - <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#stubbing">Mockito framework
-  site - Stubbing</a></li>
-  <li>Mockito Documentation - <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#12">Mockito framework site -
-  Stubbing void methods</a></li>
+  <li>Mockito Documentation - <a
+  href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/stubbing/OngoingStubbing.html">Interface
+  OngoingStubbing&lt;T&gt;</a></li>
+  <li>Mockito Documentation - <a
+  href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/stubbing/BaseStubber.html#doReturn(java.lang.Object)">Interface
+  BaseStubber</a></li>
+  <li>Mockito FAQ - <a href="https://github.com/mockito/mockito/wiki/FAQ#what-are-unfinished-verificationstubbing-errors">What are unfinished
+  verification/stubbing errors?</a></li>
 </ul>
 <h3>Related rules</h3>
 <ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.json
@@ -1,0 +1,26 @@
+{
+  "title": "Mockito stubbing chains should be completed",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "mockito",
+    "tests",
+    "junit"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9017",
+  "sqKey": "S9017",
+  "scope": "Tests",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH",
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "COMPLETE"
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9017.json
@@ -1,5 +1,5 @@
 {
-  "title": "Mockito stubbing chains should be completed",
+  "title": "Mockito stubbing chains should be complete",
   "type": "BUG",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **New rule implementation:**
  - Implemented `S9017` to detect incomplete Mockito stubbing chains using `when()` or `do*()` methods.
  - Added rule metadata, documentation, and comprehensive test cases in `MockitoStubbingChainCheckSample.java`.

<sub>This will update automatically on new commits.</sub>