### PR TITLE
SONARJAVA-6455 S7467: avoid FP when broken semantics hide lambda usages

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/MyTask.java
+++ b/java-checks-test-sources/default/src/main/java/checks/MyTask.java
@@ -1,0 +1,8 @@
+package checks;
+
+class MyTask {
+
+  public void run(Runnable consumer) {
+    // do something
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample.java
@@ -1,11 +1,9 @@
 package checks;
 
 import io.restassured.exception.PathException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
-import java.util.concurrent.*;
+
 import java.util.function.Supplier;
 
 public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample {
@@ -126,21 +124,12 @@ public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheckSample {
 
   public void e(){}
 
-  private final Logger log = LogManager.getLogger();
-
-  private void executor_run_compliant() {
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    executor.scheduleAtFixedRate(
-      () -> {
-        try {
-          Integer.parseInt("1.2");
-        } catch (Exception e) {
-          log.error("SonarQube Cloud reports 'e' should be replaced by _ while it's used", e);
-        }
-      },
-      0,
-      100_000,
-      TimeUnit.MILLISECONDS
-    );
+  public void raiseWhenInsideLambdaInUnresolvedMethod() {
+    MyTask task = new MyTask();
+    try {
+      Integer.parseInt("x");
+    } catch (NumberFormatException e) {
+      task.run(() -> System.out.println(e.getMessage()));
+    }
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ReplaceUnusedExceptionParameterWithUnnamedPatternCheck.java
@@ -19,6 +19,7 @@ package org.sonar.java.checks;
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
+import org.sonar.java.checks.helpers.UnresolvedIdentifiersVisitor;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
@@ -32,6 +33,8 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 @Rule(key = "S7467")
 public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheck extends IssuableSubscriptionVisitor implements JavaVersionAwareVisitor {
 
+  private static final UnresolvedIdentifiersVisitor UNRESOLVED_IDENTIFIERS_VISITOR = new UnresolvedIdentifiersVisitor();
+
   @Override
   public List<Tree.Kind> nodesToVisit() {
     return List.of(Tree.Kind.CATCH);
@@ -44,7 +47,10 @@ public class ReplaceUnusedExceptionParameterWithUnnamedPatternCheck extends Issu
     IdentifierTree ident = v.simpleName();
 
     // completely ignored for an absent semantic model
-    if (!ident.isUnnamedVariable() && context.getSemanticModel() != null && v.symbol().usages().isEmpty()) {
+    // also skip when the parameter name appears as an unresolved identifier in the block: broken semantics
+    // (e.g. unresolved types) can cause usages inside lambdas to go untracked
+    if (!ident.isUnnamedVariable() && context.getSemanticModel() != null && v.symbol().usages().isEmpty()
+      && !UNRESOLVED_IDENTIFIERS_VISITOR.check(catchTree.block()).contains(ident.name())) {
       QuickFixHelper.newIssue(context)
         .forRule(this)
         .onTree(ident)


### PR DESCRIPTION
When a catch parameter is used inside a lambda passed to an unresolved method, the semantic model may fail to track that usage (because the target functional interface is unknown). Use UnresolvedIdentifiersVisitor to detect this situation and skip the issue.
