### PR TITLE
SONARJAVA-6671 Add parametrized exclusion list and some exceptions for java:S1192

### DIFF
--- a/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
+++ b/its/autoscan/src/test/java/org/sonar/java/it/AutoScanTest.java
@@ -198,7 +198,7 @@ public class AutoScanTest {
     SoftAssertions softly = new SoftAssertions();
     softly.assertThat(newDiffs).containsExactlyInAnyOrderElementsOf(knownDiffs.values());
     softly.assertThat(newTotal).isEqualTo(knownTotal);
-    softly.assertThat(rulesCausingFPs).hasSize(11);
+    softly.assertThat(rulesCausingFPs).hasSize(12);
     softly.assertThat(rulesNotReporting).hasSize(19);
 
     /**

--- a/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -380,8 +380,8 @@
   {
     "ruleKey": "S1192",
     "hasTruePositives": true,
-    "falseNegatives": 3,
-    "falsePositives": 23
+    "falseNegatives": 0,
+    "falsePositives": 20
   },
   {
     "ruleKey": "S1193",

--- a/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -380,8 +380,8 @@
   {
     "ruleKey": "S1192",
     "hasTruePositives": true,
-    "falseNegatives": 0,
-    "falsePositives": 0
+    "falseNegatives": 3,
+    "falsePositives": 23
   },
   {
     "ruleKey": "S1193",

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S1192.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S1192.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S1192",
   "hasTruePositives": true,
-  "falseNegatives": 0,
-  "falsePositives": 0
+  "falseNegatives": 3,
+  "falsePositives": 23
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S1192.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S1192.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S1192",
   "hasTruePositives": true,
-  "falseNegatives": 3,
-  "falsePositives": 23
+  "falseNegatives": 0,
+  "falsePositives": 20
 }

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S1192.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S1192.json
@@ -1,21 +1,6 @@
 {
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java": [
-276
-],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java": [
 106
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java": [
-401
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/NetworkTrafficSocketChannelEndPoint.java": [
-87
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java": [
-317
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java": [
-932
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
 597
@@ -23,34 +8,13 @@
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java": [
 698
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java": [
-1002
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java": [
-1677
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/InclusiveByteRange.java": [
-167
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartParser.java": [
-581
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Request.java": [
-983
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Response.java": [
 992
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java": [
-198
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownMonitor.java": [
 359,
 360,
 366
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java": [
-1918
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java": [
 575

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S1192.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S1192.json
@@ -1,21 +1,6 @@
 {
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java": [
-276
-],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java": [
 106
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ManagedSelector.java": [
-401
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/NetworkTrafficSocketChannelEndPoint.java": [
-87
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java": [
-317
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ssl/SslConnection.java": [
-932
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
 597
@@ -23,34 +8,13 @@
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java": [
 698
 ],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannel.java": [
-1002
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java": [
-1677
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/InclusiveByteRange.java": [
-167
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartParser.java": [
-581
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Request.java": [
-983
-],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Response.java": [
 992
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ResponseWriter.java": [
-198
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ShutdownMonitor.java": [
 359,
 360,
 366
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java": [
-1918
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java": [
 575
@@ -77,17 +41,11 @@
 648,
 992
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IO.java": [
-93
-],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java": [
 289
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/Jetty.java": [
 58
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java": [
-456
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java": [
 47,
@@ -100,21 +58,8 @@
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/URIUtil.java": [
 1163
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/JarFileResource.java": [
-78
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java": [
-88
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/URLResource.java": [
-76
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/thread/ReservedThreadExecutor.java": [
-251
-],
 "org.eclipse.jetty:jetty-project:jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java": [
 366,
-556,
 1033,
 1074,
 1129,

--- a/its/ruling/src/test/resources/guava/java-S1192.json
+++ b/its/ruling/src/test/resources/guava/java-S1192.json
@@ -1,8 +1,4 @@
 {
-"com.google.guava:guava:src/com/google/common/cache/CacheBuilderSpec.java": [
-292,
-297
-],
 "com.google.guava:guava:src/com/google/common/collect/ConcurrentHashMultiset.java": [
 223
 ],

--- a/its/ruling/src/test/resources/guava/java-S2629.json
+++ b/its/ruling/src/test/resources/guava/java-S2629.json
@@ -1,5 +1,14 @@
 {
+"com.google.guava:guava:src/com/google/common/io/Closer.java": [
+253
+],
 "com.google.guava:guava:src/com/google/common/reflect/ClassPath.java": [
 448
+],
+"com.google.guava:guava:src/com/google/common/util/concurrent/ServiceManager.java": [
+763
+],
+"com.google.guava:guava:src/com/google/common/util/concurrent/UncaughtExceptionHandlers.java": [
+67
 ]
 }

--- a/its/ruling/src/test/resources/mall/java-S1192.json
+++ b/its/ruling/src/test/resources/mall/java-S1192.json
@@ -652,7 +652,6 @@
 ],
 "com.macro.mall:mall:mall-search/src/main/java/com/macro/mall/search/service/impl/EsProductServiceImpl.java": [
 121,
-125,
-151
+125
 ]
 }

--- a/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckExcludePatternsSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckExcludePatternsSample.java
@@ -1,0 +1,19 @@
+package checks;
+
+/**
+ * Verifies that S1192 respects the excludePatterns rule property.
+ * Strings matching the configured pattern are excluded from duplicate detection.
+ */
+class StringLiteralDuplicatedCheckExcludePatternsSample {
+  void test() {
+    System.out.println("excluded string"); // Compliant — matches excludePatterns
+    System.out.println("excluded string");
+    System.out.println("excluded string");
+    System.out.println("included string"); // Noncompliant {{Define a constant instead of duplicating this literal "included string" 3 times.}}
+//                     ^^^^^^^^^^^^^^^^^
+    System.out.println("included string");
+//                     ^^^^^^^^^^^^^^^^^<
+    System.out.println("included string");
+//                     ^^^^^^^^^^^^^^^^^<
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckLoggingSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckLoggingSample.java
@@ -48,9 +48,10 @@ class MixedLoggingAndNonLogging {
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(MixedLoggingAndNonLogging.class);
 
   void doStuff(String v1, String v2, String v3) {
-    LOG.error("validation error"); // Compliant — the logging occurrence does not count
-    doValidate("validation error", v1); // Noncompliant {{Define a constant instead of duplicating this literal "validation error" 3 times.}}
-//             ^^^^^^^^^^^^^^^^^^
+    LOG.error("validation error"); // Noncompliant {{Define a constant instead of duplicating this literal "validation error" 4 times.}}
+//            ^^^^^^^^^^^^^^^^^^
+    doValidate("validation error", v1);
+//             ^^^^^^^^^^^^^^^^^^<
     doValidate("validation error", v2);
 //             ^^^^^^^^^^^^^^^^^^<
     doValidate("validation error", v3);
@@ -58,4 +59,16 @@ class MixedLoggingAndNonLogging {
   }
 
   private void doValidate(String msg, String value) {}
+}
+
+class ReportedWhenConstantExists {
+
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(ReportedWhenConstantExists.class);
+
+  private static final String CONSTANT = "constant message";
+
+  void doStuff() {
+    LOG.error("constant message"); // Noncompliant {{Use already-defined constant 'CONSTANT' instead of duplicating its value here.}}
+//            ^^^^^^^^^^^^^^^^^^
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckLoggingSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckLoggingSample.java
@@ -1,0 +1,61 @@
+package checks;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies that S1192 does not flag string literals used as logging arguments.
+ * Logging calls (SLF4J, JUL, Log4j) are commonly repeated with the same message — extracting
+ * them to constants is impractical and not idiomatic, so they are intentionally suppressed.
+ */
+class SuppressedBySlf4j {
+
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SuppressedBySlf4j.class);
+
+  void doStuff() {
+    LOG.info("operation failed");  // Compliant — repeated log messages are excluded
+    LOG.warn("operation failed");
+    LOG.error("operation failed");
+  }
+}
+
+class SuppressedByJul {
+
+  private static final Logger LOG = Logger.getLogger(SuppressedByJul.class.getName());
+
+  void doStuff() {
+    LOG.warning("operation failed");  // Compliant — repeated JUL messages are excluded
+    LOG.log(Level.WARNING, "operation failed");
+    LOG.severe("operation failed");
+  }
+}
+
+class SuppressedByLog4j {
+
+  private static final org.apache.logging.log4j.Logger LOG = LogManager.getLogger(SuppressedByLog4j.class);
+
+  void doStuff() {
+    LOG.info("operation failed");  // Compliant — repeated Log4j messages are excluded
+    LOG.warn("operation failed");
+    LOG.error("operation failed");
+  }
+}
+
+class MixedLoggingAndNonLogging {
+
+  private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(MixedLoggingAndNonLogging.class);
+
+  void doStuff(String v1, String v2, String v3) {
+    LOG.error("validation error"); // Compliant — the logging occurrence does not count
+    doValidate("validation error", v1); // Noncompliant {{Define a constant instead of duplicating this literal "validation error" 3 times.}}
+//             ^^^^^^^^^^^^^^^^^^
+    doValidate("validation error", v2);
+//             ^^^^^^^^^^^^^^^^^^<
+    doValidate("validation error", v3);
+//             ^^^^^^^^^^^^^^^^^^<
+  }
+
+  private void doValidate(String msg, String value) {}
+}

--- a/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckMinimalLengthSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckMinimalLengthSample.java
@@ -1,0 +1,19 @@
+package checks;
+
+/**
+ * Verifies that S1192 respects the minimalLength rule property.
+ * With minimalLength=3, strings of 3+ chars are considered; shorter ones are ignored.
+ */
+class StringLiteralDuplicatedCheckMinimalLengthSample {
+  void test() {
+    System.out.println("abc"); // Noncompliant {{Define a constant instead of duplicating this literal "abc" 3 times.}}
+//                     ^^^^^
+    System.out.println("abc");
+//                     ^^^^^<
+    System.out.println("abc");
+//                     ^^^^^<
+    System.out.println("xy"); // Compliant — 2 chars, below minimalLength of 3
+    System.out.println("xy");
+    System.out.println("xy");
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckSample.java
@@ -9,8 +9,11 @@ public class StringLiteralDuplicatedCheckSample {
     System.out.println("bbbbb");
     System.out.println("bbbbb");
     System.out.println("ccccc"); // Noncompliant {{Define a constant instead of duplicating this literal "ccccc" 3 times.}}
+//                     ^^^^^^^
     System.out.println("ccccc");
+//                     ^^^^^^^<
     System.out.println("ccccc");
+//                     ^^^^^^^<
     System.out.println("dddd");
     System.out.println("dddd");
   }
@@ -73,8 +76,11 @@ class ConstantAlreadyDefined {
 
 class CompleteCoverage {
   private final String notConstant = "blablah"; // Noncompliant {{Define a constant instead of duplicating this literal "blablah" 3 times.}}
+//                                   ^^^^^^^^^
   private final String notConstant2 = "blablah";
+//                                    ^^^^^^^^^<
   static String notConstant3 = "blablah";
+//                             ^^^^^^^^^<
   String notConstant4;
   int notString = 42;
 
@@ -144,22 +150,28 @@ class DuplicatedExceptionArguments {
   private Throwable constructButDoNotThrow(int r) {
     if (r == 0) {
       return new NullPointerException("build message"); // Noncompliant {{Define a constant instead of duplicating this literal "build message" 3 times.}}
+//                                    ^^^^^^^^^^^^^^^
     } else if (r == 1) {
       return new IllegalArgumentException("build message");
+//                                        ^^^^^^^^^^^^^^^<
     } else {
       return new AssertionError("build message");
+//                              ^^^^^^^^^^^^^^^<
     }
   }
 
   public static void constructAndThenThrow(int r) {
     if (r == 0) {
       var first = new IllegalArgumentException("this is a repeated message"); // Noncompliant
+//                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       throw first;
     } else if (r < 0) {
       var second = new IllegalArgumentException("this is a repeated message");
+//                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^<
       throw second;
     } else {
       var third = new IllegalArgumentException("this is a repeated message");
+//                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^<
       throw third;
     }
   }
@@ -182,10 +194,13 @@ class DuplicatedExceptionArguments {
   private void areNonCompliantWhenPassedToMethod(int r) {
     if (r == 0) {
       throw new IllegalArgumentException(transform("nested string 2", "AAA")); // Noncompliant {{Define a constant instead of duplicating this literal "nested string 2" 3 times.}}
+//                                                 ^^^^^^^^^^^^^^^^^
     } else if (r == 1) {
       throw new IllegalArgumentException(transform("nested string 2", "BBB"));
+//                                                 ^^^^^^^^^^^^^^^^^<
     } else if (r == 2) {
       throw new IllegalArgumentException(transform("nested string 2", "CCC"));
+//                                                 ^^^^^^^^^^^^^^^^^<
     }
   }
 
@@ -211,12 +226,16 @@ class DuplicatedExceptionArguments {
   private void reportCorrectCount(int r) {
     if (r == 1) {
       throw new RuntimeException("message shared between exception and fun calls"); // Noncompliant {{Define a constant instead of duplicating this literal "message shared between exception and fun calls" 4 times.}}
+//                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     } else if (r == 2) {
       devNull("message shared between exception and fun calls", 2);
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<
     } else if  (r == 3) {
       devNull("message shared between exception and fun calls", 3);
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<
     } else {
       devNull("message shared between exception and fun calls", 4);
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^<
     }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckSampleTest.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StringLiteralDuplicatedCheckSampleTest.java
@@ -1,0 +1,12 @@
+package checks;
+
+// Test file: no issues should be reported regardless of duplicated literals
+public class StringLiteralDuplicatedCheckSampleTest {
+
+  public void f() {
+    System.out.println("ccccc");
+    System.out.println("ccccc");
+    System.out.println("ccccc");
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/LazyArgEvaluationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/LazyArgEvaluationCheck.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.LoggingMatchers;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
@@ -41,13 +42,10 @@ import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.ReturnStatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
-import static org.sonar.plugins.java.api.semantic.MethodMatchers.ANY;
-
 @Rule(key = "S2629")
 public class LazyArgEvaluationCheck extends BaseTreeVisitor implements JavaFileScanner {
 
   private static final String STRING = "java.lang.String";
-  private static final String OBJECT_ARR = "java.lang.Object[]";
 
   private static class SLF4J {
 
@@ -62,19 +60,6 @@ public class LazyArgEvaluationCheck extends BaseTreeVisitor implements JavaFileS
     private static final String LOGGER = "org.slf4j.Logger";
     private static final String MARKER = "org.slf4j.Marker";
 
-    private static final MethodMatchers LOG = MethodMatchers.create()
-      .ofSubTypes(LOGGER)
-      .names(METHOD_NAMES)
-      .addParametersMatcher(STRING)
-      .addParametersMatcher(STRING, ANY)
-      .addParametersMatcher(STRING, ANY, ANY)
-      .addParametersMatcher(STRING, OBJECT_ARR)
-      .addParametersMatcher(MARKER, STRING)
-      .addParametersMatcher(MARKER, STRING, ANY)
-      .addParametersMatcher(MARKER, STRING, ANY, ANY)
-      .addParametersMatcher(MARKER, STRING, OBJECT_ARR)
-      .build();
-
     private static final MethodMatchers TEST = MethodMatchers.create()
       .ofSubTypes(LOGGER)
       .names(testMethodNames(METHOD_NAMES))
@@ -85,29 +70,7 @@ public class LazyArgEvaluationCheck extends BaseTreeVisitor implements JavaFileS
 
   private static class JUL {
 
-    private static final String[] METHOD_NAMES = {
-      "severe",
-      "warning",
-      "info",
-      "config",
-      "fine",
-      "finer",
-      "finest"
-    };
-
     private static final String LOGGER = "java.util.logging.Logger";
-
-    private static final MethodMatchers LOG = MethodMatchers.or(
-      MethodMatchers.create()
-        .ofTypes(LOGGER)
-        .names(METHOD_NAMES)
-        .addParametersMatcher(STRING)
-        .build(),
-      MethodMatchers.create()
-        .ofTypes(LOGGER)
-        .names("log")
-        .addParametersMatcher("java.util.logging.Level", STRING)
-        .build());
 
     private static final MethodMatchers TEST = MethodMatchers.create()
       .ofTypes(LOGGER)
@@ -133,18 +96,6 @@ public class LazyArgEvaluationCheck extends BaseTreeVisitor implements JavaFileS
     private static final Predicate<Type> SUPPLIER = type -> type.isSubtypeOf("org.apache.logging.log4j.util.Supplier") ||
       type.isSubtypeOf("org.apache.logging.log4j.util.MessageSupplier");
 
-    private static final MethodMatchers LOG = MethodMatchers.or(
-      MethodMatchers.create()
-        .ofSubTypes(LOGGER)
-        .names(METHOD_NAMES)
-        .withAnyParameters()
-        .build(),
-      MethodMatchers.create()
-        .ofSubTypes(LOGGER)
-        .names("log")
-        .withAnyParameters()
-        .build());
-
     private static final MethodMatchers TEST = MethodMatchers.or(
       MethodMatchers.create()
         .ofSubTypes(LOGGER)
@@ -165,11 +116,7 @@ public class LazyArgEvaluationCheck extends BaseTreeVisitor implements JavaFileS
     .withAnyParameters()
     .build();
 
-  private static final MethodMatchers LAZY_ARG_METHODS = MethodMatchers.or(
-    PRECONDITIONS,
-    SLF4J.LOG,
-    JUL.LOG,
-    LOG4J.LOG);
+  private static final MethodMatchers LAZY_ARG_METHODS = MethodMatchers.or(PRECONDITIONS, LoggingMatchers.LOG_METHODS);
 
   private static final MethodMatchers LOG_LEVEL_TESTS = MethodMatchers.or(
     SLF4J.TEST,

--- a/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
@@ -60,6 +61,15 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
     defaultValue = "" + DEFAULT_MINIMAL_LENGTH)
   public int minimalLength = DEFAULT_MINIMAL_LENGTH;
 
+  @RuleProperty(
+    key = "excludePatterns",
+    description = "Regular expression that strings must match to be excluded from the check. Leave empty to disable.",
+    defaultValue = "")
+  public String excludePatterns = "";
+
+  @Nullable
+  private Pattern excludePattern = null;
+
   private final Map<String, List<LiteralTree>> occurrences = new HashMap<>();
   private final Map<String, VariableTree> constants = new HashMap<>();
 
@@ -67,6 +77,9 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
   public void scanFile(JavaFileScannerContext context) {
     if (JavaFileTypeClassifier.isTestFile(context)) {
       return;
+    }
+    if (excludePattern == null && !excludePatterns.isEmpty()) {
+      excludePattern = Pattern.compile(excludePatterns, Pattern.DOTALL);
     }
     occurrences.clear();
     constants.clear();
@@ -153,10 +166,14 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
   public void visitLiteral(LiteralTree tree) {
     if (tree.is(Tree.Kind.STRING_LITERAL, Tree.Kind.TEXT_BLOCK) && !isStringLiteralFragment(tree)) {
       String stringValue = LiteralUtils.getAsStringValue(tree).replace("\\n", "\n");
-      if (stringValue.length() >= minimalLength) {
+      if (stringValue.length() >= minimalLength && !isExcluded(stringValue)) {
         occurrences.computeIfAbsent(stringValue, key -> new ArrayList<>()).add(tree);
       }
     }
+  }
+
+  private boolean isExcluded(String stringValue) {
+    return excludePattern != null && excludePattern.matcher(stringValue).matches();
   }
 
   private static boolean isStringLiteralFragment(ExpressionTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
@@ -86,31 +86,27 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
     occurrences.forEach((key, literalTrees) -> {
       int literalOccurrence = literalTrees.size();
       // Do not consider `throw new Exception("repeated message")` or logging calls for reporting
-      // duplicates, but still report against a constant if a non-logging usage exists.
+      // duplicates, but still report all occurrences against an already-defined constant.
       int triggeringOccurrences = (int) literalTrees.stream()
         .filter(tree -> !isThrowableArgument(tree) && !isLoggingArgument(tree)).count();
       if (constants.containsKey(key)) {
         VariableTree constant = constants.get(key);
         List<LiteralTree> duplications = literalTrees.stream()
-          .filter(literal -> literal.parent() != constant && !isLoggingArgument(literal))
+          .filter(literal -> literal.parent() != constant)
           .toList();
-        if (duplications.isEmpty()) {
-          return;
-        }
         context.reportIssue(this, duplications.iterator().next(),
           "Use already-defined constant '" + constant.simpleName() + "' instead of duplicating its value here.",
           secondaryLocations(duplications.subList(1, duplications.size())), literalOccurrence);
       } else if (triggeringOccurrences >= threshold) {
-        List<LiteralTree> reportedTrees = literalTrees.stream().filter(tree -> !isLoggingArgument(tree)).toList();
-        LiteralTree literalTree = reportedTrees.iterator().next();
-        int reportedOccurrences = reportedTrees.size();
+        LiteralTree literalTree = literalTrees.iterator().next();
+        int reportedOccurrences = literalTrees.size();
         String message = literalTree.is(Tree.Kind.TEXT_BLOCK) ? ("Define a constant instead of duplicating this text block " + reportedOccurrences + " times.")
           : ("Define a constant instead of duplicating this literal \"" + key + "\" " + reportedOccurrences + " times.");
         context.reportIssue(
           this,
           literalTree,
           message,
-          secondaryLocations(reportedTrees.subList(1, reportedTrees.size())), reportedOccurrences);
+          secondaryLocations(literalTrees.subList(1, literalTrees.size())), reportedOccurrences);
       }
     });
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.java.IllegalRuleParameterException;
 import org.sonar.java.checks.helpers.LoggingMatchers;
 import org.sonar.java.model.LiteralUtils;
 import org.sonar.java.model.ModifiersUtils;
@@ -78,9 +79,7 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
     if (JavaFileTypeClassifier.isTestFile(context)) {
       return;
     }
-    if (excludePattern == null && !excludePatterns.isEmpty()) {
-      excludePattern = Pattern.compile(excludePatterns, Pattern.DOTALL);
-    }
+    compileExcludePattern();
     occurrences.clear();
     constants.clear();
     scan(context.getTree());
@@ -168,6 +167,16 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
       String stringValue = LiteralUtils.getAsStringValue(tree).replace("\\n", "\n");
       if (stringValue.length() >= minimalLength && !isExcluded(stringValue)) {
         occurrences.computeIfAbsent(stringValue, key -> new ArrayList<>()).add(tree);
+      }
+    }
+  }
+
+  private void compileExcludePattern() {
+    if (excludePattern == null && !excludePatterns.isEmpty()) {
+      try {
+        excludePattern = Pattern.compile(excludePatterns, Pattern.DOTALL);
+      } catch (RuntimeException e) {
+        throw new IllegalRuleParameterException("Unable to compile regular expression: " + excludePatterns, e);
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.java.model.LiteralUtils;
+import org.sonar.java.utils.JavaFileTypeClassifier;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
@@ -58,6 +59,9 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
 
   @Override
   public void scanFile(JavaFileScannerContext context) {
+    if (JavaFileTypeClassifier.isTestFile(context)) {
+      return;
+    }
     occurrences.clear();
     constants.clear();
     scan(context.getTree());

--- a/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
@@ -46,15 +46,19 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements JavaFileScanner {
 
   private static final int DEFAULT_THRESHOLD = 3;
-
-  // String literals include quotes, so this means length 5 as defined in RSPEC
-  private static final int MINIMAL_LITERAL_LENGTH = 7;
+  private static final int DEFAULT_MINIMAL_LENGTH = 5;
 
   @RuleProperty(
     key = "threshold",
     description = "Number of times a literal must be duplicated to trigger an issue",
     defaultValue = "" + DEFAULT_THRESHOLD)
   public int threshold = DEFAULT_THRESHOLD;
+
+  @RuleProperty(
+    key = "minimalLength",
+    description = "Minimal length a string literal must have to be considered for duplication",
+    defaultValue = "" + DEFAULT_MINIMAL_LENGTH)
+  public int minimalLength = DEFAULT_MINIMAL_LENGTH;
 
   private final Map<String, List<LiteralTree>> occurrences = new HashMap<>();
   private final Map<String, VariableTree> constants = new HashMap<>();
@@ -147,10 +151,9 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
 
   @Override
   public void visitLiteral(LiteralTree tree) {
-    if (tree.is(Tree.Kind.STRING_LITERAL, Tree.Kind.TEXT_BLOCK)) {
-      String literal = tree.value();
-      if (literal.length() >= MINIMAL_LITERAL_LENGTH && !isStringLiteralFragment(tree)) {
-        String stringValue = LiteralUtils.getAsStringValue(tree).replace("\\n", "\n");
+    if (tree.is(Tree.Kind.STRING_LITERAL, Tree.Kind.TEXT_BLOCK) && !isStringLiteralFragment(tree)) {
+      String stringValue = LiteralUtils.getAsStringValue(tree).replace("\\n", "\n");
+      if (stringValue.length() >= minimalLength) {
         occurrences.computeIfAbsent(stringValue, key -> new ArrayList<>()).add(tree);
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StringLiteralDuplicatedCheck.java
@@ -25,9 +25,10 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
+import org.sonar.java.checks.helpers.LoggingMatchers;
 import org.sonar.java.model.LiteralUtils;
-import org.sonar.java.utils.JavaFileTypeClassifier;
 import org.sonar.java.model.ModifiersUtils;
+import org.sonar.java.utils.JavaFileTypeClassifier;
 import org.sonar.plugins.java.api.JavaFileScanner;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
@@ -35,6 +36,7 @@ import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Modifier;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -67,24 +69,32 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
     scan(context.getTree());
     occurrences.forEach((key, literalTrees) -> {
       int literalOccurrence = literalTrees.size();
-      // Do not consider `throw new Exception("repeated message")` for reporting duplicates,
-      // but still report it if a constant is available.
-      int triggeringOccurrences = (int) literalTrees.stream().filter(tree -> !isThrowableArgument(tree)).count();
+      // Do not consider `throw new Exception("repeated message")` or logging calls for reporting
+      // duplicates, but still report against a constant if a non-logging usage exists.
+      int triggeringOccurrences = (int) literalTrees.stream()
+        .filter(tree -> !isThrowableArgument(tree) && !isLoggingArgument(tree)).count();
       if (constants.containsKey(key)) {
         VariableTree constant = constants.get(key);
-        List<LiteralTree> duplications = literalTrees.stream().filter(literal -> literal.parent() != constant).toList();
+        List<LiteralTree> duplications = literalTrees.stream()
+          .filter(literal -> literal.parent() != constant && !isLoggingArgument(literal))
+          .toList();
+        if (duplications.isEmpty()) {
+          return;
+        }
         context.reportIssue(this, duplications.iterator().next(),
           "Use already-defined constant '" + constant.simpleName() + "' instead of duplicating its value here.",
           secondaryLocations(duplications.subList(1, duplications.size())), literalOccurrence);
       } else if (triggeringOccurrences >= threshold) {
-        LiteralTree literalTree = literalTrees.iterator().next();
-        String message = literalTree.is(Tree.Kind.TEXT_BLOCK) ? ("Define a constant instead of duplicating this text block " + literalOccurrence + " times.")
-          : ("Define a constant instead of duplicating this literal \"" + key + "\" " + literalOccurrence + " times.");
+        List<LiteralTree> reportedTrees = literalTrees.stream().filter(tree -> !isLoggingArgument(tree)).toList();
+        LiteralTree literalTree = reportedTrees.iterator().next();
+        int reportedOccurrences = reportedTrees.size();
+        String message = literalTree.is(Tree.Kind.TEXT_BLOCK) ? ("Define a constant instead of duplicating this text block " + reportedOccurrences + " times.")
+          : ("Define a constant instead of duplicating this literal \"" + key + "\" " + reportedOccurrences + " times.");
         context.reportIssue(
           this,
           literalTree,
           message,
-          secondaryLocations(literalTrees), literalOccurrence);
+          secondaryLocations(reportedTrees.subList(1, reportedTrees.size())), reportedOccurrences);
       }
     });
   }
@@ -114,6 +124,25 @@ public class StringLiteralDuplicatedCheck extends BaseTreeVisitor implements Jav
       .map(Tree::parent)
       .filter(t -> t.is(Tree.Kind.THROW_STATEMENT))
       .isPresent();
+  }
+
+  /**
+   * Returns {@code true} when {@code literalTree} is passed as an argument to a logging method
+   * (SLF4J, Java Util Logging, or Log4j 2), including through string concatenation.
+   * Such occurrences are suppressed: log messages are rarely extracted to constants in practice.
+   */
+  private static boolean isLoggingArgument(LiteralTree literalTree) {
+    Tree parent = literalTree.parent();
+    // If the literal is part of a concatenation, move up to the argument level.
+    while (parent != null && parent.is(Tree.Kind.PLUS)) {
+      parent = parent.parent();
+    }
+    if (parent == null || !parent.is(Tree.Kind.ARGUMENTS)) {
+      return false;
+    }
+    Tree mit = parent.parent();
+    return mit != null && mit.is(Tree.Kind.METHOD_INVOCATION)
+      && LoggingMatchers.LOG_METHODS.matches((MethodInvocationTree) mit);
   }
 
   @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/LoggingMatchers.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/LoggingMatchers.java
@@ -1,0 +1,70 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.helpers;
+
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+
+/**
+ * Shared logging-framework {@link MethodMatchers} used across multiple rules.
+ *
+ * <p>Covers the three most common Java logging frameworks:
+ * <ul>
+ *   <li>SLF4J ({@code org.slf4j.Logger})</li>
+ *   <li>Java Util Logging ({@code java.util.logging.Logger})</li>
+ *   <li>Log4j 2 ({@code org.apache.logging.log4j.Logger})</li>
+ * </ul>
+ *
+ * <p>Each matcher uses {@code withAnyParameters()} intentionally: rules that import
+ * these constants typically only need to detect <em>that</em> a call is a logging call,
+ * not which specific overload is used.
+ */
+public final class LoggingMatchers {
+
+  /** SLF4J log-level methods on {@code org.slf4j.Logger} and its subtypes. */
+  public static final MethodMatchers SLF4J_LOG_METHODS = MethodMatchers.create()
+    .ofSubTypes("org.slf4j.Logger")
+    .names("trace", "debug", "info", "warn", "error")
+    .withAnyParameters()
+    .build();
+
+  /** Java Util Logging named-level and {@code log(Level, ...)} methods on {@code java.util.logging.Logger}. */
+  public static final MethodMatchers JUL_LOG_METHODS = MethodMatchers.create()
+    .ofTypes("java.util.logging.Logger")
+    .names("severe", "warning", "info", "config", "fine", "finer", "finest", "log")
+    .withAnyParameters()
+    .build();
+
+  /** Log4j 2 log-level and {@code log(...)} methods on {@code org.apache.logging.log4j.Logger} and its subtypes. */
+  public static final MethodMatchers LOG4J_LOG_METHODS = MethodMatchers.or(
+    MethodMatchers.create()
+      .ofSubTypes("org.apache.logging.log4j.Logger")
+      .names("trace", "debug", "info", "warn", "error", "fatal")
+      .withAnyParameters()
+      .build(),
+    MethodMatchers.create()
+      .ofSubTypes("org.apache.logging.log4j.Logger")
+      .names("log")
+      .withAnyParameters()
+      .build());
+
+  /** Combined matcher for all three frameworks — use when any logging call must be detected. */
+  public static final MethodMatchers LOG_METHODS = MethodMatchers.or(SLF4J_LOG_METHODS, JUL_LOG_METHODS, LOG4J_LOG_METHODS);
+
+  private LoggingMatchers() {
+    // utility class
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
@@ -59,6 +59,14 @@ class StringLiteralDuplicatedCheckTest {
   }
 
   @Test
+  void no_issues_for_logging_arguments() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StringLiteralDuplicatedCheckLoggingSample.java"))
+      .withCheck(new StringLiteralDuplicatedCheck())
+      .verifyIssues();
+  }
+
+  @Test
   void threshold_at_two() {
     StringLiteralDuplicatedCheck visitor = new StringLiteralDuplicatedCheck();
     visitor.threshold = 2;

--- a/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
@@ -67,6 +67,16 @@ class StringLiteralDuplicatedCheckTest {
   }
 
   @Test
+  void exclude_patterns() {
+    StringLiteralDuplicatedCheck check = new StringLiteralDuplicatedCheck();
+    check.excludePatterns = "excluded [a-z]+";
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StringLiteralDuplicatedCheckExcludePatternsSample.java"))
+      .withCheck(check)
+      .verifyIssues();
+  }
+
+  @Test
   void minimal_length_at_three() {
     StringLiteralDuplicatedCheck check = new StringLiteralDuplicatedCheck();
     check.minimalLength = 3;

--- a/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
@@ -67,6 +67,16 @@ class StringLiteralDuplicatedCheckTest {
   }
 
   @Test
+  void minimal_length_at_three() {
+    StringLiteralDuplicatedCheck check = new StringLiteralDuplicatedCheck();
+    check.minimalLength = 3;
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StringLiteralDuplicatedCheckMinimalLengthSample.java"))
+      .withCheck(check)
+      .verifyIssues();
+  }
+
+  @Test
   void threshold_at_two() {
     StringLiteralDuplicatedCheck visitor = new StringLiteralDuplicatedCheck();
     visitor.threshold = 2;

--- a/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
@@ -21,7 +21,6 @@ import org.sonar.java.checks.verifier.CheckVerifier;
 
 import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
-import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
 
 class StringLiteralDuplicatedCheckTest {
 

--- a/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StringLiteralDuplicatedCheckTest.java
@@ -21,6 +21,7 @@ import org.sonar.java.checks.verifier.CheckVerifier;
 
 import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
 
 class StringLiteralDuplicatedCheckTest {
 
@@ -47,6 +48,14 @@ class StringLiteralDuplicatedCheckTest {
       .onFile(nonCompilingTestSourcesPath("checks/TextBlocksDuplicatedCheckSample.java"))
       .withCheck(new StringLiteralDuplicatedCheck())
       .verifyIssues();
+  }
+
+  @Test
+  void no_issues_in_file_defined_as_test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StringLiteralDuplicatedCheckSampleTest.java"))
+      .withCheck(new StringLiteralDuplicatedCheck())
+      .verifyNoIssues();
   }
 
   @Test

--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -1,0 +1,186 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+/**
+ * Enriches test scope determination beyond the platform's {@link InputFile.Type}.
+ *
+ * <p>The platform scanner (Maven, Gradle, CLI) assigns {@link InputFile.Type#TEST} or
+ * {@link InputFile.Type#MAIN} based on build-tool conventions, but this classification
+ * can be incomplete (e.g. test helpers in {@code src/main/java}, misconfigured projects).
+ *
+ * <p>This classifier combines three signals:
+ * <ol>
+ *   <li>Platform truth: {@link InputFile#type()} from the Sonar scanner</li>
+ *   <li>Naming conventions: file name patterns like {@code FooTest}, {@code ITFoo}, {@code FooSpec}</li>
+ *   <li>AST annotations: class-level test framework annotations ({@code @RunWith}, {@code @SpringBootTest}, etc.)</li>
+ * </ol>
+ *
+ * <p>A file is considered a test file if <em>any</em> signal indicates it — the platform type
+ * takes priority when {@code TEST}, but a {@code MAIN}-typed file can be upgraded to test scope
+ * by the naming or annotation signals.
+ *
+ * <p>Usage example in a check's {@code scanFile} method:
+ * <pre>{@code
+ *   if (JavaFileTypeClassifier.isTestFile(context)) {
+ *     return; // skip test files
+ *   }
+ * }</pre>
+ */
+public final class JavaFileTypeClassifier {
+
+  /**
+   * Class-level annotations that unambiguously mark a class as part of a test framework.
+   * Method-level annotations (e.g. JUnit 4/5 {@code @Test}) are intentionally excluded here;
+   * use {@code UnitTestUtils.isTestClass(ClassTree)} for method-level detection.
+   */
+  private static final Set<String> TEST_CLASS_ANNOTATIONS = Set.of(
+    // JUnit 4
+    "org.junit.runner.RunWith",
+    // JUnit 5
+    "org.junit.jupiter.api.extension.ExtendWith",
+    // TestNG (class-level @Test marks all methods as tests)
+    "org.testng.annotations.Test",
+    // Spring Boot Test
+    "org.springframework.boot.test.context.SpringBootTest",
+    // Spring Test (used for integration tests without Spring Boot)
+    "org.springframework.test.context.ContextConfiguration"
+  );
+
+  /**
+   * Annotation package prefixes for Spring test slice annotations
+   * (e.g. {@code @WebMvcTest}, {@code @DataJpaTest}, {@code @JsonTest}).
+   */
+  private static final List<String> TEST_ANNOTATION_PACKAGE_PREFIXES = List.of(
+    "org.springframework.boot.test.autoconfigure.",
+    "org.springframework.test."
+  );
+
+  /**
+   * Path segments that indicate a file lives in an integration-test source tree
+   * (e.g. Maven's {@code src/it/java} or {@code src/its/java}).
+   * Matching is case-insensitive.
+   */
+  private static final Set<String> TEST_PATH_SEGMENTS = Set.of("it", "its");
+
+  /**
+   * Matches file names (without {@code .java} extension) that follow standard test naming conventions:
+   * <ul>
+   *   <li>Prefix: {@code Test}, {@code IT} (e.g. {@code TestFoo}, {@code ITFoo})</li>
+   *   <li>Suffix: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT}, {@code ITCase}, {@code Spec}, {@code Specs}
+   *       (e.g. {@code FooTest}, {@code FooSpec})</li>
+   * </ul>
+   */
+  private static final Pattern TEST_NAME_PATTERN = Pattern.compile(
+    "^((Test|IT)[a-zA-Z0-9_]+|[A-Z][a-zA-Z0-9_]*(Test|Tests|TestCase|IT|ITCase|Spec|Specs))$"
+  );
+
+  private JavaFileTypeClassifier() {
+    // utility class
+  }
+
+  /**
+   * Returns {@code true} if the file should be treated as test code.
+   * Combines all three signals (platform type, naming, AST annotations) with OR semantics.
+   *
+   * @param context the current file scanner context
+   */
+  public static boolean isTestFile(JavaFileScannerContext context) {
+    return isPlatformTestFile(context)
+      || hasTestNamingConvention(context)
+      || hasTestPathSegment(context)
+      || hasTestFrameworkAnnotation(context);
+  }
+
+  /**
+   * Returns {@code true} if the platform scanner classified this file as {@link InputFile.Type#TEST}.
+   * This is the authoritative signal — it cannot be overridden by the other signals.
+   *
+   * @param context the current file scanner context
+   */
+  static boolean isPlatformTestFile(JavaFileScannerContext context) {
+    return context.getInputFile().type() == InputFile.Type.TEST;
+  }
+
+  /**
+   * Returns {@code true} if the file name (without {@code .java} extension) matches a standard
+   * test naming convention: prefixes {@code Test}/  {@code IT}, or suffixes
+   * {@code Test}/{@code Tests}/{@code TestCase}/{@code IT}/{@code ITCase}/{@code Spec}/{@code Specs}.
+   *
+   * @param context the current file scanner context
+   */
+  static boolean hasTestNamingConvention(JavaFileScannerContext context) {
+    String filename = context.getInputFile().filename();
+    String baseName = filename.endsWith(".java") ? filename.substring(0, filename.length() - 5) : filename;
+    return TEST_NAME_PATTERN.matcher(baseName).matches();
+  }
+
+  /**
+   * Returns {@code true} if any segment of the file's URI path matches a known integration-test
+   * directory name: {@code it} or {@code its} (case-insensitive).
+   *
+   * <p>This covers the Maven convention of placing integration tests under
+   * {@code src/it/java} or {@code src/its/java}.
+   *
+   * @param context the current file scanner context
+   */
+  static boolean hasTestPathSegment(JavaFileScannerContext context) {
+    String[] segments = context.getInputFile().uri().getPath().split("/");
+    return Arrays.stream(segments)
+      .anyMatch(segment -> TEST_PATH_SEGMENTS.contains(segment.toLowerCase(Locale.ROOT)));
+  }
+
+  /**
+   * Returns {@code true} if any top-level class in the compilation unit carries a recognized
+   * test framework annotation at the class level.
+   *
+   * <p>Gracefully returns {@code false} if the file was not successfully parsed
+   * ({@link JavaFileScannerContext#fileParsed()} is {@code false}).
+   *
+   * @param context the current file scanner context
+   */
+  static boolean hasTestFrameworkAnnotation(JavaFileScannerContext context) {
+    if (!context.fileParsed()) {
+      return false;
+    }
+    return context.getTree().types().stream()
+      .filter(tree -> tree.is(Tree.Kind.CLASS))
+      .map(ClassTree.class::cast)
+      .anyMatch(JavaFileTypeClassifier::hasTestAnnotation);
+  }
+
+  private static boolean hasTestAnnotation(ClassTree classTree) {
+    SymbolMetadata metadata = classTree.symbol().metadata();
+    if (TEST_CLASS_ANNOTATIONS.stream().anyMatch(metadata::isAnnotatedWith)) {
+      return true;
+    }
+    return metadata.annotations().stream()
+      .map(ann -> ann.symbol().type().fullyQualifiedName())
+      .anyMatch(fqn -> TEST_ANNOTATION_PACKAGE_PREFIXES.stream().anyMatch(fqn::startsWith));
+  }
+}

--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -16,7 +16,6 @@
  */
 package org.sonar.java.utils;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -82,11 +81,10 @@ public final class JavaFileTypeClassifier {
   );
 
   /**
-   * Path segments that indicate a file lives in an integration-test source tree
-   * (e.g. Maven's {@code src/it/java} or {@code src/its/java}).
-   * Matching is case-insensitive.
+   * Path substrings that indicate a file lives in an integration-test source tree,
+   * following the Maven convention of {@code src/it/java} or {@code src/its/java}.
    */
-  private static final Set<String> TEST_PATH_SEGMENTS = Set.of("it", "its");
+  private static final List<String> TEST_PATH_SUBPATHS = List.of("src/it/java", "src/its/java");
 
   /**
    * Matches file names (without {@code .java} extension) that follow standard test naming conventions:
@@ -141,8 +139,8 @@ public final class JavaFileTypeClassifier {
   }
 
   /**
-   * Returns {@code true} if any segment of the file's URI path matches a known integration-test
-   * directory name: {@code it} or {@code its} (case-insensitive).
+   * Returns {@code true} if the file's URI path contains a known integration-test source tree
+   * substring: {@code src/it/java} or {@code src/its/java}.
    *
    * <p>This covers the Maven convention of placing integration tests under
    * {@code src/it/java} or {@code src/its/java}.
@@ -150,9 +148,8 @@ public final class JavaFileTypeClassifier {
    * @param context the current file scanner context
    */
   static boolean hasTestPathSegment(JavaFileScannerContext context) {
-    String[] segments = context.getInputFile().uri().getPath().split("/");
-    return Arrays.stream(segments)
-      .anyMatch(segment -> TEST_PATH_SEGMENTS.contains(segment.toLowerCase(Locale.ROOT)));
+    String path = context.getInputFile().uri().getPath().toLowerCase(Locale.ROOT);
+    return TEST_PATH_SUBPATHS.stream().anyMatch(path::contains);
   }
 
   /**

--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -87,15 +87,12 @@ public final class JavaFileTypeClassifier {
   private static final List<String> TEST_PATH_SUBPATHS = List.of("src/it/java", "src/its/java");
 
   /**
-   * Matches file names (without {@code .java} extension) that follow standard test naming conventions:
-   * <ul>
-   *   <li>Prefix: {@code Test}, {@code IT} (e.g. {@code TestFoo}, {@code ITFoo})</li>
-   *   <li>Suffix: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT}, {@code ITCase}, {@code Spec}, {@code Specs}
-   *       (e.g. {@code FooTest}, {@code FooSpec})</li>
-   * </ul>
+   * Matches file names (without {@code .java} extension) that follow standard test naming conventions
+   * by suffix: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT}, {@code ITCase}, {@code Spec}, {@code Specs}
+   * (e.g. {@code FooTest}, {@code FooSpec}, {@code FooIT}).
    */
   private static final Pattern TEST_NAME_PATTERN = Pattern.compile(
-    "^((Test|IT)[a-zA-Z0-9_]+|[A-Z][a-zA-Z0-9_]*(Test|Tests|TestCase|IT|ITCase|Spec|Specs))$"
+    "^[A-Z]\\w*(Test|Tests|TestCase|IT|ITCase|Spec|Specs)$"
   );
 
   private JavaFileTypeClassifier() {
@@ -126,9 +123,8 @@ public final class JavaFileTypeClassifier {
   }
 
   /**
-   * Returns {@code true} if the file name (without {@code .java} extension) matches a standard
-   * test naming convention: prefixes {@code Test}/  {@code IT}, or suffixes
-   * {@code Test}/{@code Tests}/{@code TestCase}/{@code IT}/{@code ITCase}/{@code Spec}/{@code Specs}.
+   * Returns {@code true} if the file name (without {@code .java} extension) matches
+   * {@link #TEST_NAME_PATTERN}.
    *
    * @param context the current file scanner context
    */

--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -36,7 +36,7 @@ import org.sonar.plugins.java.api.tree.Tree;
  * <p>This classifier combines three signals:
  * <ol>
  *   <li>Platform truth: {@link InputFile#type()} from the Sonar scanner</li>
- *   <li>Naming conventions: file name patterns like {@code FooTest}, {@code ITFoo}, {@code FooSpec}</li>
+ *   <li>Naming conventions: file name patterns like {@code FooTest}, {@code FooIT}, {@code FooSpec}</li>
  *   <li>AST annotations: class-level test framework annotations ({@code @RunWith}, {@code @SpringBootTest}, etc.)</li>
  * </ol>
  *

--- a/java-frontend/src/test/files/utils/PlainSample.java
+++ b/java-frontend/src/test/files/utils/PlainSample.java
@@ -1,0 +1,2 @@
+class PlainSample {
+}

--- a/java-frontend/src/test/files/utils/SampleWithExtendWith.java
+++ b/java-frontend/src/test/files/utils/SampleWithExtendWith.java
@@ -1,0 +1,6 @@
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SampleWithExtendWith {
+}

--- a/java-frontend/src/test/files/utils/SampleWithRunWith.java
+++ b/java-frontend/src/test/files/utils/SampleWithRunWith.java
@@ -1,0 +1,6 @@
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+class SampleWithRunWith {
+}

--- a/java-frontend/src/test/files/utils/SampleWithSpringBootTest.java
+++ b/java-frontend/src/test/files/utils/SampleWithSpringBootTest.java
@@ -1,0 +1,5 @@
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SampleWithSpringBootTest {
+}

--- a/java-frontend/src/test/files/utils/SampleWithWebMvcTest.java
+++ b/java-frontend/src/test/files/utils/SampleWithWebMvcTest.java
@@ -1,0 +1,5 @@
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest
+class SampleWithWebMvcTest {
+}

--- a/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
@@ -63,18 +63,15 @@ class JavaFileTypeClassifierTest {
   }
 
   @Test
-  void hasTestNamingConvention_recognizesPrefixes() {
-    assertNamingConvention(true, "TestFoo.java");
-    assertNamingConvention(true, "ITFoo.java");
-  }
-
-  @Test
   void hasTestNamingConvention_returnsFalse_forProductionNames() {
     assertNamingConvention(false, "Foo.java");
     assertNamingConvention(false, "FooService.java");
     assertNamingConvention(false, "FooController.java");
     // Lower-case 'test' in the middle is not a match
     assertNamingConvention(false, "MyTestedCode.java");
+    // Prefix-only conventions are not recognized
+    assertNamingConvention(false, "TestFoo.java");
+    assertNamingConvention(false, "ITFoo.java");
   }
 
   private void assertNamingConvention(boolean expected, String filename) {

--- a/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
@@ -1,0 +1,216 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.utils;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.java.TestUtils;
+import org.sonar.java.ast.JavaAstScanner;
+import org.sonar.java.test.classpath.TestClasspathUtils;
+import org.sonar.java.testing.VisitorsBridgeForTests;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JavaFileTypeClassifierTest {
+
+  // -------------------------------------------------------------------------
+  // isPlatformTestFile
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isPlatformTestFile_returnsTrue_forTestType() {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("Foo.java", InputFile.Type.TEST));
+    assertThat(JavaFileTypeClassifier.isPlatformTestFile(context)).isTrue();
+  }
+
+  @Test
+  void isPlatformTestFile_returnsFalse_forMainType() {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("Foo.java", InputFile.Type.MAIN));
+    assertThat(JavaFileTypeClassifier.isPlatformTestFile(context)).isFalse();
+  }
+
+  // -------------------------------------------------------------------------
+  // hasTestNamingConvention
+  // -------------------------------------------------------------------------
+
+  @Test
+  void hasTestNamingConvention_recognizesSuffixes() {
+    assertNamingConvention(true, "FooTest.java");
+    assertNamingConvention(true, "FooTests.java");
+    assertNamingConvention(true, "FooTestCase.java");
+    assertNamingConvention(true, "FooIT.java");
+    assertNamingConvention(true, "FooITCase.java");
+    assertNamingConvention(true, "FooSpec.java");
+    assertNamingConvention(true, "FooSpecs.java");
+  }
+
+  @Test
+  void hasTestNamingConvention_recognizesPrefixes() {
+    assertNamingConvention(true, "TestFoo.java");
+    assertNamingConvention(true, "ITFoo.java");
+  }
+
+  @Test
+  void hasTestNamingConvention_returnsFalse_forProductionNames() {
+    assertNamingConvention(false, "Foo.java");
+    assertNamingConvention(false, "FooService.java");
+    assertNamingConvention(false, "FooController.java");
+    // Lower-case 'test' in the middle is not a match
+    assertNamingConvention(false, "MyTestedCode.java");
+  }
+
+  private void assertNamingConvention(boolean expected, String filename) {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile(filename, InputFile.Type.MAIN));
+    assertThat(JavaFileTypeClassifier.hasTestNamingConvention(context))
+      .as("Expected hasTestNamingConvention=%s for '%s'", expected, filename)
+      .isEqualTo(expected);
+  }
+
+  // -------------------------------------------------------------------------
+  // hasTestPathSegment
+  // -------------------------------------------------------------------------
+
+  @Test
+  void hasTestPathSegment_returnsTrue_forItSegment() {
+    assertPathSegment(true, "src/it/java/Foo.java");
+  }
+
+  @Test
+  void hasTestPathSegment_returnsTrue_forItsSegment() {
+    assertPathSegment(true, "src/its/java/Foo.java");
+  }
+
+  @Test
+  void hasTestPathSegment_isCaseInsensitive() {
+    assertPathSegment(true, "src/IT/java/Foo.java");
+    assertPathSegment(true, "src/ITS/java/Foo.java");
+  }
+
+  @Test
+  void hasTestPathSegment_returnsFalse_forMainPath() {
+    assertPathSegment(false, "src/main/java/Foo.java");
+    assertPathSegment(false, "src/test/java/Foo.java");
+  }
+
+  @Test
+  void hasTestPathSegment_returnsFalse_whenSegmentIsSubstring() {
+    // "itself" or "iteration" should not match — only exact segment
+    assertPathSegment(false, "src/itself/java/Foo.java");
+    assertPathSegment(false, "src/iteration/java/Foo.java");
+  }
+
+  private void assertPathSegment(boolean expected, String relativePath) {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile(relativePath, InputFile.Type.MAIN));
+    assertThat(JavaFileTypeClassifier.hasTestPathSegment(context))
+      .as("Expected hasTestPathSegment=%s for '%s'", expected, relativePath)
+      .isEqualTo(expected);
+  }
+
+  // -------------------------------------------------------------------------
+  // hasTestFrameworkAnnotation
+  // -------------------------------------------------------------------------
+
+  @Test
+  void hasTestFrameworkAnnotation_returnsFalse_whenNotParsed() {
+    JavaFileScannerContext context = mock(JavaFileScannerContext.class);
+    when(context.fileParsed()).thenReturn(false);
+    assertThat(JavaFileTypeClassifier.hasTestFrameworkAnnotation(context)).isFalse();
+  }
+
+  @Test
+  void hasTestFrameworkAnnotation_detects_RunWith() {
+    assertAnnotationSignal(true, "src/test/files/utils/SampleWithRunWith.java");
+  }
+
+  @Test
+  void hasTestFrameworkAnnotation_detects_ExtendWith() {
+    assertAnnotationSignal(true, "src/test/files/utils/SampleWithExtendWith.java");
+  }
+
+  @Test
+  void hasTestFrameworkAnnotation_detects_SpringBootTest() {
+    assertAnnotationSignal(true, "src/test/files/utils/SampleWithSpringBootTest.java");
+  }
+
+  @Test
+  void hasTestFrameworkAnnotation_detects_SpringAutoconfigure_WebMvcTest() {
+    assertAnnotationSignal(true, "src/test/files/utils/SampleWithWebMvcTest.java");
+  }
+
+  @Test
+  void hasTestFrameworkAnnotation_returnsFalse_forPlainClass() {
+    assertAnnotationSignal(false, "src/test/files/utils/PlainSample.java");
+  }
+
+  private void assertAnnotationSignal(boolean expected, String filePath) {
+    var classpath = TestClasspathUtils.DEFAULT_MODULE.getClassPath();
+    var bridge = new VisitorsBridgeForTests.Builder(List.of())
+      .enableSemanticWithProjectClasspath(classpath)
+      .build();
+    JavaAstScanner.scanSingleFileForTests(TestUtils.inputFile(filePath), bridge);
+
+    JavaFileScannerContext context = bridge.testContexts().get(0);
+    assertThat(JavaFileTypeClassifier.hasTestFrameworkAnnotation(context))
+      .as("Expected hasTestFrameworkAnnotation=%s for '%s'", expected, filePath)
+      .isEqualTo(expected);
+  }
+
+  // -------------------------------------------------------------------------
+  // isTestFile (combined signal)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isTestFile_returnsTrue_whenPlatformSaysTest() {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("Foo.java", InputFile.Type.TEST));
+    assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
+  }
+
+  @Test
+  void isTestFile_returnsTrue_whenPathSegmentMatches_evenIfPlatformSaysMain() {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("src/it/java/Foo.java", InputFile.Type.MAIN));
+    assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
+  }
+
+  @Test
+  void isTestFile_returnsTrue_whenNamingMatches_evenIfPlatformSaysMain() {
+    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("FooTest.java", InputFile.Type.MAIN));
+    // fileParsed() not set → defaults to false (Mockito default for boolean), no AST signal
+    assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
+  }
+
+  @Test
+  void isTestFile_returnsFalse_whenNoSignal() {
+    JavaFileScannerContext context = mock(JavaFileScannerContext.class);
+    when(context.getInputFile()).thenReturn(TestUtils.emptyInputFile("Foo.java", InputFile.Type.MAIN));
+    when(context.fileParsed()).thenReturn(false);
+    assertThat(JavaFileTypeClassifier.isTestFile(context)).isFalse();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helper
+  // -------------------------------------------------------------------------
+
+  private static JavaFileScannerContext contextWithInputFile(InputFile inputFile) {
+    JavaFileScannerContext context = mock(JavaFileScannerContext.class);
+    when(context.getInputFile()).thenReturn(inputFile);
+    return context;
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1192.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S1192.html
@@ -2,7 +2,15 @@
 <p>Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all
 occurrences.</p>
 <h3>Exceptions</h3>
-<p>To prevent generating some false-positives, literals having less than 5 characters are excluded.</p>
+<p>The following cases are excluded from duplicate detection:</p>
+<ul>
+  <li>Literals shorter than the configured <code>minimalLength</code> (default: 5 characters)</li>
+  <li>Literals used in annotations</li>
+  <li>Literals that are part of a string concatenation fragment (e.g., SQL built from adjacent string literals)</li>
+  <li>Literals used in test files</li>
+  <li>Literals passed as arguments to logging methods (SLF4J, Java Util Logging, Log4j 2)</li>
+  <li>Literals matching the configured <code>excludePatterns</code> regular expression</li>
+</ul>
 <h2>How to fix it</h2>
 <p>Use constants to replace the duplicated string literals. Constants can be referenced from many places, but only need to be updated in a single
 place.</p>


### PR DESCRIPTION
Enhancements:

- Suppress when duplicate strings are used in log’s messages
- Suppress when used in test environment
- Add excludePatterns rule property to ignore strings satisfying such patterns
- Add minimalLength rule property
