### PR TITLE
SONARJAVA-6629 Fix five open SonarQube issues (S1130, S2259)

### DIFF
--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/InternalCheckVerifier.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/InternalCheckVerifier.java
@@ -427,7 +427,7 @@ public class InternalCheckVerifier implements CheckVerifier {
     AnalyzerMessage issue,
     @Nullable Expectations.RemediationFunction remediationFunction) {
 
-    int line = issue.getLine();
+    Integer line = issue.getLine();
     if (expected.containsKey(line)) {
       Expectations.Issue attrs = expected.get(line).get(0);
       validateRemediationFunction(attrs, issue, remediationFunction);

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/DroppedPropertiesSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/DroppedPropertiesSensorTest.java
@@ -40,7 +40,7 @@ class DroppedPropertiesSensorTest {
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
 
   @Test
-  void test() throws Exception {
+  void test() {
     SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     MapSettings mapSettings = new MapSettings().setProperty("sonar.jacoco.reportPaths", "/path");
     contextTester.setSettings(mapSettings);
@@ -54,7 +54,7 @@ class DroppedPropertiesSensorTest {
   }
 
   @Test
-  void test_two_reportPaths_property() throws Exception {
+  void test_two_reportPaths_property() {
     SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     MapSettings mapSettings = new MapSettings().setProperty("sonar.jacoco.reportPaths", "/path")
       .setProperty("sonar.jacoco.reportPath", "/path");
@@ -68,7 +68,7 @@ class DroppedPropertiesSensorTest {
   }
 
   @Test
-  void test_two_reportPaths_property_plus_another() throws Exception {
+  void test_two_reportPaths_property_plus_another() {
     SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     MapSettings mapSettings = new MapSettings().setProperty("sonar.jacoco.reportPaths", "/path")
       .setProperty("sonar.jacoco.reportPath", "/path")
@@ -84,7 +84,7 @@ class DroppedPropertiesSensorTest {
   }
 
   @Test
-  void test_empty() throws Exception {
+  void test_empty() {
     SensorContextTester contextTester = SensorContextTester.create(tmp.toFile());
     List<String> analysisWarnings = new ArrayList<>();
     DroppedPropertiesSensor sensor = new DroppedPropertiesSensor(analysisWarnings::add);


### PR DESCRIPTION
## Summary

- Remove redundant `throws Exception` from 4 test methods in `DroppedPropertiesSensorTest` that don't throw checked exceptions (S1130)
- Change `int line` to `Integer line` in `InternalCheckVerifier.validateIssue` to prevent NPE when `AnalyzerMessage.getLine()` returns `null` for file-level issues (S2259)

## Test plan

- [ ] Existing tests pass (no behavioral change for S1130 fixes)
- [ ] S2259 fix: `validateIssue` now safely handles file-level `AnalyzerMessage` instances where `getLine()` returns `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)