### PR TITLE
SONARJAVA-6635 Implement S9068: `@ApplicationScoped` should be preferred over `@Singleton` in Quarkus applications

### DIFF
--- a/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
@@ -123,7 +123,7 @@ public class AutoScanTest {
       .setProjectName(PROJECT_NAME)
       .setProjectVersion("0.1.0-SNAPSHOT")
       .setSourceEncoding("UTF-8")
-      .setSourceDirs("aws/src/main/java/,default/src/main/java/,java-17/src/main/java/,spring-3.2/src/main/java/,spring-web-4.0/src/main/java/")
+      .setSourceDirs("aws/src/main/java/,default/src/main/java/,java-17/src/main/java/,quarkus-arc-3.15/src/main/java/,spring-3.2/src/main/java/,spring-web-4.0/src/main/java/")
       .setTestDirs("default/src/test/java/,java-17/src/test/java/,test-classpath-reader/src/test/java")
       .setProperty("sonar.java.source", "26")
       // common properties

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9068.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9068.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9068",
+  "hasTruePositives": false,
+  "falseNegatives": 4,
+  "falsePositives": 0
+}

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9068.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9068.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S9068",
   "hasTruePositives": false,
-  "falseNegatives": 4,
+  "falseNegatives": 3,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
@@ -1,5 +1,6 @@
 package checks.quarkus;
 
+import io.quarkus.arc.Unremovable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Singleton;

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
@@ -49,14 +49,14 @@ class CompliantWithJavadocComment {
 }
 
 @ApplicationScoped
