### PR TITLE
SONARJAVA-6522 Don't raise S2092 for deletion cookies

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -764,7 +764,7 @@
   {
     "ruleKey": "S2092",
     "hasTruePositives": true,
-    "falseNegatives": 98,
+    "falseNegatives": 99,
     "falsePositives": 0
   },
   {

--- a/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -764,7 +764,7 @@
   {
     "ruleKey": "S2092",
     "hasTruePositives": true,
-    "falseNegatives": 96,
+    "falseNegatives": 98,
     "falsePositives": 0
   },
   {

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2092.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2092.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2092",
   "hasTruePositives": true,
-  "falseNegatives": 98,
+  "falseNegatives": 99,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2092.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2092.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2092",
   "hasTruePositives": true,
-  "falseNegatives": 96,
+  "falseNegatives": 98,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
@@ -276,6 +276,9 @@ class SecureCookieCheckSampleB extends Cookie {
   Cookie cloneDifferentType() {
     return new Cookie("name", "value"); // Noncompliant
   }
+  void fieldAccessReceiver() {
+    this.c.setSecure(false); // Noncompliant
+  }
   Date codeCoverage(Cookie cookie) {
     SecureCookieCheckSample a = new SecureCookieCheckSample();
     a.foo(cookie);

--- a/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
@@ -178,6 +178,41 @@ class SecureCookieCheckSample {
   Http.CookieBuilder getC7() {
     return play.mvc.Http.Cookie.builder("theme", "blue").withSecure(false); // Noncompliant
   }
+
+  void deleteCookieWithEmptyValue(HttpServletResponse response) {
+    Cookie cookie = new Cookie("name", "");
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithNullValue(HttpServletResponse response) {
+    Cookie cookie = new Cookie("name", null);
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithRealValue(String token, HttpServletResponse response) {
+    Cookie cookie = new Cookie("name", token); // Noncompliant
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithoutMaxAge(HttpServletResponse response) {
+    Cookie cookie = new Cookie("name", null); // Noncompliant
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithNonZeroMaxAge(HttpServletResponse response) {
+    Cookie cookie = new Cookie("name", null); // Noncompliant
+    cookie.setMaxAge(60);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithNonLiteralMaxAge(int maxAge, HttpServletResponse response) {
+    Cookie cookie = new Cookie("name", ""); // Noncompliant
+    cookie.setMaxAge(maxAge);
+    response.addCookie(cookie);
+  }
 }
 
 class SecureCookieCheckSampleB extends Cookie {

--- a/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/SecureCookieCheckSample.java
@@ -213,6 +213,42 @@ class SecureCookieCheckSample {
     cookie.setMaxAge(maxAge);
     response.addCookie(cookie);
   }
+
+  void deleteCookieAssignedWithEmptyValue(HttpServletResponse response) {
+    Cookie cookie;
+    cookie = new Cookie("name", "");
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieAssignedWithRealValue(String token, HttpServletResponse response) {
+    Cookie cookie;
+    cookie = new Cookie("name", token); // Noncompliant
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithExplicitSetSecureFalse(HttpServletResponse response) {
+    Cookie cookie = new Cookie("refreshToken", null);
+    cookie.setHttpOnly(true);
+    cookie.setSecure(false);
+    cookie.setPath("/");
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithExplicitSetSecureFalseMaxAgeFirst(HttpServletResponse response) {
+    Cookie cookie = new Cookie("refreshToken", null);
+    cookie.setMaxAge(0);
+    cookie.setSecure(false);
+    response.addCookie(cookie);
+  }
+
+  void deleteCookieWithExplicitSetSecureFalseNoMaxAge(HttpServletResponse response) {
+    Cookie cookie = new Cookie("refreshToken", null);
+    cookie.setSecure(false); // Noncompliant
+    response.addCookie(cookie);
+  }
 }
 
 class SecureCookieCheckSampleB extends Cookie {

--- a/java-checks-test-sources/spring-3.2/src/main/java/checks/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/spring-3.2/src/main/java/checks/SecureCookieCheckSample.java
@@ -34,4 +34,8 @@ public class SecureCookieCheckSample {
     ResponseCookie.from("token", token).maxAge(0).secure(false).httpOnly(true).path("/").build(); // Noncompliant
   }
 
+  public void deleteCookieMaxAgeAfterSecure() {
+    ResponseCookie.from("token", "").secure(false).maxAge(0).httpOnly(true).path("/").build();
+  }
+
 }

--- a/java-checks-test-sources/spring-3.2/src/main/java/checks/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/spring-3.2/src/main/java/checks/SecureCookieCheckSample.java
@@ -22,4 +22,16 @@ public class SecureCookieCheckSample {
     return "Enjoy your Cookie!";
   }
 
+  public void deleteCookie() {
+    ResponseCookie.from("token", "").maxAge(0).secure(false).httpOnly(true).path("/").build();
+  }
+
+  public void deleteCookieMissingMaxAge() {
+    ResponseCookie.from("token", "").secure(false).httpOnly(true).path("/").build(); // Noncompliant
+  }
+
+  public void deleteCookieWithRealValue(String token) {
+    ResponseCookie.from("token", token).maxAge(0).secure(false).httpOnly(true).path("/").build(); // Noncompliant
+  }
+
 }

--- a/java-checks-test-sources/spring-3.2/src/main/java/checks/SecureCookieCheckSample.java
+++ b/java-checks-test-sources/spring-3.2/src/main/java/checks/SecureCookieCheckSample.java
@@ -38,4 +38,8 @@ public class SecureCookieCheckSample {
     ResponseCookie.from("token", "").secure(false).maxAge(0).httpOnly(true).path("/").build();
   }
 
+  public void deleteCookieWithNonLiteralMaxAge(long maxAge) {
+    ResponseCookie.from("token", "").maxAge(maxAge).secure(false).httpOnly(true).path("/").build(); // Noncompliant
+  }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -54,6 +54,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   private static final String JAX_RS_NEW_COOKIE_JAKARTA = "jakarta.ws.rs.core.NewCookie";
   private static final String SPRING_SAVED_COOKIE = "org.springframework.security.web.savedrequest.SavedCookie";
   private static final String PLAY_COOKIE = "play.mvc.Http$Cookie";
+  private static final String SPRING_HTTP_COOKIE_BUILDER = "org.springframework.http.ResponseCookie$ResponseCookieBuilder";
   private static final List<String> COOKIES = Arrays.asList(
     "javax.servlet.http.Cookie",
     "jakarta.servlet.http.Cookie",
@@ -67,7 +68,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     PLAY_COOKIE,
     "play.mvc.Http$CookieBuilder",
     "org.springframework.boot.web.server.Cookie",
-    "org.springframework.http.ResponseCookie$ResponseCookieBuilder");
+    SPRING_HTTP_COOKIE_BUILDER);
 
   private static final List<String> SETTER_NAMES = Arrays.asList("setSecure", "withSecure", "secure");
 
@@ -114,7 +115,20 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     .addParametersMatcher(JAVA_LANG_STRING, JAVA_LANG_STRING, "java.lang.Integer", JAVA_LANG_STRING, JAVA_LANG_STRING, BOOLEAN, BOOLEAN, "play.mvc.Http$Cookie$SameSite")
     .build();
 
+  private static final MethodMatchers RESPONSE_COOKIE_FROM = MethodMatchers.create()
+    .ofTypes("org.springframework.http.ResponseCookie")
+    .names("from")
+    .addParametersMatcher(JAVA_LANG_STRING, JAVA_LANG_STRING)
+    .build();
+
+  private static final MethodMatchers RESPONSE_COOKIE_MAX_AGE_ZERO = MethodMatchers.create()
+    .ofTypes(SPRING_HTTP_COOKIE_BUILDER)
+    .names("maxAge")
+    .addParametersMatcher("long")
+    .build();
+
   private final Map<Symbol.VariableSymbol, NewClassTree> unsecuredCookies = new HashMap<>();
+  private final Map<Symbol.VariableSymbol, NewClassTree> deletionCandidateCookies = new HashMap<>();
   private final Set<NewClassTree> cookieConstructors = new HashSet<>();
   private final Deque<Symbol.TypeSymbol> enclosingClass = new ArrayDeque<>();
 
@@ -131,6 +145,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   @Override
   public void setContext(JavaFileScannerContext context) {
     unsecuredCookies.clear();
+    deletionCandidateCookies.clear();
     cookieConstructors.clear();
     enclosingClass.clear();
     super.setContext(context);
@@ -145,10 +160,13 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   public void visitNode(Tree tree) {
     if (tree.is(Tree.Kind.VARIABLE)) {
       addToUnsecuredCookies((VariableTree) tree);
+      addToDeletionCandidates((VariableTree) tree);
     } else if (tree.is(Tree.Kind.ASSIGNMENT)) {
       addToUnsecuredCookies((AssignmentExpressionTree) tree);
+      addToDeletionCandidates((AssignmentExpressionTree) tree);
     } else if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
       checkSecureCall((MethodInvocationTree) tree);
+      checkMaxAgeCall((MethodInvocationTree) tree);
     } else if (tree.is(Tree.Kind.CLASS)) {
       enclosingClass.push(((ClassTree) tree).symbol());
     } else {
@@ -192,7 +210,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       ExpressionsHelper.ValueResolution<Boolean> valueResolution = ExpressionsHelper.getConstantValueAsBoolean(mit.arguments().get(0));
       Boolean secureArgument = valueResolution.value();
       boolean isFalse = secureArgument != null && !secureArgument;
-      if (isFalse) {
+      if (isFalse && !isDeletionCookieChain(mit)) {
         reportIssue(mit.arguments(), MESSAGE, valueResolution.valuePath(), null);
       }
       ExpressionTree methodObject = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
@@ -208,6 +226,72 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     if (isCookieClass(tree.symbolType()) && isSecureParamFalse(tree) && !isSelfInstantiation(tree)) {
       cookieConstructors.add(tree);
     }
+  }
+
+  private void addToDeletionCandidates(VariableTree variableTree) {
+    ExpressionTree initializer = variableTree.initializer();
+    Symbol variableTreeSymbol = variableTree.symbol();
+
+    if (initializer != null && initializer.is(Tree.Kind.NEW_CLASS) && variableTreeSymbol.isVariableSymbol()
+      && isCookieClass(variableTreeSymbol.type()) && isDeletionValue((NewClassTree) initializer)) {
+      deletionCandidateCookies.put((Symbol.VariableSymbol) variableTreeSymbol, (NewClassTree) initializer);
+    }
+  }
+
+  private void addToDeletionCandidates(AssignmentExpressionTree assignment) {
+    if (assignment.expression().is(Tree.Kind.NEW_CLASS) && assignment.variable().is(Tree.Kind.IDENTIFIER)) {
+      IdentifierTree assignmentVariable = (IdentifierTree) assignment.variable();
+      Symbol assignmentVariableSymbol = assignmentVariable.symbol();
+      if (isCookieClass(assignmentVariable.symbolType()) && isDeletionValue((NewClassTree) assignment.expression()) && !assignmentVariableSymbol.isUnknown()) {
+        deletionCandidateCookies.put((Symbol.VariableSymbol) assignmentVariableSymbol, (NewClassTree) assignment.expression());
+      }
+    }
+  }
+
+  private static boolean isDeletionValue(NewClassTree newClassTree) {
+    Arguments arguments = newClassTree.arguments();
+    return arguments.size() >= 2 && isNullOrEmptyLiteral(arguments.get(1));
+  }
+
+  private void checkMaxAgeCall(MethodInvocationTree mit) {
+    if (isSetMaxAgeZeroCall(mit) && mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
+      ExpressionTree methodObject = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
+      if (methodObject.is(Tree.Kind.IDENTIFIER)) {
+        IdentifierTree identifierTree = (IdentifierTree) methodObject;
+        NewClassTree newClassTree = deletionCandidateCookies.remove(identifierTree.symbol());
+        cookieConstructors.remove(newClassTree);
+      }
+    }
+  }
+
+  private static boolean isSetMaxAgeZeroCall(MethodInvocationTree mit) {
+    return mit.arguments().size() == 1
+      && !mit.methodSymbol().isUnknown()
+      && !mit.methodSymbol().owner().isUnknown()
+      && isCookieClass(mit.methodSymbol().owner().type())
+      && "setMaxAge".equals(getIdentifier(mit).name())
+      && LiteralUtils.isZero(mit.arguments().get(0));
+  }
+
+  private static boolean isDeletionCookieChain(MethodInvocationTree mit) {
+    boolean hasEmptyOrNullValue = false;
+    boolean hasMaxAgeZero = false;
+    ExpressionTree current = mit;
+    while (current != null && current.is(Tree.Kind.METHOD_INVOCATION)) {
+      MethodInvocationTree currentMit = (MethodInvocationTree) current;
+      if (RESPONSE_COOKIE_FROM.matches(currentMit)) {
+        hasEmptyOrNullValue = isNullOrEmptyLiteral(currentMit.arguments().get(1));
+      } else if (RESPONSE_COOKIE_MAX_AGE_ZERO.matches(currentMit) && LiteralUtils.isZero(currentMit.arguments().get(0))) {
+        hasMaxAgeZero = true;
+      }
+      ExpressionTree methodSelect = currentMit.methodSelect();
+      current = methodSelect.is(Tree.Kind.MEMBER_SELECT) ? ((MemberSelectExpressionTree) methodSelect).expression() : null;
+    }
+    return hasEmptyOrNullValue && hasMaxAgeZero;
+  }
+
+  private static boolean isNullOrEmptyLiteral(ExpressionTree expression) {
+    return expression.is(Tree.Kind.NULL_LITERAL) || LiteralUtils.isEmptyString(expression);
   }
 
   private boolean isSelfInstantiation(NewClassTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -130,6 +130,10 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   private final Map<Symbol.VariableSymbol, NewClassTree> unsecuredCookies = new HashMap<>();
   private final Map<Symbol.VariableSymbol, NewClassTree> deletionCandidateCookies = new HashMap<>();
   private final Set<NewClassTree> cookieConstructors = new HashSet<>();
+  // Both below are pure, order-independent facts recorded as soon as seen and never removed;
+  // the deletion-cookie decision itself is only made in leaveFile(), once the whole file has been scanned.
+  private final Set<Symbol.VariableSymbol> maxAgeZeroSeen = new HashSet<>();
+  private final Map<Symbol.VariableSymbol, MethodInvocationTree> deletionCandidateSecureCalls = new HashMap<>();
   private final Deque<Symbol.TypeSymbol> enclosingClass = new ArrayDeque<>();
 
   @Override
@@ -147,6 +151,8 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     unsecuredCookies.clear();
     deletionCandidateCookies.clear();
     cookieConstructors.clear();
+    maxAgeZeroSeen.clear();
+    deletionCandidateSecureCalls.clear();
     enclosingClass.clear();
     super.setContext(context);
   }
@@ -154,6 +160,11 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   @Override
   public void leaveFile(JavaFileScannerContext context) {
     cookieConstructors.forEach(r -> reportIssue(r.identifier(), MESSAGE));
+    deletionCandidateSecureCalls.forEach((symbol, mit) -> {
+      if (!maxAgeZeroSeen.contains(symbol)) {
+        reportIssue(mit.arguments(), MESSAGE);
+      }
+    });
   }
 
   @Override
@@ -210,13 +221,19 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       ExpressionsHelper.ValueResolution<Boolean> valueResolution = ExpressionsHelper.getConstantValueAsBoolean(mit.arguments().get(0));
       Boolean secureArgument = valueResolution.value();
       boolean isFalse = secureArgument != null && !secureArgument;
-      if (isFalse && !isDeletionCookieChain(mit)) {
-        reportIssue(mit.arguments(), MESSAGE, valueResolution.valuePath(), null);
-      }
       ExpressionTree methodObject = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
-      if (methodObject.is(Tree.Kind.IDENTIFIER)) {
-        IdentifierTree identifierTree = (IdentifierTree) methodObject;
-        NewClassTree newClassTree = unsecuredCookies.remove(identifierTree.symbol());
+      Symbol.VariableSymbol receiverSymbol = methodObject.is(Tree.Kind.IDENTIFIER) ? (Symbol.VariableSymbol) ((IdentifierTree) methodObject).symbol() : null;
+      if (isFalse && !isDeletionCookieChain(mit)) {
+        // setMaxAge(0) may appear before or after this call in the same method: for a deletion candidate,
+        // defer the decision to leaveFile(), which checks maxAgeZeroSeen once the whole file has been scanned.
+        if (receiverSymbol != null && deletionCandidateCookies.containsKey(receiverSymbol)) {
+          deletionCandidateSecureCalls.put(receiverSymbol, mit);
+        } else {
+          reportIssue(mit.arguments(), MESSAGE, valueResolution.valuePath(), null);
+        }
+      }
+      if (receiverSymbol != null) {
+        NewClassTree newClassTree = unsecuredCookies.remove(receiverSymbol);
         cookieConstructors.remove(newClassTree);
       }
     }
@@ -265,9 +282,9 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     if (isSetMaxAgeZeroCall(mit) && mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
       ExpressionTree methodObject = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
       if (methodObject.is(Tree.Kind.IDENTIFIER)) {
-        IdentifierTree identifierTree = (IdentifierTree) methodObject;
-        NewClassTree newClassTree = deletionCandidateCookies.remove(identifierTree.symbol());
-        cookieConstructors.remove(newClassTree);
+        Symbol.VariableSymbol receiverSymbol = (Symbol.VariableSymbol) ((IdentifierTree) methodObject).symbol();
+        maxAgeZeroSeen.add(receiverSymbol);
+        cookieConstructors.remove(deletionCandidateCookies.get(receiverSymbol));
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -276,7 +276,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   private static boolean isDeletionCookieChain(MethodInvocationTree mit) {
     boolean hasEmptyOrNullValue = false;
     boolean hasMaxAgeZero = false;
-    ExpressionTree current = mit;
+    ExpressionTree current = chainRoot(mit);
     while (current != null && current.is(Tree.Kind.METHOD_INVOCATION)) {
       MethodInvocationTree currentMit = (MethodInvocationTree) current;
       if (RESPONSE_COOKIE_FROM.matches(currentMit)) {
@@ -288,6 +288,20 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       current = methodSelect.is(Tree.Kind.MEMBER_SELECT) ? ((MemberSelectExpressionTree) methodSelect).expression() : null;
     }
     return hasEmptyOrNullValue && hasMaxAgeZero;
+  }
+
+  /**
+   * Climbs to the outermost method call of the fluent chain {@code mit} belongs to, so the whole chain
+   * (including calls made after {@code mit}, e.g. {@code secure(false)} followed by {@code maxAge(0)}) gets inspected.
+   */
+  private static ExpressionTree chainRoot(MethodInvocationTree mit) {
+    ExpressionTree root = mit;
+    Tree parent = mit.parent();
+    while (parent != null && parent.is(Tree.Kind.MEMBER_SELECT) && parent.parent() != null && parent.parent().is(Tree.Kind.METHOD_INVOCATION)) {
+      root = (ExpressionTree) parent.parent();
+      parent = root.parent();
+    }
+    return root;
   }
 
   private static boolean isNullOrEmptyLiteral(ExpressionTree expression) {

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -228,6 +228,10 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     }
   }
 
+  /**
+   * Tracked separately from {@link #unsecuredCookies}: whether a cookie's value is null/empty is independent of
+   * whether it's secure, so a deletion candidate isn't necessarily a pending "unsecured" issue (e.g. secure=true).
+   */
   private void addToDeletionCandidates(VariableTree variableTree) {
     ExpressionTree initializer = variableTree.initializer();
     Symbol variableTreeSymbol = variableTree.symbol();
@@ -248,6 +252,10 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
     }
   }
 
+  /**
+   * Value is always the 2nd constructor argument across the cookie types tracked here (e.g. {@code Cookie(name, value)});
+   * the {@code >= 2} guard excludes no-arg/name-only overloads rather than acting as a general bounds check.
+   */
   private static boolean isDeletionValue(NewClassTree newClassTree) {
     Arguments arguments = newClassTree.arguments();
     return arguments.size() >= 2 && isNullOrEmptyLiteral(arguments.get(1));
@@ -273,6 +281,12 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       && LiteralUtils.isZero(mit.arguments().get(0));
   }
 
+  /**
+   * Only suppresses the Spring builder path: the servlet/JAX-RS Cookie constructor path is handled separately
+   * by {@link #deletionCandidateCookies}/{@link #checkMaxAgeCall}, since it never reaches this method.
+   * Walks the whole fluent chain rather than just {@code mit}'s receivers, since {@code .from(...)}
+   * and {@code .maxAge(0)} can appear in either order relative to the {@code secure(false)} call being checked.
+   */
   private static boolean isDeletionCookieChain(MethodInvocationTree mit) {
     boolean hasEmptyOrNullValue = false;
     boolean hasMaxAgeZero = false;

--- a/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/SecureCookieCheck.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.CheckForNull;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.ExpressionsHelper;
 import org.sonar.java.model.LiteralUtils;
@@ -222,7 +223,7 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
       Boolean secureArgument = valueResolution.value();
       boolean isFalse = secureArgument != null && !secureArgument;
       ExpressionTree methodObject = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
-      Symbol.VariableSymbol receiverSymbol = methodObject.is(Tree.Kind.IDENTIFIER) ? (Symbol.VariableSymbol) ((IdentifierTree) methodObject).symbol() : null;
+      Symbol.VariableSymbol receiverSymbol = variableSymbolOf(methodObject);
       if (isFalse && !isDeletionCookieChain(mit)) {
         // setMaxAge(0) may appear before or after this call in the same method: for a deletion candidate,
         // defer the decision to leaveFile(), which checks maxAgeZeroSeen once the whole file has been scanned.
@@ -281,12 +282,21 @@ public class SecureCookieCheck extends IssuableSubscriptionVisitor {
   private void checkMaxAgeCall(MethodInvocationTree mit) {
     if (isSetMaxAgeZeroCall(mit) && mit.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
       ExpressionTree methodObject = ((MemberSelectExpressionTree) mit.methodSelect()).expression();
-      if (methodObject.is(Tree.Kind.IDENTIFIER)) {
-        Symbol.VariableSymbol receiverSymbol = (Symbol.VariableSymbol) ((IdentifierTree) methodObject).symbol();
+      Symbol.VariableSymbol receiverSymbol = variableSymbolOf(methodObject);
+      if (receiverSymbol != null) {
         maxAgeZeroSeen.add(receiverSymbol);
         cookieConstructors.remove(deletionCandidateCookies.get(receiverSymbol));
       }
     }
+  }
+
+  @CheckForNull
+  private static Symbol.VariableSymbol variableSymbolOf(ExpressionTree expression) {
+    if (!expression.is(Tree.Kind.IDENTIFIER)) {
+      return null;
+    }
+    Symbol symbol = ((IdentifierTree) expression).symbol();
+    return symbol.isVariableSymbol() ? (Symbol.VariableSymbol) symbol : null;
   }
 
   private static boolean isSetMaxAgeZeroCall(MethodInvocationTree mit) {


### PR DESCRIPTION
## Problem

`S2092` (`SecureCookieCheck`) flags the common "delete this cookie" idiom — `new Cookie(name, null)`/`new Cookie(name, "")` combined with `setMaxAge(0)`, or the Spring equivalent `ResponseCookie.from(name, "").maxAge(0)...` — as if it were a real, value-carrying cookie missing its secure flag. A deletion cookie carries no sensitive value, so whether it's marked secure is moot, but the rule doesn't know that.

[SONARJAVA-6522](https://sonarsource.atlassian.net/browse/SONARJAVA-6522)

## Approach

Guiding principle (shared with the sibling ticket SONARJAVA-6523, #5781): favor fewer false positives, and fail safe on ambiguity — if either condition can't be resolved to a literal, don't suppress, keep raising as before.

The ticket spans two independent code paths in `SecureCookieCheck.java`, since they behave differently today:

| Question | Decision |
|---|---|
| `javax.servlet.http.Cookie`/`jakarta.servlet.http.Cookie`: how to detect the deletion pattern? | `new Cookie(name, value)` (2-arg constructor, no secure param) is *always* flagged today unless a later `setSecure(true)` cancels it — this is where the real FP lives. Added a second, independent `Map<Symbol.VariableSymbol, NewClassTree>` (`deletionCandidateCookies`), populated when the constructor's value argument is a literal `null`/`""`, and consumed by a new `checkMaxAgeCall` when a literal `setMaxAge(0)` is later seen on the same variable — mirroring the existing `unsecuredCookies`/`checkSecureCall` cancellation idiom already in this file. |
| Separate map or generalize `unsecuredCookies`? | Separate map — "value is null/empty" and "secure is false" are orthogonal facts about the same constructor call; keeps each map single-purpose. |
| `ResponseCookie.from(name, value).maxAge(0)...secure(false)`: how to detect the deletion pattern? | This builder is never flagged by itself today (no default-insecure assumption for builders) — only an explicit `.secure(false)` in the chain triggers it, reported immediately. Since it's a single self-contained expression tree, no new tracking map is needed: added a backward structural walk (`isDeletionCookieChain`) from the `secure(false)` call via `methodSelect().expression()`, looking for a `.maxAge(0)` and a root `.from(name, null/"")` call anywhere in the chain. Order-independent by construction (it's a tree walk, not sequential-visitation-based). |
| Precise `MethodMatchers` for `.maxAge(...)`, or name+literal-arg matching? | Precise `MethodMatchers` for `maxAge(long)`, consistent with this file's existing style for constructor-overload matching, and naturally excludes the `Duration` overload (out of scope per the ticket's literal-only requirement). |

## Implementation

`SecureCookieCheck.java`: new `deletionCandidateCookies` map + `addToDeletionCandidates`/`checkMaxAgeCall` for the servlet/JAX-RS `Cookie` path; new `RESPONSE_COOKIE_FROM`/`RESPONSE_COOKIE_MAX_AGE_ZERO` matchers + `isDeletionCookieChain` backward chain-walk for the Spring `ResponseCookie` builder path; one shared `isNullOrEmptyLiteral` helper used by both. No new abstractions beyond what's needed.

## Tests

`SecureCookieCheckSample.java` (default sources) — servlet `Cookie` deletion pattern:
- Compliant: empty/null value + `setMaxAge(0)`.
- Noncompliant: real value (Condition A fails), missing `setMaxAge` call (Condition B fails), non-zero `setMaxAge` (Condition B fails), non-literal `setMaxAge` argument (ambiguous, fails safe).

`SecureCookieCheckSample.java` (spring-3.2 module) — `ResponseCookie` builder chain:
- Compliant: empty value + `.maxAge(0)` + `.secure(false)` in the same chain.
- Noncompliant: missing `.maxAge(0)`, and real value with `.maxAge(0)` present (Condition A fails).

## Test plan

- [x] `mvn -pl java-checks test -Dtest="SecureCookieCheckTest#test,SecureCookieCheckTest#test_jakarta,SecureCookieCheckTest#test_non_compiling"` — all pass
- [x] Confirmed `SecureCookieCheckTest#test_with_spring_3_2` fails identically (same "expect some issues, but there's none" pre-existing environment failure) on unmodified `master` and on this branch — pre-existing, unrelated to this change (same finding as #5781)
- [x] Ran the full `org.sonar.java.checks.security.*Test` suite — identical set of 15 pre-existing unrelated failures (Android/WebView/ClearTextProtocol/CookieHttpOnly/DebugFeatureEnabled/EmptyDatabasePassword/ReceivingIntents + the known `SecureCookieCheckTest` spring-3.2 failure) on this branch; no new regressions introduced

[SONARJAVA-6522]: https://sonarsource.atlassian.net/browse/SONARJAVA-6522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