### PR TITLE
SONARJAVA-6752 Implement verifyIssueOnProject in JavaCheckVerifier and modernize MissingPackageInfoCheckTest

### DIFF
--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifier.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifier.java
@@ -96,53 +96,9 @@ public class JavaCheckVerifier implements CheckVerifier {
   private WriteCache writeCache;
   private File rootDirectory;
 
-  private MultiFileVerifier createVerifier() {
-    MultiFileVerifier verifier = MultiFileVerifier.create(Paths.get(files.get(0).uri()), UTF_8);
-
+  private VisitorsBridgeForTests scanFiles(List<JavaFileScanner> visitors) {
     JavaVersion actualVersion = javaVersion == null ? DEFAULT_JAVA_VERSION : javaVersion;
 
-    List<JavaFileScanner> visitors = new ArrayList<>(checks);
-    CommentLinesVisitor commentLinesVisitor = new CommentLinesVisitor();
-    visitors.add(commentLinesVisitor);
-    SonarComponents sonarComponents = CheckVerifierUtils.sonarComponents(isCacheEnabled, readCache, writeCache, rootDirectory);
-    VisitorsBridgeForTests.Builder visitorsBridgeBuilder = new VisitorsBridgeForTests.Builder(visitors)
-      .withJavaVersion(actualVersion)
-      .withSonarComponents(sonarComponents)
-      .withAndroidContext(inAndroidContext);
-    if (!withoutSemantic) {
-      setActualClasspath();
-      visitorsBridgeBuilder.enableSemanticWithProjectClasspath(actualClasspath);
-    }
-
-    JavaAstScanner astScanner = new JavaAstScanner(sonarComponents, new NoOpTelemetry(), TelemetryKey.JAVA_ANALYSIS_MAIN);
-    VisitorsBridgeForTests visitorsBridge = visitorsBridgeBuilder.build();
-    astScanner.setVisitorBridge(visitorsBridge);
-
-    List<InputFile> filesToParse = files;
-    if (isCacheEnabled) {
-      visitorsBridge.setCacheContext(cacheContext);
-      filesToParse = astScanner.scanWithoutParsing(files).get(false);
-    }
-    astScanner.scanForTesting(filesToParse, compilationUnitModifier);
-
-    addComments(verifier, commentLinesVisitor);
-
-    for (var fileScannerContext : visitorsBridge.testContexts()) {
-      addIssues(fileScannerContext, verifier);
-    }
-
-    JavaFileScannerContextForTests testModuleScannerContext = visitorsBridge.lastCreatedModuleContext();
-    if (testModuleScannerContext != null) {
-      addIssues(testModuleScannerContext, verifier);
-    }
-
-    return verifier;
-  }
-
-  private VisitorsBridgeForTests scanFilesForProjectIssues() {
-    JavaVersion actualVersion = javaVersion == null ? DEFAULT_JAVA_VERSION : javaVersion;
-
-    List<JavaFileScanner> visitors = new ArrayList<>(checks);
     SonarComponents sonarComponents = CheckVerifierUtils.sonarComponents(isCacheEnabled, readCache, writeCache, rootDirectory);
     VisitorsBridgeForTests.Builder visitorsBridgeBuilder = new VisitorsBridgeForTests.Builder(visitors)
       .withJavaVersion(actualVersion)
@@ -165,6 +121,29 @@ public class JavaCheckVerifier implements CheckVerifier {
     astScanner.scanForTesting(filesToParse, compilationUnitModifier);
 
     return visitorsBridge;
+  }
+
+  private MultiFileVerifier createVerifier() {
+    MultiFileVerifier verifier = MultiFileVerifier.create(Paths.get(files.get(0).uri()), UTF_8);
+
+    List<JavaFileScanner> visitors = new ArrayList<>(checks);
+    CommentLinesVisitor commentLinesVisitor = new CommentLinesVisitor();
+    visitors.add(commentLinesVisitor);
+
+    VisitorsBridgeForTests visitorsBridge = scanFiles(visitors);
+
+    addComments(verifier, commentLinesVisitor);
+
+    for (var fileScannerContext : visitorsBridge.testContexts()) {
+      addIssues(fileScannerContext, verifier);
+    }
+
+    JavaFileScannerContextForTests testModuleScannerContext = visitorsBridge.lastCreatedModuleContext();
+    if (testModuleScannerContext != null) {
+      addIssues(testModuleScannerContext, verifier);
+    }
+
+    return verifier;
   }
 
   private void setActualClasspath() {
@@ -408,7 +387,7 @@ public class JavaCheckVerifier implements CheckVerifier {
     requiresNonNull(checks, CHECK_OR_CHECKS);
     requiresNonNull(files, FILE_OR_FILES);
 
-    VisitorsBridgeForTests visitorsBridge = scanFilesForProjectIssues();
+    VisitorsBridgeForTests visitorsBridge = scanFiles(new ArrayList<>(checks));
 
     var issues = new ArrayList<AnalyzerMessage>();
     for (var fileScannerContext : visitorsBridge.testContexts()) {

--- a/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifier.java
+++ b/java-checks-testkit/src/main/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifier.java
@@ -139,6 +139,34 @@ public class JavaCheckVerifier implements CheckVerifier {
     return verifier;
   }
 
+  private VisitorsBridgeForTests scanFilesForProjectIssues() {
+    JavaVersion actualVersion = javaVersion == null ? DEFAULT_JAVA_VERSION : javaVersion;
+
+    List<JavaFileScanner> visitors = new ArrayList<>(checks);
+    SonarComponents sonarComponents = CheckVerifierUtils.sonarComponents(isCacheEnabled, readCache, writeCache, rootDirectory);
+    VisitorsBridgeForTests.Builder visitorsBridgeBuilder = new VisitorsBridgeForTests.Builder(visitors)
+      .withJavaVersion(actualVersion)
+      .withSonarComponents(sonarComponents)
+      .withAndroidContext(inAndroidContext);
+    if (!withoutSemantic) {
+      setActualClasspath();
+      visitorsBridgeBuilder.enableSemanticWithProjectClasspath(actualClasspath);
+    }
+
+    JavaAstScanner astScanner = new JavaAstScanner(sonarComponents, new NoOpTelemetry(), TelemetryKey.JAVA_ANALYSIS_MAIN);
+    VisitorsBridgeForTests visitorsBridge = visitorsBridgeBuilder.build();
+    astScanner.setVisitorBridge(visitorsBridge);
+
+    List<InputFile> filesToParse = files;
+    if (isCacheEnabled) {
+      visitorsBridge.setCacheContext(cacheContext);
+      filesToParse = astScanner.scanWithoutParsing(files).get(false);
+    }
+    astScanner.scanForTesting(filesToParse, compilationUnitModifier);
+
+    return visitorsBridge;
+  }
+
   private void setActualClasspath() {
     List<File> newClasspath = classpath == null ? new ArrayList<>(TestClasspathUtils.DEFAULT_MODULE.getClassPath()) : classpath;
     jarsToRemove.forEach(f -> newClasspath.removeIf(file -> file.getName().contains(f)));
@@ -377,7 +405,34 @@ public class JavaCheckVerifier implements CheckVerifier {
 
   @Override
   public void verifyIssueOnProject(String expectedIssueMessage) {
-    throw new UnsupportedOperationException("Not implemented!");
+    requiresNonNull(checks, CHECK_OR_CHECKS);
+    requiresNonNull(files, FILE_OR_FILES);
+
+    VisitorsBridgeForTests visitorsBridge = scanFilesForProjectIssues();
+
+    var issues = new ArrayList<AnalyzerMessage>();
+    for (var fileScannerContext : visitorsBridge.testContexts()) {
+      issues.addAll(fileScannerContext.getIssues());
+    }
+    JavaFileScannerContextForTests testModuleScannerContext = visitorsBridge.lastCreatedModuleContext();
+    if (testModuleScannerContext != null) {
+      issues.addAll(testModuleScannerContext.getIssues());
+    }
+
+    if (issues.size() != 1) {
+      String issueNumberMessage = issues.isEmpty() ? "none has been raised" : String.format("%d issues have been raised", issues.size());
+      throw new AssertionError(String.format("A single issue is expected on the project, but %s", issueNumberMessage));
+    }
+    AnalyzerMessage issue = issues.get(0);
+    if (issue.getLine() != null) {
+      throw new AssertionError(String.format("Expected an issue directly on project but was raised on line %d", issue.getLine()));
+    }
+    if (issue.getInputComponent().isFile()) {
+      throw new AssertionError("Expected the issue to be raised at project level, not at file level");
+    }
+    if (!expectedIssueMessage.equals(issue.getMessage())) {
+      throw new AssertionError(String.format("Expected the issue message to be:%n\t\"%s\"%nbut was:%n\t\"%s\"", expectedIssueMessage, issue.getMessage()));
+    }
   }
 
   @Override

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifierTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifierTest.java
@@ -155,6 +155,68 @@ class JavaCheckVerifierTest {
   }
 
   @Test
+  void verify_issue_on_project_fails_when_no_issue() {
+    Throwable e = catchThrowable(() -> JavaCheckVerifier.newInstance()
+      .onFile(TEST_FILE)
+      .withCheck(NO_EFFECT_CHECK)
+      .verifyIssueOnProject("issueOnProject"));
+
+    assertThat(e)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("A single issue is expected on the project, but none has been raised");
+  }
+
+  @Test
+  void verify_issue_on_project_fails_when_multiple_issues() {
+    Throwable e = catchThrowable(() -> JavaCheckVerifier.newInstance()
+      .onFile(TEST_FILE)
+      .withChecks(PROJECT_ISSUE_CHECK, FILE_ISSUE_CHECK)
+      .verifyIssueOnProject("issueOnProject"));
+
+    assertThat(e)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("A single issue is expected on the project, but 2 issues have been raised");
+  }
+
+  @Test
+  void verify_issue_on_project_fails_when_issue_on_line() {
+    Throwable e = catchThrowable(() -> JavaCheckVerifier.newInstance()
+      .onFile(TEST_FILE)
+      .withCheck(CheckVerifierTestUtils.fileLineIssueCheck())
+      .verifyIssueOnProject("Noncompliant"));
+
+    assertThat(e)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("Expected an issue directly on project but was raised on line");
+  }
+
+  @Test
+  void verify_issue_on_project_fails_when_issue_on_file() {
+    Throwable e = catchThrowable(() -> JavaCheckVerifier.newInstance()
+      .onFile(TEST_FILE)
+      .withCheck(FILE_ISSUE_CHECK)
+      .verifyIssueOnProject("issueOnFile"));
+
+    assertThat(e)
+      .isInstanceOf(AssertionError.class)
+      .hasMessage("Expected the issue to be raised at project level, not at file level");
+  }
+
+  @Test
+  void verify_issue_on_project_fails_when_wrong_message() {
+    Throwable e = catchThrowable(() -> JavaCheckVerifier.newInstance()
+      .onFile(TEST_FILE)
+      .withCheck(PROJECT_ISSUE_CHECK)
+      .verifyIssueOnProject("wrongMessage"));
+
+    assertThat(e)
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("Expected the issue message to be:")
+      .hasMessageContaining("wrongMessage")
+      .hasMessageContaining("issueOnProject");
+  }
+
+  @Test
   void no_issue_if_not_in_android_context() {
     JavaCheckVerifier.newInstance()
       .onFile(TEST_FILE)

--- a/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifierTest.java
+++ b/java-checks-testkit/src/test/java/org/sonar/java/checks/verifier/internal/JavaCheckVerifierTest.java
@@ -147,15 +147,11 @@ class JavaCheckVerifierTest {
   }
 
   @Test
-  void verify_on_project_is_not_implemented() {
-    Throwable e = catchThrowable(() -> JavaCheckVerifier.newInstance()
+  void verify_issue_on_project() {
+    JavaCheckVerifier.newInstance()
       .onFile(TEST_FILE)
       .withCheck(PROJECT_ISSUE_CHECK)
-      .verifyIssueOnProject("issueOnProject"));
-
-    assertThat(e)
-      .isInstanceOf(UnsupportedOperationException.class)
-      .hasMessage("Not implemented!");
+      .verifyIssueOnProject("issueOnProject");
   }
 
   @Test

--- a/java-checks/src/test/java/org/sonar/java/checks/MissingPackageInfoCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/MissingPackageInfoCheckTest.java
@@ -62,7 +62,7 @@ class MissingPackageInfoCheckTest {
   void initVerifier() {
     this.readCache = new InternalReadCache();
     this.writeCache = new InternalWriteCache().bind(readCache);
-    this.verifier = CheckVerifier.newInternalVerifier()
+    this.verifier = CheckVerifier.newVerifier()
       .withCache(readCache, writeCache);
   }
 
@@ -70,7 +70,7 @@ class MissingPackageInfoCheckTest {
   void no_package_info() {
     MissingPackageInfoCheck check = new MissingPackageInfoCheck();
 
-    CheckVerifier.newInternalVerifier()
+    CheckVerifier.newVerifier()
       .onFiles(
         mainCodeSourcesPath("DefaultPackage.java"),
         mainCodeSourcesPath("checks/packageInfo/HelloWorld.java"),
@@ -103,7 +103,7 @@ class MissingPackageInfoCheckTest {
 
     var populatedReadCache = new InternalReadCache().putAll(writeCache);
     var writeCache2 = new InternalWriteCache().bind(populatedReadCache);
-    CheckVerifier.newInternalVerifier()
+    CheckVerifier.newVerifier()
       .withCache(populatedReadCache, writeCache2)
       .addFiles(InputFile.Status.SAME,
         mainCodeSourcesPath("checks/packageInfo/HelloWorld.java"),
@@ -163,7 +163,7 @@ class MissingPackageInfoCheckTest {
 
   @Test
   void test_without_semantic() {
-    CheckVerifier.newInternalVerifier()
+    CheckVerifier.newVerifier()
       .onFiles(
         mainCodeSourcesPath("DefaultPackage.java"),
         mainCodeSourcesPath("checks/packageInfo/HelloWorld.java"),


### PR DESCRIPTION
## Summary

This is to fix the Quality Gate.

- Implement the previously unimplemented `verifyIssueOnProject()` method in `JavaCheckVerifier` (the `newVerifier()` backend)
- Migrate `MissingPackageInfoCheckTest` from the deprecated `newInternalVerifier()` to `newVerifier()`
- Update `JavaCheckVerifierTest` to verify `verifyIssueOnProject` works instead of asserting it throws

Part of RC-16

## Test plan
- [x] All 6 `MissingPackageInfoCheckTest` tests pass
- [x] All 33 `JavaCheckVerifierTest` tests pass
- [x] All `InternalCheckVerifierTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)