### PR TITLE
SONARJAVA-6666 Fix FP on S8924 when a non-Mockito method with the same name is in scope

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S1128.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S1128.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S1128",
   "hasTruePositives": true,
-  "falseNegatives": 30,
+  "falseNegatives": 31,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S3577.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S3577.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S3577",
   "hasTruePositives": true,
-  "falseNegatives": 51,
+  "falseNegatives": 52,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNameConflictSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNameConflictSample.java
@@ -1,0 +1,40 @@
+package checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
+import static checks.tests.MockitoStaticImportCheckNameConflictSample.CustomAssertions.verify;
+
+class MockitoStaticImportCheckNameConflictSample {
+
+  interface MyService {
+    int getValue();
+  }
+
+  // Simulates a non-Mockito library (e.g. WireMock) that also exposes a verify() method
+  static class CustomAssertions {
+    public static void verify(Object o) {}
+  }
+
+  // static import of a non-Mockito verify() is in scope — Mockito.verify() prefix is required to disambiguate
+  @Test
+  void compliant_static_import_conflict() {
+    MyService service = mock(MyService.class);
+    service.getValue();
+    Mockito.verify(service).getValue(); // Compliant
+  }
+
+  // local method named verify() is in scope — Mockito.verify() prefix is required to disambiguate
+  static class WithLocalVerify {
+    void verify(Object o) {}
+
+    @Test
+    void compliant_local_method_conflict() {
+      MyService service = mock(MyService.class);
+      service.getValue();
+      Mockito.verify(service).getValue(); // Compliant
+    }
+  }
+
+}

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNameConflictSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNameConflictSample.java
@@ -25,16 +25,4 @@ class MockitoStaticImportCheckNameConflictSample {
     Mockito.verify(service).getValue(); // Compliant
   }
 
-  // local method named verify() is in scope — Mockito.verify() prefix is required to disambiguate
-  static class WithLocalVerify {
-    void verify(Object o) {}
-
-    @Test
-    void compliant_local_method_conflict() {
-      MyService service = mock(MyService.class);
-      service.getValue();
-      Mockito.verify(service).getValue(); // Compliant
-    }
-  }
-
 }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckSample.java
@@ -164,4 +164,43 @@ class MockitoStaticImportCheckSample {
     verify(mock).size();
   }
 
+  static class WithLocalVerify {
+    void verify(Object o) {}
+
+    @Test
+    void compliant_local_method_in_class() {
+      MyService service = mock(MyService.class);
+      service.getValue();
+      Mockito.verify(service).getValue(); // Compliant - local verify() shadows the static import
+    }
+  }
+
+  enum WithLocalVerifyEnum {
+    INSTANCE;
+    void verify(Object o) {}
+
+    void compliant_local_method_in_enum() {
+      MyService service = mock(MyService.class);
+      Mockito.verify(service).getValue(); // Compliant
+    }
+  }
+
+  interface WithLocalVerifyInterface {
+    default void verify(Object o) {}
+
+    default void compliant_local_method_in_interface() {
+      MyService service = mock(MyService.class);
+      Mockito.verify(service).getValue(); // Compliant
+    }
+  }
+
+  record WithLocalMockRecord(int value) {
+    MyService mock(Class<MyService> myServiceClass) { return null; }
+
+    void compliant_local_method_in_record() {
+      MyService service = Mockito.mock(MyService.class); // Compliant - local mock() is in scope
+      verify(service).getValue();
+    }
+  }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStaticImportCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStaticImportCheck.java
@@ -16,14 +16,23 @@
  */
 package org.sonar.java.checks.tests;
 
-import java.util.Collections;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.ExpressionsHelper;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.ImportTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
@@ -31,6 +40,7 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
 
   private static final String MOCKITO_CLASS = "org.mockito.Mockito";
+  private static final String MOCKITO_IMPORT_PREFIX = MOCKITO_CLASS + ".";
 
   private static final MethodMatchers MOCKITO_METHODS = MethodMatchers.create()
     .ofTypes(MOCKITO_CLASS)
@@ -38,23 +48,64 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
     .withAnyParameters()
     .build();
 
