### PR TITLE
SONARJAVA-6686: Fix S2198 false positives on hex int literals with sign bit

### DIFF
--- a/its/ruling/src/test/resources/guava/java-S2198.json
+++ b/its/ruling/src/test/resources/guava/java-S2198.json
@@ -1,5 +1,2 @@
 {
-"com.google.guava:guava:src/com/google/common/net/InetAddresses.java": [
-907
-]
 }

--- a/java-checks-test-sources/default/src/main/java/checks/UselessMathematicalComparisonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/UselessMathematicalComparisonCheckSample.java
@@ -170,6 +170,37 @@ class UselessMathematicalComparisonCheckSample {
     if (b > 100 + 1) {} // Compliant - 101 within byte range
   }
 
+  void hexConstantsWithSignBit(int i, long l) {
+    // Hex int literals with the sign bit set represent valid negative int values.
+    // 0xCAFEBABE = -889275714, 0xffffffff = -1, 0x80000000 = Integer.MIN_VALUE
+    if (i == 0xCAFEBABE) {} // Compliant - 0xCAFEBABE is -889275714, within int range
+    if (i == 0xffffffff) {} // Compliant - 0xffffffff is -1, within int range
+    if (i > 0x80000000) {} // Compliant - 0x80000000 is Integer.MIN_VALUE, within int range
+    if (i != 0xDEADBEEF) {} // Compliant - 0xDEADBEEF is -559038737, within int range
+    if (i < 0xFF000000) {} // Compliant - 0xFF000000 is -16777216, within int range
+    if (i >= 0xFFFFFFFF) {} // Compliant - 0xFFFFFFFF is -1, within int range
+    if (0xCAFEBABE > i) {} // Compliant - reversed operands
+
+    // Hex long literals compared to int - truly out of range (0xCAFEBABEL = 3405691582, 0xFFFFFFFFL = 4294967295)
+    if (i > 0xCAFEBABEL) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+    if (i == 0xFFFFFFFFL) {} // Noncompliant {{Remove this comparison; it will always return false.}}
+
+    // Hex int literals without sign bit - regular compliant cases
+    if (i == 0x7FFFFFFF) {} // Compliant - 0x7FFFFFFF is Integer.MAX_VALUE
+    if (i > 0x0CAFEBAB) {} // Compliant - within int range
+
+    // Hex long literals compared to long variable
+    if (l == 0xCAFEBABEL) {} // Compliant - long can hold 3405691582
+    if (l > 0x7FFFFFFFL) {} // Compliant - long can hold values larger than Integer.MAX_VALUE
+  }
+
+  void octalAndBinaryConstantsWithSignBit(int i) {
+    // Binary int literals with sign bit set
+    if (i == 0b10000000_00000000_00000000_00000000) {} // Compliant - Integer.MIN_VALUE
+    // Octal int literals with sign bit set
+    if (i == 037777777777) {} // Compliant - 0xFFFFFFFF = -1
+  }
+
   void twoVariables(byte a, byte b) {
     if (a > b) {} // Compliant - comparing two variables
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/UselessMathematicalComparisonCheck.java
@@ -129,6 +129,13 @@ public class UselessMathematicalComparisonCheck extends IssuableSubscriptionVisi
 
   @Nullable
   private static Number resolveConstantValue(ExpressionTree expression) {
+    // Try int literal first: intLiteralValue correctly handles hex/octal/binary int literals with the sign bit set
+    // (e.g. 0xCAFEBABE = -889275714), while longLiteralValue would interpret them as large positive longs, causing
+    // false positives when compared against int variable bounds.
+    Integer intLiteral = LiteralUtils.intLiteralValue(expression);
+    if (intLiteral != null) {
+      return intLiteral.longValue();
+    }
     Long longLiteral = LiteralUtils.longLiteralValue(expression);
     if (longLiteral != null) {
       return longLiteral;


### PR DESCRIPTION
## Summary
- Fix false positives in S2198 (UselessMathematicalComparison) when hex/octal/binary int literals with the sign bit set are compared to int variables
- Hex int literals like `0xCAFEBABE`, `0xFFFFFFFF`, `0x80000000` represent valid negative int values via two's complement (e.g. `0xFFFFFFFF` = `-1`), but `longLiteralValue()` was interpreting them as large positive longs (e.g. `4294967295`), causing the check to flag these comparisons as always-true/always-false
- Fix: resolve int literals via `intLiteralValue()` first in `resolveConstantValue()`, which correctly narrows to signed int values before comparison against type bounds
- Added test samples covering hex, octal, and binary int literals with sign bits, including reversed operands and long literal counterparts

## Test plan
- [x] Unit test `UselessMathematicalComparisonCheckTest` passes with new test samples
- [ ] Ruling tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)