### PR TITLE
SONARJAVA-4121: Read nullability annotations from the method declaration instead of the substituted type

### DIFF
--- a/java-checks-test-sources/default/src/main/java/annotations/nullability/no_default/NullabilityWithInferredTypeArgument.java
+++ b/java-checks-test-sources/default/src/main/java/annotations/nullability/no_default/NullabilityWithInferredTypeArgument.java
@@ -1,0 +1,29 @@
+package annotations.nullability.no_default;
+
+import java.util.Optional;
+import org.eclipse.jdt.annotation.NonNull;
+
+public class NullabilityWithInferredTypeArgument {
+
+  private final String value = "value";
+
+  @NonNull
+  public String getValue() {
+    return value;
+  }
+
+  public String callOrElse(NullabilityWithInferredTypeArgument a) {
+    // "map" infers "Optional<@NonNull String>", the @NonNull is part of the type argument and says nothing about the parameter of "orElse"
+    return Optional.ofNullable(a)
+      .map(NullabilityWithInferredTypeArgument::getValue)
+      .orElse(null);
+  }
+
+  public boolean nullCheckAfterOrElse(NullabilityWithInferredTypeArgument a) {
+    String result = Optional.ofNullable(a)
+      .map(NullabilityWithInferredTypeArgument::getValue)
+      .orElse(null);
+    // the inferred @NonNull must not make "orElse" look like it never returns null, the check below is not always false
+    return result == null;
+  }
+}

--- a/java-frontend/src/main/java/org/sonar/java/model/JMethodSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JMethodSymbol.java
@@ -92,9 +92,15 @@ final class JMethodSymbol extends JSymbol implements Symbol.MethodSymbol {
       } else {
         parameters = new ArrayList<>();
         IMethodBinding methodBinding = methodBinding();
+        IMethodBinding methodDeclaration = methodBinding.getMethodDeclaration();
         ITypeBinding[] parameterTypeBindings = methodBinding.getParameterTypes();
+        ITypeBinding[] declaredParameterTypeBindings = methodDeclaration.getParameterTypes();
         for (int i = 0; i < parameterTypeBindings.length; i++) {
-          parameters.add(new JVariableSymbol.ParameterPlaceholderSymbol(i, sema, methodBinding.getMethodDeclaration(), parameterTypeBindings[i]));
+          // Annotations must come from the declared type: type annotations of the substituted type can be inferred from the call site
+          // (e.g. "Optional.of(x).map(A::nonNullMethod).orElse(null)" infers "Optional<@NonNull String>", making "orElse" look like it takes
+          // a @NonNull argument), which does not tell anything about the parameter of the declared method.
+          ITypeBinding declaredParameterType = i < declaredParameterTypeBindings.length ? declaredParameterTypeBindings[i] : parameterTypeBindings[i];
+          parameters.add(new JVariableSymbol.ParameterPlaceholderSymbol(i, sema, methodDeclaration, parameterTypeBindings[i], declaredParameterType));
         }
       }
     }

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbol.java
@@ -386,12 +386,18 @@ abstract class JSymbol implements Symbol {
         }
         return convertMetadata(type);
       case IBinding.METHOD:
-        ITypeBinding returnType = ((IMethodBinding) binding).getReturnType();
+        IMethodBinding methodBinding = (IMethodBinding) binding;
+        ITypeBinding returnType = methodBinding.getReturnType();
         // In rare circumstances, when the semantic information is incomplete, returnType can be null.
         if (returnType == null) {
           return Symbols.EMPTY_METADATA;
         }
-        return convertMetadata(returnType);
+        // Annotations are read from the declared return type, so that annotations inferred for a type variable at the call site
+        // (e.g. "Optional.of(x).map(A::nonNullMethod)" infers "Optional<@NonNull String>", making "orElse" look like it never returns null)
+        // are not mistaken for annotations of the method itself.
+        IMethodBinding methodDeclaration = methodBinding.getMethodDeclaration();
+        ITypeBinding declaredReturnType = methodDeclaration == null ? null : methodDeclaration.getReturnType();
+        return convertMetadata(declaredReturnType == null ? returnType : declaredReturnType);
       default:
         return new JSymbolMetadata(sema, this, binding.getAnnotations());
     }

