### PR TITLE
SONARJAVA-6741 Implement new rule S9149: Static methods should not hide methods from superclasses

### DIFF
--- a/its/autoscan/src/test/resources/autoscan/diffs/diff_S9149.json
+++ b/its/autoscan/src/test/resources/autoscan/diffs/diff_S9149.json
@@ -1,0 +1,6 @@
+{
+  "ruleKey": "S9149",
+  "hasTruePositives": true,
+  "falseNegatives": 0,
+  "falsePositives": 0
+}

--- a/its/ruling/src/test/resources/commons-beanutils/java-S9149.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9149.json
@@ -1,0 +1,18 @@
+{
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/LocaleBeanUtils.java": [
+149,
+206,
+261,
+319,
+378,
+432,
+487,
+512
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/BeanUtils2TestCase.java": [
+57
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/WrapDynaBeanTestCase.java": [
+75
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9149.json
+++ b/its/ruling/src/test/resources/guava/java-S9149.json
@@ -1,0 +1,82 @@
+{
+"com.google.guava:guava:src/com/google/common/collect/ContiguousSet.java": [
+193
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableBiMap.java": [
+41,
+48,
+57,
+66,
+75,
+85,
+97,
+246,
+268
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableListMultimap.java": [
+51,
+58,
+67,
+77,
+88,
+101,
+118,
+237,
+278
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSetMultimap.java": [
+59,
+66,
+77,
+89,
+102,
+117,
+133,
+300,
+349
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSortedMap.java": [
+85,
+180,
+218
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSortedMapFauxverideShim.java": [
+37,
+51,
+65,
+80,
+95,
+110
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSortedMultiset.java": [
+63,
+171,
+189
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSortedMultisetFauxverideShim.java": [
+44,
+58,
+72,
+86,
+100,
+115,
+130,
+145
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSortedSet.java": [
+78,
+200,
+237,
+256
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSortedSetFauxverideShim.java": [
+46,
+60,
+74,
+88,
+103,
+118,
+133,
+147
+]
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/StaticMethodHidingCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/StaticMethodHidingCheckSample.java
@@ -1,0 +1,17 @@
+package checks;
+
+class StaticMethodHidingCheckSample {
+
+  // --- Compliant: unknown parameter types should not raise issues ---
+
+  static class ParentWithUnknown {
+    static void process(Unknown param) {
+    }
+  }
+
+  static class ChildWithUnknown extends ParentWithUnknown {
+    static void process(Unknown param) { // Compliant - parameter type is unknown
+    }
+  }
+
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/StaticMethodHidingCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/StaticMethodHidingCheckSample.java
@@ -2,6 +2,19 @@ package checks;
 
 class StaticMethodHidingCheckSample {
 
+  // --- Noncompliant: hiding is still detected with partial semantic ---
+
+  static class ParentWithKnownMethod {
+    static void doWork() {
+    }
+  }
+
+  static class ChildHidingWithUnknownField extends ParentWithKnownMethod {
+    Unknown field; // causes partial semantic, but hiding is still detectable
+    static void doWork() { // Noncompliant {{Rename this method; it hides "doWork" in "ParentWithKnownMethod".}}
+    }
+  }
+
   // --- Compliant: unknown parameter types should not raise issues ---
 
   static class ParentWithUnknown {

--- a/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
@@ -1,0 +1,213 @@
+package checks;
+
+import java.util.List;
+
+class StaticMethodHidingCheckSample {
+
+  // --- Basic hiding ---
+
+  static class Animal {
+    static void describe() {
+    }
+  }
+
+  static class Dog extends Animal {
+    static void describe() { // Noncompliant {{Rename this method; it hides "describe" in "Animal".}}
+//              ^^^^^^^^
+    }
+  }
+
+  // --- Hiding with parameters ---
+
+  static class Formatter {
+    static String format(String input) {
+      return input;
+    }
+
+    static String format(String input, int width) {
+      return input;
+    }
+  }
+
+  static class CustomFormatter extends Formatter {
+    static String format(String input) { // Noncompliant {{Rename this method; it hides "format" in "Formatter".}}
+      return input.trim();
+    }
+
+    static String format(String input, int width) { // Noncompliant {{Rename this method; it hides "format" in "Formatter".}}
+      return input.trim();
+    }
+  }
+
+  // --- Deep hierarchy hiding ---
+
+  static class Base {
+    static void process() {
+    }
+  }
+
+  static class Middle extends Base {
+    static void process() { // Noncompliant {{Rename this method; it hides "process" in "Base".}}
+    }
+  }
+
+  static class Leaf extends Middle {
+    static void process() { // Noncompliant {{Rename this method; it hides "process" in "Middle".}}
+    }
+  }
+
+  // --- Compliant: different parameter types (overloading, not hiding) ---
+
+  static class ParentA {
+    static void compute(int x) {
+    }
+  }
+
+  static class ChildA extends ParentA {
+    static void compute(String x) { // Compliant - different param type
+    }
+  }
+
+  // --- Compliant: different parameter count ---
+
+  static class ParentB {
+    static void compute(int x) {
+    }
+  }
+
+  static class ChildB extends ParentB {
+    static void compute(int x, int y) { // Compliant - different param count
+    }
+  }
+
+  // --- Compliant: instance method overriding ---
+
+  static class ParentC {
+    void display() {
+    }
+  }
+
+  static class ChildC extends ParentC {
+    @Override
+    void display() { // Compliant - instance method override
+    }
+  }
+
+  // --- Compliant: no inheritance ---
+
+  static class Unrelated1 {
+    static void helper() {
+    }
+  }
+
+  static class Unrelated2 {
+    static void helper() { // Compliant - no inheritance relationship
+    }
+  }
+
+  // --- Compliant: renamed methods ---
+
+  static class ParentD {
+    static void calculate() {
+    }
+  }
+
+  static class ChildD extends ParentD {
+    static void calculateExtended() { // Compliant - different name
+    }
+  }
+
+  // --- Compliant: private superclass method ---
+
+  static class ParentE {
+    private static void internalHelper() {
+    }
+  }
+
+  static class ChildE extends ParentE {
+    static void internalHelper() { // Compliant - parent method is private
+    }
+  }
+
+  // --- Compliant: interface static methods (not inherited) ---
+
+  interface Printable {
+    static void print() {
+    }
+  }
+
+  static class Printer implements Printable {
+    static void print() { // Compliant - interface static methods are not inherited
+    }
+  }
+
+  // --- Generics: hiding with generic parameter types ---
+
+  static class GenericParent<T> {
+    static void transform(List<String> items) {
+    }
+  }
+
+  static class GenericChild extends GenericParent<Integer> {
+    static void transform(List<String> items) { // Noncompliant {{Rename this method; it hides "transform" in "GenericParent".}}
+    }
+  }
+
+  // --- Compliant: static method in child, instance in parent ---
+
+  static class ParentF {
+    void action() {
+    }
+  }
+
+  static class ChildF extends ParentF {
+    static void action() { // Compliant - parent method is not static
+    }
+  }
+
+  // --- Compliant: instance method in child, static in parent (covered by S2177) ---
+
+  static class ParentG {
+    static void action() {
+    }
+  }
+
+  static class ChildG extends ParentG {
+    void action() { // Compliant for this rule - covered by S2177
+    }
+  }
+
+  // --- Hiding through intermediate class that doesn't define the method ---
+
+  static class GrandParent {
+    static void legacy() {
+    }
+  }
+
+  static class IntermediateParent extends GrandParent {
+    // does not override legacy()
+  }
+
+  static class GrandChild extends IntermediateParent {
+    static void legacy() { // Noncompliant {{Rename this method; it hides "legacy" in "GrandParent".}}
+    }
+  }
+
+  // --- Multiple methods hiding from the same parent ---
+
+  static class MultiParent {
+    static void first() {
+    }
+
+    static void second() {
+    }
+  }
+
+  static class MultiChild extends MultiParent {
+    static void first() { // Noncompliant {{Rename this method; it hides "first" in "MultiParent".}}
+    }
+
+    static void second() { // Noncompliant {{Rename this method; it hides "second" in "MultiParent".}}
+    }
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
@@ -153,29 +153,8 @@ class StaticMethodHidingCheckSample {
     }
   }
 
-  // --- Compliant: static method in child, instance in parent ---
-
-  static class ParentF {
-    void action() {
-    }
-  }
-
-  static class ChildF extends ParentF {
-    static void action() { // Compliant - parent method is not static
-    }
-  }
-
-  // --- Compliant: instance method in child, static in parent (covered by S2177) ---
-
-  static class ParentG {
-    static void action() {
-    }
-  }
-
-  static class ChildG extends ParentG {
-    void action() { // Compliant for this rule - covered by S2177
-    }
-  }
+  // Note: static-in-child/instance-in-parent and instance-in-child/static-in-parent
+  // cases are not tested here because they are compilation errors in Java.
 
   // --- Hiding through intermediate class that doesn't define the method ---
 

--- a/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
@@ -176,7 +176,33 @@ class StaticMethodHidingCheckSample {
   // Covers the branch where declaration() returns null
 
   static class MyThread extends Thread {
-    static void sleep(long millis) throws InterruptedException { // Noncompliant {{Rename this method; it hides "sleep" in "Thread".}}
+    public static void sleep(long millis) throws InterruptedException { // Noncompliant {{Rename this method; it hides "sleep" in "Thread".}}
+    }
+  }
+
+  // --- Compliant: parent has a field with same name as child's static method ---
+
+  static class ParentWithField {
+    static int action = 0;
+  }
+
+  static class ChildWithMethodSameNameAsField extends ParentWithField {
+    static void action() { // Compliant - parent has a field, not a method
+    }
+  }
+
+  // --- Compliant: parent has non-static non-private method, child has static method with different params ---
+  // (Same name + same params + static child + non-static parent is a compile error)
+
+  static class ParentWithInstanceMethod {
+    void doWork(int x) {
+    }
+    static void doWork(String s) {
+    }
+  }
+
+  static class ChildWithStaticMethod extends ParentWithInstanceMethod {
+    static void doWork(String s) { // Noncompliant {{Rename this method; it hides "doWork" in "ParentWithInstanceMethod".}}
     }
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/StaticMethodHidingCheckSample.java
@@ -172,6 +172,14 @@ class StaticMethodHidingCheckSample {
     }
   }
 
+  // --- Hiding a method from a binary dependency (JDK class) ---
+  // Covers the branch where declaration() returns null
+
+  static class MyThread extends Thread {
+    static void sleep(long millis) throws InterruptedException { // Noncompliant {{Rename this method; it hides "sleep" in "Thread".}}
+    }
+  }
+
   // --- Multiple methods hiding from the same parent ---
 
   static class MultiParent {

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -34,17 +34,9 @@ public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
     return Collections.singletonList(Tree.Kind.METHOD);
   }
 
-  private boolean hasSemantic;
-
-  @Override
-  public void setContext(JavaFileScannerContext context) {
-    hasSemantic = context.getSemanticModel() != null;
-    super.setContext(context);
-  }
-
   @Override
   public void visitNode(Tree tree) {
-    if (!hasSemantic) {
+    if (context.getSemanticModel() == null) {
       return;
     }
     MethodTree methodTree = (MethodTree) tree;

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -57,12 +57,14 @@ public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
         && symbol.isStatic()
         && !symbol.isPrivate()
         && hasSameParameterTypes(methodSymbol, (Symbol.MethodSymbol) symbol)) {
+        Symbol.MethodSymbol hiddenMethod = (Symbol.MethodSymbol) symbol;
         String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
           methodSymbol.name(), symbol.owner().name());
-        MethodTree declaration = (MethodTree) ((Symbol.MethodSymbol) symbol).declaration();
+        Tree declaration = hiddenMethod.declaration();
         if (declaration != null) {
           reportIssue(methodTree.simpleName(), message,
-            Collections.singletonList(new JavaFileScannerContext.Location("Hidden method", declaration.simpleName())),
+            Collections.singletonList(new JavaFileScannerContext.Location("Hidden method",
+              ((MethodTree) declaration).simpleName())),
             null);
         } else {
           reportIssue(methodTree.simpleName(), message);

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -53,24 +53,25 @@ public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
 
   private boolean checkHiding(MethodTree methodTree, Symbol.MethodSymbol methodSymbol, Type superClass) {
     for (Symbol symbol : superClass.symbol().lookupSymbols(methodSymbol.name())) {
-      if (symbol.isMethodSymbol()
-        && symbol.isStatic()
-        && !symbol.isPrivate()
-        && hasSameParameterTypes(methodSymbol, (Symbol.MethodSymbol) symbol)) {
-        Symbol.MethodSymbol hiddenMethod = (Symbol.MethodSymbol) symbol;
-        String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
-          methodSymbol.name(), symbol.owner().name());
-        MethodTree declaration = hiddenMethod.declaration();
-        if (declaration != null) {
-          reportIssue(methodTree.simpleName(), message,
-            Collections.singletonList(new JavaFileScannerContext.Location("Hidden method",
-              declaration.simpleName())),
-            null);
-        } else {
-          reportIssue(methodTree.simpleName(), message);
-        }
-        return true;
+      if (!symbol.isMethodSymbol() || !symbol.isStatic() || symbol.isPrivate()) {
+        continue;
       }
+      Symbol.MethodSymbol hiddenMethod = (Symbol.MethodSymbol) symbol;
+      if (!hasSameParameterTypes(methodSymbol, hiddenMethod)) {
+        continue;
+      }
+      String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
+        methodSymbol.name(), hiddenMethod.owner().name());
+      MethodTree declaration = hiddenMethod.declaration();
+      if (declaration != null) {
+        reportIssue(methodTree.simpleName(), message,
+          Collections.singletonList(new JavaFileScannerContext.Location("Hidden method",
+            declaration.simpleName())),
+          null);
+      } else {
+        reportIssue(methodTree.simpleName(), message);
+      }
+      return true;
     }
     return false;
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -34,8 +34,19 @@ public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
     return Collections.singletonList(Tree.Kind.METHOD);
   }
 
+  private boolean hasSemantic;
+
+  @Override
+  public void setContext(JavaFileScannerContext context) {
+    hasSemantic = context.getSemanticModel() != null;
+    super.setContext(context);
+  }
+
   @Override
   public void visitNode(Tree tree) {
+    if (!hasSemantic) {
+      return;
+    }
     MethodTree methodTree = (MethodTree) tree;
     Symbol.MethodSymbol methodSymbol = methodTree.symbol();
     if (!methodSymbol.isStatic()) {

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -1,0 +1,95 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.Collections;
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9149")
+public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    MethodTree methodTree = (MethodTree) tree;
+    Symbol.MethodSymbol methodSymbol = methodTree.symbol();
+    if (!methodSymbol.isStatic()) {
+      return;
+    }
+    Symbol.TypeSymbol owner = (Symbol.TypeSymbol) methodSymbol.owner();
+    Type superClass = owner.superClass();
+    while (superClass != null) {
+      if (checkHiding(methodTree, methodSymbol, superClass)) {
+        return;
+      }
+      superClass = superClass.symbol().superClass();
+    }
+  }
+
+  private boolean checkHiding(MethodTree methodTree, Symbol.MethodSymbol methodSymbol, Type superClass) {
+    for (Symbol symbol : superClass.symbol().lookupSymbols(methodSymbol.name())) {
+      if (symbol.isMethodSymbol()
+        && symbol.isStatic()
+        && !symbol.isPrivate()
+        && hasSameParameterTypes(methodSymbol, (Symbol.MethodSymbol) symbol)) {
+        String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
+          methodSymbol.name(), symbol.owner().name());
+        MethodTree declaration = (MethodTree) ((Symbol.MethodSymbol) symbol).declaration();
+        if (declaration != null) {
+          reportIssue(methodTree.simpleName(), message,
+            Collections.singletonList(new JavaFileScannerContext.Location("Hidden method", declaration.simpleName())),
+            null);
+        } else {
+          reportIssue(methodTree.simpleName(), message);
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasSameParameterTypes(Symbol.MethodSymbol method, Symbol.MethodSymbol candidate) {
+    List<Type> methodParams = method.parameterTypes();
+    List<Type> candidateParams = candidate.parameterTypes();
+    if (methodParams.size() != candidateParams.size()) {
+      return false;
+    }
+    for (int i = 0; i < methodParams.size(); i++) {
+      Type methodParam = methodParams.get(i);
+      Type candidateParam = candidateParams.get(i);
+      if (methodParam.isUnknown() || candidateParam.isUnknown()) {
+        return false;
+      }
+      if (!methodParam.erasure().equals(candidateParam.erasure())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -60,11 +60,11 @@ public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
         Symbol.MethodSymbol hiddenMethod = (Symbol.MethodSymbol) symbol;
         String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
           methodSymbol.name(), symbol.owner().name());
-        Tree declaration = hiddenMethod.declaration();
+        MethodTree declaration = hiddenMethod.declaration();
         if (declaration != null) {
           reportIssue(methodTree.simpleName(), message,
             Collections.singletonList(new JavaFileScannerContext.Location("Hidden method",
-              ((MethodTree) declaration).simpleName())),
+              declaration.simpleName())),
             null);
         } else {
           reportIssue(methodTree.simpleName(), message);

--- a/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/StaticMethodHidingCheck.java
@@ -53,27 +53,27 @@ public class StaticMethodHidingCheck extends IssuableSubscriptionVisitor {
 
   private boolean checkHiding(MethodTree methodTree, Symbol.MethodSymbol methodSymbol, Type superClass) {
     for (Symbol symbol : superClass.symbol().lookupSymbols(methodSymbol.name())) {
-      if (!symbol.isMethodSymbol() || !symbol.isStatic() || symbol.isPrivate()) {
-        continue;
+      if (symbol.isMethodSymbol() && symbol.isStatic() && !symbol.isPrivate()
+        && hasSameParameterTypes(methodSymbol, (Symbol.MethodSymbol) symbol)) {
+        reportHidingIssue(methodTree, methodSymbol, (Symbol.MethodSymbol) symbol);
+        return true;
       }
-      Symbol.MethodSymbol hiddenMethod = (Symbol.MethodSymbol) symbol;
-      if (!hasSameParameterTypes(methodSymbol, hiddenMethod)) {
-        continue;
-      }
-      String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
-        methodSymbol.name(), hiddenMethod.owner().name());
-      MethodTree declaration = hiddenMethod.declaration();
-      if (declaration != null) {
-        reportIssue(methodTree.simpleName(), message,
-          Collections.singletonList(new JavaFileScannerContext.Location("Hidden method",
-            declaration.simpleName())),
-          null);
-      } else {
-        reportIssue(methodTree.simpleName(), message);
-      }
-      return true;
     }
     return false;
+  }
+
+  private void reportHidingIssue(MethodTree methodTree, Symbol.MethodSymbol methodSymbol, Symbol.MethodSymbol hiddenMethod) {
+    String message = String.format("Rename this method; it hides \"%s\" in \"%s\".",
+      methodSymbol.name(), hiddenMethod.owner().name());
+    MethodTree declaration = hiddenMethod.declaration();
+    if (declaration != null) {
+      reportIssue(methodTree.simpleName(), message,
+        Collections.singletonList(new JavaFileScannerContext.Location("Hidden method",
+          declaration.simpleName())),
+        null);
+    } else {
+      reportIssue(methodTree.simpleName(), message);
+    }
   }
 
   private static boolean hasSameParameterTypes(Symbol.MethodSymbol method, Symbol.MethodSymbol candidate) {

--- a/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
@@ -33,6 +33,15 @@ class StaticMethodHidingCheckTest {
   }
 
   @Test
+  void withoutSemantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StaticMethodHidingCheckSample.java"))
+      .withCheck(new StaticMethodHidingCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+
+  @Test
   void test_non_compiling() {
     CheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/StaticMethodHidingCheckSample.java"))

--- a/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
@@ -46,7 +46,7 @@ class StaticMethodHidingCheckTest {
     CheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/StaticMethodHidingCheckSample.java"))
       .withCheck(new StaticMethodHidingCheck())
-      .verifyNoIssues();
+      .verifyIssues();
   }
 
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
@@ -1,0 +1,34 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class StaticMethodHidingCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/StaticMethodHidingCheckSample.java"))
+      .withCheck(new StaticMethodHidingCheck())
+      .verifyIssues();
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/StaticMethodHidingCheckTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 
 class StaticMethodHidingCheckTest {
 
@@ -29,6 +30,14 @@ class StaticMethodHidingCheckTest {
       .onFile(mainCodeSourcesPath("checks/StaticMethodHidingCheckSample.java"))
       .withCheck(new StaticMethodHidingCheck())
       .verifyIssues();
+  }
+
+  @Test
+  void test_non_compiling() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/StaticMethodHidingCheckSample.java"))
+      .withCheck(new StaticMethodHidingCheck())
+      .verifyNoIssues();
   }
 
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9149.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9149.html
@@ -1,0 +1,44 @@
+<h2>Why is this an issue?</h2>
+<p>Method hiding occurs when a subclass defines a static method with the same signature as a static method in its superclass. Unlike instance
+method overriding, static methods are resolved at compile time based on the declared type of the reference, not the actual runtime type of the
+object. This behavior is counterintuitive and can lead to subtle bugs.</p>
+<p>When a variable is declared as the parent type but holds a child instance, calling a hidden static method through that variable invokes the
+parent's version, not the child's. This contradicts the polymorphic behavior developers expect from instance methods.</p>
+<h3>Noncompliant code example</h3>
+<pre>
+class Parent {
+    static void calculate() {
+        // Parent implementation
+    }
+}
+
+class Child extends Parent {
+    static void calculate() {  // Noncompliant
+        // Child implementation
+    }
+}
+</pre>
+<h3>Compliant solution</h3>
+<pre>
+class Parent {
+    static void calculate() {
+        // Parent implementation
+    }
+}
+
+class Child extends Parent {
+    static void calculateExtended() {
+        // Child implementation
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/tutorial/java/IandI/hidevariables.html">Hiding Fields and Methods</a></li>
+  <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.4.8.2">Method Declarations - Hiding</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li>CERT - <a href="https://wiki.sei.cmu.edu/confluence/display/java/MET07-J.+Never+declare+a+class+method+that+hides+a+method+declared+in+a+superclass+or+superinterface">CERT-MET07-J.: Never declare a class method that hides a method declared in a superclass or superinterface</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9149.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9149.json
@@ -1,0 +1,23 @@
+{
+  "title": "Static methods should not hide methods from superclasses",
+  "type": "CODE_SMELL",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  },
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "10min"
+  },
+  "tags": [
+    "pitfall"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9149",
+  "sqKey": "S9149",
+  "scope": "All",
+  "quickfix": "unknown"
+}


### PR DESCRIPTION
Detect static methods in subclasses that hide static methods from superclasses by having the same name and parameter types. This catches a common source of confusion where developers expect polymorphic behavior but get compile-time binding instead.

