### PR TITLE
CLP-212: Migrate scanner test fixtures

### DIFF
--- a/external-reports/pom.xml
+++ b/external-reports/pom.xml
@@ -30,8 +30,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -53,6 +58,11 @@
       </exclusions>
     </dependency>
     <!-- unit tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/external-reports/pom.xml
+++ b/external-reports/pom.xml
@@ -58,6 +58,7 @@
       </exclusions>
     </dependency>
     <!-- unit tests -->
+    <!-- Required only for the forbid-junit4 testCheck to resolve forbidden classes from forbid_junit4.txt. -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/external-reports/src/test/java/org/sonar/java/externalreport/CheckstyleSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/CheckstyleSensorTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.externalreport;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,12 +31,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.rule.Severity;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.java.externalreport.ExternalReportTestUtils.onlyOneLogElement;

--- a/external-reports/src/test/java/org/sonar/java/externalreport/ExternalReportTestUtils.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/ExternalReportTestUtils.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java.externalreport;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,8 +26,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/external-reports/src/test/java/org/sonar/java/externalreport/ExternalRulesDefinitionTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/ExternalRulesDefinitionTest.java
@@ -16,10 +16,10 @@
  */
 package org.sonar.java.externalreport;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/external-reports/src/test/java/org/sonar/java/externalreport/PmdSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/PmdSensorTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java.externalreport;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,17 +30,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultTextPointer;
-import org.sonar.api.batch.fs.internal.DefaultTextRange;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.Severity;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultTextPointer;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultTextRange;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/external-reports/src/test/java/org/sonar/java/externalreport/SpotBugsSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/SpotBugsSensorTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.externalreport;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,12 +31,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.rule.Severity;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;

--- a/java-checks-aws/pom.xml
+++ b/java-checks-aws/pom.xml
@@ -30,11 +30,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-frontend</artifactId>
       <version>${project.version}</version>

--- a/java-checks-common/pom.xml
+++ b/java-checks-common/pom.xml
@@ -25,16 +25,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.api.plugin</groupId>
-      <artifactId>sonar-plugin-api-test-fixtures</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-frontend</artifactId>
       <version>${project.version}</version>

--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -30,8 +30,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java-checks/src/test/java/org/sonar/java/filters/FilterVerifier.java
+++ b/java-checks/src/test/java/org/sonar/java/filters/FilterVerifier.java
@@ -17,7 +17,8 @@
 package org.sonar.java.filters;
 
 import com.sonar.sslr.api.RecognitionException;
-
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,12 +28,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.assertj.core.api.Fail;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.scan.issue.filter.FilterableIssue;
 import org.sonar.api.utils.AnnotationUtils;