--- a/java-frontend/src/main/java/org/sonar/java/model/JVariableSymbol.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JVariableSymbol.java
@@ -89,11 +89,16 @@ final class JVariableSymbol extends JSymbol implements Symbol.VariableSymbol {
     private final Type type;
     private final SymbolMetadata metadata;
 
-    ParameterPlaceholderSymbol(int index, JSema sema, IMethodBinding owner, ITypeBinding typeBinding) {
+    /**
+     * @param typeBinding the type of the parameter at the call site, after type substitution
+     * @param declaredTypeBinding the type of the parameter as declared, before type substitution. Annotations are read from it, so that
+     *   annotations inferred for a type variable are not mistaken for annotations of the parameter itself.
+     */
+    ParameterPlaceholderSymbol(int index, JSema sema, IMethodBinding owner, ITypeBinding typeBinding, ITypeBinding declaredTypeBinding) {
       this.name = "arg" + index;
       this.owner = sema.methodSymbol(owner);
       this.type = sema.type(typeBinding);
-      this.metadata = JSymbolMetadata.of(sema, this, typeBinding, owner.getParameterAnnotations(index));
+      this.metadata = JSymbolMetadata.of(sema, this, declaredTypeBinding, owner.getParameterAnnotations(index));
     }
 
     @Override

--- a/java-frontend/src/test/java/org/sonar/java/model/JSymbolMetadataTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/JSymbolMetadataTest.java
@@ -41,6 +41,7 @@ import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.ReturnStatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -235,6 +236,34 @@ class JSymbolMetadataTest {
     assertThat(declarationData)
       .isSameAs(invocation1ParamData)
       .isSameAs(invocation2ParamData);
+  }
+
+  @Test
+  void nullability_is_not_inferred_from_type_arguments() throws IOException {
+    Path sourceFile = NULLABILITY_SOURCE_DIR.resolve(Paths.get("no_default", "NullabilityWithInferredTypeArgument.java"));
+    CompilationUnitTree cut = JParserTestUtils.parse(sourceFile.toRealPath().toFile(), JParserTestUtils.checksTestClassPath());
+    ClassTree classTree = (ClassTree) cut.types().get(0);
+    MethodTree callOrElse = (MethodTree) classTree.members().get(2);
+
+    MethodInvocationTree orElseInvocation = (MethodInvocationTree) ((ReturnStatementTree) callOrElse.block().body().get(0)).expression();
+    Symbol orElseParameter = orElseInvocation.methodSymbol().declarationParameters().get(0);
+
+    assertThat(orElseParameter.metadata().annotations()).isEmpty();
+    assertThat(orElseParameter.metadata().nullabilityData().type()).isEqualTo(NullabilityType.NO_ANNOTATION);
+  }
+
+  @Test
+  void method_nullability_is_not_inferred_from_type_arguments() throws IOException {
+    Path sourceFile = NULLABILITY_SOURCE_DIR.resolve(Paths.get("no_default", "NullabilityWithInferredTypeArgument.java"));
+    CompilationUnitTree cut = JParserTestUtils.parse(sourceFile.toRealPath().toFile(), JParserTestUtils.checksTestClassPath());
+    ClassTree classTree = (ClassTree) cut.types().get(0);
+    MethodTree callOrElse = (MethodTree) classTree.members().get(2);
+
+    MethodInvocationTree orElseInvocation = (MethodInvocationTree) ((ReturnStatementTree) callOrElse.block().body().get(0)).expression();
+    SymbolMetadata orElseMetadata = orElseInvocation.methodSymbol().metadata();
+
+    assertThat(orElseMetadata.symbolAnnotations()).isEmpty();
+    assertThat(orElseMetadata.nullabilityData().type()).isEqualTo(NullabilityType.NO_ANNOTATION);
   }
 
   @Nested


### PR DESCRIPTION
Fixes the false positive reported in SONARJAVA-4121 (and its twin JAVASE-87).

Discussed in https://community.sonarsource.com/t/false-positive-on-optional-orelse-null/82410

## Problem

```java
import java.util.Optional;
import org.eclipse.jdt.annotation.NonNull;

class A {
  private final String value = "value";

  @NonNull // when this is removed, the FP disappears
  public String getValue() {
    return value;
  }

  public String test(A a) {
    return Optional.ofNullable(a)
      .map(A::getValue)
      .orElse(null); // FP: Parameter 1 to this call is marked "@NonNull" but null could be passed
  }
}
```

`org.eclipse.jdt.annotation.NonNull` and `lombok.NonNull` are `TYPE_USE` annotations, so ECJ keeps them in
the type binding. In the snippet above the type argument is inferred as `@NonNull String`, the receiver
becomes `Optional<@NonNull String>` and the substituted signature of `orElse` becomes
`@NonNull String orElse(@NonNull String)`. With `javax.annotation.Nonnull`, which is not `TYPE_USE`, the
FP does not appear.

The frontend copied those inferred annotations onto the symbols of the call:

* `JMethodSymbol#declarationParameters` built the parameter placeholder from the substituted parameter
  type, so `JSymbolMetadata#of` stored `@NonNull` among the annotations of the parameter. The parameter
  was then reported as `NON_NULL` at `VARIABLE` level, which is what S2637 reads.
* `JSymbol#convertMetadata` used the substituted return type, so the same annotation ended up on the
  method symbol. `Optional#orElse` was reported as `NON_NULL` at `METHOD` level, which makes the
  symbolic execution engine constrain the result of the call to `NOT_NULL`.

Note that the annotation only leaks when the type variable is substituted directly. For `map`, whose
return type is `Optional<@NonNull String>`, the annotation correctly stays in the type argument metadata.

## Fix

Annotations are read from the declared types, while `type()` and `returnType()` keep the substituted
types, as checks rely on them. Annotations written explicitly on a declaration, including those on type
arguments of a declared parameter, are unaffected; only annotations inferred at the call site are
dropped.

* `JMethodSymbol` and `JVariableSymbol`: parameter metadata comes from the declared parameter type
* `JSymbol`: method metadata comes from the declared return type

## Tests

`NullabilityWithInferredTypeArgument` reproduces the reported snippet and the null check that the leaked
return type annotation would turn into an always-false condition. Two tests in `JSymbolMetadataTest`
cover the parameter and the method side; both fail without the change:

```
Expecting empty but was: [org.sonar.java.model.JSymbolMetadata$JAnnotationInstance@5dac488d]
```

Ran on JDK 26: `java-frontend` (1595 tests), `java-checks-testkit` (210 tests) and `java-checks`
(1706 tests) show no new failures compared to master.
