### PR TITLE
SONARJAVA-6686 Implement new rule S2198: Unnecessary mathematical comparisons

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2198.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2198.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S2198",
+  "hasTruePositives": true,
+  "falseNegatives": 0,
+  "falsePositives": 0
+}

--- a/its/ruling/src/test/resources/diff_S2198.json
+++ b/its/ruling/src/test/resources/diff_S2198.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S2198",
+  "hasTruePositives": true,
+  "falseNegatives": 0,
+  "falsePositives": 0
+}

--- a/its/ruling/src/test/resources/diff_S2198.json
+++ b/its/ruling/src/test/resources/diff_S2198.json
@@ -1,6 +1,0 @@
-{
-  "ruleKey": "S2198",
-  "hasTruePositives": true,
-  "falseNegatives": 0,
-  "falsePositives": 0
-}

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S2198.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S2198.json
@@ -1,0 +1,6 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java": [
+876,
+890
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S2198.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S2198.json
@@ -1,0 +1,17 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java": [
+876,
+890
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ByteArrayISO8859Writer.java": [
+107,
+124,
+142,
+167,
+185
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/TreeTrie.java": [
+98,
+135
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S2198.json
+++ b/its/ruling/src/test/resources/guava/java-S2198.json
@@ -1,0 +1,5 @@
+{
+"com.google.guava:guava:src/com/google/common/net/InetAddresses.java": [
+907
+]
+}

