### PR TITLE
SONARJAVA-6455 S7467: FP on broken semantics

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample.java
@@ -1,7 +1,11 @@
 package checks;
 
 import io.restassured.exception.PathException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
+import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample {
@@ -121,4 +125,22 @@ public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample {
   }
 
   public void e(){}
+
+  private final Logger log = LogManager.getLogger();
+
+  private void executor_run_compliant() {
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    executor.scheduleAtFixedRate(
+      () -> {
+        try {
+          Integer.parseInt("1.2");
+        } catch (Exception e) {
+          log.error("SonarQube Cloud reports 'e' should be replaced by _ while it's used", e);
+        }
+      },
+      0,
+      100_000,
+      TimeUnit.MILLISECONDS
+    );
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheck.java
@@ -43,7 +43,8 @@ public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheck extends Issu
     VariableTree v = catchTree.parameter();
     IdentifierTree ident = v.simpleName();
 
-    if (!ident.isUnnamedVariable() && v.symbol().usages().isEmpty()) {
+    // completely ignored for an absent semantic model
+    if (!ident.isUnnamedVariable() && context.getSemanticModel() != null && v.symbol().usages().isEmpty()) {
       QuickFixHelper.newIssue(context)
         .forRule(this)
         .onTree(ident)

--- a/java-checks/src/test/java/org/sonar/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheckTest.java
@@ -48,7 +48,7 @@ class ReplaceUnusedExceptionParameterWithUnnamedPatternCheckTest {
       .withCheck(new ReplaceUnusedExceptionParameterWithUnnamedPatternCheck())
       .withoutSemantic()
       .withJavaVersion(22)
-      .verifyIssues();
+      .verifyNoIssues();
   }
 
 }


### PR DESCRIPTION
Without semantics, catch parameter usages() is always empty, causing false positives. Guard with context.getSemanticModel() != null.
