### PR TITLE
SONARJAVA-6745 Implement new rule S9146: Apache XML RPC extensions should not be enabled

### DIFF
--- a/java-checks-test-sources/default/pom.xml
+++ b/java-checks-test-sources/default/pom.xml
@@ -844,6 +844,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.xmlrpc</groupId>
+      <artifactId>xmlrpc-client</artifactId>
+      <version>3.1.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlrpc</groupId>
+      <artifactId>xmlrpc-server</artifactId>
+      <version>3.1.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>au.com.dius.pact.provider</groupId>
       <artifactId>junit5</artifactId>
       <version>4.1.0</version>

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/security/XmlRpcExtensionsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/security/XmlRpcExtensionsCheckSample.java
@@ -1,0 +1,79 @@
+package checks.security;
+
+import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
+import org.apache.xmlrpc.common.XmlRpcHttpRequestConfigImpl;
+import org.apache.xmlrpc.server.XmlRpcServerConfigImpl;
+
+class XmlRpcExtensionsCheckSample {
+
+  private static final boolean EXTENSIONS_ENABLED = true;
+  private static final boolean EXTENSIONS_DISABLED = false;
+
+  void serverConfigNoncompliant() {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setEnabledForExtensions(true); // Noncompliant {{Disable extensions on this Apache XML RPC configuration.}}
+  }
+
+  void clientConfigNoncompliant() {
+    XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+    config.setEnabledForExtensions(true); // Noncompliant
+  }
+
+  void serverConfigWithOtherSettings() {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setBasicEncoding("UTF-8");
+    config.setEnabledForExtensions(true); // Noncompliant
+  }
+
+  void constantTrue() {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setEnabledForExtensions(EXTENSIONS_ENABLED); // Noncompliant
+  }
+
+  void unknownVariable(boolean enable) {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setEnabledForExtensions(enable); // Noncompliant
+  }
+
+  void parentType() {
+    XmlRpcHttpRequestConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setEnabledForExtensions(true); // Noncompliant
+  }
+
+  // Compliant examples
+
+  void serverConfigDefault() {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    // Extensions are disabled by default
+  }
+
+  void clientConfigDefault() {
+    XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+    // Extensions are disabled by default
+  }
+
+  void explicitlyDisabled() {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setEnabledForExtensions(false);
+  }
+
+  void clientExplicitlyDisabled() {
+    XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+    config.setEnabledForExtensions(false);
+  }
+
+  void constantFalse() {
+    XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+    config.setEnabledForExtensions(EXTENSIONS_DISABLED);
+  }
+
+  void unrelatedType() {
+    UnrelatedConfig config = new UnrelatedConfig();
+    config.setEnabledForExtensions(true);
+  }
+}
+
+class UnrelatedConfig {
+  void setEnabledForExtensions(boolean enabled) {
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/security/XmlRpcExtensionsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/XmlRpcExtensionsCheckSample.java
@@ -32,7 +32,7 @@ class XmlRpcExtensionsCheckSample {
 
   void unknownVariable(boolean enable) {
     XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
-    config.setEnabledForExtensions(enable); // Noncompliant
+    config.setEnabledForExtensions(enable); // Compliant - unknown value, not provably true
   }
 
   void parentType() {

--- a/java-checks-test-sources/default/src/main/java/checks/security/XmlRpcExtensionsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/XmlRpcExtensionsCheckSample.java
@@ -1,7 +1,7 @@
 package checks.security;
 
+import org.apache.xmlrpc.XmlRpcConfigImpl;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
-import org.apache.xmlrpc.common.XmlRpcHttpRequestConfigImpl;
 import org.apache.xmlrpc.server.XmlRpcServerConfigImpl;
 
 class XmlRpcExtensionsCheckSample {
@@ -36,7 +36,7 @@ class XmlRpcExtensionsCheckSample {
   }
 
   void parentType() {
-    XmlRpcHttpRequestConfigImpl config = new XmlRpcServerConfigImpl();
+    XmlRpcConfigImpl config = new XmlRpcServerConfigImpl();
     config.setEnabledForExtensions(true); // Noncompliant
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/security/XmlRpcExtensionsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/XmlRpcExtensionsCheck.java
@@ -38,7 +38,7 @@ public class XmlRpcExtensionsCheck extends AbstractMethodDetection {
   @Override
   protected void onMethodInvocationFound(MethodInvocationTree mit) {
     ExpressionTree argument = mit.arguments().get(0);
-    if (!Boolean.FALSE.equals(ExpressionUtils.resolveAsConstant(argument))) {
+    if (Boolean.TRUE.equals(ExpressionUtils.resolveAsConstant(argument))) {
       reportIssue(mit, "Disable extensions on this Apache XML RPC configuration.");
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/security/XmlRpcExtensionsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/XmlRpcExtensionsCheck.java
@@ -29,7 +29,7 @@ public class XmlRpcExtensionsCheck extends AbstractMethodDetection {
   @Override
   protected MethodMatchers getMethodInvocationMatchers() {
     return MethodMatchers.create()
-      .ofSubTypes("org.apache.xmlrpc.common.XmlRpcHttpRequestConfigImpl")
+      .ofSubTypes("org.apache.xmlrpc.XmlRpcConfigImpl")
       .names("setEnabledForExtensions")
       .addParametersMatcher("boolean")
       .build();

--- a/java-checks/src/main/java/org/sonar/java/checks/security/XmlRpcExtensionsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/XmlRpcExtensionsCheck.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.security;
+
+import org.sonar.check.Rule;
+import org.sonar.java.checks.methods.AbstractMethodDetection;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+
+@Rule(key = "S9146")
+public class XmlRpcExtensionsCheck extends AbstractMethodDetection {
+
+  @Override
+  protected MethodMatchers getMethodInvocationMatchers() {
+    return MethodMatchers.create()
+      .ofSubTypes("org.apache.xmlrpc.common.XmlRpcHttpRequestConfigImpl")
+      .names("setEnabledForExtensions")
+      .addParametersMatcher("boolean")
+      .build();
+  }
+
+  @Override
+  protected void onMethodInvocationFound(MethodInvocationTree mit) {
+    ExpressionTree argument = mit.arguments().get(0);
+    if (!Boolean.FALSE.equals(ExpressionUtils.resolveAsConstant(argument))) {
+      reportIssue(mit, "Disable extensions on this Apache XML RPC configuration.");
+    }
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/security/XmlRpcExtensionsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/security/XmlRpcExtensionsCheckTest.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.security;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
+
+class XmlRpcExtensionsCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/security/XmlRpcExtensionsCheckSample.java"))
+      .withCheck(new XmlRpcExtensionsCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void testWithoutSemantic() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/security/XmlRpcExtensionsCheckSample.java"))
+      .withCheck(new XmlRpcExtensionsCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/security/XmlRpcExtensionsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/security/XmlRpcExtensionsCheckTest.java
@@ -19,14 +19,14 @@ package org.sonar.java.checks.security;
 import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
-import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
 
 class XmlRpcExtensionsCheckTest {
 
   @Test
   void test() {
     CheckVerifier.newVerifier()
-      .onFile(nonCompilingTestSourcesPath("checks/security/XmlRpcExtensionsCheckSample.java"))
+      .onFile(mainCodeSourcesPath("checks/security/XmlRpcExtensionsCheckSample.java"))
       .withCheck(new XmlRpcExtensionsCheck())
       .verifyIssues();
   }
@@ -34,7 +34,7 @@ class XmlRpcExtensionsCheckTest {
   @Test
   void testWithoutSemantic() {
     CheckVerifier.newVerifier()
-      .onFile(nonCompilingTestSourcesPath("checks/security/XmlRpcExtensionsCheckSample.java"))
+      .onFile(mainCodeSourcesPath("checks/security/XmlRpcExtensionsCheckSample.java"))
       .withCheck(new XmlRpcExtensionsCheck())
       .withoutSemantic()
       .verifyNoIssues();

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9146.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9146.html
@@ -1,0 +1,36 @@
+<p>Enabling extensions on Apache XML RPC configuration objects activates support for serializable Java objects, which can lead to remote code execution through deserialization attacks.</p>
+<h2>Why is this an issue?</h2>
+<p>The Apache XML RPC library implements the XML-RPC protocol. By default, the library supports a standard set of data types defined in the protocol specification. However, the library also provides optional extension types that are disabled by default for security reasons.</p>
+<p>When you enable extensions by calling <code>setEnabledForExtensions(true)</code>, you activate the <code>&lt;ex:serializable&gt;</code> type that allows Java object serialization. This means an attacker who can send requests to your endpoint can craft a malicious serialized object and trigger arbitrary code execution when the server deserializes it.</p>
+<h3>What is the potential impact?</h3>
+<p>An attacker who can send requests to your XML RPC endpoint can achieve remote code execution on the server. This allows them to:</p>
+<ul>
+  <li>Execute arbitrary system commands</li>
+  <li>Read or modify sensitive data</li>
+  <li>Install backdoors or malware</li>
+  <li>Compromise the entire server and potentially pivot to other systems</li>
+</ul>
+<h2>How to fix it</h2>
+<p>Do not enable extensions on your Apache XML RPC configuration. The default behavior (extensions disabled) is secure and sufficient for most use cases.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+config.setEnabledForExtensions(true); // Noncompliant
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+XmlRpcServerConfigImpl config = new XmlRpcServerConfigImpl();
+// Extensions are disabled by default - no action needed
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li><a href="https://ws.apache.org/xmlrpc/extensions.html">Apache XML-RPC - Extensions</a></li>
+  <li>OWASP - <a href="https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data">Deserialization of untrusted data</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li>CWE - <a href="https://cwe.mitre.org/data/definitions/502">CWE-502 - Deserialization of Untrusted Data</a></li>
+  <li>OWASP - <a href="https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/">Top 10 2021 Category A8 - Software and Data Integrity Failures</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9146.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9146.json
@@ -1,0 +1,34 @@
+{
+  "title": "Apache XML RPC extensions should not be enabled",
+  "type": "VULNERABILITY",
+  "code": {
+    "impacts": {
+      "SECURITY": "HIGH"
+    },
+    "attribute": "CONVENTIONAL"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2min"
+  },
+  "tags": [
+    "cwe"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9146",
+  "sqKey": "S9146",
+  "scope": "All",
+  "securityStandards": {
+    "CWE": [
+      502
+    ],
+    "OWASP": [
+      "A8"
+    ],
+    "OWASP Top 10 2021": [
+      "A8"
+    ]
+  },
+  "quickfix": "unknown"
+}


### PR DESCRIPTION
Detect calls to setEnabledForExtensions() on Apache XML-RPC configuration objects where the argument is not provably false, as enabling extensions activates Java object deserialization which can lead to remote code execution.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
