### PR TITLE
SONARJAVA-6714 - Fix FP for S2638 on type arguments when the method has `@Nullable` return type

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2638.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2638.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2638",
   "hasTruePositives": true,
-  "falseNegatives": 14,
+  "falseNegatives": 16,
   "falsePositives": 0
 }

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S2638.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S2638.json
@@ -1,6 +1,6 @@
 {
   "ruleKey": "S2638",
   "hasTruePositives": true,
-  "falseNegatives": 20,
+  "falseNegatives": 14,
   "falsePositives": 0
 }

--- a/java-checks-test-sources/default/src/main/java/checks/jspecify/nullmarked/ChangeMethodContractCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/jspecify/nullmarked/ChangeMethodContractCheck.java
@@ -38,7 +38,7 @@ class NullableGenericChild_WithNullable extends NullableGenericParent {
 class NullableGenericChild_NoNullable extends NullableGenericParent {
   @Override
   protected List<Object> handle(@Nullable Object body) { // Compliant
-    return null;
+    return new java.util.ArrayList<>();
   }
 }
 

--- a/java-checks-test-sources/default/src/main/java/checks/jspecify/nullmarked/ChangeMethodContractCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/jspecify/nullmarked/ChangeMethodContractCheck.java
@@ -1,7 +1,9 @@
 package checks.jspecify.nullmarked;
 
+import java.util.List;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 
 // NullMarked at the package level
 class ChangeMethodContractCheck {
@@ -19,4 +21,27 @@ class ChangeMethodContractCheck_B extends ChangeMethodContractCheck {
   String annotatedUnmarked(Object a) { return null; } // Compliant - NullUnmarked doesn't add any information about nullability
 
 }
+
+class NullableGenericParent {
+  protected @Nullable List<Object> handle(@Nullable Object body) {
+    return null;
+  }
+}
+
+class NullableGenericChild_WithNullable extends NullableGenericParent {
+  @Override
+  protected @Nullable List<Object> handle(@Nullable Object body) { // Compliant
+    return null;
+  }
+}
+
+class NullableGenericChild_NoNullable extends NullableGenericParent {
+  @Override
+  protected List<Object> handle(@Nullable Object body) { // Compliant
+    return null;
+  }
+}
+
+
+
 

--- a/java-checks-test-sources/default/src/main/java/checks/jspecify/nullmarked/ChangeMethodContractCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/jspecify/nullmarked/ChangeMethodContractCheck.java
@@ -12,6 +12,11 @@ class ChangeMethodContractCheck {
 
   @NullUnmarked
   String annotatedUnmarked(Object a) { return null; }
+
+  void nullableParameter(@Nullable Object nullable) {}
+
+  String nonNullReturn() { return ""; }
+
 }
 
 class ChangeMethodContractCheck_B extends ChangeMethodContractCheck {
@@ -19,6 +24,14 @@ class ChangeMethodContractCheck_B extends ChangeMethodContractCheck {
   @NullMarked
   @Override
   String annotatedUnmarked(Object a) { return null; } // Compliant - NullUnmarked doesn't add any information about nullability
+
+  @Override
+  void nullableParameter(Object nonNull) {} // Noncompliant
+  //                     ^^^^^^
+
+  @Override
+  @Nullable String nonNullReturn() { return null; } // Noncompliant {{Fix the incompatibility of the annotation @Nullable to honor @NullMarked at package level of the overridden method.}}
+  //        ^^^^^^
 
 }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/ChangeMethodContractCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/ChangeMethodContractCheckTest.java
@@ -57,7 +57,7 @@ class ChangeMethodContractCheckTest {
     CheckVerifier.newVerifier()
       .onFile(mainCodeSourcesPath("checks/jspecify/nullmarked/ChangeMethodContractCheck.java"))
       .withCheck(new ChangeMethodContractCheck())
-      .verifyNoIssues();
+      .verifyIssues();
   }
 
   @Test

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbolMetadata.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbolMetadata.java
@@ -63,20 +63,26 @@ final class JSymbolMetadata implements SymbolMetadata {
 
   private final Map<NullabilityTarget, NullabilityData> nullabilityCache = new EnumMap<>(NullabilityTarget.class);
 
+  // True when this metadata represents a type argument (e.g. Object in List<Object>).
+  // Type argument nullability should not inherit from the enclosing method's return type annotations.
+  private final boolean isTypeArgMetadata;
+
   JSymbolMetadata(JSema sema, Symbol symbol, IAnnotationBinding[] annotationBindings) {
     this.sema = Objects.requireNonNull(sema);
     this.symbol = symbol;
     this.symbolBindings = annotationBindings;
     this.parameterMetas = new SymbolMetadata[0];
+    this.isTypeArgMetadata = false;
 
     this.annotationBindings = annotationBindings;
   }
 
-  private JSymbolMetadata(JSema sema, Symbol symbol, IAnnotationBinding[] symbolAnnotations, JSymbolMetadata[] parameterMetaDatas) {
+  private JSymbolMetadata(JSema sema, Symbol symbol, IAnnotationBinding[] symbolAnnotations, JSymbolMetadata[] parameterMetaDatas, boolean isTypeArgMetadata) {
     this.sema = Objects.requireNonNull(sema);
     this.symbol = symbol;
     this.symbolBindings = symbolAnnotations;
     this.parameterMetas = parameterMetaDatas;
+    this.isTypeArgMetadata = isTypeArgMetadata;
 
     int total = symbolBindings.length;
     for (JSymbolMetadata parameterMetaData : parameterMetaDatas) {
@@ -100,15 +106,18 @@ final class JSymbolMetadata implements SymbolMetadata {
     System.arraycopy(type.getTypeAnnotations(), 0, symbolAnnotations, externalAnnotations.length, type.getTypeAnnotations().length);
 
     var parameterMetaDatas = Arrays.stream(type.getTypeArguments())
-      .map(param -> of(sema, owner, param, new IAnnotationBinding[0]))
+      .map(param -> ofTypeArg(sema, owner, param))
       .toArray(JSymbolMetadata[]::new);
 
-    return new JSymbolMetadata(
-      sema,
-      owner,
-      symbolAnnotations,
-      parameterMetaDatas
-    );
+    return new JSymbolMetadata(sema, owner, symbolAnnotations, parameterMetaDatas, false);
+  }
+
+  private static JSymbolMetadata ofTypeArg(JSema sema, Symbol owner, ITypeBinding param) {
+    var symbolAnnotations = param.getTypeAnnotations();
+    var parameterMetaDatas = Arrays.stream(param.getTypeArguments())
+      .map(p -> ofTypeArg(sema, owner, p))
+      .toArray(JSymbolMetadata[]::new);
+    return new JSymbolMetadata(sema, owner, symbolAnnotations, parameterMetaDatas, true);
   }
 
   private static NullabilityData[] forEachLevel(Function<NullabilityLevel, NullabilityData> initializer) {
@@ -212,8 +221,10 @@ final class JSymbolMetadata implements SymbolMetadata {
       return nullabilityDataAtLevel;
     }
 
-    // Check nullability from the inheritance hierarchy
-    if (symbol.isMethodSymbol()) {
+    // Check nullability from the inheritance hierarchy.
+    // Skipped for type argument metadata: type arg nullability must not inherit from the enclosing
+    // method's return type annotations, which belong to the outer type, not the type argument.
+    if (symbol.isMethodSymbol() && !isTypeArgMetadata) {
       NullabilityData nullabilityDataFromInheritance = getNullabilityDataFromInheritance((Symbol.MethodSymbol) symbol, target);
       if (nullabilityDataFromInheritance.type() != NullabilityType.NO_ANNOTATION) {
         return nullabilityDataFromInheritance;

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbolMetadata.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbolMetadata.java
@@ -63,8 +63,6 @@ final class JSymbolMetadata implements SymbolMetadata {
 
   private final Map<NullabilityTarget, NullabilityData> nullabilityCache = new EnumMap<>(NullabilityTarget.class);
 
-  // True when this metadata represents a type argument (e.g. Object in List<Object>).
-  // Type argument nullability should not inherit from the enclosing method's return type annotations.
   private final boolean isTypeArgMetadata;
 
   JSymbolMetadata(JSema sema, Symbol symbol, IAnnotationBinding[] annotationBindings) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
    - Fixed false positive S2638 on type arguments when methods have `@Nullable` return types by avoiding inheritance of enclosing method return annotations in `JSymbolMetadata`

<sub>This will update automatically on new commits.</sub>