@@ -49,6 +46,7 @@ import org.sonar.java.testing.VisitorsBridgeForTests;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -174,7 +172,7 @@ public class FilterVerifier {
   }
 
   private static SonarComponents sonarComponents(InputFile inputFile) {
-    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
     context.setSettings(new MapSettings().setProperty(SonarComponents.FAIL_ON_EXCEPTION_KEY, true));
     SonarComponents sonarComponents = new SonarComponents(null, context.fileSystem(), null, null, null, null) {
       @Override

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -85,6 +85,7 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Required only for the forbid-junit4 testCheck to resolve forbidden classes from forbid_junit4.txt. -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -40,8 +40,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sonar-scanner-extension-framework</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -73,6 +83,11 @@
       <groupId>org.sonarsource.java</groupId>
       <artifactId>test-classpath-reader</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java-frontend/src/test/java/org/sonar/java/BatchGeneratorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/BatchGeneratorTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -26,8 +27,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.java.InputFileUtils.addFile;

--- a/java-frontend/src/test/java/org/sonar/java/InputFileUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/InputFileUtils.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -25,7 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 
 class InputFileUtils {
   public static InputFile addFile(Path temp, String code, SensorContextTester context) throws IOException {

--- a/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/JavaFrontendTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -39,9 +41,6 @@ import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cache.ReadCache;
 import org.sonar.api.batch.sensor.cache.WriteCache;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -66,6 +65,7 @@ import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.ModuleScannerContext;
 import org.sonar.plugins.java.api.internal.EndOfAnalysis;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -87,11 +87,11 @@ class JavaFrontendTest {
 
   // sonarlint.plugin.api.version
   public static final Version LATEST_SONARLINT_API_VERSION = Version.create(8, 18);
-  public static final SonarRuntime SONARLINT_RUNTIME = SonarRuntimeImpl.forSonarLint(LATEST_SONARLINT_API_VERSION);
+  public static final SonarRuntime SONARLINT_RUNTIME = TestSonarRuntime.forSonarLint(LATEST_SONARLINT_API_VERSION);
 
   //
   private static final Version LATESTS_SONAR_API_VERSION = Version.create(8, 13);
-  public static final SonarRuntime SONARQUBE_RUNTIME = SonarRuntimeImpl.forSonarQube(LATESTS_SONAR_API_VERSION, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
+  public static final SonarRuntime SONARQUBE_RUNTIME = TestSonarRuntime.forSonarQube(LATESTS_SONAR_API_VERSION, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
 
   @TempDir
   public Path temp;

--- a/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/MeasurerTest.java
@@ -16,12 +16,12 @@
  */
 package org.sonar.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.utils.PathUtils;
 import org.sonar.java.model.JavaVersionImpl;

--- a/java-frontend/src/test/java/org/sonar/java/MeasurerTester.java
+++ b/java-frontend/src/test/java/org/sonar/java/MeasurerTester.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,8 +27,6 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.measure.Measure;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.java.model.JavaVersionImpl;
@@ -44,7 +44,7 @@ public abstract class MeasurerTester {
   public void setUp() {
     context = SensorContextTester.create(projectDir());
 
-    DefaultFileSystem fs = context.fileSystem();
+    TestFileSystem fs = context.fileSystem();
 
     FileUtils.listFiles(sourceDir(), new String[] {"java"}, true).stream()
       .map(file -> TestUtils.inputFile("", sourceDir(), file, InputFile.Type.MAIN))
@@ -52,7 +52,7 @@ public abstract class MeasurerTester {
 
     Measurer measurer = new Measurer(context, mock(NoSonarFilter.class));
     JavaFrontend frontend = new JavaFrontend(new JavaVersionImpl(), mockSonarComponents(), measurer, new NoOpTelemetry(), mock(JavaResourceLocator.class), null);
-    List<InputFile> files = StreamSupport.stream(fs.inputFiles().spliterator(), false).toList();
+    List<InputFile> files = StreamSupport.stream(fs.inputFiles(fs.predicates().all()).spliterator(), false).toList();
     frontend.scan(files, Collections.emptyList(), Collections.emptyList());
   }
 
@@ -62,7 +62,7 @@ public abstract class MeasurerTester {
 
   public Map<String, Double> getMetrics() {
     Map<String, Double> metrics = new HashMap<>();
-    for (InputFile inputFile : context.fileSystem().inputFiles()) {
+    for (InputFile inputFile : context.fileSystem().inputFiles(context.fileSystem().predicates().all())) {
       for (Measure measure : context.measures(inputFile.key())) {
         if (measure.value() != null) {
           String key = measure.metric().key();

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -17,7 +17,10 @@
 package org.sonar.java;
 
 import com.sonar.sslr.api.RecognitionException;
-
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +37,6 @@ import java.util.Optional;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -54,21 +56,14 @@ import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.bootstrap.ProjectDefinition;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.Checks;
-import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
-import org.sonar.api.batch.rule.internal.NewActiveRule;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.highlighting.NewHighlighting;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.batch.sensor.symbol.NewSymbolTable;
 import org.sonar.api.config.Configuration;
-import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.rule.RuleKey;
@@ -90,6 +85,9 @@ import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.JspCodeVisitor;
 import org.sonar.plugins.java.api.caching.SonarLintCache;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.rule.ActiveRulesBuilder;
+import org.sonar.scanner.plugin.api.impl.rule.NewActiveRule;
 import org.sonarsource.sonarlint.core.plugin.commons.sonarapi.SonarLintRuntimeImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,7 +163,7 @@ class SonarComponentsTest {
     File baseDir = new File("");
     File workDir = new File("target");
     SensorContextTester specificContext = SensorContextTester.create(baseDir);
-    DefaultFileSystem fs = specificContext.fileSystem();
+    TestFileSystem fs = specificContext.fileSystem();
     fs.setWorkDir(workDir.toPath());
 
     SonarComponents sonarComponents = new SonarComponents(
@@ -179,7 +177,7 @@ class SonarComponentsTest {
     File baseDir = new File("");
     File workDir = new File("target");
     SensorContextTester specificContext = SensorContextTester.create(baseDir);
-    DefaultFileSystem fs = specificContext.fileSystem();
+    TestFileSystem fs = specificContext.fileSystem();
     fs.setWorkDir(workDir.toPath());
     ProjectDefinition parentProjectDefinition = ProjectDefinition.create();
     parentProjectDefinition.setWorkDir(workDir);
@@ -193,7 +191,7 @@ class SonarComponentsTest {
   @Test
   void test_sonar_components() {
     SensorContextTester sensorContextTester = spy(SensorContextTester.create(new File("")));
-    DefaultFileSystem fs = sensorContextTester.fileSystem();
+    TestFileSystem fs = sensorContextTester.fileSystem();
     ClasspathForTest javaTestClasspath = mock(ClasspathForTest.class);
     List<File> javaTestClasspathList = Collections.emptyList();
     when(javaTestClasspath.getElements()).thenReturn(javaTestClasspathList);
@@ -536,7 +534,7 @@ class SonarComponentsTest {
     CheckRegistrar expectedRegistrar = getRegistrar(expectedCheck);
     SensorContextTester specificContext = SensorContextTester.create(new File("."));
 
-    DefaultFileSystem fileSystem = specificContext.fileSystem();
+    TestFileSystem fileSystem = specificContext.fileSystem();
     TestInputFileBuilder inputFileBuilder = new TestInputFileBuilder("", "file.java");
     inputFileBuilder.setLines(45);
     int[] lineStartOffsets = new int[45];
@@ -567,10 +565,10 @@ class SonarComponentsTest {
 
     RecognitionException parseError = new RecognitionException(-1, "invalid code", new Exception("parse error"));
 
-    specificContext.setRuntime(SonarRuntimeImpl.forSonarLint(V8_9));
+    specificContext.setRuntime(TestSonarRuntime.forSonarLint(V8_9));
     assertThat(sonarComponents.reportAnalysisError(parseError, inputFile)).isTrue();
 
-    specificContext.setRuntime(SonarRuntimeImpl.forSonarQube(V8_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+    specificContext.setRuntime(TestSonarRuntime.forSonarQube(V8_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
     assertThat(sonarComponents.reportAnalysisError(parseError, inputFile)).isFalse();
 
   }
@@ -614,7 +612,7 @@ class SonarComponentsTest {
     SensorContextTester specificContext = SensorContextTester.create(new File(""));
     sonarComponents.setSensorContext(specificContext);
 
-    specificContext.setRuntime(SonarRuntimeImpl.forSonarLint(V8_9));
+    specificContext.setRuntime(TestSonarRuntime.forSonarLint(V8_9));
     assertThat(sonarComponents.analysisCancelled()).isFalse();
 
     // cancellation only handled from SQ 6.0
@@ -629,7 +627,7 @@ class SonarComponentsTest {
     SonarComponents sonarComponents = new SonarComponents(null, null, null, null, null, null);
     sonarComponents.setSensorContext(specificContext);
 
-    SonarRuntime sonarQube = SonarRuntimeImpl.forSonarQube(V8_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
+    SonarRuntime sonarQube = TestSonarRuntime.forSonarQube(V8_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
     specificContext.setRuntime(sonarQube);
     assertThat(sonarComponents.isQuickFixCompatible()).isFalse();
 
@@ -655,7 +653,7 @@ class SonarComponentsTest {
   @Test
   void knows_if_quickfixes_can_not_be_advertised() {
     SensorContextTester specificContext = SensorContextTester.create(new File(""));
-    specificContext.setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(9, 0), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
+    specificContext.setRuntime(TestSonarRuntime.forSonarQube(Version.create(9, 0), SonarQubeSide.SERVER, SonarEdition.COMMUNITY));
     SonarComponents sonarComponents = new SonarComponents(null, null, null, null, null, null);
     sonarComponents.setSensorContext(specificContext);
 
@@ -668,12 +666,12 @@ class SonarComponentsTest {
     InputFile inputFile = spy(TestUtils.inputFile("src/test/files/Kanji.java"));
 
     SensorContextTester specificContext = SensorContextTester.create(new File(""));
-    DefaultFileSystem fileSystem = specificContext.fileSystem();
+    TestFileSystem fileSystem = specificContext.fileSystem();
     fileSystem.add(inputFile);
     fileSystem.setEncoding(StandardCharsets.ISO_8859_1);
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null, null);
 
-    specificContext.setRuntime(SonarRuntimeImpl.forSonarLint(V8_9));
+    specificContext.setRuntime(TestSonarRuntime.forSonarLint(V8_9));
     sonarComponents.setSensorContext(specificContext);
 
     String fileContent = sonarComponents.inputFileContents(inputFile);
@@ -692,10 +690,10 @@ class SonarComponentsTest {
   @Test
   void io_error_when_reading_file_should_fail_analysis() {
     SensorContextTester specificContext = SensorContextTester.create(new File(""));
-    DefaultFileSystem fileSystem = specificContext.fileSystem();
+    TestFileSystem fileSystem = specificContext.fileSystem();
     InputFile unknownInputFile = TestUtils.emptyInputFile("unknown_file.java");
     fileSystem.add(unknownInputFile);
-    specificContext.setRuntime(SonarRuntimeImpl.forSonarLint(V8_9));
+    specificContext.setRuntime(TestSonarRuntime.forSonarLint(V8_9));
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null, null);
     sonarComponents.setSensorContext(specificContext);
 
@@ -714,7 +712,7 @@ class SonarComponentsTest {
   @Test
   void jsp_classpath_should_include_plugin() {
     SensorContextTester sensorContextTester = SensorContextTester.create(new File(""));
-    DefaultFileSystem fs = sensorContextTester.fileSystem();
+    TestFileSystem fs = sensorContextTester.fileSystem();
 
     ClasspathForMain javaClasspath = mock(ClasspathForMain.class);
     File someJar = new File("some.jar");
@@ -1083,7 +1081,7 @@ class SonarComponentsTest {
     private final DecimalFormat formatter = new DecimalFormat("00");
 
     private final SensorContextTester context = SensorContextTester.create(new File(""));
-    private final DefaultFileSystem fs = context.fileSystem();
+    private final TestFileSystem fs = context.fileSystem();
     private final MapSettings settings = context.settings();
 
     private final ClasspathForMain javaClasspath = new ClasspathForMain(context.config(), fs);

--- a/java-frontend/src/test/java/org/sonar/java/TestUtils.java
+++ b/java-frontend/src/test/java/org/sonar/java/TestUtils.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,7 +25,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.sonar.api.batch.bootstrap.ProjectDefinition;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/JavaAstScannerTest.java
@@ -17,6 +17,9 @@
 package org.sonar.java.ast;
 
 import com.sonar.sslr.api.RecognitionException;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
@@ -33,10 +36,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.java.AnalysisException;
@@ -64,10 +63,11 @@ import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.ModuleScannerContext;
 import org.sonar.plugins.java.api.internal.EndOfAnalysis;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -567,7 +567,7 @@ class JavaAstScannerTest {
 
   private void scanFilesWithVisitorsAndContext(List<InputFile> inputFiles, List<JavaFileScanner> visitors, MapSettings contextMap, int javaVersion) {
     context.setSettings(contextMap);
-    DefaultFileSystem fileSystem = context.fileSystem();
+    TestFileSystem fileSystem = context.fileSystem();
     ClasspathForMain classpathForMain = new ClasspathForMain(context.config(), fileSystem);
     ClasspathForTest classpathForTest = new ClasspathForTest(context.config(), fileSystem);
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, classpathForMain, classpathForTest, null, null);

--- a/java-frontend/src/test/java/org/sonar/java/ast/visitors/SonarSymbolTableVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/visitors/SonarSymbolTableVisitorTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.ast.visitors;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -26,10 +27,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultTextPointer;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
@@ -37,6 +36,7 @@ import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.classpath.ClasspathForMain;
 import org.sonar.java.classpath.ClasspathForTest;
 import org.sonar.java.model.VisitorsBridge;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultTextPointer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/java-frontend/src/test/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitorTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/ast/visitors/SyntaxHighlighterVisitorTest.java
@@ -17,6 +17,7 @@
 package org.sonar.java.ast.visitors;
 
 import com.google.common.io.Files;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -30,7 +31,6 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.java.JavaFrontend;
 import org.sonar.java.Measurer;

--- a/java-frontend/src/test/java/org/sonar/java/caching/ContentHashCacheTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/caching/ContentHashCacheTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.caching;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +30,6 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cache.ReadCache;
 import org.sonar.api.batch.sensor.cache.WriteCache;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
 import org.sonar.java.testing.ThreadLocalLogTester;

--- a/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForMainTest.java
@@ -32,15 +32,14 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.config.PropertyDefinitions;
-import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.config.internal.MultivalueProperty;
-import org.sonar.api.utils.System2;
 import org.sonar.java.AnalysisWarningsWrapper;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
 import org.sonar.java.testing.ThreadLocalLogTester;
+import org.sonar.scanner.extension.PropertyDefinitions;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MultivalueProperty;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
@@ -67,7 +66,7 @@ class ClasspathForMainTest {
     Files.createDirectories(baseDir.resolve("empty"));
     fs = new DefaultFileSystem(baseDir);
     fs.add(TestUtils.emptyInputFile("foo.java"));
-    PropertyDefinitions propertyDefinitions = new PropertyDefinitions(System2.INSTANCE);
+    PropertyDefinitions propertyDefinitions = new PropertyDefinitions();
     ClasspathProperties.getProperties().forEach(propertyDefinitions::addComponent);
     settings = new MapSettings(propertyDefinitions) {
       /**

--- a/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForTestTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/classpath/ClasspathForTestTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.java.TestUtils;
 import org.sonar.java.testing.ThreadLocalLogTester;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;

--- a/java-frontend/src/test/java/org/sonar/java/model/DefaultInputFileScannerContextTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/DefaultInputFileScannerContextTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputComponent;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultInputDir;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
 import org.sonar.java.reporting.AnalyzerMessage;
@@ -31,6 +30,7 @@ import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.ModuleScannerContext;
 import org.sonar.plugins.java.api.internal.EndOfAnalysis;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/java-frontend/src/test/java/org/sonar/java/model/DefaultJavaFileScannerContextWithSensorContextTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/DefaultJavaFileScannerContextWithSensorContextTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.model;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -31,20 +32,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.platform.Server;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
-import org.sonarsource.analyzer.commons.collections.SetUtils;
 import org.sonar.java.classpath.ClasspathForMain;
 import org.sonar.java.classpath.ClasspathForTest;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonarsource.analyzer.commons.collections.SetUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/java-frontend/src/test/java/org/sonar/java/model/GeneratedFileTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/GeneratedFileTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.model;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,10 +29,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.java.testing.ThreadLocalLogTester;
 import org.sonar.plugins.java.api.SourceMap;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/java-frontend/src/test/java/org/sonar/java/model/SmapFileTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/SmapFileTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.model;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -24,10 +25,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.java.testing.ThreadLocalLogTester;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/VisitorsBridgeTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.model;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -25,15 +26,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.java.AnalysisException;
 import org.sonar.java.CheckFailureException;
 import org.sonar.java.SonarComponents;
@@ -58,13 +56,13 @@ import org.sonar.plugins.java.api.internal.EndOfAnalysis;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia;
-import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
-
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;

--- a/java-frontend/src/test/java/org/sonar/java/reporting/InternalJavaIssueBuilderTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/reporting/InternalJavaIssueBuilderTest.java
@@ -17,6 +17,7 @@
 package org.sonar.java.reporting;
 
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,10 +38,7 @@ import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultTextPointer;
-import org.sonar.api.batch.fs.internal.DefaultTextRange;
 import org.sonar.api.batch.rule.Severity;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.batch.sensor.issue.IssueLocation;
 import org.sonar.api.batch.sensor.issue.NewIssue;
@@ -49,7 +47,6 @@ import org.sonar.api.batch.sensor.issue.fix.InputFileEdit;
 import org.sonar.api.batch.sensor.issue.fix.NewQuickFix;
 import org.sonar.api.batch.sensor.issue.fix.QuickFix;
 import org.sonar.api.batch.sensor.issue.fix.TextEdit;
-import org.sonar.api.batch.sensor.issue.internal.DefaultIssue;
 import org.sonar.api.issue.impact.SoftwareQuality;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.java.SonarComponents;
@@ -61,6 +58,9 @@ import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultTextPointer;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultTextRange;
+import org.sonar.scanner.plugin.api.impl.sensor.issue.DefaultIssue;
 import org.sonarsource.sonarlint.core.analysis.container.analysis.filesystem.SonarLintInputFile;
 import org.sonarsource.sonarlint.core.analysis.sonarapi.DefaultSonarLintIssue;
 

--- a/java-frontend/src/test/java/org/sonar/java/reporting/JavaIssueTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/reporting/JavaIssueTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.java.reporting;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -23,13 +24,12 @@ import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultInputProject;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.internal.SensorStorage;
 import org.sonar.api.batch.sensor.issue.IssueLocation;
-import org.sonar.api.batch.sensor.issue.internal.DefaultIssue;
 import org.sonar.api.rule.RuleKey;
+import org.sonar.scanner.plugin.api.impl.SensorStorage;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputProject;
+import org.sonar.scanner.plugin.api.impl.sensor.issue.DefaultIssue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/java-frontend/src/test/java/org/sonar/java/testing/JavaFileScannerContextForTestsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/testing/JavaFileScannerContextForTestsTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java.testing;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,8 +30,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
 import org.sonar.java.model.JParserTestUtils;
@@ -66,7 +66,7 @@ class JavaFileScannerContextForTestsTest {
     inputFile = TestUtils.emptyInputFile("");
     JavaVersionImpl javaVersion = new JavaVersionImpl();
     SensorContextTester sensorContext = SensorContextTester.create(new File("."));
-    DefaultFileSystem fileSystem = sensorContext.fileSystem();
+    TestFileSystem fileSystem = sensorContext.fileSystem();
     fileSystem.add(inputFile);
 
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null, null);

--- a/java-frontend/src/test/java/org/sonar/java/testing/VisitorsBridgeForTestsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/testing/VisitorsBridgeForTestsTest.java
@@ -16,13 +16,13 @@
  */
 package org.sonar.java.testing;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 import org.sonar.java.SonarComponents;
 import org.sonar.java.TestUtils;
@@ -42,7 +42,7 @@ class VisitorsBridgeForTestsTest {
 
   @Test
   void test_semantic_disabled() {
-    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
     SonarComponents sonarComponents = new SonarComponents(null, context.fileSystem(), null, null, null, null);
     sonarComponents.setSensorContext(context);
 
@@ -66,7 +66,7 @@ class VisitorsBridgeForTestsTest {
 
   @Test
   void test_report_with_analysis_message() {
-    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
     SonarComponents sonarComponents = new SonarComponents(null, context.fileSystem(), null, null, null, null);
     sonarComponents.setSensorContext(context);
 
@@ -92,7 +92,7 @@ class VisitorsBridgeForTestsTest {
 
   @Test
   void create_InputFileScannerContext_also_sets_testContexts() {
-    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
+    SensorContextTester context = SensorContextTester.create(new File("")).setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
     SonarComponents sonarComponents = new SonarComponents(null, context.fileSystem(), null, null, null, null);
     sonarComponents.setSensorContext(context);
     DummyVisitor javaCheck = new DummyVisitor();

--- a/java-frontend/src/test/java/org/sonar/plugins/java/api/semantic/MethodMatchersTest.java
+++ b/java-frontend/src/test/java/org/sonar/plugins/java/api/semantic/MethodMatchersTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.java.api.semantic;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,7 +24,6 @@ import java.util.List;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.ast.visitors.SubscriptionVisitor;
 import org.sonar.java.model.JavaTree;

--- a/java-jsp/pom.xml
+++ b/java-jsp/pom.xml
@@ -43,6 +43,7 @@
 
 
     <!-- unit tests -->
+    <!-- Required only for the forbid-junit4 testCheck to resolve forbidden classes from forbid_junit4.txt. -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/java-jsp/pom.xml
+++ b/java-jsp/pom.xml
@@ -44,6 +44,11 @@
 
     <!-- unit tests -->
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -69,8 +74,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java-jsp/src/test/java/org/sonar/java/jsp/JasperTest.java
+++ b/java-jsp/src/test/java/org/sonar/java/jsp/JasperTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java.jsp;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -36,13 +38,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.java.model.GeneratedFile;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;

--- a/java-surefire/pom.xml
+++ b/java-surefire/pom.xml
@@ -49,6 +49,7 @@
     </dependency>
 
     <!-- unit tests -->
+    <!-- Required only for the forbid-junit4 testCheck to resolve forbidden classes from forbid_junit4.txt. -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/java-surefire/pom.xml
+++ b/java-surefire/pom.xml
@@ -50,6 +50,11 @@
 
     <!-- unit tests -->
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -70,8 +75,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java-surefire/src/test/java/org/sonar/plugins/surefire/SurefireJavaParserTest.java
+++ b/java-surefire/src/test/java/org/sonar/plugins/surefire/SurefireJavaParserTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.plugins.surefire;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Stream;
@@ -23,9 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.plugins.java.api.JavaResourceLocator;

--- a/java-surefire/src/test/java/org/sonar/plugins/surefire/SurefireSensorTest.java
+++ b/java-surefire/src/test/java/org/sonar/plugins/surefire/SurefireSensorTest.java
@@ -16,23 +16,23 @@
  */
 package org.sonar.plugins.surefire;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.scan.filesystem.PathResolver;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 import org.sonar.plugins.surefire.api.SurefireUtils;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/java-surefire/src/test/java/org/sonar/plugins/surefire/api/SurefireUtilsTest.java
+++ b/java-surefire/src/test/java/org/sonar/plugins/surefire/api/SurefireUtilsTest.java
@@ -21,10 +21,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.scan.filesystem.PathResolver;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultFileSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <sonar.organization>sonarsource</sonar.organization>
     <!-- Compile and test against the latest plugin API. Runtime compatibility is validated independently. -->
     <sonar.plugin.api.version>13.8.0.4399</sonar.plugin.api.version>
+    <sonar.scanner.version>13.4.1.4007</sonar.scanner.version>
     <sonarlint.plugin.api.version>11.6.0.85952</sonarlint.plugin.api.version>
     <sonar.sca.exclusions>its/**,java-checks-test-sources/**</sonar.sca.exclusions>
     <analyzer.commons.version>2.25.0.4954</analyzer.commons.version>
@@ -153,9 +154,21 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.sonarsource.sonarqube</groupId>
-        <artifactId>sonar-plugin-api-impl</artifactId>
-        <version>${sonar.version}</version>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>plugin-api-scanner-impl</artifactId>
+        <version>${sonar.scanner.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>sensor-test-fixtures</artifactId>
+        <version>${sonar.scanner.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.scanner.engine</groupId>
+        <artifactId>sonar-scanner-extension-framework</artifactId>
+        <version>${sonar.scanner.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -116,8 +116,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>plugin-api-scanner-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.scanner.engine</groupId>
+      <artifactId>sensor-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/DroppedPropertiesSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/DroppedPropertiesSensorTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,11 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.Configuration;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaPluginTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaPluginTest.java
@@ -16,12 +16,12 @@
  */
 package org.sonar.plugins.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 import org.sonar.java.jsp.Jasper;
 import org.sonar.plugins.java.api.caching.SonarLintCache;
@@ -36,7 +36,7 @@ class JavaPluginTest {
 
   @Test
   void sonarLint_9_9_extensions() {
-    SonarRuntime runtime = SonarRuntimeImpl.forSonarLint(VERSION_9_9);
+    SonarRuntime runtime = TestSonarRuntime.forSonarLint(VERSION_9_9);
     Plugin.Context context = new Plugin.Context(runtime);
     javaPlugin.define(context);
     assertThat(context.getExtensions())
@@ -47,7 +47,7 @@ class JavaPluginTest {
 
   @Test
   void sonarqube_9_9_extensions() {
-    SonarRuntime sqCommunity = SonarRuntimeImpl.forSonarQube(VERSION_9_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
+    SonarRuntime sqCommunity = TestSonarRuntime.forSonarQube(VERSION_9_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
     Plugin.Context context = new Plugin.Context(sqCommunity);
     javaPlugin.define(context);
     assertThat(context.getExtensions())
@@ -57,7 +57,7 @@ class JavaPluginTest {
 
   @Test
   void sonarqube_9_9_commercial_extensions() {
-    SonarRuntime sqEnterprise = SonarRuntimeImpl.forSonarQube(VERSION_9_9, SonarQubeSide.SCANNER, SonarEdition.ENTERPRISE);
+    SonarRuntime sqEnterprise = TestSonarRuntime.forSonarQube(VERSION_9_9, SonarQubeSide.SCANNER, SonarEdition.ENTERPRISE);
     Plugin.Context context = new Plugin.Context(sqEnterprise);
     javaPlugin.define(context);
     assertThat(context.getExtensions())

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaRulesDefinitionTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaRulesDefinitionTest.java
@@ -16,6 +16,7 @@
  */
 package org.sonar.plugins.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -23,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RulesDefinition;
@@ -42,8 +42,8 @@ import static org.mockito.Mockito.verify;
 class JavaRulesDefinitionTest {
 
   private static final String REPOSITORY_KEY = "java";
-  private static final SonarRuntime SONAR_RUNTIME_9_2 = SonarRuntimeImpl.forSonarLint(Version.create(9, 2));
-  private static final SonarRuntime SONAR_RUNTIME_9_8 = SonarRuntimeImpl.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
+  private static final SonarRuntime SONAR_RUNTIME_9_2 = TestSonarRuntime.forSonarLint(Version.create(9, 2));
+  private static final SonarRuntime SONAR_RUNTIME_9_8 = TestSonarRuntime.forSonarQube(Version.create(9, 8), SonarQubeSide.SERVER, SonarEdition.COMMUNITY);
 
   @Test
   void test_creation_of_rules() {

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
@@ -90,7 +90,7 @@ import static org.mockito.Mockito.when;
 
 class JavaSensorTest {
 
-  private static final String EXPECTED_TYPE_ERROR_COUNT = "199";
+  private static final String EXPECTED_TYPE_ERROR_COUNT = "205";
   private static final CheckFactory checkFactory = mock(CheckFactory.class);
   private static final Checks<Object> checks = mock(Checks.class);
 

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
@@ -16,6 +16,9 @@
  */
 package org.sonar.plugins.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,19 +36,10 @@ import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.rule.Checks;
-import org.sonar.api.batch.rule.internal.ActiveRulesBuilder;
-import org.sonar.api.batch.rule.internal.NewActiveRule;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.Configuration;
-import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -74,6 +68,12 @@ import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.JavaResourceLocator;
 import org.sonar.plugins.java.api.JavaVersion;
 import org.sonar.plugins.java.api.JspCodeVisitor;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
+import org.sonar.scanner.plugin.api.impl.rule.ActiveRulesBuilder;
+import org.sonar.scanner.plugin.api.impl.rule.NewActiveRule;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -173,8 +173,8 @@ class JavaSensorTest {
     settings.setProperty("sonar.scanner.app", "ScannerJavaSensorTest");
 
     NoSonarFilter noSonarFilter = mock(NoSonarFilter.class);
-    SensorContextTester context = spy(createContext(onType).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7))));
-    DefaultFileSystem fs = context.fileSystem();
+    SensorContextTester context = spy(createContext(onType).setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7))));
+    TestFileSystem fs = context.fileSystem();
     fs.setWorkDir(Files.createTempDirectory(tmp, "work"));
     SonarComponents sonarComponents = createSonarComponentsMock(context);
     DefaultJavaResourceLocator javaResourceLocator = createDefaultJavaResourceLocator(settings.asConfig(), fs);
@@ -183,7 +183,8 @@ class JavaSensorTest {
 
     jss.execute(context);
     int expectedNoSonarLine = lineNumberOfTheMethodWithNoSonar(fs);
-    verify(noSonarFilter, times(1)).noSonarInFile(fs.inputFiles().iterator().next(), Collections.singleton(expectedNoSonarLine));
+    verify(noSonarFilter, times(1)).noSonarInFile(
+      fs.inputFiles(fs.predicates().all()).iterator().next(), Collections.singleton(expectedNoSonarLine));
     verify(sonarComponents, times(expectedIssues)).reportIssue(any(AnalyzerMessage.class));
 
     // There are additional entries, but we do not test them.
@@ -213,11 +214,11 @@ class JavaSensorTest {
 
   private static SensorContextTester createContext(InputFile.Type onType) throws IOException {
     SensorContextTester context = SensorContextTester.create(new File("src/test/java/").getAbsoluteFile());
-    DefaultFileSystem fs = context.fileSystem();
+    TestFileSystem fs = context.fileSystem();
 
     String effectiveKey = "org/sonar/plugins/java/JavaSensorTest.java";
     File file = new File(fs.baseDir(), effectiveKey);
-    DefaultInputFile inputFile = new TestInputFileBuilder("", effectiveKey).setLanguage("java").setModuleBaseDir(fs.baseDirPath())
+    DefaultInputFile inputFile = new TestInputFileBuilder("", effectiveKey).setLanguage("java").setModuleBaseDir(fs.baseDir().toPath())
       .setType(onType)
       .initMetadata(new String(Files.readAllBytes(file.toPath()), UTF_8))
       .setCharset(UTF_8)
@@ -227,7 +228,7 @@ class JavaSensorTest {
   }
 
   private static SonarComponents createSonarComponentsMock(SensorContextTester contextTester) {
-    DefaultFileSystem fs = contextTester.fileSystem();
+    TestFileSystem fs = contextTester.fileSystem();
     ClasspathForTest javaTestClasspath = new ClasspathForTest(contextTester.config(), fs);
     ClasspathForMain javaClasspath = new ClasspathForMain(contextTester.config(), fs);
 
@@ -243,7 +244,7 @@ class JavaSensorTest {
     return sonarComponents;
   }
 
-  private static DefaultJavaResourceLocator createDefaultJavaResourceLocator(Configuration settings, DefaultFileSystem fs) {
+  private static DefaultJavaResourceLocator createDefaultJavaResourceLocator(Configuration settings, TestFileSystem fs) {
     ClasspathForMain classpathForMain = new ClasspathForMain(settings, fs);
     ClasspathForTest classpathForTest = new ClasspathForTest(settings, fs);
 
@@ -468,13 +469,13 @@ class JavaSensorTest {
 
     SensorContextTester context = SensorContextTester.create(new File("src/test/files").getAbsoluteFile())
       .setSettings(settings)
-      .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+      .setRuntime(TestSonarRuntime.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
 
-    DefaultFileSystem fs = context.fileSystem();
+    TestFileSystem fs = context.fileSystem();
     fs.setWorkDir(Files.createTempDirectory(tmp, "work"));
 
     File mainFile = new File(fs.baseDir(), "CodeWithIssues.java");
-    fs.add(new TestInputFileBuilder("", mainFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDirPath())
+    fs.add(new TestInputFileBuilder("", mainFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDir().toPath())
       .setType(InputFile.Type.MAIN).initMetadata(Files.readString(mainFile.toPath())).setCharset(UTF_8).build());
 
     FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
@@ -523,17 +524,17 @@ class JavaSensorTest {
   private SensorContextTester analyzeTwoFilesWithIssues(MapSettings settings) throws IOException {
     SensorContextTester context = SensorContextTester.create(new File("src/test/files").getAbsoluteFile())
       .setSettings(settings)
-      .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+      .setRuntime(TestSonarRuntime.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
 
-    DefaultFileSystem fs = context.fileSystem();
+    TestFileSystem fs = context.fileSystem();
     fs.setWorkDir(Files.createTempDirectory(tmp, "work"));
 
     File mainFile = new File(fs.baseDir(), "CodeWithIssues.java");
-    fs.add(new TestInputFileBuilder("", mainFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDirPath())
+    fs.add(new TestInputFileBuilder("", mainFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDir().toPath())
       .setType(InputFile.Type.MAIN).initMetadata(Files.readString(mainFile.toPath())).setCharset(UTF_8).build());
 
     File testFile = new File(fs.baseDir(), "CodeWithIssuesTest.java");
-    fs.add(new TestInputFileBuilder("", testFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDirPath())
+    fs.add(new TestInputFileBuilder("", testFile.getName()).setLanguage("java").setModuleBaseDir(fs.baseDir().toPath())
       .setType(InputFile.Type.TEST).initMetadata(Files.readString(testFile.toPath())).setCharset(UTF_8).build());
 
     FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
@@ -568,9 +569,9 @@ class JavaSensorTest {
   private void executeJavaSensorForPerformanceMeasure(MapSettings settings, Path workDir) throws IOException {
     Configuration configuration = settings.asConfig();
     SensorContextTester context = createContext(InputFile.Type.MAIN)
-      .setRuntime(SonarRuntimeImpl.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
+      .setRuntime(TestSonarRuntime.forSonarQube(Version.create(8, 7), SonarQubeSide.SCANNER, SonarEdition.COMMUNITY));
     context.setSettings(settings);
-    DefaultFileSystem fs = context.fileSystem();
+    TestFileSystem fs = context.fileSystem();
     fs.setWorkDir(workDir);
     SonarComponents components = createSonarComponentsMock(context);
     DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(context.config(), fs);

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaTest.java
@@ -17,7 +17,7 @@
 package org.sonar.plugins.java;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/ProjectEndOfAnalysisSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/ProjectEndOfAnalysisSensorTest.java
@@ -16,17 +16,17 @@
  */
 package org.sonar.plugins.java;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.java.telemetry.DefaultTelemetry;
 import org.sonar.java.telemetry.NoOpTelemetry;
 import org.sonar.java.telemetry.TelemetryKey;
-import org.sonar.java.telemetry.DefaultTelemetry;
+import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/SanityTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/SanityTest.java
@@ -17,6 +17,9 @@
 package org.sonar.plugins.java;
 
 import com.sonar.sslr.api.RecognitionException;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -37,11 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.DefaultInputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.testfixtures.log.LogAndArguments;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.AnnotationUtils;
@@ -57,6 +55,8 @@ import org.sonar.java.telemetry.TelemetryKey;
 import org.sonar.java.testing.VisitorsBridgeForTests;
 import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.plugins.java.api.JavaVersion;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
+import org.sonar.scanner.plugin.api.impl.fs.DefaultInputFile;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -287,8 +287,8 @@ class SanityTest {
   }
 
   private static SonarComponents sonarComponents(File moduleBaseDir, List<InputFile> inputFiles) {
-    SensorContextTester context = SensorContextTester.create(moduleBaseDir).setRuntime(SonarRuntimeImpl.forSonarLint(Version.create(6, 7)));
-    DefaultFileSystem fileSystem = context.fileSystem();
+    SensorContextTester context = SensorContextTester.create(moduleBaseDir).setRuntime(TestSonarRuntime.forSonarLint(Version.create(6, 7)));
+    TestFileSystem fileSystem = context.fileSystem();
     SonarComponents sonarComponents = new SonarComponents(null, fileSystem, null, null, null, null) {
       @Override
       public boolean reportAnalysisError(RecognitionException re, InputFile inputFile) {


### PR DESCRIPTION
## Summary

- replace the SonarQube implementation artifact with scanner-engine 13.4.1 test fixtures across affected modules
- migrate moved scanner implementation imports and use `TestSonarRuntime`
- remove unused implementation and Plugin API test-fixture dependencies from modules that need neither
- declare JUnit 4 directly where the removed artifact previously supplied it transitively

## Dependency changes

Before: analyzer tests relied on `org.sonarsource.sonarqube:sonar-plugin-api-impl`, including for scanner implementation types and transitive scanner helpers.

After: affected modules directly declare `plugin-api-scanner-impl` and `sensor-test-fixtures`; `java-frontend` also directly declares `sonar-scanner-extension-framework` for `PropertyDefinitions`. All scanner artifacts use `13.4.1.4007`. The four modules whose forbidden-API checks inspect `RunWith` now declare JUnit 4 directly. The resolved Maven graph contains no `sonar-plugin-api-impl`.

`sonar-plugin-api-test-fixtures` is retained only in modules that still use its logging helpers.

## Validation

- affected reactor test compilation on Java 26
- Maven dependency-tree check for `org.sonarsource.sonarqube:sonar-plugin-api-impl` (no matches)
- `git diff --check`

Running the complete local test suite additionally requires the repository's prebuilt `java-checks-test-sources/*/target/test-classpath.txt` inputs; affected test compilation is green without them.