-class CompliantApplicationScoped {
+class SingletonCheckCompliantApplicationScoped {
   public String hello() {
     return "hello";
   }
 }
 
 @Dependent
-class CompliantDependent {
+class SingletonCheckCompliantDependent {
 }
 
 class CompliantNoScope {

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
@@ -4,7 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Singleton;
 
-@Singleton // Noncompliant {{Replace "@Singleton" by "@ApplicationScoped" or add a comment indicating why "@Singleton" is necessary.}} [[sc=1;ec=11]]
+@Singleton // Noncompliant [[sc=1;ec=11]]
 class NoncompliantService {
   public String foo() {
     return "foo";
@@ -12,7 +12,7 @@ class NoncompliantService {
 }
 
 class NoncompliantProducerClass {
-  @Singleton // Noncompliant {{Replace "@Singleton" by "@ApplicationScoped" or add a comment indicating why "@Singleton" is necessary.}}
+  @Singleton // Noncompliant
 //^^^^^^^^^^
   public NoncompliantService produceService() {
     return new NoncompliantService();
@@ -45,6 +45,36 @@ class CompliantProducerWithComment {
 class CompliantWithJavadocComment {
   public String getConfig() {
     return "config";
+  }
+}
+
+@Singleton // singleton scope required: this bean is a lightweight config holder with no interception needs
+class CompliantWithInlineComment {
+  public String getConfig() {
+    return "config";
+  }
+}
+
+class CompliantProducerWithInlineComment {
+  @Singleton // singleton scope required: non-proxied instance expected by external library
+  public CompliantWithInlineComment produceConfig() {
+    return new CompliantWithInlineComment();
+  }
+}
+
+@Singleton
+// singleton scope required: lightweight config holder with no interception needs
+class CompliantWithFollowingLineComment {
+  public String getConfig() {
+    return "config";
+  }
+}
+
+class CompliantProducerWithFollowingLineComment {
+  @Singleton
+  // singleton scope required: non-proxied instance expected by external library
+  public CompliantWithFollowingLineComment produceConfig() {
+    return new CompliantWithFollowingLineComment();
   }
 }
 

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
@@ -1,0 +1,66 @@
+package checks.quarkus;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Singleton;
+
+@Singleton // Noncompliant {{Replace "@Singleton" by "@ApplicationScoped" or add a comment indicating why "@Singleton" is necessary.}} [[sc=1;ec=11]]
+class NoncompliantService {
+  public String foo() {
+    return "foo";
+  }
+}
+
+class NoncompliantProducerClass {
+  @Singleton // Noncompliant {{Replace "@Singleton" by "@ApplicationScoped" or add a comment indicating why "@Singleton" is necessary.}}
+//^^^^^^^^^^
+  public NoncompliantService produceService() {
+    return new NoncompliantService();
+  }
+}
+
+// Using @Singleton intentionally: low-level config holder, singleton scope required for eager init.
+@Singleton
+class CompliantWithComment {
+  private static final String VERSION = "1.0";
+
+  public String getVersion() {
+    return VERSION;
+  }
+}
+
+class CompliantProducerWithComment {
+  // Singleton scope required: external library expects a non-proxied instance.
+  @Singleton
+  public CompliantWithComment produceConfig() {
+    return new CompliantWithComment();
+  }
+}
+
+/**
+ * Using @Singleton intentionally: this is a low-level infrastructure bean with no interceptor requirements.
+ * Singleton scope required to avoid proxy overhead measured on this critical path.
+ */
+@Singleton
+class CompliantWithJavadocComment {
+  public String getConfig() {
+    return "config";
+  }
+}
+
+@ApplicationScoped
+class CompliantApplicationScoped {
+  public String hello() {
+    return "hello";
+  }
+}
+
+@Dependent
+class CompliantDependent {
+}
+
+class CompliantNoScope {
+  public String hello() {
+    return "hello";
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
@@ -78,6 +78,13 @@ class CompliantProducerWithFollowingLineComment {
   }
 }
 
+@Singleton // Noncompliant [[sc=1;ec=11]]
+record NoncompliantRecord(String value) {}
+
+// Singleton scope required: external lib needs a non-proxied instance.
+@Singleton
+record CompliantRecord(String value) {}
+
 @ApplicationScoped
 class SingletonCheckCompliantApplicationScoped {
   public String hello() {

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSampleNonQuarkus.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSampleNonQuarkus.java
@@ -1,0 +1,8 @@
+package checks.quarkus;
+
+import jakarta.inject.Singleton;
+
+// No io.quarkus.* import: rule should not trigger
+@Singleton
+class NonQuarkusSingleton {
+}

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSampleNonQuarkus.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSampleNonQuarkus.java
@@ -1,8 +1,0 @@
-package checks.quarkus;
-
-import jakarta.inject.Singleton;
-
-// No io.quarkus.* import: rule should not trigger
-@Singleton
-class NonQuarkusSingleton {
-}

--- a/java-checks-test-sources/pom.xml
+++ b/java-checks-test-sources/pom.xml
@@ -22,6 +22,7 @@
     <module>java-17</module>
     <module>spring-3.2</module>
     <module>spring-web-4.0</module>
+    <module>quarkus-arc-3.15</module>
 
     <!-- should be the last module to be able to test classpath files "target/test-classpath.txt" of the previous modules -->
     <module>test-classpath-reader</module>

--- a/java-checks-test-sources/quarkus-arc-3.15/pom.xml
+++ b/java-checks-test-sources/quarkus-arc-3.15/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonarsource.java</groupId>
+    <artifactId>java-checks-test-sources</artifactId>
+    <version>8.37.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>quarkus-arc-3.15</artifactId>
+
+  <name>SonarQube Java :: Checks Test Sources :: Quarkus ArC 3.15</name>
+
+  <properties>
+    <sonar.skip>true</sonar.skip>
+    <forbiddenapis.skip>true</forbiddenapis.skip>
+    <skipTests>true</skipTests>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+      <version>3.15.1</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>analyze-tests</id>
+      <properties>
+        <sonar.skip>false</sonar.skip>
+      </properties>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>17</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.simplify4u.plugins</groupId>
+        <artifactId>sign-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <licenseSets>
+            <licenseSet>
+              <excludes>
+                <exclude>src/main/java/**</exclude>
+                <exclude>src/test/java/**</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/java-checks-test-sources/quarkus-arc-3.15/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
+++ b/java-checks-test-sources/quarkus-arc-3.15/src/main/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java
@@ -1,6 +1,5 @@
 package checks.quarkus;
 
-import io.quarkus.arc.Unremovable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Singleton;

--- a/java-checks-test-sources/test-classpath-reader/src/main/java/org/sonar/java/test/classpath/TestClasspathUtils.java
+++ b/java-checks-test-sources/test-classpath-reader/src/main/java/org/sonar/java/test/classpath/TestClasspathUtils.java
@@ -48,6 +48,7 @@ public final class TestClasspathUtils {
   public static final Module JAVA_17_MODULE = new Module("java-checks-test-sources/java-17");
   public static final Module SPRING_32_MODULE = new Module("java-checks-test-sources/spring-3.2");
   public static final Module SPRING_WEB_40_MODULE = new Module("java-checks-test-sources/spring-web-4.0");
+  public static final Module QUARKUS_ARC_315_MODULE = new Module("java-checks-test-sources/quarkus-arc-3.15");
   private static final Path testJarsPath = Path.of("java-checks-test-sources/target/test-jars");
 
   public static List<File> getTestJars(List<String> jars) {

--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
@@ -23,26 +23,48 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.ImportTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.ModifierKeywordTree;
 import org.sonar.plugins.java.api.tree.ModifiersTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.java.checks.helpers.ExpressionsHelper;
 
 @Rule(key = "S9068")
 public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscriptionVisitor {
 
   private static final String JAKARTA_SINGLETON = "jakarta.inject.Singleton";
+  private static final String QUARKUS_PREFIX = "io.quarkus";
   private static final String MESSAGE = "Replace \"@Singleton\" by \"@ApplicationScoped\" or add a comment indicating why \"@Singleton\" is necessary.";
+
+  private boolean analyzingQuarkusFile = false;
+
+  @Override
+  public void leaveFile(org.sonar.plugins.java.api.JavaFileScannerContext context) {
+    analyzingQuarkusFile = false;
+  }
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return List.of(Tree.Kind.CLASS, Tree.Kind.RECORD, Tree.Kind.METHOD);
+    return List.of(Tree.Kind.COMPILATION_UNIT, Tree.Kind.CLASS, Tree.Kind.RECORD, Tree.Kind.METHOD);
   }
 
   @Override
   public void visitNode(Tree tree) {
+    if (tree instanceof CompilationUnitTree compilationUnit) {
+      analyzingQuarkusFile = compilationUnit.imports().stream()
+        .filter(ImportTree.class::isInstance)
+        .map(ImportTree.class::cast)
+        .anyMatch(i -> ExpressionsHelper.concatenate((ExpressionTree) i.qualifiedIdentifier()).startsWith(QUARKUS_PREFIX));
+      return;
+    }
+    if (!analyzingQuarkusFile) {
+      return;
+    }
     ModifiersTree modifiers;
     SyntaxToken declarationToken;
     if (tree instanceof ClassTree classTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
@@ -17,12 +17,17 @@
 package org.sonar.java.checks.quarkus;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.ModifierKeywordTree;
 import org.sonar.plugins.java.api.tree.ModifiersTree;
+import org.sonar.plugins.java.api.tree.SyntaxToken;
+import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S9068")
@@ -38,18 +43,51 @@ public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscripti
 
   @Override
   public void visitNode(Tree tree) {
-    ModifiersTree modifiers = tree instanceof ClassTree classTree
-      ? classTree.modifiers()
-      : ((MethodTree) tree).modifiers();
+    ModifiersTree modifiers;
+    SyntaxToken declarationToken;
+    if (tree instanceof ClassTree classTree) {
+      modifiers = classTree.modifiers();
+      declarationToken = classTree.declarationKeyword();
+    } else {
+      MethodTree methodTree = (MethodTree) tree;
+      modifiers = methodTree.modifiers();
+      declarationToken = methodTree.returnType().firstToken();
+    }
 
     modifiers.annotations().stream()
       .filter(annotation -> annotation.annotationType().symbolType().is(JAKARTA_SINGLETON))
-      .filter(annotation -> !hasJustifyingComment(annotation))
+      .filter(annotation -> !hasJustifyingComment(annotation, modifiers, declarationToken))
       .forEach(annotation -> reportIssue(annotation, MESSAGE));
   }
 
-  private static boolean hasJustifyingComment(AnnotationTree annotation) {
-    return annotation.firstToken().trivias().stream()
-      .anyMatch(trivia -> trivia.comment().toLowerCase(java.util.Locale.ROOT).contains("singleton"));
+  private static boolean hasJustifyingComment(AnnotationTree annotation, ModifiersTree modifiers, SyntaxToken declarationToken) {
+    // Comment appearing before the annotation (trivia on its @ token)
+    if (containsSingletonComment(annotation.firstToken().trivias())) {
+      return true;
+    }
+    // Comment after the annotation (inline or on the following line): it attaches as trivia to the
+    // next token in the stream, which may be another annotation's @, a modifier keyword, or the
+    // declaration keyword / return type.
+    Stream<SyntaxToken> candidateTokens = Stream.concat(
+      Stream.concat(
+        modifiers.annotations().stream()
+          .map(Tree::firstToken)
+          .filter(t -> !t.equals(annotation.firstToken())),
+        modifiers.modifiers().stream()
+          .map(ModifierKeywordTree::keyword)
+      ),
+      Stream.of(declarationToken)
+    );
+    return candidateTokens
+      .flatMap(token -> token.trivias().stream())
+      .anyMatch(SingletonInsteadOfApplicationScopedCheck::isSingletonComment);
+  }
+
+  private static boolean containsSingletonComment(List<SyntaxTrivia> trivias) {
+    return trivias.stream().anyMatch(SingletonInsteadOfApplicationScopedCheck::isSingletonComment);
+  }
+
+  private static boolean isSingletonComment(SyntaxTrivia trivia) {
+    return trivia.comment().toLowerCase(Locale.ROOT).contains("singleton");
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
@@ -18,53 +18,40 @@ package org.sonar.java.checks.quarkus;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.DependencyVersionAware;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.Version;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
-import org.sonar.plugins.java.api.tree.CompilationUnitTree;
-import org.sonar.plugins.java.api.tree.ExpressionTree;
-import org.sonar.plugins.java.api.tree.ImportTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.ModifierKeywordTree;
 import org.sonar.plugins.java.api.tree.ModifiersTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.java.checks.helpers.ExpressionsHelper;
 
 @Rule(key = "S9068")
-public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscriptionVisitor {
+public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
 
   private static final String JAKARTA_SINGLETON = "jakarta.inject.Singleton";
-  private static final String QUARKUS_PREFIX = "io.quarkus";
   private static final String MESSAGE = "Replace \"@Singleton\" by \"@ApplicationScoped\" or add a comment indicating why \"@Singleton\" is necessary.";
 
-  private boolean analyzingQuarkusFile = false;
-
   @Override
-  public void leaveFile(org.sonar.plugins.java.api.JavaFileScannerContext context) {
-    analyzingQuarkusFile = false;
+  public boolean isCompatibleWithDependencies(Function<String, Optional<Version>> dependencyFinder) {
+    return dependencyFinder.apply("quarkus-arc").isPresent();
   }
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return List.of(Tree.Kind.COMPILATION_UNIT, Tree.Kind.CLASS, Tree.Kind.RECORD, Tree.Kind.METHOD);
+    return List.of(Tree.Kind.CLASS, Tree.Kind.RECORD, Tree.Kind.METHOD);
   }
 
   @Override
   public void visitNode(Tree tree) {
-    if (tree instanceof CompilationUnitTree compilationUnit) {
-      analyzingQuarkusFile = compilationUnit.imports().stream()
-        .filter(ImportTree.class::isInstance)
-        .map(ImportTree.class::cast)
-        .anyMatch(i -> ExpressionsHelper.concatenate((ExpressionTree) i.qualifiedIdentifier()).startsWith(QUARKUS_PREFIX));
-      return;
-    }
-    if (!analyzingQuarkusFile) {
-      return;
-    }
     ModifiersTree modifiers;
     SyntaxToken declarationToken;
     if (tree instanceof ClassTree classTree) {
@@ -96,10 +83,8 @@ public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscripti
           .map(Tree::firstToken)
           .filter(t -> !t.equals(annotation.firstToken())),
         modifiers.modifiers().stream()
-          .map(ModifierKeywordTree::keyword)
-      ),
-      Stream.of(declarationToken)
-    );
+          .map(ModifierKeywordTree::keyword)),
+      Stream.of(declarationToken));
     return candidateTokens
       .flatMap(token -> token.trivias().stream())
       .anyMatch(SingletonInsteadOfApplicationScopedCheck::isSingletonComment);

--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
@@ -1,0 +1,55 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.quarkus;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.ModifiersTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9068")
+public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscriptionVisitor {
+
+  private static final String JAKARTA_SINGLETON = "jakarta.inject.Singleton";
+  private static final String MESSAGE = "Replace \"@Singleton\" by \"@ApplicationScoped\" or add a comment indicating why \"@Singleton\" is necessary.";
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.CLASS, Tree.Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ModifiersTree modifiers = tree instanceof ClassTree classTree
+      ? classTree.modifiers()
+      : ((MethodTree) tree).modifiers();
+
+    modifiers.annotations().stream()
+      .filter(annotation -> annotation.annotationType().symbolType().is(JAKARTA_SINGLETON))
+      .filter(annotation -> !hasJustifyingComment(annotation))
+      .forEach(annotation -> reportIssue(annotation, MESSAGE));
+  }
+
+  private static boolean hasJustifyingComment(AnnotationTree annotation) {
+    return annotation.firstToken().trivias().stream()
+      .anyMatch(trivia -> trivia.comment().toLowerCase(java.util.Locale.ROOT).contains("singleton"));
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheck.java
@@ -38,7 +38,7 @@ public class SingletonInsteadOfApplicationScopedCheck extends IssuableSubscripti
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return List.of(Tree.Kind.CLASS, Tree.Kind.METHOD);
+    return List.of(Tree.Kind.CLASS, Tree.Kind.RECORD, Tree.Kind.METHOD);
   }
 
   @Override

--- a/java-checks/src/test/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckTest.java
@@ -39,4 +39,12 @@ class SingletonInsteadOfApplicationScopedCheckTest {
       .withoutSemantic()
       .verifyNoIssues();
   }
+
+  @Test
+  void testNonQuarkusFile() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/quarkus/SingletonInsteadOfApplicationScopedCheckSampleNonQuarkus.java"))
+      .withCheck(new SingletonInsteadOfApplicationScopedCheck())
+      .verifyNoIssues();
+  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.quarkus;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class SingletonInsteadOfApplicationScopedCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java"))
+      .withCheck(new SingletonInsteadOfApplicationScopedCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void testWithoutSemantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java"))
+      .withCheck(new SingletonInsteadOfApplicationScopedCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/quarkus/SingletonInsteadOfApplicationScopedCheckTest.java
@@ -19,32 +19,37 @@ package org.sonar.java.checks.quarkus;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPathInModule;
+import static org.sonar.java.test.classpath.TestClasspathUtils.QUARKUS_ARC_315_MODULE;
 
 class SingletonInsteadOfApplicationScopedCheckTest {
+
+  private static final String SAMPLE = mainCodeSourcesPathInModule(QUARKUS_ARC_315_MODULE, "checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java");
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java"))
+      .onFile(SAMPLE)
       .withCheck(new SingletonInsteadOfApplicationScopedCheck())
+      .withClassPath(QUARKUS_ARC_315_MODULE.getClassPath())
       .verifyIssues();
   }
 
   @Test
   void testWithoutSemantic() {
     CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/quarkus/SingletonInsteadOfApplicationScopedCheckSample.java"))
+      .onFile(SAMPLE)
       .withCheck(new SingletonInsteadOfApplicationScopedCheck())
       .withoutSemantic()
       .verifyNoIssues();
   }
 
   @Test
-  void testNonQuarkusFile() {
+  void testWithoutQuarkusOnClasspath() {
     CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/quarkus/SingletonInsteadOfApplicationScopedCheckSampleNonQuarkus.java"))
+      .onFile(SAMPLE)
       .withCheck(new SingletonInsteadOfApplicationScopedCheck())
+      .withClassPath(java.util.List.of())
       .verifyNoIssues();
   }
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9068.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9068.html
@@ -1,0 +1,217 @@
+<p>This rule raises an issue when a CDI bean uses the <code>@Singleton</code> annotation from <code>jakarta.inject</code> instead of
+<code>@ApplicationScoped</code> in a Quarkus application.</p>
+<h2>Why is this an issue?</h2>
+<p>In Quarkus applications, both <code>@Singleton</code> (from Jakarta Dependency Injection) and <code>@ApplicationScoped</code> (from Jakarta
+Contexts and Dependency Injection) create single-instance beans. However, they behave differently in important ways.</p>
+<p><code>@ApplicationScoped</code> beans are full CDI beans with these capabilities:</p>
+<ul>
+  <li>Support for CDI interceptors (like <code>@Transactional</code>, <code>@CacheResult</code>, custom interceptors)</li>
+  <li>Support for CDI decorators</li>
+  <li>Can be mocked in tests using QuarkusMock</li>
+  <li>Participate in CDI events and observers</li>
+  <li>Support lazy initialization via client proxies</li>
+</ul>
+<p><code>@Singleton</code> beans are simpler but more limited:</p>
+<ul>
+  <li>Created eagerly at startup</li>
+  <li>Do not support interception - methods annotated with interceptor annotations will be ignored</li>
+  <li>Cannot be mocked using QuarkusMock in tests</li>
+  <li>Direct references without proxy support</li>
+</ul>
+<p>For most application-level services, <code>@ApplicationScoped</code> is the better choice because it provides the full CDI feature set that Quarkus
+applications typically need.</p>
+<h3>When @Singleton might be acceptable</h3>
+<p>There are specific scenarios where <code>@Singleton</code> may be intentionally chosen:</p>
+<ul>
+  <li><strong>Low-level infrastructure beans</strong>: Beans that provide basic utilities without needing interceptors, decorators, or mocking (e.g.,
+  configuration holders, simple factories)</li>
+  <li><strong>Performance-critical paths</strong>: Beans where the proxy overhead of <code>@ApplicationScoped</code> is measured and found to be
+  significant (rare, and should be documented)</li>
+  <li><strong>Third-party integration</strong>: When integrating libraries that specifically expect non-proxied instances</li>
+  <li><strong>Startup beans</strong>: Beans that must be instantiated eagerly at startup and have no CDI feature requirements</li>
+</ul>
+<p>If you choose to use <code>@Singleton</code>, document why you need it and confirm that:</p>
+<ul>
+  <li>The bean does not and will not use CDI interceptors</li>
+  <li>The bean does not need to be mocked in tests, or you use alternative mocking strategies</li>
+  <li>You understand the limitations and accept them for this specific case</li>
+</ul>
+<h3>Exceptions</h3>
+<p>This rule may be safely ignored when:</p>
+<ul>
+  <li>The bean is a low-level infrastructure component with no interceptor requirements</li>
+  <li>The bean’s design explicitly prohibits the use of CDI proxies (e.g., final classes used intentionally)</li>
+  <li>You have documented performance reasons for avoiding the proxy overhead</li>
+</ul>
+<p>However, these cases are rare. Most application services should use <code>@ApplicationScoped</code>.</p>
+<h3>Distinguishing false positives from intentional usage</h3>
+<p>To determine if a flagged <code>@Singleton</code> is a false positive or intentional:</p>
+<p><strong>It’s likely a real issue if:</strong></p>
+<ul>
+  <li>The bean uses any CDI interceptor annotations (<code>@Transactional</code>, <code>@CacheResult</code>, <code>@Retry</code>, etc.)</li>
+  <li>The bean needs to be mocked in tests</li>
+  <li>The bean is an application-level service (controllers, services, repositories)</li>
+  <li>There’s no documented reason for using <code>@Singleton</code></li>
+</ul>
+<p><strong>It might be intentional if:</strong></p>
+<ul>
+  <li>The bean is clearly infrastructure-level (e.g., named <code>ConfigurationHolder</code>, <code>SimpleFactory</code>)</li>
+  <li>There’s a comment explaining why <code>@Singleton</code> is used</li>
+  <li>The bean is extremely simple with no methods that would benefit from interception</li>
+  <li>The bean is part of a documented design pattern that requires non-proxied instances</li>
+</ul>
+<p>When in doubt, prefer <code>@ApplicationScoped</code> unless you have a specific, documented reason to use <code>@Singleton</code>.</p>
+<h3>What is the potential impact?</h3>
+<p>Using <code>@Singleton</code> instead of <code>@ApplicationScoped</code> can lead to several issues:</p>
+<h3>Silent interceptor failures</h3>
+<p>Interceptors like <code>@Transactional</code>, <code>@CacheResult</code>, or custom interceptors will be silently ignored on
+<code>@Singleton</code> beans. This can cause:</p>
+<ul>
+  <li>Database transactions not being created, leading to data inconsistency</li>
+  <li>Cache annotations being ignored, resulting in performance degradation</li>
+  <li>Security checks being bypassed if implemented via interceptors</li>
+</ul>
+<p>These failures are particularly dangerous because the code compiles and runs without errors - the interceptors simply don’t work.</p>
+<h3>Testing difficulties</h3>
+<p><code>@Singleton</code> beans cannot be mocked using QuarkusMock in tests. This means:</p>
+<ul>
+  <li>Integration tests cannot isolate the bean for testing</li>
+  <li>External dependencies (databases, APIs) cannot be easily stubbed</li>
+  <li>Tests may become slower and more fragile</li>
+  <li>Test coverage may be reduced</li>
+</ul>
+<h3>Reduced flexibility</h3>
+<p>Choosing <code>@Singleton</code> limits your future options:</p>
+<ul>
+  <li>Adding interceptors later requires changing the scope annotation</li>
+  <li>Adopting CDI decorators becomes impossible</li>
+  <li>Lazy initialization via proxies is unavailable</li>
+</ul>
+<h2>How to fix it in Quarkus</h2>
+<p>Replace the <code>@Singleton</code> annotation with <code>@ApplicationScoped</code>. Update the import statement to use
+<code>jakarta.enterprise.context.ApplicationScoped</code> instead of <code>jakarta.inject.Singleton</code>. This is the recommended approach for most
+application beans.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+import jakarta.inject.Singleton;
+
+@Singleton // Noncompliant
+public class UserService {
+    public String getUser(Long id) {
+        // implementation
+        return "user";
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class UserService {
+    public String getUser(Long id) {
+        // implementation
+        return "user";
+    }
+}
+</pre>
+<p>When using interceptors like <code>@Transactional</code>, <code>@ApplicationScoped</code> is required for the interceptor to function.
+<code>@Singleton</code> beans are not intercepted, so the transaction will not work.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+import jakarta.inject.Singleton;
+import jakarta.transaction.Transactional;
+
+@Singleton // Noncompliant
+public class OrderService {
+    @Transactional
+    public void createOrder(Order order) {
+        // This transaction will NOT work as expected
+        // because @Singleton doesn't support interception
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class OrderService {
+    @Transactional
+    public void createOrder(Order order) {
+        // Transaction works correctly
+    }
+}
+</pre>
+<p>In test scenarios, <code>@ApplicationScoped</code> beans can be mocked using QuarkusMock, while <code>@Singleton</code> beans cannot. This makes
+testing easier and more reliable.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="3" data-diff-type="noncompliant">
+import jakarta.inject.Singleton;
+
+@Singleton // Noncompliant
+public class EmailService {
+    public void sendEmail(String to, String subject) {
+        // Actual email sending logic
+        // Cannot be easily mocked in tests
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="3" data-diff-type="compliant">
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class EmailService {
+    public void sendEmail(String to, String subject) {
+        // Actual email sending logic
+        // Can be mocked in tests with QuarkusMock
+    }
+}
+
+// In test:
+// QuarkusMock.installMockForType(mockEmailService, EmailService.class);
+</pre>
+<p>If you have a documented, valid reason to use <code>@Singleton</code> (such as a low-level infrastructure bean with no interceptor needs), you can
+keep it but should add a comment explaining why. This is an alternative to changing the annotation, though it’s only appropriate in specific
+cases.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="4" data-diff-type="noncompliant">
+import jakarta.inject.Singleton;
+
+@Singleton // Noncompliant
+public class ApplicationConfig {
+    private final String version = "1.0.0";
+
+    public String getVersion() {
+        return version;
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="4" data-diff-type="compliant">
+import jakarta.inject.Singleton;
+
+// Using @Singleton intentionally: this is a simple configuration holder
+// with no interceptor requirements and no need for testing isolation.
+// It's instantiated eagerly at startup to validate configuration.
+@Singleton
+public class ApplicationConfig {
+    private final String version = "1.0.0";
+
+    public String getVersion() {
+        return version;
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Quarkus - <a href="https://quarkus.io/guides/cdi-reference#supported_features">Contexts and Dependency Injection - Supported Features</a></li>
+  <li>Quarkus - <a href="https://quarkus.io/guides/cdi-reference#applicationscoped-vs-singleton">Contexts and Dependency Injection - ApplicationScoped
+  vs Singleton</a></li>
+  <li>Quarkus - <a href="https://quarkus.io/guides/getting-started-testing#quarkus-mock">Testing Guide - Mocking</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9068.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9068.html
@@ -5,73 +5,33 @@
 Contexts and Dependency Injection) create single-instance beans. However, they behave differently in important ways.</p>
 <p><code>@ApplicationScoped</code> beans are full CDI beans with these capabilities:</p>
 <ul>
-  <li>Support for CDI interceptors (like <code>@Transactional</code>, <code>@CacheResult</code>, custom interceptors)</li>
-  <li>Support for CDI decorators</li>
-  <li>Can be mocked in tests using QuarkusMock</li>
-  <li>Participate in CDI events and observers</li>
   <li>Support lazy initialization via client proxies</li>
+  <li>Can be mocked in tests using QuarkusMock</li>
+  <li>Can be destroyed and recreated at runtime thanks to proxy-based method delegation</li>
 </ul>
 <p><code>@Singleton</code> beans are simpler but more limited:</p>
 <ul>
-  <li>Created eagerly at startup</li>
-  <li>Do not support interception - methods annotated with interceptor annotations will be ignored</li>
+  <li>Created eagerly when the bean is injected</li>
   <li>Cannot be mocked using QuarkusMock in tests</li>
-  <li>Direct references without proxy support</li>
 </ul>
 <p>For most application-level services, <code>@ApplicationScoped</code> is the better choice because it provides the full CDI feature set that Quarkus
 applications typically need.</p>
 <h3>When @Singleton might be acceptable</h3>
-<p>There are specific scenarios where <code>@Singleton</code> may be intentionally chosen:</p>
+<p><code>@Singleton</code> might have a slightly better performance than <code>@ApplicationScoped</code> because of the absence of client proxy. Thus,
+there are specific scenarios where <code>@Singleton</code> may be intentionally chosen:</p>
 <ul>
-  <li><strong>Low-level infrastructure beans</strong>: Beans that provide basic utilities without needing interceptors, decorators, or mocking (e.g.,
-  configuration holders, simple factories)</li>
+  <li><strong>Low-level infrastructure beans</strong>: Beans that provide basic utilities and don’t require lazy initialization</li>
   <li><strong>Performance-critical paths</strong>: Beans where the proxy overhead of <code>@ApplicationScoped</code> is measured and found to be
   significant (rare, and should be documented)</li>
   <li><strong>Third-party integration</strong>: When integrating libraries that specifically expect non-proxied instances</li>
-  <li><strong>Startup beans</strong>: Beans that must be instantiated eagerly at startup and have no CDI feature requirements</li>
 </ul>
 <p>If you choose to use <code>@Singleton</code>, document why you need it and confirm that:</p>
 <ul>
-  <li>The bean does not and will not use CDI interceptors</li>
   <li>The bean does not need to be mocked in tests, or you use alternative mocking strategies</li>
   <li>You understand the limitations and accept them for this specific case</li>
 </ul>
-<h3>Exceptions</h3>
-<p>This rule may be safely ignored when:</p>
-<ul>
-  <li>The bean is a low-level infrastructure component with no interceptor requirements</li>
-  <li>The bean’s design explicitly prohibits the use of CDI proxies (e.g., final classes used intentionally)</li>
-  <li>You have documented performance reasons for avoiding the proxy overhead</li>
-</ul>
-<p>However, these cases are rare. Most application services should use <code>@ApplicationScoped</code>.</p>
-<h3>Distinguishing false positives from intentional usage</h3>
-<p>To determine if a flagged <code>@Singleton</code> is a false positive or intentional:</p>
-<p><strong>It’s likely a real issue if:</strong></p>
-<ul>
-  <li>The bean uses any CDI interceptor annotations (<code>@Transactional</code>, <code>@CacheResult</code>, <code>@Retry</code>, etc.)</li>
-  <li>The bean needs to be mocked in tests</li>
-  <li>The bean is an application-level service (controllers, services, repositories)</li>
-  <li>There’s no documented reason for using <code>@Singleton</code></li>
-</ul>
-<p><strong>It might be intentional if:</strong></p>
-<ul>
-  <li>The bean is clearly infrastructure-level (e.g., named <code>ConfigurationHolder</code>, <code>SimpleFactory</code>)</li>
-  <li>There’s a comment explaining why <code>@Singleton</code> is used</li>
-  <li>The bean is extremely simple with no methods that would benefit from interception</li>
-  <li>The bean is part of a documented design pattern that requires non-proxied instances</li>
-</ul>
-<p>When in doubt, prefer <code>@ApplicationScoped</code> unless you have a specific, documented reason to use <code>@Singleton</code>.</p>
 <h3>What is the potential impact?</h3>
 <p>Using <code>@Singleton</code> instead of <code>@ApplicationScoped</code> can lead to several issues:</p>
-<h3>Silent interceptor failures</h3>
-<p>Interceptors like <code>@Transactional</code>, <code>@CacheResult</code>, or custom interceptors will be silently ignored on
-<code>@Singleton</code> beans. This can cause:</p>
-<ul>
-  <li>Database transactions not being created, leading to data inconsistency</li>
-  <li>Cache annotations being ignored, resulting in performance degradation</li>
-  <li>Security checks being bypassed if implemented via interceptors</li>
-</ul>
-<p>These failures are particularly dangerous because the code compiles and runs without errors - the interceptors simply don’t work.</p>
 <h3>Testing difficulties</h3>
 <p><code>@Singleton</code> beans cannot be mocked using QuarkusMock in tests. This means:</p>
 <ul>
@@ -83,14 +43,11 @@ applications typically need.</p>
 <h3>Reduced flexibility</h3>
 <p>Choosing <code>@Singleton</code> limits your future options:</p>
 <ul>
-  <li>Adding interceptors later requires changing the scope annotation</li>
-  <li>Adopting CDI decorators becomes impossible</li>
   <li>Lazy initialization via proxies is unavailable</li>
 </ul>
 <h2>How to fix it in Quarkus</h2>
 <p>Replace the <code>@Singleton</code> annotation with <code>@ApplicationScoped</code>. Update the import statement to use
-<code>jakarta.enterprise.context.ApplicationScoped</code> instead of <code>jakarta.inject.Singleton</code>. This is the recommended approach for most
-application beans.</p>
+<code>jakarta.enterprise.context.ApplicationScoped</code> instead of <code>jakarta.inject.Singleton</code>.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
@@ -116,67 +73,8 @@ public class UserService {
     }
 }
 </pre>
-<p>When using interceptors like <code>@Transactional</code>, <code>@ApplicationScoped</code> is required for the interceptor to function.
-<code>@Singleton</code> beans are not intercepted, so the transaction will not work.</p>
-<h4>Noncompliant code example</h4>
-<pre data-diff-id="2" data-diff-type="noncompliant">
-import jakarta.inject.Singleton;
-import jakarta.transaction.Transactional;
-
-@Singleton // Noncompliant
-public class OrderService {
-    @Transactional
-    public void createOrder(Order order) {
-        // This transaction will NOT work as expected
-        // because @Singleton doesn't support interception
-    }
-}
-</pre>
-<h4>Compliant solution</h4>
-<pre data-diff-id="2" data-diff-type="compliant">
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
-
-@ApplicationScoped
-public class OrderService {
-    @Transactional
-    public void createOrder(Order order) {
-        // Transaction works correctly
-    }
-}
-</pre>
-<p>In test scenarios, <code>@ApplicationScoped</code> beans can be mocked using QuarkusMock, while <code>@Singleton</code> beans cannot. This makes
-testing easier and more reliable.</p>
-<h4>Noncompliant code example</h4>
-<pre data-diff-id="3" data-diff-type="noncompliant">
-import jakarta.inject.Singleton;
-
-@Singleton // Noncompliant
-public class EmailService {
-    public void sendEmail(String to, String subject) {
-        // Actual email sending logic
-        // Cannot be easily mocked in tests
-    }
-}
-</pre>
-<h4>Compliant solution</h4>
-<pre data-diff-id="3" data-diff-type="compliant">
-import jakarta.enterprise.context.ApplicationScoped;
-
-@ApplicationScoped
-public class EmailService {
-    public void sendEmail(String to, String subject) {
-        // Actual email sending logic
-        // Can be mocked in tests with QuarkusMock
-    }
-}
-
-// In test:
-// QuarkusMock.installMockForType(mockEmailService, EmailService.class);
-</pre>
-<p>If you have a documented, valid reason to use <code>@Singleton</code> (such as a low-level infrastructure bean with no interceptor needs), you can
-keep it but should add a comment explaining why. This is an alternative to changing the annotation, though it’s only appropriate in specific
-cases.</p>
+<p>If you have a documented, valid reason to use <code>@Singleton</code>, you can keep it but should add a comment explaining why. This is an
+alternative to changing the annotation, though it’s only appropriate in specific cases.</p>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="4" data-diff-type="noncompliant">
 import jakarta.inject.Singleton;
@@ -209,9 +107,8 @@ public class ApplicationConfig {
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
-  <li>Quarkus - <a href="https://quarkus.io/guides/cdi-reference#supported_features">Contexts and Dependency Injection - Supported Features</a></li>
-  <li>Quarkus - <a href="https://quarkus.io/guides/cdi-reference#applicationscoped-vs-singleton">Contexts and Dependency Injection - ApplicationScoped
-  vs Singleton</a></li>
-  <li>Quarkus - <a href="https://quarkus.io/guides/getting-started-testing#quarkus-mock">Testing Guide - Mocking</a></li>
+  <li>Quarkus - <a href="https://quarkus.io/guides/cdi-reference">Contexts and Dependency Injection</a></li>
+  <li>Quarkus - <a
+  href="https://quarkus.io/guides/cdi#applicationscoped-and-singleton-look-very-similar-which-one-should-i-choose-for-my-quarkus-application">@ApplicationScoped and @Singleton look very similar. Which one should I choose for my Quarkus application?</a></li>
 </ul>
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9068.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9068.json
@@ -1,0 +1,25 @@
+{
+  "title": "\"@ApplicationScoped\" should be preferred over \"@Singleton\" in Quarkus applications",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "jee",
+    "injection",
+    "testing"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9068",
+  "sqKey": "S9068",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "MODULAR"
+  }
+}


### PR DESCRIPTION

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **New code rule:**
    - Implemented `S9068` to encourage the use of `@ApplicationScoped` over `@Singleton` in Quarkus applications.
- **Heuristics and configuration:**
    - Added logic to trigger the check only in files containing `io.quarkus` imports.
    - Added support for justifying comments to prevent false positives when `@Singleton` is used intentionally.
- **Test coverage:**
    - Included unit tests for the new rule, covering both compliant and noncompliant scenarios for classes and records.

<sub>This will update automatically on new commits.</sub>