### PR TITLE
SONARJAVA-6688 Fix ruling tests bug with recursive nesting of git eclipse-jetty-* sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "its/sources"]
 	path = its/sources
 	url = https://github.com/SonarSource/ruling_java.git
-	branch = lp/add-spring-ruling


### PR DESCRIPTION
Remove stale branch tracking config for its/sources and update the submodule pointer to the ruling_java commit that includes empty .gitmodules on each eclipse-jetty branch, preventing spurious nested directory creation.
