### PR TITLE
SONARJAVA-6713 Update rule S2696: Unwrap parenthesis in static field

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/StaticFieldUpateCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StaticFieldUpateCheckSample.java
@@ -21,6 +21,10 @@ class StaticFieldUpateCheckSample {
     myA.staticValue = 1; // Noncompliant {{Make the enclosing method "static" or remove this set.}}
     myA.staticArray[0] = 1; // Noncompliant {{Make the enclosing method "static" or remove this set.}}
     myA.toString();
+    (staticValue)++; // Noncompliant {{Make the enclosing method "static" or remove this set.}}
+    (StaticFieldUpateCheckSample.staticValue)++; // Noncompliant {{Make the enclosing method "static" or remove this set.}}
+    (staticValue) = value + 1; // Noncompliant {{Make the enclosing method "static" or remove this set.}}
+    ((staticValue))++; // Noncompliant {{Make the enclosing method "static" or remove this set.}}
 
     class InnerClass {
       InnerClass() {

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticFieldUpateCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticFieldUpateCheck.java
@@ -32,6 +32,7 @@ import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Modifier;
+import org.sonar.plugins.java.api.tree.ParenthesizedTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
 import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
@@ -116,6 +117,8 @@ public class StaticFieldUpateCheck extends AbstractInSynchronizeChecker {
       checkFieldModification(((MemberSelectExpressionTree) expression).identifier());
     } else if (expression.is(Kind.ARRAY_ACCESS_EXPRESSION)) {
       checkVariableModification(((ArrayAccessExpressionTree) expression).expression());
+    } else if (expression.is(Kind.PARENTHESIZED_EXPRESSION)) {
+      checkVariableModification(((ParenthesizedTree) expression).expression());
     }
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule updates:**
    - Updated `StaticFieldUpateCheck` to unwrap parenthesis when checking static field modifications.
    - Added test cases in `StaticFieldUpateCheckSample.java` covering parenthesized static field assignments and increments.

<sub>This will update automatically on new commits.</sub>