### PR TITLE
SONARJAVA-6716: Fix FN in S8909 for classes with explicit constructors but no no-arg constructor

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/CacheKeyGeneratorInstantiableCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/CacheKeyGeneratorInstantiableCheckSample.java
@@ -99,6 +99,20 @@ class CompliantRequestScoped implements CacheKeyGenerator {
   }
 }
 
+class NoncompliantPublicWithExplicitConstructor implements CacheKeyGenerator { // Noncompliant
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  private final ConfigService configService;
+
+  public NoncompliantPublicWithExplicitConstructor(ConfigService configService) {
+    this.configService = configService;
+  }
+
+  @Override
+  public Object generate(Method method, Object... methodParams) {
+    return configService.getPrefix() + methodParams[0];
+  }
+}
+
 class NoncompliantPackagePrivateImplicitConstructor implements CacheKeyGenerator { // Noncompliant
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   @Override

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/CacheKeyGeneratorInstantiableCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/CacheKeyGeneratorInstantiableCheckSample.java
@@ -121,10 +121,17 @@ class NoncompliantPackagePrivateImplicitConstructor implements CacheKeyGenerator
   }
 }
 
-public class CacheKeyGeneratorInstantiableCheckSample implements CacheKeyGenerator {
+public class CacheKeyGeneratorInstantiableCheckSample implements CacheKeyGenerator { // Noncompliant
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  private final String prefix;
+
+  public CacheKeyGeneratorInstantiableCheckSample(String prefix) {
+    this.prefix = prefix;
+  }
+
   @Override
   public Object generate(Method method, Object... methodParams) {
-    return methodParams[0];
+    return prefix + methodParams[0];
   }
 }
 

--- a/java-checks-test-sources/default/src/main/java/checks/quarkus/CacheKeyGeneratorInstantiableCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/quarkus/CacheKeyGeneratorInstantiableCheckSample.java
@@ -121,6 +121,13 @@ class NoncompliantPackagePrivateImplicitConstructor implements CacheKeyGenerator
   }
 }
 
+public class CacheKeyGeneratorInstantiableCheckSample implements CacheKeyGenerator {
+  @Override
+  public Object generate(Method method, Object... methodParams) {
+    return methodParams[0];
+  }
+}
+
 class CompliantExplicitNoArgsConstructor implements CacheKeyGenerator {
   public CompliantExplicitNoArgsConstructor() {}
 

--- a/java-checks/src/main/java/org/sonar/java/checks/quarkus/CacheKeyGeneratorInstantiableCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/quarkus/CacheKeyGeneratorInstantiableCheck.java
@@ -95,12 +95,17 @@ public class CacheKeyGeneratorInstantiableCheck extends IssuableSubscriptionVisi
 
   private static boolean hasPublicNoArgsConstructor(ClassTree classTree) {
     Collection<Symbol> constructors = classTree.symbol().lookupSymbols("<init>");
+    if (constructors.isEmpty()) {
+      // No explicit constructors: the compiler generates an implicit no-arg constructor
+      // with the same visibility as the class.
+      return classTree.symbol().isPublic();
+    }
     return constructors.stream()
       .map(Symbol.MethodSymbol.class::cast)
       .filter(CacheKeyGeneratorInstantiableCheck::isNoArgConstructor)
       .findFirst()
       .map(Symbol::isPublic)
-      .orElse(classTree.symbol().isPublic());
+      .orElse(false);
   }
 
   private static boolean isNoArgConstructor(Symbol.MethodSymbol constructor) {


### PR DESCRIPTION
## Summary
- Fixed false negative in `CacheKeyGeneratorInstantiableCheck` (S8909) where public classes implementing `CacheKeyGenerator` with explicit constructors but no no-arg constructor were not flagged
- The `hasPublicNoArgsConstructor()` method now correctly distinguishes between classes with no explicit constructors (implicit default constructor inherits class visibility) and classes with explicit constructors that lack a no-arg option
- Added test case for a class with an explicit parameterized constructor but no no-arg constructor

## Test plan
- [x] Existing tests pass (`CacheKeyGeneratorInstantiableCheckTest`)
- [x] New noncompliant test case added for the FN scenario
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **New features:**
    - Added `verifyAnalysisSucceeds()` method to `CheckVerifier` to test analysis execution without assertions
- **Refactoring:**
    - Removed the obsolete autoscan integration test module and associated test files

<sub>This will update automatically on new commits.</sub>