### PR TITLE
SONARJAVA-5917 Raise content hash cache misses log message to DEBUG level

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/caching/ContentHashCache.java
+++ b/java-frontend/src/main/java/org/sonar/java/caching/ContentHashCache.java
@@ -69,7 +69,7 @@ public class ContentHashCache {
       }
       return isHashEqual;
     } catch (IllegalArgumentException e) {
-      LOG.trace(String.format("Could not find key %s in the cache", cacheKey));
+      LOG.debug("Could not find key {} in the cache", cacheKey);
       writeToCache(inputFile);
     } catch (IOException | NoSuchAlgorithmException e) {
       LOG.warn(String.format(HASH_COMPUTE_FAIL_MSG, inputFile.key()));

--- a/java-frontend/src/test/java/org/sonar/java/caching/ContentHashCacheTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/caching/ContentHashCacheTest.java
@@ -62,13 +62,14 @@ class ContentHashCacheTest {
 
   @Test
   void hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache_with_proper_logging() {
-    String[] messages = new String[]{
-      "Could not find key java:contentHash:MD5:" + inputFile.key() + " in the cache",
+    String cacheMissMessage = "Could not find key java:contentHash:MD5:" + inputFile.key() + " in the cache";
+    String[] traceMessages = new String[]{
       "Reading cache for the file " + inputFile.key(),
       "Writing to the cache for file " + inputFile.key()
     };
-    assertThat(hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache(Level.TRACE)).contains(messages);
-    assertThat(hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache(Level.WARN)).doesNotContain(messages);
+    assertThat(hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache(Level.TRACE)).contains(traceMessages);
+    assertThat(hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache(Level.DEBUG)).contains(cacheMissMessage);
+    assertThat(hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache(Level.WARN)).doesNotContain(cacheMissMessage);
   }
 
   private List<String> hasSameHashCached_returns_false_when_content_hash_file_is_not_in_read_cache(Level level) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Logging:**
    - Raised content hash cache misses log message from `TRACE` to `DEBUG` level in `ContentHashCache.java`

<sub>This will update automatically on new commits.</sub>