### PR TITLE
SONARJAVA-6625 Migrate remaining tests to JUnit 5

### DIFF
--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -66,12 +66,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/docs/java-custom-rules-example/src/test/java/org/sonar/samples/java/checks/AvoidBrandInMethodNamesRuleTest.java
+++ b/docs/java-custom-rules-example/src/test/java/org/sonar/samples/java/checks/AvoidBrandInMethodNamesRuleTest.java
@@ -4,19 +4,17 @@
  */
 package org.sonar.samples.java.checks;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
-import org.sonar.api.testfixtures.log.LogTester;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-@EnableRuleMigrationSupport
 class AvoidBrandInMethodNamesRuleTest {
 
   // Set a LogTester to see the Syntax Tree when running tests and executing the rule
-  @Rule
-  public LogTester logTester = new LogTester().setLevel(Level.DEBUG);
+  @RegisterExtension
+  public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
 
   @Test
   void detected() {

--- a/docs/java-custom-rules-example/src/test/java/org/sonar/samples/java/checks/SecurityAnnotationMandatoryRuleTest.java
+++ b/docs/java-custom-rules-example/src/test/java/org/sonar/samples/java/checks/SecurityAnnotationMandatoryRuleTest.java
@@ -4,19 +4,17 @@
  */
 package org.sonar.samples.java.checks;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
-import org.sonar.api.testfixtures.log.LogTester;
+import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-@EnableRuleMigrationSupport
 class SecurityAnnotationMandatoryRuleTest {
 
   // Set a LogTester to see the Syntax Tree when running tests and executing the rule
-  @Rule
-  public LogTester logTester = new LogTester().setLevel(Level.DEBUG);
+  @RegisterExtension
+  public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
 
   @Test
   void detected() {

--- a/external-reports/pom.xml
+++ b/external-reports/pom.xml
@@ -59,11 +59,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/external-reports/src/test/java/org/sonar/java/externalreport/CheckstyleSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/CheckstyleSensorTest.java
@@ -23,13 +23,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
@@ -42,7 +40,6 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.java.externalreport.ExternalReportTestUtils.onlyOneLogElement;
 
-@EnableRuleMigrationSupport
 class CheckstyleSensorTest {
 
   private static final Path PROJECT_DIR = Paths.get("src", "test", "resources", "checkstyle")
@@ -51,8 +48,8 @@ class CheckstyleSensorTest {
   private static SensorContextTester sensorContext = SensorContextTester.create(PROJECT_DIR);
   private static CheckstyleSensor checkstyleSensor = new CheckstyleSensor(sensorContext.runtime());
 
-  @Rule
-  public final TemporaryFolder tmp = new TemporaryFolder();
+  @TempDir
+  public Path tmp;
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);

--- a/external-reports/src/test/java/org/sonar/java/externalreport/ExternalReportTestUtils.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/ExternalReportTestUtils.java
@@ -22,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
@@ -50,14 +49,14 @@ public final class ExternalReportTestUtils {
     return elements.get(0);
   }
 
-  public static File generateReport(Path projectDir, TemporaryFolder tmp, String fileName) throws IOException {
+  public static File generateReport(Path projectDir, Path tmp, String fileName) throws IOException {
     Path filePath = projectDir.resolve(fileName);
     if (!filePath.toFile().exists()) {
       return filePath.toFile();
     }
     String reportData = new String(Files.readAllBytes(filePath), UTF_8);
     reportData = reportData.replace("${PROJECT_DIR}", projectDir.toRealPath() + File.separator);
-    File reportFile = tmp.newFile(fileName).getCanonicalFile();
+    File reportFile = Files.createFile(tmp.resolve(fileName)).toFile().getCanonicalFile();
     Files.write(reportFile.toPath(), reportData.getBytes(UTF_8));
     return reportFile;
   }

--- a/external-reports/src/test/java/org/sonar/java/externalreport/SpotBugsSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/SpotBugsSensorTest.java
@@ -23,13 +23,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
@@ -43,7 +41,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.sonar.java.externalreport.ExternalReportTestUtils.onlyOneLogElement;
 
-@EnableRuleMigrationSupport
 class SpotBugsSensorTest {
 
   private static final Path PROJECT_DIR = Paths.get("src", "test", "resources", "spotbugs")
@@ -52,8 +49,8 @@ class SpotBugsSensorTest {
   private static SensorContextTester sensorContext = SensorContextTester.create(PROJECT_DIR);
   private static SpotBugsSensor spotBugsSensor = new SpotBugsSensor(sensorContext.runtime());
 
-  @Rule
-  public final TemporaryFolder tmp = new TemporaryFolder();
+  @TempDir
+  public Path tmp;
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);

--- a/java-checks-testkit/pom.xml
+++ b/java-checks-testkit/pom.xml
@@ -51,11 +51,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>
       <artifactId>sonar-analyzer-test-commons</artifactId>
       <scope>compile</scope>

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/FilesUtilsTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/FilesUtilsTest.java
@@ -22,19 +22,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableRuleMigrationSupport
 class FilesUtilsTest {
-  @org.junit.Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   @Test
   void verify_get_classpath_files() throws IOException {
-    Path tmp = temp.newFolder().toPath();
+    Path tmp = Files.createDirectory(temp.resolve("tmp"));
     Path jar = tmp.resolve("test.jar");
     Path zip = tmp.resolve("test.zip");
     Path invalid = tmp.resolve("test.txt");
@@ -43,7 +41,7 @@ class FilesUtilsTest {
     Files.createFile(zip);
     Files.createFile(invalid);
 
-    List<File> list = FilesUtils.getFilesRecursively(temp.getRoot().toPath(), new String[] {"zip", "jar"});
+    List<File> list = FilesUtils.getFilesRecursively(temp, new String[] {"zip", "jar"});
     assertThat(list).containsOnly(jar.toFile(), zip.toFile());
   }
 

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -81,11 +81,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/java-frontend/src/test/java/org/sonar/java/BatchGeneratorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/BatchGeneratorTest.java
@@ -18,14 +18,13 @@ package org.sonar.java;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
@@ -33,10 +32,9 @@ import org.sonar.api.config.internal.MapSettings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.java.InputFileUtils.addFile;
 
-@EnableRuleMigrationSupport
 class BatchGeneratorTest {
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   @Test
   void batch_generator_returns_an_empty_list_when_no_input_files() {
@@ -48,7 +46,7 @@ class BatchGeneratorTest {
 
   @Test
   void batch_generator_returns_at_most_one_item_per_batch_when_size_is_zero() throws IOException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setSettings(new MapSettings());
     List<InputFile> inputFiles = new ArrayList<>();
@@ -69,7 +67,7 @@ class BatchGeneratorTest {
 
   @Test
   void batch_generator_returns_batches_with_multiple_files_that_are_smaller_than_batch_size() throws IOException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setSettings(new MapSettings());
     InputFile fileA = addFile(temp, "class A { public void doSomething() {} }", sensorContext);
@@ -107,7 +105,7 @@ class BatchGeneratorTest {
 
   @Test
   void batch_generator_includes_file_excluded_from_previous_batch_into_next_batch() throws IOException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContext = SensorContextTester.create(baseDir);
     sensorContext.setSettings(new MapSettings());
     InputFile fileA = addFile(temp, "class A { public void doSomething() {} }", sensorContext);

--- a/java-frontend/src/test/java/org/sonar/java/InputFileUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/InputFileUtils.java
@@ -16,10 +16,10 @@
  */
 package org.sonar.java;
 
-import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,17 +33,17 @@ class InputFileUtils {
     if (matcher.find()) {
       String className = matcher.group(1);
       InputFile.Type type = className.endsWith("Test") ? InputFile.Type.TEST : InputFile.Type.MAIN;
-      File file = java.nio.file.Files.createFile(temp.resolve(className + ".java")).toFile().getAbsoluteFile();
+      File file = Files.createFile(temp.resolve(className + ".java")).toFile().getAbsoluteFile();
       return generateInputFile(code, context, file, type);
     } else {
-      File file = java.nio.file.Files.createFile(temp.resolve("Unnamed.java")).toFile().getAbsoluteFile();
+      File file = Files.createFile(temp.resolve("Unnamed.java")).toFile().getAbsoluteFile();
       return generateInputFile(code, context, file, InputFile.Type.MAIN);
     }
   }
 
   @NotNull
   private static InputFile generateInputFile(String code, SensorContextTester context, File file, InputFile.Type type) throws IOException {
-    Files.asCharSink(file, StandardCharsets.UTF_8).write(code);
+    Files.writeString(file.toPath(), code, StandardCharsets.UTF_8);
     InputFile defaultFile = TestUtils.inputFile(context.fileSystem().baseDir().getAbsolutePath(), file, type);
     context.fileSystem().add(defaultFile);
     return defaultFile;

--- a/java-frontend/src/test/java/org/sonar/java/InputFileUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/InputFileUtils.java
@@ -20,23 +20,23 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
-import org.junit.rules.TemporaryFolder;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 
 class InputFileUtils {
-  public static InputFile addFile(TemporaryFolder temp, String code, SensorContextTester context) throws IOException {
+  public static InputFile addFile(Path temp, String code, SensorContextTester context) throws IOException {
     Matcher matcher = Pattern.compile("(?:^|\\s)(?:class|interface|enum|record)\\s++(\\w++)").matcher(code);
     if (matcher.find()) {
       String className = matcher.group(1);
       InputFile.Type type = className.endsWith("Test") ? InputFile.Type.TEST : InputFile.Type.MAIN;
-      File file = temp.newFile(className + ".java").getAbsoluteFile();
+      File file = java.nio.file.Files.createFile(temp.resolve(className + ".java")).toFile().getAbsoluteFile();
       return generateInputFile(code, context, file, type);
     } else {
-      File file = temp.newFile("Unnamed.java").getAbsoluteFile();
+      File file = java.nio.file.Files.createFile(temp.resolve("Unnamed.java")).toFile().getAbsoluteFile();
       return generateInputFile(code, context, file, InputFile.Type.MAIN);
     }
   }

--- a/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
@@ -18,18 +18,17 @@ package org.sonar.java;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
@@ -83,7 +82,6 @@ import static org.mockito.Mockito.when;
 import static org.sonar.java.InputFileUtils.addFile;
 import static org.sonar.java.TestUtils.mockSonarComponents;
 
-@EnableRuleMigrationSupport
 class JavaFrontendTest {
 
 
@@ -95,8 +93,8 @@ class JavaFrontendTest {
   private static final Version LATESTS_SONAR_API_VERSION = Version.create(8, 13);
   public static final SonarRuntime SONARQUBE_RUNTIME = SonarRuntimeImpl.forSonarQube(LATESTS_SONAR_API_VERSION, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
@@ -211,7 +209,7 @@ class JavaFrontendTest {
 
     var settings = new MapSettings();
     if (sensorContext == null) {
-      File baseDir = temp.getRoot().getAbsoluteFile();
+      File baseDir = temp.toFile().getAbsoluteFile();
       sensorContext = SensorContextTester.create(baseDir);
       sensorContext.setSettings(settings);
     }
@@ -239,7 +237,7 @@ class JavaFrontendTest {
 
   @Test
   void test_scan_logs_when_caching_is_enabled_and_can_skip_unchanged_files() throws ApiMismatchException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContextTester = SensorContextTester.create(baseDir);
     sensorContextTester.setSettings(new MapSettings());
 
@@ -273,7 +271,7 @@ class JavaFrontendTest {
 
   @Test
   void test_scan_logs_when_caching_is_enabled_and_cannot_skip_unchanged_files() throws ApiMismatchException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContextTester = SensorContextTester.create(baseDir);
     sensorContextTester.setSettings(new MapSettings());
 
@@ -307,7 +305,7 @@ class JavaFrontendTest {
 
   @Test
   void test_scan_logs_when_caching_is_enabled_and_cannot_determine_if_unchanged_files_can_be_skipped() throws ApiMismatchException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContextTester = SensorContextTester.create(baseDir);
     sensorContextTester.setSettings(new MapSettings());
 
@@ -341,7 +339,7 @@ class JavaFrontendTest {
 
   @Test
   void test_scan_logs_when_caching_is_disabled_and_can_skip_unchanged_files() throws ApiMismatchException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContextTester = SensorContextTester.create(baseDir);
     sensorContextTester.setSettings(new MapSettings());
 
@@ -374,7 +372,7 @@ class JavaFrontendTest {
 
   @Test
   void test_scan_logs_when_caching_is_disabled_and_cannot_skip_unchanged_files() throws ApiMismatchException {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContextTester = SensorContextTester.create(baseDir);
     sensorContextTester.setSettings(new MapSettings());
 
@@ -407,7 +405,7 @@ class JavaFrontendTest {
 
   @Test
   void test_scan_logs_when_caching_is_disabled_when_sonar_components_is_null() {
-    File baseDir = temp.getRoot().getAbsoluteFile();
+    File baseDir = temp.toFile().getAbsoluteFile();
     SensorContextTester sensorContextTester = SensorContextTester.create(baseDir);
     sensorContextTester.setSettings(new MapSettings());
 
@@ -751,7 +749,7 @@ class JavaFrontendTest {
 
   private List<InputFile> scan(MapSettings settings, SonarRuntime sonarRuntime, String... codeList) throws IOException {
     if (sensorContext == null) {
-      File baseDir = temp.getRoot().getAbsoluteFile();
+      File baseDir = temp.toFile().getAbsoluteFile();
       sensorContext = SensorContextTester.create(baseDir);
       sensorContext.setSettings(settings);
     }
@@ -768,7 +766,7 @@ class JavaFrontendTest {
 
   private List<InputFile> scan(MapSettings settings, SonarRuntime sonarRuntime, List<InputFile> inputFiles, @Nullable CheckRegistrar[] checkRegistrars) {
     if (sensorContext == null) {
-      File baseDir = temp.getRoot().getAbsoluteFile();
+      File baseDir = temp.toFile().getAbsoluteFile();
       sensorContext = SensorContextTester.create(baseDir);
       sensorContext.setSettings(settings);
     }

--- a/java-frontend/src/test/java/org/sonar/java/ast/visitors/SonarSymbolTableVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/visitors/SonarSymbolTableVisitorTest.java
@@ -17,13 +17,12 @@
 package org.sonar.java.ast.visitors;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.batch.fs.TextRange;
@@ -42,17 +41,16 @@ import org.sonar.java.model.VisitorsBridge;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-@EnableRuleMigrationSupport
 class SonarSymbolTableVisitorTest {
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
   private SensorContextTester context;
   private SonarComponents sonarComponents;
 
   @BeforeEach
   void setUp() {
-    context = SensorContextTester.create(temp.getRoot());
+    context = SensorContextTester.create(temp.toFile());
     sonarComponents = new SonarComponents(mock(FileLinesContextFactory.class), context.fileSystem(),
       mock(ClasspathForMain.class), mock(ClasspathForTest.class), mock(CheckFactory.class), mock(ActiveRules.class));
     sonarComponents.setSensorContext(context);

--- a/java-frontend/src/test/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitorTest.java
@@ -19,14 +19,13 @@ package org.sonar.java.ast.visitors;
 import com.google.common.io.Files;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Collections;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.rules.TemporaryFolder;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
@@ -50,11 +49,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.sonar.java.TestUtils.mockSonarComponents;
 
-@EnableRuleMigrationSupport
 class SyntaxHighlighterVisitorTest {
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   private SensorContextTester context;
   private SonarComponents sonarComponents;
@@ -63,7 +61,7 @@ class SyntaxHighlighterVisitorTest {
 
   @BeforeEach
   void setUp() {
-    context = SensorContextTester.create(temp.getRoot());
+    context = SensorContextTester.create(temp.toFile());
     sonarComponents = new SonarComponents(mock(FileLinesContextFactory.class), context.fileSystem(),
       mock(ClasspathForMain.class), mock(ClasspathForTest.class), mock(CheckFactory.class), mock(ActiveRules.class));
     sonarComponents.setSensorContext(context);
@@ -73,7 +71,7 @@ class SyntaxHighlighterVisitorTest {
   @Test
   void parse_error() throws Exception {
     SensorContextTester spy = spy(context);
-    File file = temp.newFile().getAbsoluteFile();
+    File file = temp.resolve("parseError.java").toFile().getAbsoluteFile();
     Files.asCharSink(file, StandardCharsets.UTF_8).write("ParseError");
     scan(TestUtils.inputFile(file));
     verify(spy, never()).newHighlighting();

--- a/java-frontend/src/test/java/org/sonar/java/model/JParserReleasingJarsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JParserReleasingJarsTest.java
@@ -18,11 +18,11 @@ package org.sonar.java.model;
 
 import com.google.common.io.Files;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
@@ -31,11 +31,10 @@ import org.sonar.plugins.java.api.tree.MethodTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableRuleMigrationSupport
 class JParserReleasingJarsTest {
 
-  @org.junit.Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   private static final String PROJECT_JAR = "src/test/files/other/project.jar";
   private static final String SOURCE = "package foo.bar;\n"
@@ -75,7 +74,7 @@ class JParserReleasingJarsTest {
    */
   @Test
   void should_be_able_to_delete_jar() throws Exception {
-    File newJar = new File(temp.newFolder(), "project2.jar");
+    File newJar = temp.resolve("project2.jar").toFile();
     Files.copy(new File(PROJECT_JAR), newJar);
 
     assertThat(newJar).exists();
@@ -90,7 +89,7 @@ class JParserReleasingJarsTest {
    */
   @Test
   void jParser_should_release_jar_after_use() throws Exception {
-    File newJar = new File(temp.newFolder(), "project3.jar");
+    File newJar = temp.resolve("project3.jar").toFile();
     Files.copy(new File(PROJECT_JAR), newJar);
 
     assertThat(newJar).exists();

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -101,11 +101,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/DroppedPropertiesSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/DroppedPropertiesSensorTest.java
@@ -16,13 +16,12 @@
  */
 package org.sonar.plugins.java;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
@@ -32,18 +31,17 @@ import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@EnableRuleMigrationSupport
 class DroppedPropertiesSensorTest {
 
-  @Rule
-  public TemporaryFolder tmp = new TemporaryFolder();
+  @TempDir
+  public Path tmp;
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
 
   @Test
   void test() throws Exception {
-    SensorContextTester contextTester = SensorContextTester.create(tmp.newFolder());
+    SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     MapSettings mapSettings = new MapSettings().setProperty("sonar.jacoco.reportPaths", "/path");
     contextTester.setSettings(mapSettings);
     List<String> analysisWarnings = new ArrayList<>();
@@ -57,7 +55,7 @@ class DroppedPropertiesSensorTest {
 
   @Test
   void test_two_reportPaths_property() throws Exception {
-    SensorContextTester contextTester = SensorContextTester.create(tmp.newFolder());
+    SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     MapSettings mapSettings = new MapSettings().setProperty("sonar.jacoco.reportPaths", "/path")
       .setProperty("sonar.jacoco.reportPath", "/path");
     contextTester.setSettings(mapSettings);
@@ -71,7 +69,7 @@ class DroppedPropertiesSensorTest {
 
   @Test
   void test_two_reportPaths_property_plus_another() throws Exception {
-    SensorContextTester contextTester = SensorContextTester.create(tmp.newFolder());
+    SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     MapSettings mapSettings = new MapSettings().setProperty("sonar.jacoco.reportPaths", "/path")
       .setProperty("sonar.jacoco.reportPath", "/path")
       .setProperty("sonar.jacoco.itReportPath", "/path");
@@ -87,7 +85,7 @@ class DroppedPropertiesSensorTest {
 
   @Test
   void test_empty() throws Exception {
-    SensorContextTester contextTester = SensorContextTester.create(tmp.newFolder());
+    SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     List<String> analysisWarnings = new ArrayList<>();
     DroppedPropertiesSensor sensor = new DroppedPropertiesSensor(analysisWarnings::add);
     sensor.execute(contextTester);

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
@@ -24,11 +24,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.event.Level;
 import org.sonar.api.SonarEdition;
@@ -90,9 +88,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@EnableRuleMigrationSupport
 class JavaSensorTest {
 
+  private static final String EXPECTED_TYPE_ERROR_COUNT = "199";
   private static final CheckFactory checkFactory = mock(CheckFactory.class);
   private static final Checks<Object> checks = mock(Checks.class);
 
@@ -102,8 +100,8 @@ class JavaSensorTest {
     when(checkFactory.create(anyString())).thenReturn(checks);
   }
 
-  @Rule
-  public final TemporaryFolder tmp = new TemporaryFolder();
+  @TempDir
+  public Path tmp;
 
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
@@ -135,7 +133,7 @@ class JavaSensorTest {
       "java.scanner_app");
     assertThat(telemetryMap.get("java.analysis.main.success.size_chars")).matches("\\d{5}");
     assertThat(telemetryMap.get("java.analysis.main.success.time_ms")).matches("\\d+");
-    assertThat(telemetryMap).containsEntry("java.analysis.main.success.type_error_count", "205");
+    assertThat(telemetryMap).containsEntry("java.analysis.main.success.type_error_count", EXPECTED_TYPE_ERROR_COUNT);
   }
 
   @Test
@@ -157,7 +155,7 @@ class JavaSensorTest {
       "java.scanner_app");
     assertThat(telemetryMap.get("java.analysis.test.success.size_chars")).matches("\\d{5}");
     assertThat(telemetryMap.get("java.analysis.test.success.time_ms")).matches("\\d+");
-    assertThat(telemetryMap).containsEntry("java.analysis.test.success.type_error_count", "205");
+    assertThat(telemetryMap).containsEntry("java.analysis.test.success.type_error_count", EXPECTED_TYPE_ERROR_COUNT);
   }
 
   private static int lineNumberOfTheMethodWithNoSonar(FileSystem fs) throws IOException {
@@ -177,7 +175,7 @@ class JavaSensorTest {
     NoSonarFilter noSonarFilter = mock(NoSonarFilter.class);
     SensorContextTester context = spy(createContext(onType).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7))));
     DefaultFileSystem fs = context.fileSystem();
-    fs.setWorkDir(tmp.newFolder().toPath());
+    fs.setWorkDir(Files.createTempDirectory(tmp, "work"));
     SonarComponents sonarComponents = createSonarComponentsMock(context);
     DefaultJavaResourceLocator javaResourceLocator = createDefaultJavaResourceLocator(settings.asConfig(), fs);
 
@@ -265,14 +263,14 @@ class JavaSensorTest {
   }
 
   private void assertJasperIsInvoked(MapSettings settings) throws IOException {
-    Path base = tmp.newFolder().toPath();
-    Path generatedFilePath = tmp.newFile("Generated.java").toPath();
+    Path base = Files.createTempDirectory(tmp, "base");
+    Path generatedFilePath = Files.createFile(tmp.resolve("Generated.java"));
     Files.write(generatedFilePath, "class Generated {}".getBytes());
     GeneratedFile generatedFile = new GeneratedFile(generatedFilePath);
 
     SensorContextTester context = SensorContextTester.create(base);
     context.setSettings(settings);
-    context.fileSystem().setWorkDir(tmp.newFolder().toPath());
+    context.fileSystem().setWorkDir(Files.createTempDirectory(tmp, "work"));
     SonarComponents sonarComponents = createSonarComponentsMock(context);
     JavaFileScanner javaFileScanner = mock(JavaFileScanner.class);
     JspCodeScanner testCodeVisitor = mock(JspCodeScanner.class);
@@ -295,13 +293,13 @@ class JavaSensorTest {
 
   @Test
   void should_not_invoke_jasper_jsp_compilation_in_autoscan_for_security_reasons() throws Exception {
-    Path base = tmp.newFolder().toPath();
+    Path base = Files.createTempDirectory(tmp, "base");
     MapSettings settings = new MapSettings();
     settings.setProperty("sonar.internal.analysis.autoscan", "true");
 
     SensorContextTester context = SensorContextTester.create(base);
     context.setSettings(settings);
-    context.fileSystem().setWorkDir(tmp.newFolder().toPath());
+    context.fileSystem().setWorkDir(Files.createTempDirectory(tmp, "work"));
     SonarComponents sonarComponents = createSonarComponentsMock(context);
     JspCodeScanner jspCodeVisitor = mock(JspCodeScanner.class);
     when(sonarComponents.mainChecks()).thenReturn(Collections.emptyList());
@@ -321,7 +319,7 @@ class JavaSensorTest {
   void performance_measure_should_not_be_activated_by_default() throws IOException {
     logTester.setLevel(Level.DEBUG);
     MapSettings settings = new MapSettings();
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     executeJavaSensorForPerformanceMeasure(settings, workDir);
     String debugLogs = String.join("\n", logTester.logs(Level.DEBUG));
     assertThat(debugLogs).doesNotContain("Performance Measures:");
@@ -333,7 +331,7 @@ class JavaSensorTest {
   void performance_measure_should_log_in_debug_mode() throws IOException {
     MapSettings settings = new MapSettings();
     settings.setProperty("sonar.java.performance.measure", "true");
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     executeJavaSensorForPerformanceMeasure(settings, workDir);
     String debugLogs = String.join("\n", logTester.logs(Level.DEBUG));
     assertThat(debugLogs).contains("Performance Measures:\n{ \"name\": \"JavaSensor\"");
@@ -346,7 +344,7 @@ class JavaSensorTest {
   void custom_performance_measure_file_path_can_be_provided() throws IOException {
     logTester.setLevel(Level.DEBUG);
     MapSettings settings = new MapSettings();
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     Path customPerformanceFile = workDir.resolve("custom.performance.measure.json");
     settings.setProperty("sonar.java.performance.measure", "true");
     settings.setProperty("sonar.java.performance.measure.path", customPerformanceFile.toString());
@@ -365,7 +363,7 @@ class JavaSensorTest {
     MapSettings settings = new MapSettings();
     settings.setProperty("sonar.java.performance.measure", "true");
     settings.setProperty("sonar.java.performance.measure.path", "");
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     executeJavaSensorForPerformanceMeasure(settings, workDir);
     String debugLogs = String.join("\n", logTester.logs(Level.DEBUG));
     assertThat(debugLogs).contains("{ \"name\": \"JavaSensor\"");
@@ -379,7 +377,7 @@ class JavaSensorTest {
     MapSettings settings = new MapSettings();
     settings.setProperty("sonar.java.source", JavaVersionImpl.MAX_SUPPORTED);
     settings.setProperty("sonar.java.enablePreview", "True");
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     executeJavaSensorForPerformanceMeasure(settings, workDir);
     assertThat(logTester.logs(Level.WARN)).isEmpty();
     List<String> infoLogs = logTester.logs(Level.INFO);
@@ -393,7 +391,7 @@ class JavaSensorTest {
     int version = JavaVersionImpl.MAX_SUPPORTED - 1;
     settings.setProperty("sonar.java.source", version);
     settings.setProperty("sonar.java.enablePreview", "True");
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     executeJavaSensorForPerformanceMeasure(settings, workDir);
     assertThat(logTester.logs(Level.WARN)).contains(
       "sonar.java.enablePreview is set but will be discarded as the Java version is less than the max supported version (" +
@@ -409,7 +407,7 @@ class JavaSensorTest {
     // We set the sonar.java.enablePreview flag to true but it will be ignored because there is no sonar.java.source
     MapSettings settings = new MapSettings();
     settings.setProperty("sonar.java.enablePreview", "true");
-    Path workDir = tmp.newFolder().toPath();
+    Path workDir = Files.createTempDirectory(tmp, "work");
     executeJavaSensorForPerformanceMeasure(settings, workDir);
     assertThat(logTester.logs(Level.WARN)).noneMatch(
       log -> log.startsWith("sonar.java.enablePreview is set but will be discarded as the Java version is less than the max supported version")
@@ -473,7 +471,7 @@ class JavaSensorTest {
       .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
 
     DefaultFileSystem fs = context.fileSystem();
-    fs.setWorkDir(tmp.newFolder().toPath());
+    fs.setWorkDir(Files.createTempDirectory(tmp, "work"));
 
     File mainFile = new File(fs.baseDir(), "CodeWithIssues.java");
     fs.add(new TestInputFileBuilder("", mainFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDirPath())
@@ -528,7 +526,7 @@ class JavaSensorTest {
       .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
 
     DefaultFileSystem fs = context.fileSystem();
-    fs.setWorkDir(tmp.newFolder().toPath());
+    fs.setWorkDir(Files.createTempDirectory(tmp, "work"));
 
     File mainFile = new File(fs.baseDir(), "CodeWithIssues.java");
     fs.add(new TestInputFileBuilder("", mainFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDirPath())


### PR DESCRIPTION
## Summary

- replace the deprecated JUnit rule migration bridge with native JUnit 5 extensions and `@TempDir`
- migrate the shared external-report and input-file test helpers
- remove `junit-jupiter-migrationsupport` from all five affected modules
- keep the Java sensor telemetry assertion aligned with the migrated source it analyzes

## Why

The Next quality gate reports 12 open `java:S5738` issues, all caused by `@EnableRuleMigrationSupport`, which is deprecated and marked for removal.

## Verification

- Java 26: targeted Maven reactor build across 15 modules (`BUILD SUCCESS`)
- 115 selected test executions: 114 passed, 1 skipped
- confirmed no `EnableRuleMigrationSupport` or `junit-jupiter-migrationsupport` references remain
