### PR TITLE
SONARJAVA-6509 Implement S9024: `@InjectMocks` should be preferred over manual initialization

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S8745.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S8745.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S8745",
   "hasTruePositives": true,
-  "falseNegatives": 2,
+  "falseNegatives": 3,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9024.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9024.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9024",
+  "hasTruePositives": false,
+  "falseNegatives": 8,
+  "falsePositives": 0
+}

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9024.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9024.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S9024",
   "hasTruePositives": false,
-  "falseNegatives": 8,
+  "falseNegatives": 12,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoInjectMocksShouldBeUsedSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoInjectMocksShouldBeUsedSample.java
@@ -1,0 +1,277 @@
+package checks.tests;
+
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+public class MockitoInjectMocksShouldBeUsedSample {
+
+  interface PaymentGateway {
+    void process();
+  }
+
+  interface InventoryService {
+    int getStock(String item);
+  }
+
+  static class OrderProcessor {
+    OrderProcessor(PaymentGateway gateway, InventoryService inventory) {}
+    OrderProcessor(PaymentGateway gateway) {}
+    OrderProcessor() {}
+    OrderProcessor(PaymentGateway gateway, String name) {}
+  }
+
+  // ===== JUnit 4 - @RunWith(MockitoJUnitRunner.class) =====
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class JUnit4NoncompliantBothMocks {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway, inventoryService); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class JUnit4NoncompliantSingleMock {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class JUnit4NoncompliantWithSpy {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Spy
+    private InventoryService inventoryService = null;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway, inventoryService); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class JUnit4NoncompliantWithThisPrefix {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      this.orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
+  public class JUnit4NoncompliantStrictStubs {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  // ===== JUnit 5 - @ExtendWith(MockitoExtension.class) =====
+
+  @ExtendWith(MockitoExtension.class)
+  class JUnit5NoncompliantBeforeEach {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway, inventoryService); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  // ===== openMocks / initMocks =====
+
+  class OpenMocksNoncompliant {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      MockitoAnnotations.openMocks(this);
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  class InitMocksNoncompliant {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      MockitoAnnotations.initMocks(this);
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  // ===== Compliant cases =====
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantAlreadyUsingInjectMocks {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    @org.mockito.InjectMocks
+    private OrderProcessor orderProcessor; // Compliant - uses @InjectMocks
+
+    @Before
+    public void setUp() {
+      // nothing to construct manually
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantNoMockArgs {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(); // Compliant - no args passed
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantMixedArgs {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway, "real-name"); // Compliant - not all args are mock fields
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantNewLocalVariable {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Before
+    public void setUp() {
+      OrderProcessor local = new OrderProcessor(paymentGateway); // Compliant - assigned to local variable, not a field
+    }
+  }
+
+  class CompliantNotMockitoManaged {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Compliant - class is not Mockito-managed
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantNoMockFields {
+    private PaymentGateway paymentGateway = new PaymentGateway() {
+      public void process() {}
+    };
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Compliant - paymentGateway is not a @Mock field
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantNotInSetupMethod {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @org.junit.Test
+    public void testSomething() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Compliant - not in a setup method
+    }
+  }
+
+  @RunWith(org.junit.runners.JUnit4.class)
+  public class CompliantNonMockitoRunner {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Compliant - not a Mockito runner
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantNoSetupMethod {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @org.junit.Test
+    public void test() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Compliant - not in a @Before method
+    }
+  }
+}

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoInjectMocksShouldBeUsedSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoInjectMocksShouldBeUsedSample.java
@@ -29,6 +29,10 @@ public class MockitoInjectMocksShouldBeUsedSample {
     OrderProcessor(PaymentGateway gateway, String name) {}
   }
 
+  static class SameTypeDependenciesOrderProcessor {
+    SameTypeDependenciesOrderProcessor(PaymentGateway primaryGateway, PaymentGateway backupGateway) {}
+  }
+
   // ===== JUnit 4 - @RunWith(MockitoJUnitRunner.class) =====
 
   @RunWith(MockitoJUnitRunner.class)
@@ -207,6 +211,23 @@ public class MockitoInjectMocksShouldBeUsedSample {
   }
 
   // ===== Compliant cases =====
+
+  // @InjectMocks resolves by type: two mocks of the same type make injection ambiguous
+  @RunWith(MockitoJUnitRunner.class)
+  public class CompliantSameTypeMocks {
+    @Mock
+    private PaymentGateway primaryGateway;
+
+    @Mock
+    private PaymentGateway backupGateway;
+
+    private SameTypeDependenciesOrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+      orderProcessor = new SameTypeDependenciesOrderProcessor(primaryGateway, backupGateway); // Compliant - two @Mock fields of the same type
+    }
+  }
 
   @RunWith(MockitoJUnitRunner.class)
   public class CompliantAlreadyUsingInjectMocks {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoInjectMocksShouldBeUsedSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoInjectMocksShouldBeUsedSample.java
@@ -1,6 +1,7 @@
 package checks.tests;
 
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
@@ -9,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 
 public class MockitoInjectMocksShouldBeUsedSample {
 
@@ -107,6 +109,35 @@ public class MockitoInjectMocksShouldBeUsedSample {
 
   // ===== JUnit 5 - @ExtendWith(MockitoExtension.class) =====
 
+  @ExtendWith({MockitoExtension.class, org.junit.jupiter.api.extension.Extension.class})
+  class JUnit5NoncompliantMultipleExtensions {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  // checkMockitoExtensionInMetadata: meta-annotation recursion
+  @MockitoSettings
+  class JUnit5NoncompliantMetaAnnotation {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
   @ExtendWith(MockitoExtension.class)
   class JUnit5NoncompliantBeforeEach {
     @Mock
@@ -121,6 +152,27 @@ public class MockitoInjectMocksShouldBeUsedSample {
     void setUp() {
       orderProcessor = new OrderProcessor(paymentGateway, inventoryService); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
       //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  @RunWith(MockitoJUnitRunner.class)
+  public class JUnit4NoncompliantMultipleSetupMethods {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+    private OrderProcessor anotherProcessor;
+
+    @Before
+    public void setUpFirst() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    }
+
+    @Before
+    public void setUpSecond() {
+      anotherProcessor = new OrderProcessor(paymentGateway); // Noncompliant {{Use "@InjectMocks" to inject these mock fields instead of manually constructing the object.}}
+      //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     }
   }
 
@@ -246,6 +298,66 @@ public class MockitoInjectMocksShouldBeUsedSample {
     @org.junit.Test
     public void testSomething() {
       orderProcessor = new OrderProcessor(paymentGateway); // Compliant - not in a setup method
+    }
+  }
+
+  @ExtendWith(MockitoExtension.class)
+  class CompliantBeforeAll {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private static OrderProcessor orderProcessor;
+
+    @BeforeAll
+    static void setUp() {
+      orderProcessor = new OrderProcessor(); // Compliant - @BeforeAll is not a recognised setup annotation
+    }
+  }
+
+  @ExtendWith(org.junit.jupiter.api.extension.Extension.class)
+  class CompliantNonMockitoExtension {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      orderProcessor = new OrderProcessor(paymentGateway); // Compliant - not a Mockito extension
+    }
+  }
+
+  @ExtendWith(MockitoExtension.class)
+  class CompliantAnonymousClassInSetup {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      orderProcessor = new OrderProcessor(); // Compliant - no mock args
+      Runnable r = new Runnable() {
+        @Override
+        public void run() {
+          // assignment inside anonymous class body - visitClass override stops traversal here
+          OrderProcessor inner = new OrderProcessor(paymentGateway); // Compliant - inside anonymous class, not visited
+        }
+      };
+    }
+  }
+
+  // this.mockField as constructor arg - non-identifier arg, allArgsMockFields returns false
+  @ExtendWith(MockitoExtension.class)
+  class CompliantThisPrefixOnArg {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    void setUp() {
+      orderProcessor = new OrderProcessor(this.paymentGateway); // Compliant - this.field args are not recognised
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockFieldShouldUseMockAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockFieldShouldUseMockAnnotationCheck.java
@@ -17,14 +17,10 @@
 package org.sonar.java.checks.tests;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
-import org.sonar.plugins.java.api.semantic.Symbol;
-import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
@@ -33,11 +29,6 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9015")
 public class MockFieldShouldUseMockAnnotationCheck extends IssuableSubscriptionVisitor {
-
-  private static final String MOCKITO_EXTENSION = "org.mockito.junit.jupiter.MockitoExtension";
-  private static final String EXTEND_WITH_ANNOTATION = "org.junit.jupiter.api.extension.ExtendWith";
-  private static final String RUN_WITH_ANNOTATION = "org.junit.runner.RunWith";
-  private static final String MOCKITO_JUNIT_RUNNER_PREFIX = "org.mockito.junit.MockitoJUnitRunner";
 
   private static final MethodMatchers MOCK_METHOD = MethodMatchers.create()
     .ofTypes("org.mockito.Mockito")
@@ -55,7 +46,7 @@ public class MockFieldShouldUseMockAnnotationCheck extends IssuableSubscriptionV
   @Override
   public void visitNode(Tree tree) {
     ClassTree classTree = (ClassTree) tree;
-    if (!isMockitoManagedClass(classTree)) {
+    if (!MockitoManagedClassHelper.isMockitoManagedClass(classTree)) {
       return;
     }
     classTree.members().stream()
@@ -63,62 +54,6 @@ public class MockFieldShouldUseMockAnnotationCheck extends IssuableSubscriptionV
       .map(VariableTree.class::cast)
       .filter(MockFieldShouldUseMockAnnotationCheck::hasFieldMockInitializer)
       .forEach(field -> reportIssue(field.initializer(), MESSAGE));
-  }
-
-  private static boolean isMockitoManagedClass(ClassTree classTree) {
-    Symbol classSymbol = classTree.symbol();
-    return isAnnotatedWithMockitoExtension(classSymbol) || isAnnotatedWithMockitoJUnitRunner(classSymbol);
-  }
-
-  private static boolean isAnnotatedWithMockitoExtension(Symbol classSymbol) {
-    return checkMockitoExtensionInMetadata(classSymbol.metadata(), new HashSet<>());
-  }
-
-  private static boolean checkMockitoExtensionInMetadata(SymbolMetadata metadata, Set<Symbol> visited) {
-    List<SymbolMetadata.AnnotationValue> extendWithValues = metadata.valuesForAnnotation(EXTEND_WITH_ANNOTATION);
-    if (extendWithValues != null) {
-      for (SymbolMetadata.AnnotationValue av : extendWithValues) {
-        if (isMockitoExtensionClass(av.value())) {
-          return true;
-        }
-      }
-    }
-    for (SymbolMetadata.AnnotationInstance annotation : metadata.annotations()) {
-      Symbol annotationSymbol = annotation.symbol();
-      if (!visited.contains(annotationSymbol)) {
-        visited.add(annotationSymbol);
-        if (checkMockitoExtensionInMetadata(annotationSymbol.metadata(), visited)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private static boolean isMockitoExtensionClass(Object value) {
-    if (value instanceof Symbol symbol) {
-      return symbol.type().is(MOCKITO_EXTENSION);
-    }
-    if (value instanceof Object[] values) {
-      for (Object v : values) {
-        if (v instanceof Symbol symbol && symbol.type().is(MOCKITO_EXTENSION)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private static boolean isAnnotatedWithMockitoJUnitRunner(Symbol classSymbol) {
-    List<SymbolMetadata.AnnotationValue> runWithValues = classSymbol.metadata().valuesForAnnotation(RUN_WITH_ANNOTATION);
-    if (runWithValues != null && runWithValues.size() == 1) {
-      Object value = runWithValues.get(0).value();
-      if (value instanceof Symbol.TypeSymbol typeSymbol) {
-        String fqn = typeSymbol.type().fullyQualifiedName();
-        return fqn.equals(MOCKITO_JUNIT_RUNNER_PREFIX) || fqn.startsWith(MOCKITO_JUNIT_RUNNER_PREFIX + "$");
-      }
-    }
-    return false;
   }
 
   private static boolean hasFieldMockInitializer(VariableTree field) {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
@@ -30,12 +30,14 @@ import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
+import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
@@ -181,29 +183,18 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
 
   private static boolean callsOpenOrInitMocksInSetup(List<MethodTree> setupMethods) {
     for (MethodTree method : setupMethods) {
-      OpenMocksVisitor visitor = new OpenMocksVisitor();
-      method.accept(visitor);
-      if (visitor.found) {
-        return true;
+      if (method.block() == null) {
+        return false;
+      }
+      for (StatementTree statement : method.block().body()) {
+        if (statement instanceof ExpressionStatementTree expressionStatementTree
+          && expressionStatementTree.expression() instanceof MethodInvocationTree mit
+          && OPEN_OR_INIT_MOCKS.matches(mit)) {
+          return true;
+        }
       }
     }
     return false;
-  }
-
-  private static class OpenMocksVisitor extends BaseTreeVisitor {
-    private boolean found = false;
-
-    @Override
-    public void visitMethodInvocation(MethodInvocationTree tree) {
-      if (OPEN_OR_INIT_MOCKS.matches(tree)) {
-        found = true;
-      }
-    }
-
-    @Override
-    public void visitClass(ClassTree tree) {
-      // don't descend into nested/anonymous classes
-    }
   }
 
   private static class SetupMethodVisitor extends BaseTreeVisitor {
@@ -219,11 +210,10 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
     @Override
     public void visitAssignmentExpression(AssignmentExpressionTree tree) {
       ExpressionTree expression = tree.expression();
-      if (expression.is(Tree.Kind.NEW_CLASS) && isFieldAssignment(tree.variable())) {
-        NewClassTree newClass = (NewClassTree) expression;
-        if (allArgsMockFields(newClass)) {
-          issues.add(newClass);
-        }
+      if (expression instanceof NewClassTree newClass
+        && isFieldAssignment(tree.variable())
+        && allArgsMockFields(newClass)) {
+        issues.add(newClass);
       }
       super.visitAssignmentExpression(tree);
     }
@@ -234,15 +224,13 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
     }
 
     private static Symbol extractSymbol(ExpressionTree expression) {
-      if (expression.is(Tree.Kind.IDENTIFIER)) {
-        return ((IdentifierTree) expression).symbol();
+      if (expression instanceof IdentifierTree identifierTree) {
+        return identifierTree.symbol();
       }
-      if (expression.is(Tree.Kind.MEMBER_SELECT)) {
-        MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expression;
-        ExpressionTree expr = memberSelect.expression();
-        if (expr.is(Tree.Kind.IDENTIFIER) && "this".equals(((IdentifierTree) expr).name())) {
-          return memberSelect.identifier().symbol();
-        }
+      if (expression instanceof MemberSelectExpressionTree memberSelect
+        && memberSelect.expression() instanceof IdentifierTree identifierTree
+        && "this".equals(identifierTree.name())) {
+        return memberSelect.identifier().symbol();
       }
       return null;
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
@@ -18,6 +18,7 @@ package org.sonar.java.checks.tests;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -180,7 +181,20 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
       if (args.isEmpty()) {
         return false;
       }
-      return args.stream().allMatch(arg -> arg.is(Tree.Kind.IDENTIFIER) && mockFields.contains(((IdentifierTree) arg).symbol()));
+      List<Symbol> argSymbols = new ArrayList<>();
+      for (ExpressionTree arg : args) {
+        if (!arg.is(Tree.Kind.IDENTIFIER)) {
+          return false;
+        }
+        Symbol symbol = ((IdentifierTree) arg).symbol();
+        if (!mockFields.contains(symbol)) {
+          return false;
+        }
+        argSymbols.add(symbol);
+      }
+      // @InjectMocks resolves by type: two args of the same type make injection ambiguous
+      Set<String> seenTypes = new HashSet<>();
+      return argSymbols.stream().allMatch(s -> seenTypes.add(s.type().fullyQualifiedName()));
     }
 
     @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
@@ -1,0 +1,263 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.NewClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.VariableTree;
+
+@Rule(key = "S9024")
+public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVisitor {
+
+  private static final String MOCK_ANNOTATION = "org.mockito.Mock";
+  private static final String SPY_ANNOTATION = "org.mockito.Spy";
+  private static final String MOCKITO_EXTENSION = "org.mockito.junit.jupiter.MockitoExtension";
+  private static final String EXTEND_WITH_ANNOTATION = "org.junit.jupiter.api.extension.ExtendWith";
+  private static final String RUN_WITH_ANNOTATION = "org.junit.runner.RunWith";
+  private static final String MOCKITO_JUNIT_RUNNER_PREFIX = "org.mockito.junit.MockitoJUnitRunner";
+
+  private static final List<String> SETUP_ANNOTATIONS = List.of(
+    "org.junit.Before",
+    "org.junit.jupiter.api.BeforeEach");
+
+  private static final MethodMatchers OPEN_OR_INIT_MOCKS = MethodMatchers.create()
+    .ofTypes("org.mockito.MockitoAnnotations")
+    .names("openMocks", "initMocks")
+    .addParametersMatcher("java.lang.Object")
+    .build();
+
+  private static final String MESSAGE = "Use \"@InjectMocks\" to inject these mock fields instead of manually constructing the object.";
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ClassTree classTree = (ClassTree) tree;
+
+    Set<Symbol> mockAndSpyFields = collectMockAndSpyFields(classTree);
+    if (mockAndSpyFields.isEmpty()) {
+      return;
+    }
+
+    List<MethodTree> setupMethods = getSetupMethods(classTree);
+    if (setupMethods.isEmpty()) {
+      return;
+    }
+
+    if (!isMockitoManagedClass(classTree, setupMethods)) {
+      return;
+    }
+
+    Symbol classSymbol = classTree.symbol();
+    setupMethods.forEach(method -> checkSetupMethod(method, mockAndSpyFields, classSymbol));
+  }
+
+  private void checkSetupMethod(MethodTree method, Set<Symbol> mockFields, Symbol classSymbol) {
+    SetupMethodVisitor visitor = new SetupMethodVisitor(mockFields, classSymbol);
+    method.accept(visitor);
+    visitor.issues.forEach(node -> reportIssue(node, MESSAGE));
+  }
+
+  private static Set<Symbol> collectMockAndSpyFields(ClassTree classTree) {
+    return classTree.members().stream()
+      .filter(m -> m.is(Tree.Kind.VARIABLE))
+      .map(VariableTree.class::cast)
+      .filter(MockitoInjectMocksShouldBeUsedCheck::isMockOrSpyAnnotated)
+      .map(VariableTree::symbol)
+      .collect(Collectors.toSet());
+  }
+
+  private static boolean isMockOrSpyAnnotated(VariableTree field) {
+    SymbolMetadata metadata = field.symbol().metadata();
+    return metadata.isAnnotatedWith(MOCK_ANNOTATION) || metadata.isAnnotatedWith(SPY_ANNOTATION);
+  }
+
+  private static List<MethodTree> getSetupMethods(ClassTree classTree) {
+    return classTree.members().stream()
+      .filter(m -> m.is(Tree.Kind.METHOD))
+      .map(MethodTree.class::cast)
+      .filter(MockitoInjectMocksShouldBeUsedCheck::isSetupMethod)
+      .toList();
+  }
+
+  private static boolean isSetupMethod(MethodTree method) {
+    SymbolMetadata metadata = method.symbol().metadata();
+    return SETUP_ANNOTATIONS.stream().anyMatch(metadata::isAnnotatedWith);
+  }
+
+  private static boolean isMockitoManagedClass(ClassTree classTree, List<MethodTree> setupMethods) {
+    Symbol classSymbol = classTree.symbol();
+    return isAnnotatedWithMockitoExtension(classSymbol)
+      || isAnnotatedWithMockitoJUnitRunner(classSymbol)
+      || callsOpenOrInitMocksInSetup(setupMethods);
+  }
+
+  private static boolean isAnnotatedWithMockitoExtension(Symbol classSymbol) {
+    return checkMockitoExtensionInMetadata(classSymbol.metadata(), new HashSet<>());
+  }
+
+  private static boolean checkMockitoExtensionInMetadata(SymbolMetadata metadata, Set<Symbol> visited) {
+    List<SymbolMetadata.AnnotationValue> extendWithValues = metadata.valuesForAnnotation(EXTEND_WITH_ANNOTATION);
+    if (extendWithValues != null) {
+      for (SymbolMetadata.AnnotationValue av : extendWithValues) {
+        if (isMockitoExtensionClass(av.value())) {
+          return true;
+        }
+      }
+    }
+    for (SymbolMetadata.AnnotationInstance annotation : metadata.annotations()) {
+      Symbol annotationSymbol = annotation.symbol();
+      if (!visited.contains(annotationSymbol)) {
+        visited.add(annotationSymbol);
+        if (checkMockitoExtensionInMetadata(annotationSymbol.metadata(), visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isMockitoExtensionClass(Object value) {
+    if (value instanceof Symbol symbol) {
+      return symbol.type().is(MOCKITO_EXTENSION);
+    }
+    if (value instanceof Object[] values) {
+      for (Object v : values) {
+        if (v instanceof Symbol symbol && symbol.type().is(MOCKITO_EXTENSION)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isAnnotatedWithMockitoJUnitRunner(Symbol classSymbol) {
+    List<SymbolMetadata.AnnotationValue> runWithValues = classSymbol.metadata().valuesForAnnotation(RUN_WITH_ANNOTATION);
+    if (runWithValues != null && runWithValues.size() == 1) {
+      Object value = runWithValues.get(0).value();
+      if (value instanceof Symbol.TypeSymbol typeSymbol) {
+        String fqn = typeSymbol.type().fullyQualifiedName();
+        return fqn.equals(MOCKITO_JUNIT_RUNNER_PREFIX) || fqn.startsWith(MOCKITO_JUNIT_RUNNER_PREFIX + "$");
+      }
+    }
+    return false;
+  }
+
+  private static boolean callsOpenOrInitMocksInSetup(List<MethodTree> setupMethods) {
+    for (MethodTree method : setupMethods) {
+      OpenMocksVisitor visitor = new OpenMocksVisitor();
+      method.accept(visitor);
+      if (visitor.found) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static class OpenMocksVisitor extends BaseTreeVisitor {
+    private boolean found = false;
+
+    @Override
+    public void visitMethodInvocation(MethodInvocationTree tree) {
+      if (OPEN_OR_INIT_MOCKS.matches(tree)) {
+        found = true;
+      }
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // don't descend into nested/anonymous classes
+    }
+  }
+
+  private static class SetupMethodVisitor extends BaseTreeVisitor {
+    private final Set<Symbol> mockFields;
+    private final Symbol classSymbol;
+    final List<NewClassTree> issues = new ArrayList<>();
+
+    SetupMethodVisitor(Set<Symbol> mockFields, Symbol classSymbol) {
+      this.mockFields = mockFields;
+      this.classSymbol = classSymbol;
+    }
+
+    @Override
+    public void visitAssignmentExpression(AssignmentExpressionTree tree) {
+      ExpressionTree expression = tree.expression();
+      if (expression.is(Tree.Kind.NEW_CLASS) && isFieldAssignment(tree.variable())) {
+        NewClassTree newClass = (NewClassTree) expression;
+        if (allArgsMockFields(newClass)) {
+          issues.add(newClass);
+        }
+      }
+      super.visitAssignmentExpression(tree);
+    }
+
+    private boolean isFieldAssignment(ExpressionTree variable) {
+      Symbol symbol = extractSymbol(variable);
+      return symbol != null && symbol.isVariableSymbol() && symbol.owner().equals(classSymbol);
+    }
+
+    private static Symbol extractSymbol(ExpressionTree expression) {
+      if (expression.is(Tree.Kind.IDENTIFIER)) {
+        return ((IdentifierTree) expression).symbol();
+      }
+      if (expression.is(Tree.Kind.MEMBER_SELECT)) {
+        MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expression;
+        ExpressionTree expr = memberSelect.expression();
+        if (expr.is(Tree.Kind.IDENTIFIER) && "this".equals(((IdentifierTree) expr).name())) {
+          return memberSelect.identifier().symbol();
+        }
+      }
+      return null;
+    }
+
+    private boolean allArgsMockFields(NewClassTree newClass) {
+      List<ExpressionTree> args = newClass.arguments();
+      if (args.isEmpty()) {
+        return false;
+      }
+      return args.stream().allMatch(arg -> arg.is(Tree.Kind.IDENTIFIER) && mockFields.contains(((IdentifierTree) arg).symbol()));
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // don't descend into nested/anonymous classes
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
@@ -183,14 +183,13 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
 
   private static boolean callsOpenOrInitMocksInSetup(List<MethodTree> setupMethods) {
     for (MethodTree method : setupMethods) {
-      if (method.block() == null) {
-        return false;
-      }
-      for (StatementTree statement : method.block().body()) {
-        if (statement instanceof ExpressionStatementTree expressionStatementTree
-          && expressionStatementTree.expression() instanceof MethodInvocationTree mit
-          && OPEN_OR_INIT_MOCKS.matches(mit)) {
-          return true;
+      if (method.block() != null) {
+        for (StatementTree statement : method.block().body()) {
+          if (statement instanceof ExpressionStatementTree expressionStatementTree
+            && expressionStatementTree.expression() instanceof MethodInvocationTree mit
+            && OPEN_OR_INIT_MOCKS.matches(mit)) {
+            return true;
+          }
         }
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheck.java
@@ -18,7 +18,6 @@ package org.sonar.java.checks.tests;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,10 +45,6 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
 
   private static final String MOCK_ANNOTATION = "org.mockito.Mock";
   private static final String SPY_ANNOTATION = "org.mockito.Spy";
-  private static final String MOCKITO_EXTENSION = "org.mockito.junit.jupiter.MockitoExtension";
-  private static final String EXTEND_WITH_ANNOTATION = "org.junit.jupiter.api.extension.ExtendWith";
-  private static final String RUN_WITH_ANNOTATION = "org.junit.runner.RunWith";
-  private static final String MOCKITO_JUNIT_RUNNER_PREFIX = "org.mockito.junit.MockitoJUnitRunner";
 
   private static final List<String> SETUP_ANNOTATIONS = List.of(
     "org.junit.Before",
@@ -124,61 +119,7 @@ public class MockitoInjectMocksShouldBeUsedCheck extends IssuableSubscriptionVis
   }
 
   private static boolean isMockitoManagedClass(ClassTree classTree, List<MethodTree> setupMethods) {
-    Symbol classSymbol = classTree.symbol();
-    return isAnnotatedWithMockitoExtension(classSymbol)
-      || isAnnotatedWithMockitoJUnitRunner(classSymbol)
-      || callsOpenOrInitMocksInSetup(setupMethods);
-  }
-
-  private static boolean isAnnotatedWithMockitoExtension(Symbol classSymbol) {
-    return checkMockitoExtensionInMetadata(classSymbol.metadata(), new HashSet<>());
-  }
-
-  private static boolean checkMockitoExtensionInMetadata(SymbolMetadata metadata, Set<Symbol> visited) {
-    List<SymbolMetadata.AnnotationValue> extendWithValues = metadata.valuesForAnnotation(EXTEND_WITH_ANNOTATION);
-    if (extendWithValues != null) {
-      for (SymbolMetadata.AnnotationValue av : extendWithValues) {
-        if (isMockitoExtensionClass(av.value())) {
-          return true;
-        }
-      }
-    }
-    for (SymbolMetadata.AnnotationInstance annotation : metadata.annotations()) {
-      Symbol annotationSymbol = annotation.symbol();
-      if (!visited.contains(annotationSymbol)) {
-        visited.add(annotationSymbol);
-        if (checkMockitoExtensionInMetadata(annotationSymbol.metadata(), visited)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private static boolean isMockitoExtensionClass(Object value) {
-    if (value instanceof Symbol symbol) {
-      return symbol.type().is(MOCKITO_EXTENSION);
-    }
-    if (value instanceof Object[] values) {
-      for (Object v : values) {
-        if (v instanceof Symbol symbol && symbol.type().is(MOCKITO_EXTENSION)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private static boolean isAnnotatedWithMockitoJUnitRunner(Symbol classSymbol) {
-    List<SymbolMetadata.AnnotationValue> runWithValues = classSymbol.metadata().valuesForAnnotation(RUN_WITH_ANNOTATION);
-    if (runWithValues != null && runWithValues.size() == 1) {
-      Object value = runWithValues.get(0).value();
-      if (value instanceof Symbol.TypeSymbol typeSymbol) {
-        String fqn = typeSymbol.type().fullyQualifiedName();
-        return fqn.equals(MOCKITO_JUNIT_RUNNER_PREFIX) || fqn.startsWith(MOCKITO_JUNIT_RUNNER_PREFIX + "$");
-      }
-    }
-    return false;
+    return MockitoManagedClassHelper.isMockitoManagedClass(classTree) || callsOpenOrInitMocksInSetup(setupMethods);
   }
 
   private static boolean callsOpenOrInitMocksInSetup(List<MethodTree> setupMethods) {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoManagedClassHelper.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoManagedClassHelper.java
@@ -1,0 +1,91 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.tree.ClassTree;
+
+class MockitoManagedClassHelper {
+
+  private static final String MOCKITO_EXTENSION = "org.mockito.junit.jupiter.MockitoExtension";
+  private static final String EXTEND_WITH_ANNOTATION = "org.junit.jupiter.api.extension.ExtendWith";
+  private static final String RUN_WITH_ANNOTATION = "org.junit.runner.RunWith";
+  private static final String MOCKITO_JUNIT_RUNNER_PREFIX = "org.mockito.junit.MockitoJUnitRunner";
+
+  private MockitoManagedClassHelper() {
+  }
+
+  static boolean isMockitoManagedClass(ClassTree classTree) {
+    Symbol classSymbol = classTree.symbol();
+    return isAnnotatedWithMockitoExtension(classSymbol) || isAnnotatedWithMockitoJUnitRunner(classSymbol);
+  }
+
+  private static boolean isAnnotatedWithMockitoExtension(Symbol classSymbol) {
+    return checkMockitoExtensionInMetadata(classSymbol.metadata(), new HashSet<>());
+  }
+
+  private static boolean checkMockitoExtensionInMetadata(SymbolMetadata metadata, Set<Symbol> visited) {
+    List<SymbolMetadata.AnnotationValue> extendWithValues = metadata.valuesForAnnotation(EXTEND_WITH_ANNOTATION);
+    if (extendWithValues != null) {
+      for (SymbolMetadata.AnnotationValue av : extendWithValues) {
+        if (isMockitoExtensionClass(av.value())) {
+          return true;
+        }
+      }
+    }
+    for (SymbolMetadata.AnnotationInstance annotation : metadata.annotations()) {
+      Symbol annotationSymbol = annotation.symbol();
+      if (!visited.contains(annotationSymbol)) {
+        visited.add(annotationSymbol);
+        if (checkMockitoExtensionInMetadata(annotationSymbol.metadata(), visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isMockitoExtensionClass(Object value) {
+    if (value instanceof Symbol symbol) {
+      return symbol.type().is(MOCKITO_EXTENSION);
+    }
+    if (value instanceof Object[] values) {
+      for (Object v : values) {
+        if (v instanceof Symbol symbol && symbol.type().is(MOCKITO_EXTENSION)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean isAnnotatedWithMockitoJUnitRunner(Symbol classSymbol) {
+    List<SymbolMetadata.AnnotationValue> runWithValues = classSymbol.metadata().valuesForAnnotation(RUN_WITH_ANNOTATION);
+    if (runWithValues != null && runWithValues.size() == 1) {
+      Object value = runWithValues.get(0).value();
+      if (value instanceof Symbol.TypeSymbol typeSymbol) {
+        String fqn = typeSymbol.type().fullyQualifiedName();
+        return fqn.equals(MOCKITO_JUNIT_RUNNER_PREFIX) || fqn.startsWith(MOCKITO_JUNIT_RUNNER_PREFIX + "$");
+      }
+    }
+    return false;
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoInjectMocksShouldBeUsedCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
+
+class MockitoInjectMocksShouldBeUsedCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/MockitoInjectMocksShouldBeUsedSample.java"))
+      .withCheck(new MockitoInjectMocksShouldBeUsedCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void testWithoutSemantics() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/MockitoInjectMocksShouldBeUsedSample.java"))
+      .withCheck(new MockitoInjectMocksShouldBeUsedCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.html
@@ -1,7 +1,7 @@
 <p>This is an issue when a test class manually instantiates the object under test in a setup method by passing mock-annotated fields as constructor
 arguments, instead of using the test framework’s automatic dependency injection annotation.</p>
-<p>In Java, this specifically refers to fields annotated with <code>@Mock</code> and using Mockito’s <code>@InjectMocks</code> annotation instead of
-manual instantiation.</p>
+<p>In Java with Mockito, this specifically refers to instantiating the object under test manually instead of using the <code>@InjectMocks</code>
+annotation, in a class annotated with @ExtendWith(MockitoExtension.class) (JUnit 5) or @RunWith(MockitoJUnitRunner.class) (JUnit 4).</p>
 <h2>Why is this an issue?</h2>
 <p>When writing unit tests with mocking frameworks, developers often need to inject mock dependencies into the object being tested. While it’s
 possible to manually construct this object by passing mock-annotated fields as constructor arguments in a test setup method, this approach creates
@@ -20,14 +20,14 @@ annotated fields into the object under test, eliminating the need for manual con
 <p>By contrast, automatic dependency injection annotations automatically adapt to constructor changes, keep test code concise, and clearly signal
 which object is under test.</p>
 <p>In Mockito specifically, use the <code>@InjectMocks</code> annotation to mark the object under test, and <code>@Mock</code> or <code>@Spy</code>
-annotations for dependencies. The setup method would typically be a <code>@BeforeEach</code> (JUnit 5) or <code>@Before</code> (JUnit 4) method.</p>
+annotations for dependencies.</p>
 <h3>What is the potential impact?</h3>
 <p>This issue impacts code maintainability. Tests with manual object construction require more effort to write and update, especially during
 refactoring. While the tests still function correctly, the extra boilerplate increases the cognitive load on developers and makes the codebase harder
 to maintain over time.</p>
 <h2>How to fix it in JUnit 4</h2>
-<p>For JUnit 4 tests, ensure you’re using <code>@RunWith(MockitoJUnitRunner.class)</code> to enable Mockito annotations, then replace manual
-construction with <code>@InjectMocks</code>.</p>
+<p>For JUnit 4 tests using <code>@RunWith(MockitoJUnitRunner.class)</code>, replace manual construction in a setup method with the
+<code>@InjectMocks</code> annotation.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
@@ -71,11 +71,56 @@ public class OrderProcessorTest {
     }
 }
 </pre>
+<h2>How to fix it in JUnit 5</h2>
+<p>For JUnit 5 tests using MockitoExtension, replace manual construction with <code>@InjectMocks</code>.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+@ExtendWith(MockitoExtension.class)
+public class OrderProcessorTest {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    private OrderProcessor orderProcessor;
+
+    @BeforeEach
+    public void setUp() {
+        orderProcessor = new OrderProcessor(paymentGateway, inventoryService); // Noncompliant
+    }
+
+    @Test
+    public void testProcessOrder() {
+        // test implementation
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+@ExtendWith(MockitoExtension.class)
+public class OrderProcessorTest {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    @InjectMocks
+    private OrderProcessor orderProcessor;
+
+    @Test
+    public void testProcessOrder() {
+        // test implementation
+    }
+}
+</pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
-  <li>Mockito Documentation - <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/InjectMocks.html">@InjectMocks</a></li>
-  <li>Baeldung - <a href="https://www.baeldung.com/mockito-annotations">Mockito @Mock, @Spy, @Captor and @InjectMocks</a></li>
-  <li>Mockito Documentation - <a href="https://site.mockito.org/">Mockito Framework Site</a></li>
+  <li>Mockito Documentation - <a
+  href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/InjectMocks.html">@InjectMocks</a></li>
+  <li>Baeldung - <a href="https://www.baeldung.com/mockito-annotations">Getting Started with Mockito @Mock, @Spy, @Captor and @InjectMocks</a></li>
 </ul>
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.html
@@ -1,0 +1,81 @@
+<p>This is an issue when a test class manually instantiates the object under test in a setup method by passing mock-annotated fields as constructor
+arguments, instead of using the test framework’s automatic dependency injection annotation.</p>
+<p>In Java, this specifically refers to fields annotated with <code>@Mock</code> and using Mockito’s <code>@InjectMocks</code> annotation instead of
+manual instantiation.</p>
+<h2>Why is this an issue?</h2>
+<p>When writing unit tests with mocking frameworks, developers often need to inject mock dependencies into the object being tested. While it’s
+possible to manually construct this object by passing mock-annotated fields as constructor arguments in a test setup method, this approach creates
+unnecessary boilerplate code.</p>
+<p>Mocking frameworks provide dependency injection annotations specifically for this purpose. These annotations automatically inject all mock and spy
+annotated fields into the object under test, eliminating the need for manual construction.</p>
+<p>The manual approach has several drawbacks:</p>
+<ul>
+  <li><strong>Boilerplate code</strong>: You must write and maintain a setup method that constructs the object.</li>
+  <li><strong>Fragility</strong>: When the constructor signature changes (adding, removing, or reordering parameters), you must manually update the
+  setup method. This is error-prone and time-consuming.</li>
+  <li><strong>Reduced readability</strong>: The manual wiring obscures the test’s intent, making it harder to understand at a glance which object is
+  under test.</li>
+  <li><strong>Maintenance burden</strong>: Across many test classes, this pattern multiplies the effort required for refactoring.</li>
+</ul>
+<p>By contrast, automatic dependency injection annotations automatically adapt to constructor changes, keep test code concise, and clearly signal
+which object is under test.</p>
+<p>In Mockito specifically, use the <code>@InjectMocks</code> annotation to mark the object under test, and <code>@Mock</code> or <code>@Spy</code>
+annotations for dependencies. The setup method would typically be a <code>@BeforeEach</code> (JUnit 5) or <code>@Before</code> (JUnit 4) method.</p>
+<h3>What is the potential impact?</h3>
+<p>This issue impacts code maintainability. Tests with manual object construction require more effort to write and update, especially during
+refactoring. While the tests still function correctly, the extra boilerplate increases the cognitive load on developers and makes the codebase harder
+to maintain over time.</p>
+<h2>How to fix it in JUnit 4</h2>
+<p>For JUnit 4 tests, ensure you’re using <code>@RunWith(MockitoJUnitRunner.class)</code> to enable Mockito annotations, then replace manual
+construction with <code>@InjectMocks</code>.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@RunWith(MockitoJUnitRunner.class)
+public class OrderProcessorTest {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    private OrderProcessor orderProcessor;
+
+    @Before
+    public void setUp() {
+        orderProcessor = new OrderProcessor(paymentGateway, inventoryService); // Noncompliant
+    }
+
+    @Test
+    public void testProcessOrder() {
+        // test implementation
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@RunWith(MockitoJUnitRunner.class)
+public class OrderProcessorTest {
+    @Mock
+    private PaymentGateway paymentGateway;
+
+    @Mock
+    private InventoryService inventoryService;
+
+    @InjectMocks
+    private OrderProcessor orderProcessor;
+
+    @Test
+    public void testProcessOrder() {
+        // test implementation
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Mockito Documentation - <a href="https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/InjectMocks.html">@InjectMocks</a></li>
+  <li>Baeldung - <a href="https://www.baeldung.com/mockito-annotations">Mockito @Mock, @Spy, @Captor and @InjectMocks</a></li>
+  <li>Mockito Documentation - <a href="https://site.mockito.org/">Mockito Framework Site</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.json
@@ -1,5 +1,5 @@
 {
-  "title": "@InjectMocks should be used instead of manually constructing test objects",
+  "title": "\"@InjectMocks\" should be used instead of manually constructing test objects",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9024.json
@@ -1,0 +1,25 @@
+{
+  "title": "@InjectMocks should be used instead of manually constructing test objects",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "mockito",
+    "junit",
+    "tests"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9024",
+  "sqKey": "S9024",
+  "scope": "Tests",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **New rule implementation:**
  - Added `MockitoInjectMocksShouldBeUsedCheck` (S9024) to flag manual instantiation of test objects when `@InjectMocks` could be used.
  - Implemented rule metadata and localized documentation for S9024.
- **Test coverage:**
  - Created `MockitoInjectMocksShouldBeUsedSample` covering various JUnit 4/5 scenarios and Mockito configurations.
  - Added `MockitoInjectMocksShouldBeUsedCheckTest` to verify the detection logic.

<sub>This will update automatically on new commits.</sub>