+  private Set<String> conflictingImportedNames = new HashSet<>();
+  private final Deque<Set<String>> classMethodsStack = new ArrayDeque<>();
+
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return Collections.singletonList(Tree.Kind.METHOD_INVOCATION);
+    return List.of(Tree.Kind.COMPILATION_UNIT, Tree.Kind.CLASS, Tree.Kind.METHOD_INVOCATION);
   }
 
   @Override
   public void visitNode(Tree tree) {
-    MethodInvocationTree mit = (MethodInvocationTree) tree;
+    switch (tree.kind()) {
+      case COMPILATION_UNIT -> collectConflictingImports((CompilationUnitTree) tree);
+      case CLASS -> pushClassMethods((ClassTree) tree);
+      case METHOD_INVOCATION -> checkMethodInvocation((MethodInvocationTree) tree);
+      default -> { /* not visited */ }
+    }
+  }
+
+  @Override
+  public void leaveNode(Tree tree) {
+    if (tree.is(Tree.Kind.CLASS)) {
+      classMethodsStack.pop();
+    }
+  }
+
+  private void collectConflictingImports(CompilationUnitTree compilationUnitTree) {
+    conflictingImportedNames = compilationUnitTree.imports().stream()
+      .filter(clause -> clause instanceof ImportTree importTree && importTree.isStatic())
+      .map(clause -> ExpressionsHelper.concatenate((ExpressionTree) ((ImportTree) clause).qualifiedIdentifier()))
+      .filter(fqn -> !fqn.startsWith(MOCKITO_IMPORT_PREFIX))
+      .map(fqn -> fqn.substring(fqn.lastIndexOf('.') + 1))
+      .collect(Collectors.toSet());
+  }
+
+  private void pushClassMethods(ClassTree classTree) {
+    Set<String> methodNames = new HashSet<>();
+    for (Tree member : classTree.members()) {
+      if (member instanceof MethodTree methodTree) {
+        methodNames.add(methodTree.simpleName().name());
+      }
+    }
+    classMethodsStack.push(methodNames);
+  }
+
+  private void checkMethodInvocation(MethodInvocationTree mit) {
     ExpressionTree methodSelect = mit.methodSelect();
-    if (!methodSelect.is(Tree.Kind.MEMBER_SELECT)) {
+    if (!(methodSelect instanceof MemberSelectExpressionTree mset)) {
       return;
     }
-    MemberSelectExpressionTree mset = (MemberSelectExpressionTree) methodSelect;
     String methodName = mset.identifier().name();
-    if (MOCKITO_METHODS.matches(mit.methodSymbol()) && !requiresTypeWitness(mit)) {
+    if (MOCKITO_METHODS.matches(mit.methodSymbol()) && !requiresTypeWitness(mit) && !isNameInConflict(methodName)) {
       reportIssue(methodSelect, "Use a static import for \"%s\".".formatted(methodName));
     }
+  }
+
+  private boolean isNameInConflict(String methodName) {
+    return conflictingImportedNames.contains(methodName)
+      || classMethodsStack.stream().anyMatch(methods -> methods.contains(methodName));
   }
 
   private static boolean requiresTypeWitness(MethodInvocationTree mit) {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStaticImportCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStaticImportCheck.java
@@ -53,14 +53,14 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return List.of(Tree.Kind.COMPILATION_UNIT, Tree.Kind.CLASS, Tree.Kind.METHOD_INVOCATION);
+    return List.of(Tree.Kind.COMPILATION_UNIT, Tree.Kind.CLASS, Tree.Kind.ENUM, Tree.Kind.INTERFACE, Tree.Kind.RECORD, Tree.Kind.METHOD_INVOCATION);
   }
 
   @Override
   public void visitNode(Tree tree) {
     switch (tree.kind()) {
       case COMPILATION_UNIT -> collectConflictingImports((CompilationUnitTree) tree);
-      case CLASS -> pushClassMethods((ClassTree) tree);
+      case CLASS, ENUM, INTERFACE, RECORD -> pushClassMethods((ClassTree) tree);
       case METHOD_INVOCATION -> checkMethodInvocation((MethodInvocationTree) tree);
       default -> { /* not visited */ }
     }
@@ -68,8 +68,9 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void leaveNode(Tree tree) {
-    if (tree.is(Tree.Kind.CLASS)) {
-      classMethodsStack.pop();
+    switch (tree.kind()) {
+      case CLASS, ENUM, INTERFACE, RECORD -> classMethodsStack.pop();
+      default -> { /* nothing */ }
     }
   }
 
@@ -77,7 +78,7 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
     conflictingImportedNames = compilationUnitTree.imports().stream()
       .filter(clause -> clause instanceof ImportTree importTree && importTree.isStatic())
       .map(clause -> ExpressionsHelper.concatenate((ExpressionTree) ((ImportTree) clause).qualifiedIdentifier()))
-      .filter(fqn -> !fqn.startsWith(MOCKITO_IMPORT_PREFIX))
+      .filter(fqn -> !fqn.startsWith(MOCKITO_IMPORT_PREFIX) && !fqn.endsWith(".*"))
       .map(fqn -> fqn.substring(fqn.lastIndexOf('.') + 1))
       .collect(Collectors.toSet());
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoStaticImportCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoStaticImportCheckTest.java
@@ -39,4 +39,12 @@ class MockitoStaticImportCheckTest {
       .withoutSemantic()
       .verifyNoIssues();
   }
+
+  @Test
+  void test_name_conflict() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/MockitoStaticImportCheckNameConflictSample.java"))
+      .withCheck(new MockitoStaticImportCheck())
+      .verifyNoIssues();
+  }
 }


### PR DESCRIPTION
## Summary

- Rule S8924 was raising a false positive when `Mockito.<method>(...)` was called with an explicit qualifier but a method with the same name was already in scope (via a static import from another class, or a locally defined method), making the `Mockito.` prefix necessary for disambiguation.
- Fix: before reporting, the check now collects non-Mockito static imports and enclosing class method names, and suppresses the issue if the method name conflicts with either.

## Test plan

- [ ] Existing `MockitoStaticImportCheckSample` tests still pass (no regression on noncompliant cases)
- [ ] New `MockitoStaticImportCheckNameConflictSample` test covers the two FP scenarios: static import conflict and local method conflict