### PR TITLE
SONARJAVA-6743 Implement new rule S9147: "NaN" should not be tested for equality using "==" or "!="

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9147.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9147.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9147",
+  "hasTruePositives": true,
+  "falseNegatives": 0,
+  "falsePositives": 0
+}

--- a/its/ruling/src/test/resources/diff_S9147.json
+++ b/its/ruling/src/test/resources/diff_S9147.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9147",
+  "hasTruePositives": true,
+  "falseNegatives": 0,
+  "falsePositives": 0
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/NanEqualityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/NanEqualityCheckSample.java
@@ -1,0 +1,18 @@
+package checks;
+
+import static com.example.UnknownClass.NaN;
+
+class NanEqualityCheckSample {
+
+  void unknownNaN() {
+    double x = 1.0;
+    if (x == NaN) { } // Compliant - NaN symbol is unknown, cannot determine type
+    if (NaN == x) { } // Compliant
+  }
+
+  void unknownMemberSelect() {
+    double x = 1.0;
+    if (x == UnknownType.NaN) { } // Compliant - UnknownType is not resolvable
+  }
+
+}

--- a/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
@@ -1,5 +1,7 @@
 package checks;
 
+import static java.lang.Double.NaN;
+
 class NanEqualityCheckSample {
 
   void noncompliantDoubleNaN() {
@@ -76,6 +78,16 @@ class NanEqualityCheckSample {
   void compliantInstanceIsNaN() {
     Double d = Double.valueOf(1.0);
     if (d.isNaN()) { } // Compliant - instance method usage
+  }
+
+  void noncompliantStaticImportNaN() {
+    double x = 1.0;
+    if (x == NaN) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//        ^^
+    if (NaN == x) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//          ^^
+    if (x != NaN) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//        ^^
   }
 
 }

--- a/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
@@ -101,6 +101,42 @@ class NanEqualityCheckSample {
     if (x == NaN) { } // Compliant - NaN is a local variable, not Double.NaN or Float.NaN
   }
 
+  void compliantEqualsOnDoubles() {
+    Double a = 1.0;
+    Double b = Double.NaN;
+    if (a.equals(b)) { } // Compliant - using .equals() method
+    if (a.equals(Double.NaN)) { } // Compliant
+    if (Double.valueOf(1.0).equals(Double.NaN)) { } // Compliant
+    if (a.equals(0.0)) { } // Compliant
+  }
+
+  void compliantEqualsOnFloats() {
+    Float a = 1.0f;
+    Float b = Float.NaN;
+    if (a.equals(b)) { } // Compliant - using .equals() method
+    if (a.equals(Float.NaN)) { } // Compliant
+  }
+
+  void compliantComparisonOperatorsWithNaN() {
+    double x = 1.0;
+    if (x > Double.NaN) { } // Compliant - rule only covers == and !=
+    if (x >= Double.NaN) { } // Compliant
+    if (x < Double.NaN) { } // Compliant
+    if (x <= Double.NaN) { } // Compliant
+    if (Double.NaN > x) { } // Compliant
+    if (Double.NaN >= x) { } // Compliant
+    if (Double.NaN < x) { } // Compliant
+    if (Double.NaN <= x) { } // Compliant
+  }
+
+  void compliantComparisonOperatorsWithFloatNaN() {
+    float x = 1.0f;
+    if (x > Float.NaN) { } // Compliant
+    if (x >= Float.NaN) { } // Compliant
+    if (x < Float.NaN) { } // Compliant
+    if (x <= Float.NaN) { } // Compliant
+  }
+
   static class CustomClass {
     static final double NaN = -1.0;
     double value;

--- a/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
@@ -1,0 +1,81 @@
+package checks;
+
+class NanEqualityCheckSample {
+
+  void noncompliantDoubleNaN() {
+    double result = Math.sqrt(-1);
+    if (result == Double.NaN) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//             ^^
+    if (result != Double.NaN) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//             ^^
+  }
+
+  void noncompliantFloatNaN() {
+    float value = 0.0f / 0.0f;
+    if (value == Float.NaN) { } // Noncompliant {{Use "Float.isNaN()" instead of comparison with "Float.NaN".}}
+//            ^^
+    if (value != Float.NaN) { } // Noncompliant {{Use "Float.isNaN()" instead of comparison with "Float.NaN".}}
+//            ^^
+  }
+
+  void noncompliantReversedOperandOrder() {
+    double result = 0.0;
+    if (Double.NaN == result) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//                 ^^
+    if (Double.NaN != result) { } // Noncompliant {{Use "Double.isNaN()" instead of comparison with "Double.NaN".}}
+//                 ^^
+  }
+
+  void noncompliantNaNComparedToItself() {
+    if (Double.NaN == Double.NaN) { } // Noncompliant
+//                 ^^
+  }
+
+  void noncompliantInExpressions() {
+    double x = 1.0;
+    boolean isNan = x == Double.NaN; // Noncompliant
+//                    ^^
+    boolean notNan = x != Double.NaN; // Noncompliant
+//                     ^^
+    String s = x != Double.NaN ? "valid" : "invalid"; // Noncompliant
+//               ^^
+  }
+
+  boolean noncompliantInReturn(double x) {
+    return x == Double.NaN; // Noncompliant
+//           ^^
+  }
+
+  void noncompliantWithParentheses(double x) {
+    if (x == (Double.NaN)) { } // Noncompliant
+//        ^^
+    if ((x) == Double.NaN) { } // Noncompliant
+//          ^^
+  }
+
+  void compliantIsNaN() {
+    double result = Math.sqrt(-1);
+    if (Double.isNaN(result)) { } // Compliant
+    if (!Double.isNaN(result)) { } // Compliant
+  }
+
+  void compliantFloatIsNaN() {
+    float value = 0.0f / 0.0f;
+    if (Float.isNaN(value)) { } // Compliant
+  }
+
+  void compliantRegularComparisons() {
+    double a = 1.0;
+    double b = 2.0;
+    if (a == b) { } // Compliant - regular double comparison
+    if (a == 0.0) { } // Compliant - comparison with regular constant
+    if (a == Double.POSITIVE_INFINITY) { } // Compliant - comparison with other Double constant
+    if (a == Double.MAX_VALUE) { } // Compliant
+  }
+
+  void compliantInstanceIsNaN() {
+    Double d = Double.valueOf(1.0);
+    if (d.isNaN()) { } // Compliant - instance method usage
+  }
+
+}

--- a/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/NanEqualityCheckSample.java
@@ -90,4 +90,20 @@ class NanEqualityCheckSample {
 //        ^^
   }
 
+  void compliantCustomNaN() {
+    CustomClass c = new CustomClass();
+    if (c.value == CustomClass.NaN) { } // Compliant - NaN is not from Double or Float
+  }
+
+  void compliantLocalVariableNaN() {
+    double NaN = -1.0;
+    double x = 1.0;
+    if (x == NaN) { } // Compliant - NaN is a local variable, not Double.NaN or Float.NaN
+  }
+
+  static class CustomClass {
+    static final double NaN = -1.0;
+    double value;
+  }
+
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
@@ -21,8 +21,10 @@ import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
@@ -53,14 +55,32 @@ public class NanEqualityCheck extends IssuableSubscriptionVisitor {
     if (expr.is(Tree.Kind.MEMBER_SELECT)) {
       MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expr;
       if ("NaN".equals(memberSelect.identifier().name())) {
-        String ownerType = memberSelect.identifier().symbol().owner().type().fullyQualifiedName();
-        if ("java.lang.Double".equals(ownerType)) {
-          return "Double";
-        }
-        if ("java.lang.Float".equals(ownerType)) {
-          return "Float";
-        }
+        return resolveNanOwnerType(memberSelect.identifier().symbol());
       }
+    } else if (expr.is(Tree.Kind.IDENTIFIER)) {
+      IdentifierTree identifier = (IdentifierTree) expr;
+      if ("NaN".equals(identifier.name())) {
+        return resolveNanOwnerType(identifier.symbol());
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static String resolveNanOwnerType(Symbol symbol) {
+    if (symbol.isUnknown()) {
+      return null;
+    }
+    Symbol owner = symbol.owner();
+    if (owner == null || owner.type() == null) {
+      return null;
+    }
+    String ownerType = owner.type().fullyQualifiedName();
+    if ("java.lang.Double".equals(ownerType)) {
+      return "Double";
+    }
+    if ("java.lang.Float".equals(ownerType)) {
+      return "Float";
     }
     return null;
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
@@ -22,6 +22,7 @@ import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
@@ -75,12 +76,9 @@ public class NanEqualityCheck extends IssuableSubscriptionVisitor {
     if (owner == null || owner.type() == null) {
       return null;
     }
-    String ownerType = owner.type().fullyQualifiedName();
-    if ("java.lang.Double".equals(ownerType)) {
-      return "Double";
-    }
-    if ("java.lang.Float".equals(ownerType)) {
-      return "Float";
+    Type ownerType = owner.type();
+    if (ownerType.is("java.lang.Double") || ownerType.is("java.lang.Float")) {
+      return ownerType.name();
     }
     return null;
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
@@ -1,0 +1,68 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9147")
+public class NanEqualityCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.EQUAL_TO, Tree.Kind.NOT_EQUAL_TO);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    BinaryExpressionTree binaryExpression = (BinaryExpressionTree) tree;
+    String typeName = getNanTypeName(binaryExpression.leftOperand());
+    if (typeName == null) {
+      typeName = getNanTypeName(binaryExpression.rightOperand());
+    }
+    if (typeName != null) {
+      reportIssue(binaryExpression.operatorToken(),
+        String.format("Use \"%s.isNaN()\" instead of comparison with \"%s.NaN\".", typeName, typeName));
+    }
+  }
+
+  @Nullable
+  private static String getNanTypeName(ExpressionTree expression) {
+    ExpressionTree expr = ExpressionUtils.skipParentheses(expression);
+    if (expr.is(Tree.Kind.MEMBER_SELECT)) {
+      MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expr;
+      if ("NaN".equals(memberSelect.identifier().name())) {
+        String ownerType = memberSelect.identifier().symbol().owner().type().fullyQualifiedName();
+        if ("java.lang.Double".equals(ownerType)) {
+          return "Double";
+        }
+        if ("java.lang.Float".equals(ownerType)) {
+          return "Float";
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/NanEqualityCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/NanEqualityCheckTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 
 class NanEqualityCheckTest {
 
@@ -29,5 +30,13 @@ class NanEqualityCheckTest {
       .onFile(mainCodeSourcesPath("checks/NanEqualityCheckSample.java"))
       .withCheck(new NanEqualityCheck())
       .verifyIssues();
+  }
+
+  @Test
+  void test_non_compiling() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/NanEqualityCheckSample.java"))
+      .withCheck(new NanEqualityCheck())
+      .verifyNoIssues();
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/NanEqualityCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/NanEqualityCheckTest.java
@@ -1,0 +1,33 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class NanEqualityCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/NanEqualityCheckSample.java"))
+      .withCheck(new NanEqualityCheck())
+      .verifyIssues();
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/NanEqualityCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/NanEqualityCheckTest.java
@@ -33,6 +33,15 @@ class NanEqualityCheckTest {
   }
 
   @Test
+  void no_issue_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/NanEqualityCheckSample.java"))
+      .withCheck(new NanEqualityCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+
+  @Test
   void test_non_compiling() {
     CheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/NanEqualityCheckSample.java"))

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9147.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9147.html
@@ -1,0 +1,41 @@
+<h2>Why is this an issue?</h2>
+<p>In most programming languages, floating-point numbers follow the IEEE 754 standard for arithmetic. This standard defines <code>NaN</code> (Not a
+Number) as a special value that represents undefined or unrepresentable results, such as dividing zero by zero or taking the square root of a negative
+number.</p>
+<p>A critical aspect of IEEE 754 is that <code>NaN</code> is defined as never being equal to anything—not even to itself. This means:</p>
+<ul>
+  <li><code>NaN == NaN</code> evaluates to <code>false</code></li>
+  <li>Any comparison <code>x == NaN</code> will always be <code>false</code>, regardless of the value of <code>x</code></li>
+</ul>
+<p>Similarly, inequality comparisons are also unreliable:</p>
+<ul>
+  <li><code>x != NaN</code> will always be <code>true</code>, even when <code>x</code> is actually <code>NaN</code></li>
+</ul>
+<p>This behavior makes equality tests for <code>NaN</code> fundamentally broken. Code that attempts to check whether a variable is <code>NaN</code>
+using <code>==</code> or <code>!=</code> will never work as intended, leading to incorrect program logic.</p>
+<p>The correct approach is to use <code>Double.isNaN()</code> or <code>Float.isNaN()</code> methods, which return accurate results.</p>
+<h2>How to fix it</h2>
+<p>Replace equality comparisons with <code>NaN</code> constants using the appropriate <code>isNaN()</code> method for the floating-point type you're
+working with.</p>
+<h3>Noncompliant code example</h3>
+<pre>
+double result = Math.sqrt(-1);
+if (result == Double.NaN) {  // Noncompliant
+    System.out.println("Invalid result");
+}
+</pre>
+<h3>Compliant solution</h3>
+<pre>
+double result = Math.sqrt(-1);
+if (Double.isNaN(result)) {
+    System.out.println("Invalid result");
+}
+</pre>
+<h2>Resources</h2>
+<ul>
+  <li><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Double.html#isNaN(double)">Oracle Java Documentation -
+  Double.isNaN()</a></li>
+  <li><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Float.html#isNaN(float)">Oracle Java Documentation -
+  Float.isNaN()</a></li>
+  <li><a href="https://en.wikipedia.org/wiki/IEEE_754#NaN">Wikipedia - IEEE 754 - NaN</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9147.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9147.json
@@ -1,0 +1,21 @@
+{
+  "title": "\"NaN\" should not be tested for equality using \"==\" or \"!=\"",
+  "type": "BUG",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "LOGICAL"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9147",
+  "sqKey": "S9147",
+  "scope": "All",
+  "quickfix": "unknown"
+}


### PR DESCRIPTION
Detect equality and inequality comparisons (== and !=) with Double.NaN and Float.NaN constants, which always produce incorrect results due to IEEE 754 semantics. Suggests using Double.isNaN() or Float.isNaN() instead.