--- a/java-checks-test-sources/default/src/main/java/checks/UselessMathematicalComparisonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/UselessMathematicalComparisonCheckSample.java
@@ -6,6 +6,7 @@ class UselessMathematicalComparisonCheckSample {
 
   void byteComparisons(byte b) {
     if (b > 200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+//      ^^^^^^^
     if (b > 127) {} // Noncompliant {{Remove this comparison; it will always return false.}}
     if (b >= 128) {} // Noncompliant {{Remove this comparison; it will always return false.}}
     if (b < -200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
@@ -82,19 +83,73 @@ class UselessMathematicalComparisonCheckSample {
     if (200 >= b) {} // Noncompliant {{Remove this comparison; it will always return true.}}
     if (200 == b) {} // Noncompliant {{Remove this comparison; it will always return false.}}
     if (200 != b) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+
+    if (100 == b) {} // Compliant - 100 within byte range
+    if (100 != b) {} // Compliant
+    if (100 < b) {} // Compliant
+    if (-100 > b) {} // Compliant
   }
 
   void longVariable(long l) {
+    if (l > 9223372036854775807L) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (l >= Long.MIN_VALUE) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (l < Long.MIN_VALUE) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
     if (l > 2147483648L) {} // Compliant - long can hold this value
     if (l < -2147483649L) {} // Compliant
+    if (l != 9223372036854775807L) {} // Compliant - Long.MAX_VALUE is reachable
   }
 
+  void integralVariableAgainstFloatingConstant(byte b, int i, long l) {
+    if (b > 200.5) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b <= -128.5) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b < 127.5) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (i > 1e10) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (l > 1e30) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (l < 1e30) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+
+    if (b > Float.MAX_VALUE) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
+    if (b > 126.5) {} // Compliant - b can be 127
+    if (b == 100.0) {} // Compliant
+    if (i > 1e5) {} // Compliant
+    if (l > 1e18) {} // Compliant - long can hold this value
+    if (b > Double.NaN) {} // Compliant - not modelled, although every comparison with NaN is false
+  }
+
+  void boxedVariable(Integer boxed, Byte boxedByte) {
+    if (boxed == 5) {} // Compliant - not a primitive type
+    if (boxedByte > 200) {} // Compliant - not a primitive type
+  }
+
+  // A float or double variable can hold +/-Infinity, so nothing can be concluded from the finite range of the
+  // type: "f > 1e40" is true when f is +Infinity. Equality would be decidable, but every equality test on a
+  // float or double is already reported by S1244, so floating-point variables are out of scope entirely.
   void floatVariable(float f) {
-    if (f > 1000000) {} // Compliant - float/double not checked
+    if (f > 1e40) {} // Compliant - true when f is +Infinity
+    if (f < 1e40) {} // Compliant - false when f is +Infinity
+    if (f > Float.MAX_VALUE) {} // Compliant - a legitimate way to test for +Infinity
+    if (f == 1e40) {} // Compliant - covered by S1244
+    if (f != 1e40) {} // Compliant - covered by S1244
+    if (f == Double.MAX_VALUE) {} // Compliant - covered by S1244
+    if (f > 1000000) {} // Compliant - within range
   }
 
   void doubleVariable(double d) {
-    if (d > 1000000) {} // Compliant - float/double not checked
+    if (d > 1000000) {} // Compliant
+    if (d > Double.MAX_VALUE) {} // Compliant - a legitimate way to test for +Infinity
+    if (d == Double.POSITIVE_INFINITY) {} // Compliant - covered by S1244
+  }
+
+  void reversedFloatingOperands(byte b, float f) {
+    if (200.5 < b) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (1e40 > f) {} // Compliant - false when f is +Infinity
+    if (1e40 == f) {} // Compliant - covered by S1244
+  }
+
+  void charAgainstNegativeZero(char c) {
+    if (c < -0.0) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (c == -0.0) {} // Compliant - c can be 0, and 0.0 == -0.0
   }
 
   void intVariableWithinRange(int b) {
@@ -108,9 +163,18 @@ class UselessMathematicalComparisonCheckSample {
 
   void constantExpressions(byte b) {
     if (b > CONSTANT_200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b > 127 + 1) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b > 100 * 3) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b < -100 - 100) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (CONSTANT_200 - 100 > b) {} // Compliant - 100 within byte range
+    if (b > 100 + 1) {} // Compliant - 101 within byte range
   }
 
   void twoVariables(byte a, byte b) {
     if (a > b) {} // Compliant - comparing two variables
+  }
+
+  void nonConstantExpression(byte b, int i) {
+    if (b > i + 1) {} // Compliant - right operand is not a compile-time constant
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/UselessMathematicalComparisonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/UselessMathematicalComparisonCheckSample.java
@@ -1,0 +1,116 @@
+package checks;
+
+class UselessMathematicalComparisonCheckSample {
+
+  static final int CONSTANT_200 = 200;
+
+  void byteComparisons(byte b) {
+    if (b > 200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b > 127) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b >= 128) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b < -200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b < -128) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b <= -129) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b == 200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b == -200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
+    if (b < 200) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (b <= 127) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (b >= -128) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (b >= -200) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (b > -129) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (b != 200) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+
+    if (b > 100) {} // Compliant - 100 within byte range
+    if (b < -100) {} // Compliant
+    if (b == 0) {} // Compliant
+    if (b <= 126) {} // Compliant - 126 < max, not always true
+  }
+
+  void shortComparisons(short s) {
+    if (s > 40000) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (s >= 32768) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (s < -32769) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (s <= -32769) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (s == 40000) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
+    if (s < 32768) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (s <= 32767) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (s >= -32768) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (s != 40000) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+
+    if (s > 30000) {} // Compliant - within range
+    if (s < -30000) {} // Compliant
+  }
+
+  void charComparisons(char c) {
+    if (c < 0) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (c > 65535) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (c >= 65536) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (c < -1) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (c == -1) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (c == 65536) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
+    if (c >= 0) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (c <= 65535) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (c != -1) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+
+    if (c > 1000) {} // Compliant - within range
+    if (c < 60000) {} // Compliant
+  }
+
+  void intComparisons(int i) {
+    if (i > 2147483648L) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (i >= 2147483648L) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (i < -2147483649L) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (i == 2147483648L) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
+    if (i < 2147483648L) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (i <= 2147483647L) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (i >= -2147483648L) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (i != 2147483648L) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+
+    if (i > 1000000) {} // Compliant
+    if (i < -1000000) {} // Compliant
+  }
+
+  void reversedOperands(byte b) {
+    if (200 < b) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (200 <= b) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (-200 > b) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (200 > b) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (200 >= b) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+    if (200 == b) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (200 != b) {} // Noncompliant {{Remove this comparison; it will always return true.}}
+  }
+
+  void longVariable(long l) {
+    if (l > 2147483648L) {} // Compliant - long can hold this value
+    if (l < -2147483649L) {} // Compliant
+  }
+
+  void floatVariable(float f) {
+    if (f > 1000000) {} // Compliant - float/double not checked
+  }
+
+  void doubleVariable(double d) {
+    if (d > 1000000) {} // Compliant - float/double not checked
+  }
+
+  void intVariableWithinRange(int b) {
+    if (b > 200) {} // Compliant - int can hold 200
+  }
+
+  void parenthesizedExpressions(byte b) {
+    if ((b) > 200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (b > (200)) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+  }
+
+  void constantExpressions(byte b) {
+    if (b > CONSTANT_200) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+  }
+
+  void twoVariables(byte a, byte b) {
+    if (a > b) {} // Compliant - comparing two variables
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
@@ -117,48 +117,61 @@ public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisi
       case GREATER_THAN_OR_EQUAL_TO -> Kind.LESS_THAN_OR_EQUAL_TO;
       case LESS_THAN -> Kind.GREATER_THAN;
       case LESS_THAN_OR_EQUAL_TO -> Kind.GREATER_THAN_OR_EQUAL_TO;
-      default -> kind; // EQUAL_TO, NOT_EQUAL_TO are symmetric
+      // EQUAL_TO, NOT_EQUAL_TO are symmetric
+      default -> kind;
     };
   }
 
   @Nullable
   private static Boolean evaluateComparison(Kind normalizedKind, long min, long max, long constant) {
     return switch (normalizedKind) {
-      // var > constant
-      case GREATER_THAN -> {
-        if (constant >= max) yield Boolean.FALSE;
-        else if (constant < min) yield Boolean.TRUE;
-        else yield null;
-      }
-      // var >= constant
-      case GREATER_THAN_OR_EQUAL_TO -> {
-        if (constant > max) yield Boolean.FALSE;
-        else if (constant <= min) yield Boolean.TRUE;
-        else yield null;
-      }
-      // var < constant
-      case LESS_THAN -> {
-        if (constant <= min) yield Boolean.FALSE;
-        else if (constant > max) yield Boolean.TRUE;
-        else yield null;
-      }
-      // var <= constant
-      case LESS_THAN_OR_EQUAL_TO -> {
-        if (constant < min) yield Boolean.FALSE;
-        else if (constant >= max) yield Boolean.TRUE;
-        else yield null;
-      }
-      // var == constant
-      case EQUAL_TO -> {
-        if (constant < min || constant > max) yield Boolean.FALSE;
-        else yield null;
-      }
-      // var != constant
-      case NOT_EQUAL_TO -> {
-        if (constant < min || constant > max) yield Boolean.TRUE;
-        else yield null;
-      }
+      case GREATER_THAN -> evaluateGreaterThan(min, max, constant);
+      case GREATER_THAN_OR_EQUAL_TO -> evaluateGreaterThanOrEqual(min, max, constant);
+      case LESS_THAN -> evaluateLessThan(min, max, constant);
+      case LESS_THAN_OR_EQUAL_TO -> evaluateLessThanOrEqual(min, max, constant);
+      case EQUAL_TO -> (constant < min || constant > max) ? Boolean.FALSE : null;
+      case NOT_EQUAL_TO -> (constant < min || constant > max) ? Boolean.TRUE : null;
       default -> null;
     };
+  }
+
+  @Nullable
+  private static Boolean evaluateGreaterThan(long min, long max, long constant) {
+    if (constant >= max) {
+      return Boolean.FALSE;
+    } else if (constant < min) {
+      return Boolean.TRUE;
+    }
+    return null;
+  }
+
+  @Nullable
+  private static Boolean evaluateGreaterThanOrEqual(long min, long max, long constant) {
+    if (constant > max) {
+      return Boolean.FALSE;
+    } else if (constant <= min) {
+      return Boolean.TRUE;
+    }
+    return null;
+  }
+
+  @Nullable
+  private static Boolean evaluateLessThan(long min, long max, long constant) {
+    if (constant <= min) {
+      return Boolean.FALSE;
+    } else if (constant > max) {
+      return Boolean.TRUE;
+    }
+    return null;
+  }
+
+  @Nullable
+  private static Boolean evaluateLessThanOrEqual(long min, long max, long constant) {
+    if (constant < min) {
+      return Boolean.FALSE;
+    } else if (constant >= max) {
+      return Boolean.TRUE;
+    }
+    return null;
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
@@ -32,11 +32,18 @@ import org.sonar.plugins.java.api.tree.Tree.Kind;
 @Rule(key = "S2198")
 public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisitor {
 
-  private static final Map<Type.Primitives, long[]> TYPE_BOUNDS = Map.of(
+  /**
+   * Only the integral types. A float or double variable can also hold +/-Infinity, so a constant outside the
+   * finite range of the type does not make a relational comparison constant: "f > 1e40" is true when f is
+   * +Infinity, and "d > Double.MAX_VALUE" is a legitimate way to test for +Infinity. Equality would be
+   * decidable, but every equality test on a float or double is already reported by S1244.
+   */
+  private static final Map<Type.Primitives, long[]> INTEGRAL_BOUNDS = Map.of(
     Type.Primitives.BYTE, new long[] {Byte.MIN_VALUE, Byte.MAX_VALUE},
     Type.Primitives.SHORT, new long[] {Short.MIN_VALUE, Short.MAX_VALUE},
     Type.Primitives.CHAR, new long[] {Character.MIN_VALUE, Character.MAX_VALUE},
-    Type.Primitives.INT, new long[] {Integer.MIN_VALUE, Integer.MAX_VALUE}
+    Type.Primitives.INT, new long[] {Integer.MIN_VALUE, Integer.MAX_VALUE},
+    Type.Primitives.LONG, new long[] {Long.MIN_VALUE, Long.MAX_VALUE}
   );
 
   @Override
@@ -70,24 +77,34 @@ public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisi
 
   @Nullable
   private static Boolean evaluate(ExpressionTree variableCandidate, ExpressionTree constantCandidate, Kind operatorKind, boolean reversed) {
+    Number constantValue = resolveConstantValue(constantCandidate);
+    if (constantValue == null) {
+      return null;
+    }
     long[] bounds = resolveTypeBounds(variableCandidate);
     if (bounds == null) {
       return null;
     }
-    Long constantValue = resolveConstantValue(constantCandidate);
-    if (constantValue == null) {
-      return null;
-    }
-    long min = bounds[0];
-    long max = bounds[1];
     Kind normalizedKind = reversed ? reverseOperator(operatorKind) : operatorKind;
-    return evaluateComparison(normalizedKind, min, max, constantValue);
+    if (isFloatingPoint(constantValue)) {
+      double value = constantValue.doubleValue();
+      if (Double.isNaN(value)) {
+        // Every comparison with NaN is false, which the range reasoning does not model.
+        return null;
+      }
+      // The variable is promoted to double before the comparison, so both bounds are converted to double as
+      // well. That is exact for byte, short, char and int, and rounds to +/-2^63 for long, the very values
+      // (double) Long.MIN_VALUE and (double) Long.MAX_VALUE can take.
+      return evaluateComparison(normalizedKind, compare(value, bounds[0]), compare(value, bounds[1]));
+    }
+    long value = constantValue.longValue();
+    return evaluateComparison(normalizedKind, Long.compare(value, bounds[0]), Long.compare(value, bounds[1]));
   }
 
   @Nullable
   private static long[] resolveTypeBounds(ExpressionTree expression) {
     Type type = expression.symbolType();
-    for (Map.Entry<Type.Primitives, long[]> entry : TYPE_BOUNDS.entrySet()) {
+    for (Map.Entry<Type.Primitives, long[]> entry : INTEGRAL_BOUNDS.entrySet()) {
       if (type.isPrimitive(entry.getKey())) {
         return entry.getValue();
       }
@@ -95,18 +112,34 @@ public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisi
     return null;
   }
 
+  private static boolean isFloatingPoint(Number constant) {
+    return constant instanceof Double || constant instanceof Float;
+  }
+
+  /**
+   * Ordering consistent with the Java comparison operators, unlike {@link Double#compare}, which orders -0.0
+   * before 0.0 while "-0.0 == 0.0" evaluates to true. NaN must be excluded by the caller.
+   */
+  private static int compare(double value, double bound) {
+    if (value < bound) {
+      return -1;
+    }
+    return value > bound ? 1 : 0;
+  }
+
   @Nullable
-  private static Long resolveConstantValue(ExpressionTree expression) {
-    Long literal = LiteralUtils.longLiteralValue(expression);
-    if (literal != null) {
-      return literal;
+  private static Number resolveConstantValue(ExpressionTree expression) {
+    Long longLiteral = LiteralUtils.longLiteralValue(expression);
+    if (longLiteral != null) {
+      return longLiteral;
+    }
+    Double doubleLiteral = LiteralUtils.doubleLiteralValue(expression);
+    if (doubleLiteral != null) {
+      return doubleLiteral;
     }
     Object constant = ExpressionUtils.resolveAsConstant(expression);
-    if (constant instanceof Integer intVal) {
-      return intVal.longValue();
-    }
-    if (constant instanceof Long longVal) {
-      return longVal;
+    if (constant instanceof Integer || constant instanceof Long || constant instanceof Float || constant instanceof Double) {
+      return (Number) constant;
     }
     return null;
   }
@@ -122,56 +155,31 @@ public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisi
     };
   }
 
+  /**
+   * Decides "variable op constant", where the variable ranges over [min, max] and both bounds are reachable.
+   *
+   * @param toMin the sign of "constant - min"
+   * @param toMax the sign of "constant - max"
+   * @return the constant result of the comparison, or null when it depends on the value of the variable
+   */
   @Nullable
-  private static Boolean evaluateComparison(Kind normalizedKind, long min, long max, long constant) {
+  private static Boolean evaluateComparison(Kind normalizedKind, int toMin, int toMax) {
     return switch (normalizedKind) {
-      case GREATER_THAN -> evaluateGreaterThan(min, max, constant);
-      case GREATER_THAN_OR_EQUAL_TO -> evaluateGreaterThanOrEqual(min, max, constant);
-      case LESS_THAN -> evaluateLessThan(min, max, constant);
-      case LESS_THAN_OR_EQUAL_TO -> evaluateLessThanOrEqual(min, max, constant);
-      case EQUAL_TO -> (constant < min || constant > max) ? Boolean.FALSE : null;
-      case NOT_EQUAL_TO -> (constant < min || constant > max) ? Boolean.TRUE : null;
+      case GREATER_THAN -> constantResult(toMax >= 0, toMin < 0);
+      case GREATER_THAN_OR_EQUAL_TO -> constantResult(toMax > 0, toMin <= 0);
+      case LESS_THAN -> constantResult(toMin <= 0, toMax > 0);
+      case LESS_THAN_OR_EQUAL_TO -> constantResult(toMin < 0, toMax >= 0);
+      case EQUAL_TO -> constantResult(toMin < 0 || toMax > 0, false);
+      case NOT_EQUAL_TO -> constantResult(false, toMin < 0 || toMax > 0);
       default -> null;
     };
   }
 
   @Nullable
-  private static Boolean evaluateGreaterThan(long min, long max, long constant) {
-    if (constant >= max) {
+  private static Boolean constantResult(boolean alwaysFalse, boolean alwaysTrue) {
+    if (alwaysFalse) {
       return Boolean.FALSE;
-    } else if (constant < min) {
-      return Boolean.TRUE;
     }
-    return null;
-  }
-
-  @Nullable
-  private static Boolean evaluateGreaterThanOrEqual(long min, long max, long constant) {
-    if (constant > max) {
-      return Boolean.FALSE;
-    } else if (constant <= min) {
-      return Boolean.TRUE;
-    }
-    return null;
-  }
-
-  @Nullable
-  private static Boolean evaluateLessThan(long min, long max, long constant) {
-    if (constant <= min) {
-      return Boolean.FALSE;
-    } else if (constant > max) {
-      return Boolean.TRUE;
-    }
-    return null;
-  }
-
-  @Nullable
-  private static Boolean evaluateLessThanOrEqual(long min, long max, long constant) {
-    if (constant < min) {
-      return Boolean.FALSE;
-    } else if (constant >= max) {
-      return Boolean.TRUE;
-    }
-    return null;
+    return alwaysTrue ? Boolean.TRUE : null;
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
@@ -1,0 +1,164 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.java.model.LiteralUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+@Rule(key = "S2198")
+public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisitor {
+
+  private static final Map<Type.Primitives, long[]> TYPE_BOUNDS = Map.of(
+    Type.Primitives.BYTE, new long[] {Byte.MIN_VALUE, Byte.MAX_VALUE},
+    Type.Primitives.SHORT, new long[] {Short.MIN_VALUE, Short.MAX_VALUE},
+    Type.Primitives.CHAR, new long[] {Character.MIN_VALUE, Character.MAX_VALUE},
+    Type.Primitives.INT, new long[] {Integer.MIN_VALUE, Integer.MAX_VALUE}
+  );
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return List.of(
+      Kind.GREATER_THAN,
+      Kind.GREATER_THAN_OR_EQUAL_TO,
+      Kind.LESS_THAN,
+      Kind.LESS_THAN_OR_EQUAL_TO,
+      Kind.EQUAL_TO,
+      Kind.NOT_EQUAL_TO);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    BinaryExpressionTree binaryExpression = (BinaryExpressionTree) tree;
+    ExpressionTree leftOperand = ExpressionUtils.skipParentheses(binaryExpression.leftOperand());
+    ExpressionTree rightOperand = ExpressionUtils.skipParentheses(binaryExpression.rightOperand());
+
+    // Try left=variable, right=constant
+    Boolean result = evaluate(leftOperand, rightOperand, binaryExpression.kind(), false);
+    if (result == null) {
+      // Try left=constant, right=variable (reversed)
+      result = evaluate(rightOperand, leftOperand, binaryExpression.kind(), true);
+    }
+
+    if (result != null) {
+      reportIssue(binaryExpression, "Remove this comparison; it will always return " + result + ".");
+    }
+  }
+
+  @Nullable
+  private static Boolean evaluate(ExpressionTree variableCandidate, ExpressionTree constantCandidate, Kind operatorKind, boolean reversed) {
+    long[] bounds = resolveTypeBounds(variableCandidate);
+    if (bounds == null) {
+      return null;
+    }
+    Long constantValue = resolveConstantValue(constantCandidate);
+    if (constantValue == null) {
+      return null;
+    }
+    long min = bounds[0];
+    long max = bounds[1];
+    Kind normalizedKind = reversed ? reverseOperator(operatorKind) : operatorKind;
+    return evaluateComparison(normalizedKind, min, max, constantValue);
+  }
+
+  @Nullable
+  private static long[] resolveTypeBounds(ExpressionTree expression) {
+    Type type = expression.symbolType();
+    for (Map.Entry<Type.Primitives, long[]> entry : TYPE_BOUNDS.entrySet()) {
+      if (type.isPrimitive(entry.getKey())) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static Long resolveConstantValue(ExpressionTree expression) {
+    Long literal = LiteralUtils.longLiteralValue(expression);
+    if (literal != null) {
+      return literal;
+    }
+    Object constant = ExpressionUtils.resolveAsConstant(expression);
+    if (constant instanceof Integer intVal) {
+      return intVal.longValue();
+    }
+    if (constant instanceof Long longVal) {
+      return longVal;
+    }
+    return null;
+  }
+
+  private static Kind reverseOperator(Kind kind) {
+    return switch (kind) {
+      case GREATER_THAN -> Kind.LESS_THAN;
+      case GREATER_THAN_OR_EQUAL_TO -> Kind.LESS_THAN_OR_EQUAL_TO;
+      case LESS_THAN -> Kind.GREATER_THAN;
+      case LESS_THAN_OR_EQUAL_TO -> Kind.GREATER_THAN_OR_EQUAL_TO;
+      default -> kind; // EQUAL_TO, NOT_EQUAL_TO are symmetric
+    };
+  }
+
+  @Nullable
+  private static Boolean evaluateComparison(Kind normalizedKind, long min, long max, long constant) {
+    return switch (normalizedKind) {
+      // var > constant
+      case GREATER_THAN -> {
+        if (constant >= max) yield Boolean.FALSE;
+        else if (constant < min) yield Boolean.TRUE;
+        else yield null;
+      }
+      // var >= constant
+      case GREATER_THAN_OR_EQUAL_TO -> {
+        if (constant > max) yield Boolean.FALSE;
+        else if (constant <= min) yield Boolean.TRUE;
+        else yield null;
+      }
+      // var < constant
+      case LESS_THAN -> {
+        if (constant <= min) yield Boolean.FALSE;
+        else if (constant > max) yield Boolean.TRUE;
+        else yield null;
+      }
+      // var <= constant
+      case LESS_THAN_OR_EQUAL_TO -> {
+        if (constant < min) yield Boolean.FALSE;
+        else if (constant >= max) yield Boolean.TRUE;
+        else yield null;
+      }
+      // var == constant
+      case EQUAL_TO -> {
+        if (constant < min || constant > max) yield Boolean.FALSE;
+        else yield null;
+      }
+      // var != constant
+      case NOT_EQUAL_TO -> {
+        if (constant < min || constant > max) yield Boolean.TRUE;
+        else yield null;
+      }
+      default -> null;
+    };
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/UselessMathematicalComparisonCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/UselessMathematicalComparisonCheckTest.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class UselessMathematicalComparisonCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/UselessMathematicalComparisonCheckSample.java"))
+      .withCheck(new UselessMathematicalComparisonCheck())
+      .verifyIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.html
@@ -1,0 +1,30 @@
+<h2>Why is this an issue?</h2>
+<p>In Java, primitive numeric types have fixed value ranges defined by the language specification. When you compare a variable of a bounded type
+against a constant that is outside the type's range, the result is predetermined and the comparison is unnecessary.</p>
+<p>For example, a <code>byte</code> variable can only hold values from -128 to 127. Comparing it against 200 will always yield the same result,
+regardless of the variable's actual value.</p>
+<p>These comparisons indicate a logic error, a wrong variable type, or dead code.</p>
+<h2>How to fix it</h2>
+<p>Ensure the constant is within the variable's type range, or change the variable to a wider type if comparisons against larger values are
+needed.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+byte b = 0;
+if (b &gt; 200) { // Noncompliant - always false
+    doSomething();
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+int b = 0;
+if (b &gt; 200) { // Compliant
+    doSomething();
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">Primitive Data Types</a></li>
+  <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.2">Integral Types and Values</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.html
@@ -1,24 +1,61 @@
+<p>This is an issue when comparing a numeric variable with a limited value range against a constant that falls outside the variable’s possible value
+range, resulting in a comparison that always evaluates to <code>true</code> or always to <code>false</code>.</p>
 <h2>Why is this an issue?</h2>
-<p>In Java, primitive numeric types have fixed value ranges defined by the language specification. When you compare a variable of a bounded type
-against a constant that is outside the type's range, the result is predetermined and the comparison is unnecessary.</p>
-<p>For example, a <code>byte</code> variable can only hold values from -128 to 127. Comparing it against 200 will always yield the same result,
-regardless of the variable's actual value.</p>
-<p>These comparisons indicate a logic error, a wrong variable type, or dead code.</p>
+<p>In statically-typed languages with fixed-width numeric types, primitive numeric types have value ranges defined by the language specification:</p>
+<ul>
+  <li>8-bit signed integers: -128 to 127</li>
+  <li>16-bit signed integers: -32,768 to 32,767</li>
+  <li>16-bit unsigned integers: 0 to 65,535</li>
+  <li>32-bit signed integers: -2,147,483,648 to 2,147,483,647</li>
+  <li>64-bit signed integers: -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807</li>
+  <li>Single-precision floating-point: approximately ±3.4 × 10<sup>38</sup> (limited by IEEE 754 single precision)</li>
+  <li>Double-precision floating-point: approximately ±1.7 × 10<sup>308</sup> (limited by IEEE 754 double precision)</li>
+</ul>
+<p>When you compare a variable of one of these types against a constant that is outside its range, the type system guarantees the result before the
+program even runs. For example, an 8-bit signed integer variable can never be greater than 127, so a comparison checking if it exceeds 200 will always
+be <code>false</code>.</p>
+<p>These comparisons indicate one of several problems:</p>
+<ul>
+  <li><strong>Logic error</strong>: The developer misunderstood the range of values the variable can hold</li>
+  <li><strong>Wrong type</strong>: The variable should have been declared with a larger type (e.g., 32-bit instead of 8-bit)</li>
+  <li><strong>Wrong constant</strong>: The constant value is incorrect for the intended comparison</li>
+  <li><strong>Dead code</strong>: The condition guards code that can never execute (if always <code>false</code>) or always executes (if always
+  <code>true</code>)</li>
+</ul>
+<p>Such comparisons make the code confusing and harder to maintain. They may also hide genuine bugs where the developer’s intent does not match the
+actual behavior.</p>
+<p>In Java, these types are named: <code>byte</code> (8-bit signed), <code>short</code> (16-bit signed), <code>char</code> (16-bit unsigned),
+<code>int</code> (32-bit signed), <code>long</code> (64-bit signed), <code>float</code> (single-precision), and <code>double</code>
+(double-precision).</p>
+<h3>What is the potential impact?</h3>
+<p>Impossible comparisons create several problems:</p>
+<ul>
+  <li><strong>Dead code branches</strong>: When a comparison is always <code>false</code>, the code inside the conditional block will never execute.
+  When always <code>true</code>, the <code>else</code> branch becomes unreachable.</li>
+  <li><strong>Hidden logic errors</strong>: The comparison may reflect a misunderstanding of the data’s range, suggesting that other parts of the code
+  may also be incorrect.</li>
+  <li><strong>Maintenance burden</strong>: Future developers reading the code may waste time trying to understand why a seemingly meaningful check is
+  present.</li>
+  <li><strong>Misleading intent</strong>: The code suggests validation or range checking that isn’t actually happening, which could lead to incorrect
+  assumptions about data safety.</li>
+</ul>
 <h2>How to fix it</h2>
-<p>Ensure the constant is within the variable's type range, or change the variable to a wider type if comparisons against larger values are
-needed.</p>
+<p>When comparing a <code>byte</code> variable against a constant, ensure the constant is within the <code>byte</code> range (-128 to 127). If you
+need to compare against larger values, declare the variable as a wider type like <code>short</code> or <code>int</code>.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 byte b = 0;
-if (b &gt; 200) { // Noncompliant - always false
+if (b &gt; 200) { // Noncompliant
+    // This code never executes
     doSomething();
 }
 </pre>
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
-int b = 0;
-if (b &gt; 200) { // Compliant
+int b = getUserInput();
+if (b &gt; 200) {
+    // With an int, b can actually exceed 200
     doSomething();
 }
 </pre>
@@ -27,4 +64,7 @@ if (b &gt; 200) { // Compliant
 <ul>
   <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">Primitive Data Types</a></li>
   <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.2">Integral Types and Values</a></li>
+  <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.2.3">Floating-Point Types and
+  Values</a></li>
 </ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.json
@@ -3,14 +3,14 @@
   "type": "CODE_SMELL",
   "code": {
     "impacts": {
-      "RELIABILITY": "HIGH"
+      "MAINTAINABILITY": "HIGH"
     },
     "attribute": "LOGICAL"
   },
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
-    "constantCost": "5min"
+    "constantCost": "15min"
   },
   "tags": [
     "suspicious"

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2198.json
@@ -1,0 +1,23 @@
+{
+  "title": "Unnecessary mathematical comparisons should not be made",
+  "type": "CODE_SMELL",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "LOGICAL"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "suspicious"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-2198",
+  "sqKey": "S2198",
+  "scope": "Main",
+  "quickfix": "unknown"
+}


### PR DESCRIPTION
Detect comparisons between a bounded numeric primitive (byte, short, char, int) and a compile-time constant outside the type's value range, which always evaluate to true or false.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
