### PR TITLE
SONARJAVA-6711 USER-2405 Fix S3252 false positive for Quarkus Panache entity static methods

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/S3252_StaticMemberAccessCheckSample/StaticMemberAccessCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/S3252_StaticMemberAccessCheckSample/StaticMemberAccessCheckSample.java
@@ -34,6 +34,21 @@ class Generic<X> {
   }
 }
 
+// Quarkus Panache: static methods are bytecode-generated in subclasses, so accessing them via the subclass is intended
+class MeetingType extends io.quarkus.hibernate.orm.panache.PanacheEntityBase {
+  void doSomething() {
+    MeetingType.listAll(); // Compliant - Panache generates static methods in subclasses
+    MeetingType.count(); // Compliant
+  }
+}
+
+class MongoMeetingType extends io.quarkus.mongodb.panache.PanacheMongoEntityBase {
+  void doSomething() {
+    MongoMeetingType.listAll(); // Compliant - Panache generates static methods in subclasses
+    MongoMeetingType.count(); // Compliant
+  }
+}
+
 class GuavaFP {
   // method is incorrectly resolved as Set.of, specifically excluded in implementation to avoid
   // see SONARJAVA-3095

--- a/java-checks-test-sources/default/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
+++ b/java-checks-test-sources/default/src/main/java/io/quarkus/hibernate/orm/panache/PanacheEntityBase.java
@@ -1,4 +1,13 @@
 package io.quarkus.hibernate.orm.panache;
 
+import java.util.List;
+
 public abstract class PanacheEntityBase {
+  public static <T extends PanacheEntityBase> List<T> listAll() {
+    return null;
+  }
+
+  public static long count() {
+    return 0;
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
+++ b/java-checks-test-sources/default/src/main/java/io/quarkus/mongodb/panache/PanacheMongoEntityBase.java
@@ -1,4 +1,13 @@
 package io.quarkus.mongodb.panache;
 
+import java.util.List;
+
 public abstract class PanacheMongoEntityBase {
+  public static <T extends PanacheMongoEntityBase> List<T> listAll() {
+    return null;
+  }
+
+  public static long count() {
+    return 0;
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMemberAccessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMemberAccessCheck.java
@@ -71,6 +71,7 @@ public class StaticMemberAccessCheck extends IssuableSubscriptionVisitor {
       if (!staticType.isUnknown() && !expressionType.isUnknown()
         && !expressionType.erasure().equals(staticType.erasure())
         && (memberOwnerIsInCurrentPackage || owner.isPublic())
+        && !isPanacheEntityBase(staticType)
       ) {
         QuickFixHelper.newIssue(context)
           .forRule(this)
@@ -85,6 +86,11 @@ public class StaticMemberAccessCheck extends IssuableSubscriptionVisitor {
   private static String classPackage(Type classType) {
     int endPackage = classType.fullyQualifiedName().lastIndexOf('.');
     return endPackage == -1 ? "" : classType.fullyQualifiedName().substring(0, endPackage);
+  }
+
+  private static boolean isPanacheEntityBase(Type type) {
+    return type.isSubtypeOf("io.quarkus.hibernate.orm.panache.PanacheEntityBase")
+      || type.isSubtypeOf("io.quarkus.mongodb.panache.PanacheMongoEntityBase");
   }
 
   private static boolean isListOrSetOf(MemberSelectExpressionTree mse) {


### PR DESCRIPTION
Panache uses bytecode generation to create static method implementations in entity subclasses, so accessing them via the derived type is the intended usage pattern. Skip the issue when the static member's owner is a Panache entity base class.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
