### PR TITLE
SONARJAVA-6725: Restrict rules S9130 to main code only

### DIFF
--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9130.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9130.json
@@ -1,9 +1,0 @@
-{
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
-1379,
-1386,
-1407,
-1414,
-1423
-]
-}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9130.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9130.json
@@ -1,17 +1,4 @@
 {
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/DumpHandler.java": [
-84
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
-1379,
-1386,
-1407,
-1414,
-1423
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/ssl/SSLSelectChannelConnectorLoadTest.java": [
-303
-],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/UrlEncoded.java": [
 466,
 467

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9130.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9130.json
@@ -10,7 +10,7 @@
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-9130",
   "sqKey": "S9130",
-  "scope": "All",
+  "scope": "Main",
   "quickfix": "unknown",
   "code": {
     "impacts": {


### PR DESCRIPTION
## Summary
- Change scope of rules S9130 and S9133 from "All" to "Main" so they only apply to production code and not test code.

## Test plan
- [ ] Verify that rules S9130 and S9133 no longer trigger on test source files
- [ ] Verify that rules S9130 and S9133 still trigger on main source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)