### PR TITLE
Extract inline Mockito mock creations

### DIFF
--- a/java-checks/src/test/java/org/sonar/java/filters/PostAnalysisIssueFilterTest.java
+++ b/java-checks/src/test/java/org/sonar/java/filters/PostAnalysisIssueFilterTest.java
@@ -50,7 +50,8 @@ class PostAnalysisIssueFilterTest {
 
     context = mock(JavaFileScannerContext.class);
     when(context.getInputFile()).thenReturn(INPUT_FILE);
-    when(context.getSemanticModel()).thenReturn(mock(Sema.class));
+    Sema sema = mock(Sema.class);
+    when(context.getSemanticModel()).thenReturn(sema);
 
     fakeIssue = mock(FilterableIssue.class);
     when(fakeIssue.componentKey()).thenReturn("component");

--- a/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/SonarComponentsTest.java
@@ -547,7 +547,8 @@ class SonarComponentsTest {
     InputFile inputFile = inputFileBuilder.build();
     fileSystem.add(inputFile);
 
-    when(this.checks.ruleKey(any(JavaCheck.class))).thenReturn(mock(RuleKey.class));
+    RuleKey ruleKey = mock(RuleKey.class);
+    when(this.checks.ruleKey(any(JavaCheck.class))).thenReturn(ruleKey);
 
     SonarComponents sonarComponents = new SonarComponents(fileLinesContextFactory, fileSystem, null,
       null, checkFactory, specificContext.activeRules(), new CheckRegistrar[]{expectedRegistrar});

--- a/java-frontend/src/test/java/org/sonar/java/model/JParserTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JParserTest.java
@@ -703,7 +703,8 @@ class JParserTest {
     JParserConfig config = spy(JParserConfig.Mode.BATCH
       .create(MAXIMUM_SUPPORTED_JAVA_VERSION, List.of(), false));
     // Return a lazy ASTParser that do nothing to ensure that we have not analyzed files
-    when(config.astParser()).thenReturn(mock(ASTParser.class));
+    ASTParser astParser = mock(ASTParser.class);
+    when(config.astParser()).thenReturn(astParser);
 
     config.parse(inputFiles, () -> false, new AnalysisProgress(inputFiles.size()), doNothingAction);
 

--- a/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
+++ b/sonar-java-plugin/src/test/java/org/sonar/plugins/java/JavaSensorTest.java
@@ -479,7 +479,8 @@ class JavaSensorTest {
       .setType(InputFile.Type.MAIN).initMetadata(Files.readString(mainFile.toPath())).setCharset(UTF_8).build());
 
     FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
-    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
+    FileLinesContext fileLinesContext = mock(FileLinesContext.class);
+    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(fileLinesContext);
     ClasspathForTest javaTestClasspath = new ClasspathForTest(context.config(), fs);
     ClasspathForMain javaClasspath = new ClasspathForMain(context.config(), fs);
     DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(context.config(), fs);
@@ -538,7 +539,8 @@ class JavaSensorTest {
       .setType(InputFile.Type.TEST).initMetadata(Files.readString(testFile.toPath())).setCharset(UTF_8).build());
 
     FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
-    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(mock(FileLinesContext.class));
+    FileLinesContext fileLinesContext = mock(FileLinesContext.class);
+    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(fileLinesContext);
     ClasspathForTest javaTestClasspath = new ClasspathForTest(context.config(), fs);
     ClasspathForMain javaClasspath = new ClasspathForMain(context.config(), fs);
     DefaultJavaResourceLocator resourceLocator = createDefaultJavaResourceLocator(context.config(), fs);


### PR DESCRIPTION
## Summary

- extract Mockito mocks passed inline to `thenReturn` into named local variables
- resolve the five `java:S9016` issues failing the SonarQube Next quality gate
- preserve the existing test behavior

## Testing

CI will verify the affected test suites and SonarQube quality gate.