### PR TITLE
SONARJAVA-6744 Implement new rule S9148: "Float.compare" or "Double.compare" should be used for floating-point comparisons

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
+++ b/its/autoscan/src/test/resources/autoscan/autoscan-diff-by-rules.json
@@ -3202,5 +3202,11 @@
     "hasTruePositives": false,
     "falseNegatives": 13,
     "falsePositives": 0
+  },
+  {
+    "ruleKey": "S9148",
+    "hasTruePositives": true,
+    "falseNegatives": 0,
+    "falsePositives": 0
   }
 ]

--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9148.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9148.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9148",
+  "hasTruePositives": true,
+  "falseNegatives": 0,
+  "falsePositives": 0
+}

--- a/java-checks-test-sources/default/src/main/java/checks/FloatingPointComparisonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FloatingPointComparisonCheckSample.java
@@ -2,6 +2,7 @@ package checks;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.DoubleSupplier;
 
 class FloatingPointComparisonCheckSample {
 
@@ -212,6 +213,72 @@ class FloatingPointComparisonCheckSample {
   static class DoubleUtils {
     int compare(double a, double b) {
       return (int) (a - b); // Compliant - not in a Comparator
+    }
+  }
+
+  // === Noncompliant: only one operand is floating-point ===
+
+  static class MixedOperands implements Comparable<MixedOperands> {
+    private double value;
+
+    @Override
+    public int compareTo(MixedOperands other) {
+      if (0 < other.value) { // Noncompliant
+        return -1;
+      }
+      return Double.compare(this.value, other.value); // Compliant
+    }
+  }
+
+  // === Compliant: lambda which is not a Comparator, nested in compareTo ===
+
+  static class NonComparatorLambda implements Comparable<NonComparatorLambda> {
+    private double value;
+
+    @Override
+    public int compareTo(NonComparatorLambda other) {
+      DoubleSupplier difference = () -> this.value - other.value; // Compliant - not a Comparator
+      return Double.compare(difference.getAsDouble(), 0.0); // Compliant
+    }
+  }
+
+  // === Compliant: local class nested in compareTo is checked independently ===
+
+  static class LocalClassInCompareTo implements Comparable<LocalClassInCompareTo> {
+    private double value;
+
+    @Override
+    public int compareTo(LocalClassInCompareTo other) {
+      class Difference {
+        double between(double a, double b) {
+          return a - b; // Compliant - not in a comparison method
+        }
+      }
+      return Double.compare(new Difference().between(this.value, other.value), 0.0); // Compliant
+    }
+  }
+
+  // === Compliant: methods which only look like comparison methods ===
+
+  static class LookAlikeMethods {
+    double compareTo(Object other) {
+      return other.hashCode() - 1.0; // Compliant - does not return an int
+    }
+
+    int compareTo(Object a, Object b) {
+      return (int) (a.hashCode() - b.hashCode() - 0.5); // Compliant - compareTo takes exactly one parameter
+    }
+
+    int compareTo(double a) {
+      return (int) (a - 1.0); // Compliant - the parameter is primitive
+    }
+
+    int compare(Double a) {
+      return (int) (a - 1.0); // Compliant - compare takes exactly two parameters
+    }
+
+    double compare(Double a, Double b) {
+      return a - b; // Compliant - does not return an int
     }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FloatingPointComparisonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FloatingPointComparisonCheckSample.java
@@ -14,7 +14,7 @@ class FloatingPointComparisonCheckSample {
     @Override
     public int compareTo(PositionBySubtraction other) {
       int latComparison = (int) (this.latitude - other.latitude); // Noncompliant {{Use "Double.compare" or "Float.compare" to compare floating-point values.}}
-//                                              ^
+//                                             ^
       if (latComparison != 0) {
         return latComparison;
       }
@@ -191,6 +191,27 @@ class FloatingPointComparisonCheckSample {
     @Override
     public int compare(long[] a, long[] b) {
       return (int) (a[0] - b[0]); // Compliant - not floating-point
+    }
+  }
+
+  // === Compliant: abstract compareTo method (no body) ===
+
+  interface CustomComparable<T> {
+    int compareTo(T other); // Compliant - abstract method, no body
+  }
+
+  // === Compliant: abstract compare method in Comparator (no body) ===
+
+  abstract static class AbstractDoubleComparator implements Comparator<Double> {
+    @Override
+    public abstract int compare(Double a, Double b); // Compliant - abstract method, no body
+  }
+
+  // === Compliant: compare method not in a Comparator ===
+
+  static class DoubleUtils {
+    int compare(double a, double b) {
+      return (int) (a - b); // Compliant - not in a Comparator
     }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FloatingPointComparisonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FloatingPointComparisonCheckSample.java
@@ -1,0 +1,196 @@
+package checks;
+
+import java.util.Comparator;
+import java.util.List;
+
+class FloatingPointComparisonCheckSample {
+
+  // === Noncompliant: subtraction in compareTo with double ===
+
+  static class PositionBySubtraction implements Comparable<PositionBySubtraction> {
+    private double latitude;
+    private double longitude;
+
+    @Override
+    public int compareTo(PositionBySubtraction other) {
+      int latComparison = (int) (this.latitude - other.latitude); // Noncompliant {{Use "Double.compare" or "Float.compare" to compare floating-point values.}}
+//                                              ^
+      if (latComparison != 0) {
+        return latComparison;
+      }
+      return (int) (this.longitude - other.longitude); // Noncompliant
+    }
+  }
+
+  // === Noncompliant: subtraction in compareTo with float ===
+
+  static class FloatHolder implements Comparable<FloatHolder> {
+    private float value;
+
+    @Override
+    public int compareTo(FloatHolder other) {
+      return (int) (this.value - other.value); // Noncompliant
+    }
+  }
+
+  // === Noncompliant: subtraction in Comparator.compare ===
+
+  static class DoubleComparator implements Comparator<double[]> {
+    @Override
+    public int compare(double[] a, double[] b) {
+      return (int) (a[0] - b[0]); // Noncompliant
+    }
+  }
+
+  // === Noncompliant: subtraction in lambda Comparator ===
+
+  void lambdaSubtraction() {
+    List<double[]> list = null;
+    list.sort((a, b) -> (int) (a[0] - b[0])); // Noncompliant
+  }
+
+  // === Noncompliant: relational operators in compareTo ===
+
+  static class RelationalCompareTo implements Comparable<RelationalCompareTo> {
+    private double value;
+
+    @Override
+    public int compareTo(RelationalCompareTo other) {
+      if (this.value < other.value) { // Noncompliant
+        return -1;
+      }
+      if (this.value > other.value) { // Noncompliant
+        return 1;
+      }
+      return 0;
+    }
+  }
+
+  // === Noncompliant: relational operators in Comparator.compare ===
+
+  static class RelationalComparator implements Comparator<Float> {
+    @Override
+    public int compare(Float a, Float b) {
+      float x = a;
+      float y = b;
+      if (x <= y) { // Noncompliant
+        return x >= y ? 0 : -1; // Noncompliant
+      }
+      return 1;
+    }
+  }
+
+  // === Noncompliant: relational operators in lambda ===
+
+  void lambdaRelational() {
+    List<Double> list = null;
+    list.sort((a, b) -> {
+      double x = a;
+      double y = b;
+      if (x > y) return 1; // Noncompliant
+      if (x < y) return -1; // Noncompliant
+      return 0;
+    });
+  }
+
+  // === Compliant: using Double.compare in compareTo ===
+
+  static class CorrectCompareTo implements Comparable<CorrectCompareTo> {
+    private double value;
+
+    @Override
+    public int compareTo(CorrectCompareTo other) {
+      return Double.compare(this.value, other.value); // Compliant
+    }
+  }
+
+  // === Compliant: using Float.compare in compareTo ===
+
+  static class CorrectFloatCompareTo implements Comparable<CorrectFloatCompareTo> {
+    private float value;
+
+    @Override
+    public int compareTo(CorrectFloatCompareTo other) {
+      return Float.compare(this.value, other.value); // Compliant
+    }
+  }
+
+  // === Compliant: using Double.compare in Comparator ===
+
+  static class CorrectComparator implements Comparator<double[]> {
+    @Override
+    public int compare(double[] a, double[] b) {
+      return Double.compare(a[0], b[0]); // Compliant
+    }
+  }
+
+  // === Compliant: using Double.compare in lambda ===
+
+  void lambdaCorrect() {
+    List<double[]> list = null;
+    list.sort((a, b) -> Double.compare(a[0], b[0])); // Compliant
+  }
+
+  // === Compliant: integer subtraction in compareTo ===
+
+  static class IntegerCompareTo implements Comparable<IntegerCompareTo> {
+    private int value;
+
+    @Override
+    public int compareTo(IntegerCompareTo other) {
+      return this.value - other.value; // Compliant - not floating-point
+    }
+  }
+
+  // === Compliant: integer relational in compareTo ===
+
+  static class IntegerRelational implements Comparable<IntegerRelational> {
+    private int value;
+
+    @Override
+    public int compareTo(IntegerRelational other) {
+      if (this.value < other.value) { // Compliant - not floating-point
+        return -1;
+      }
+      return this.value > other.value ? 1 : 0; // Compliant
+    }
+  }
+
+  // === Compliant: floating-point subtraction outside compareTo/compare ===
+
+  double subtract(double a, double b) {
+    return a - b; // Compliant - not in a comparison method
+  }
+
+  boolean isGreater(double a, double b) {
+    return a > b; // Compliant - not in a comparison method
+  }
+
+  // === Compliant: inner class has its own compareTo ===
+
+  static class OuterWithInner implements Comparable<OuterWithInner> {
+    private double value;
+
+    @Override
+    public int compareTo(OuterWithInner other) {
+      return Double.compare(this.value, other.value); // Compliant
+
+      // Inner class should be checked independently
+    }
+
+    static class InnerNotComparable {
+      double compute(double a, double b) {
+        return a - b; // Compliant - not in a comparison method
+      }
+    }
+  }
+
+  // === Compliant: long subtraction in Comparator ===
+
+  static class LongComparator implements Comparator<long[]> {
+    @Override
+    public int compare(long[] a, long[] b) {
+      return (int) (a[0] - b[0]); // Compliant - not floating-point
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
@@ -1,0 +1,113 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.Arrays;
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TypeTree;
+import org.sonar.plugins.java.api.tree.VariableTree;
+
+@Rule(key = "S9148")
+public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
+
+  private static final String MESSAGE = "Use \"Double.compare\" or \"Float.compare\" to compare floating-point values.";
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Arrays.asList(Tree.Kind.METHOD, Tree.Kind.LAMBDA_EXPRESSION);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    if (tree.is(Tree.Kind.METHOD)) {
+      MethodTree methodTree = (MethodTree) tree;
+      if (isCompareToMethod(methodTree) || isCompareMethod(methodTree)) {
+        methodTree.block().accept(new FloatingPointComparisonVisitor());
+      }
+    } else {
+      LambdaExpressionTree lambda = (LambdaExpressionTree) tree;
+      if (lambda.symbolType().isSubtypeOf("java.util.Comparator")) {
+        lambda.body().accept(new FloatingPointComparisonVisitor());
+      }
+    }
+  }
+
+  private static boolean isCompareToMethod(MethodTree tree) {
+    return "compareTo".equals(tree.simpleName().name())
+      && returnsInt(tree)
+      && hasOneNonPrimitiveParameter(tree);
+  }
+
+  private static boolean isCompareMethod(MethodTree tree) {
+    return "compare".equals(tree.simpleName().name())
+      && returnsInt(tree)
+      && tree.parameters().size() == 2;
+  }
+
+  private static boolean returnsInt(MethodTree tree) {
+    TypeTree returnType = tree.returnType();
+    return returnType != null && returnType.symbolType().isPrimitive(Type.Primitives.INT);
+  }
+
+  private static boolean hasOneNonPrimitiveParameter(MethodTree tree) {
+    List<VariableTree> parameters = tree.parameters();
+    return parameters.size() == 1 && !parameters.get(0).type().symbolType().isPrimitive();
+  }
+
+  private static boolean hasFloatingType(ExpressionTree tree) {
+    return tree.symbolType().isPrimitive(Type.Primitives.FLOAT)
+      || tree.symbolType().isPrimitive(Type.Primitives.DOUBLE);
+  }
+
+  private class FloatingPointComparisonVisitor extends BaseTreeVisitor {
+
+    @Override
+    public void visitBinaryExpression(BinaryExpressionTree tree) {
+      if (tree.is(Tree.Kind.MINUS) && hasFloatingOperand(tree)) {
+        reportIssue(tree.operatorToken(), MESSAGE);
+      } else if (tree.is(Tree.Kind.LESS_THAN, Tree.Kind.GREATER_THAN, Tree.Kind.LESS_THAN_OR_EQUAL_TO, Tree.Kind.GREATER_THAN_OR_EQUAL_TO)
+        && hasFloatingOperand(tree)) {
+        reportIssue(tree.operatorToken(), MESSAGE);
+      }
+      super.visitBinaryExpression(tree);
+    }
+
+    private boolean hasFloatingOperand(BinaryExpressionTree tree) {
+      return hasFloatingType(tree.leftOperand()) || hasFloatingType(tree.rightOperand());
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // Do not visit inner classes
+    }
+
+    @Override
+    public void visitLambdaExpression(LambdaExpressionTree tree) {
+      // Do not visit nested lambdas
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
@@ -45,7 +45,8 @@ public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
   public void visitNode(Tree tree) {
     if (tree.is(Tree.Kind.METHOD)) {
       MethodTree methodTree = (MethodTree) tree;
-      if (isCompareToMethod(methodTree) || isCompareMethod(methodTree)) {
+      if ((isCompareToMethod(methodTree) || isCompareMethod(methodTree))
+        && methodTree.block() != null) {
         methodTree.block().accept(new FloatingPointComparisonVisitor());
       }
     } else {
@@ -65,7 +66,8 @@ public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
   private static boolean isCompareMethod(MethodTree tree) {
     return "compare".equals(tree.simpleName().name())
       && returnsInt(tree)
-      && tree.parameters().size() == 2;
+      && tree.parameters().size() == 2
+      && tree.symbol().owner().type().isSubtypeOf("java.util.Comparator");
   }
 
   private static boolean returnsInt(MethodTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
@@ -28,13 +29,23 @@ import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.TypeTree;
-import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9148")
 public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
 
   private static final String MESSAGE = "Use \"Double.compare\" or \"Float.compare\" to compare floating-point values.";
+
+  private static final MethodMatchers COMPARE_METHODS = MethodMatchers.or(
+    MethodMatchers.create()
+      .ofSubTypes("java.lang.Comparable")
+      .names("compareTo")
+      .addParametersMatcher(MethodMatchers.ANY)
+      .build(),
+    MethodMatchers.create()
+      .ofSubTypes("java.util.Comparator")
+      .names("compare")
+      .addParametersMatcher(MethodMatchers.ANY, MethodMatchers.ANY)
+      .build());
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -43,10 +54,12 @@ public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
+    if (context.getSemanticModel() == null) {
+      return;
+    }
     if (tree.is(Tree.Kind.METHOD)) {
       MethodTree methodTree = (MethodTree) tree;
-      if ((isCompareToMethod(methodTree) || isCompareMethod(methodTree))
-        && methodTree.block() != null) {
+      if (COMPARE_METHODS.matches(methodTree) && methodTree.block() != null) {
         methodTree.block().accept(new FloatingPointComparisonVisitor());
       }
     } else {
@@ -55,29 +68,6 @@ public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
         lambda.body().accept(new FloatingPointComparisonVisitor());
       }
     }
-  }
-
-  private static boolean isCompareToMethod(MethodTree tree) {
-    return "compareTo".equals(tree.simpleName().name())
-      && returnsInt(tree)
-      && hasOneNonPrimitiveParameter(tree);
-  }
-
-  private static boolean isCompareMethod(MethodTree tree) {
-    return "compare".equals(tree.simpleName().name())
-      && returnsInt(tree)
-      && tree.parameters().size() == 2
-      && tree.symbol().owner().type().isSubtypeOf("java.util.Comparator");
-  }
-
-  private static boolean returnsInt(MethodTree tree) {
-    TypeTree returnType = tree.returnType();
-    return returnType != null && returnType.symbolType().isPrimitive(Type.Primitives.INT);
-  }
-
-  private static boolean hasOneNonPrimitiveParameter(MethodTree tree) {
-    List<VariableTree> parameters = tree.parameters();
-    return parameters.size() == 1 && !parameters.get(0).type().symbolType().isPrimitive();
   }
 
   private static boolean hasFloatingType(ExpressionTree tree) {
@@ -89,7 +79,8 @@ public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitBinaryExpression(BinaryExpressionTree tree) {
-      if (tree.is(Tree.Kind.MINUS, Tree.Kind.LESS_THAN, Tree.Kind.GREATER_THAN, Tree.Kind.LESS_THAN_OR_EQUAL_TO, Tree.Kind.GREATER_THAN_OR_EQUAL_TO)
+      if (tree.is(Tree.Kind.MINUS, Tree.Kind.LESS_THAN, Tree.Kind.GREATER_THAN,
+        Tree.Kind.LESS_THAN_OR_EQUAL_TO, Tree.Kind.GREATER_THAN_OR_EQUAL_TO)
         && hasFloatingOperand(tree)) {
         reportIssue(tree.operatorToken(), MESSAGE);
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FloatingPointComparisonCheck.java
@@ -89,9 +89,7 @@ public class FloatingPointComparisonCheck extends IssuableSubscriptionVisitor {
 
     @Override
     public void visitBinaryExpression(BinaryExpressionTree tree) {
-      if (tree.is(Tree.Kind.MINUS) && hasFloatingOperand(tree)) {
-        reportIssue(tree.operatorToken(), MESSAGE);
-      } else if (tree.is(Tree.Kind.LESS_THAN, Tree.Kind.GREATER_THAN, Tree.Kind.LESS_THAN_OR_EQUAL_TO, Tree.Kind.GREATER_THAN_OR_EQUAL_TO)
+      if (tree.is(Tree.Kind.MINUS, Tree.Kind.LESS_THAN, Tree.Kind.GREATER_THAN, Tree.Kind.LESS_THAN_OR_EQUAL_TO, Tree.Kind.GREATER_THAN_OR_EQUAL_TO)
         && hasFloatingOperand(tree)) {
         reportIssue(tree.operatorToken(), MESSAGE);
       }

--- a/java-checks/src/test/java/org/sonar/java/checks/FloatingPointComparisonCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FloatingPointComparisonCheckTest.java
@@ -31,4 +31,13 @@ class FloatingPointComparisonCheckTest {
       .verifyIssues();
   }
 
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FloatingPointComparisonCheckSample.java"))
+      .withCheck(new FloatingPointComparisonCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/FloatingPointComparisonCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FloatingPointComparisonCheckTest.java
@@ -1,0 +1,34 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class FloatingPointComparisonCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FloatingPointComparisonCheckSample.java"))
+      .withCheck(new FloatingPointComparisonCheck())
+      .verifyIssues();
+  }
+
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9148.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9148.html
@@ -1,0 +1,65 @@
+<h2>Why is this an issue?</h2>
+<p>Comparing floating-point values (single or double precision) using subtraction or simple comparison operators does not correctly handle special
+IEEE 754 values such as <code>NaN</code> (Not a Number) and negative zero (<code>-0.0</code>).</p>
+<p>When you implement comparison using subtraction (e.g., converting the difference between two floating-point values to an integer result), several
+problems occur:</p>
+<ul>
+  <li><strong>Precision loss</strong>: Casting the result to an integer loses information and can produce incorrect results for values that are close
+  but not equal.</li>
+  <li><strong>NaN handling</strong>: Subtraction involving <code>NaN</code> produces <code>NaN</code>, which when cast to an integer becomes
+  <code>0</code>, incorrectly suggesting the values are equal.</li>
+  <li><strong>Overflow</strong>: For values near the maximum range, subtraction can overflow.</li>
+</ul>
+<p>Using simple comparison operators like <code>&lt;</code> or <code>&gt;</code> also fails:</p>
+<ul>
+  <li>Any comparison with <code>NaN</code> (except inequality) returns false, breaking the transitivity requirement of comparison interface
+  contracts.</li>
+  <li>The operators don't provide a consistent three-way comparison result needed for comparison methods that must return negative, zero, or positive
+  values.</li>
+</ul>
+<p>Use <code>Float.compare()</code> and <code>Double.compare()</code> instead. These methods correctly implement a total ordering that handles all IEEE
+754 special cases and satisfies the contracts of <code>Comparable</code> and <code>Comparator</code>.</p>
+<h2>How to fix it</h2>
+<p>Replace subtraction-based or relational-operator-based comparison with <code>Double.compare()</code> or <code>Float.compare()</code>.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+class Position implements Comparable&lt;Position&gt; {
+    private double latitude;
+    private double longitude;
+
+    @Override
+    public int compareTo(Position other) {
+        int latComparison = (int)(this.latitude - other.latitude); // Noncompliant
+        if (latComparison != 0) {
+            return latComparison;
+        }
+        return (int)(this.longitude - other.longitude); // Noncompliant
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+class Position implements Comparable&lt;Position&gt; {
+    private double latitude;
+    private double longitude;
+
+    @Override
+    public int compareTo(Position other) {
+        int latComparison = Double.compare(this.latitude, other.latitude);
+        if (latComparison != 0) {
+            return latComparison;
+        }
+        return Double.compare(this.longitude, other.longitude);
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Double.html#compare(double,double)">Double.compare(double,
+  double)</a></li>
+  <li><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Float.html#compare(float,float)">Float.compare(float,
+  float)</a></li>
+  <li><a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Comparable.html">Comparable Interface</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9148.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9148.json
@@ -1,0 +1,21 @@
+{
+  "title": "\"Float.compare\" or \"Double.compare\" should be used for floating-point comparisons",
+  "type": "BUG",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "LOGICAL"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9148",
+  "sqKey": "S9148",
+  "scope": "All",
+  "quickfix": "unknown"
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9148.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9148.json
@@ -17,5 +17,5 @@
   "ruleSpecification": "RSPEC-9148",
   "sqKey": "S9148",
   "scope": "All",
-  "quickfix": "unknown"
+  "quickfix": "infeasible"
 }


### PR DESCRIPTION
Detect incorrect floating-point comparisons (subtraction and relational operators on float/double) inside compareTo, Comparator.compare methods, and Comparator lambdas. Users should use Double.compare or Float.compare instead to correctly handle NaN and negative zero.
