### PR TITLE
SONARJAVA-6767 Implement new rule S9341: Redundant Spring annotations should be removed

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
@@ -1,0 +1,184 @@
+package checks.spring;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Controller;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+// === Stereotype redundancy ===
+
+@Component // Noncompliant {{Remove this "@Component" annotation, already implied by "@Service".}}
+@Service
+class ComponentWithService {
+}
+
+@Component // Noncompliant {{Remove this "@Component" annotation, already implied by "@Repository".}}
+@Repository
+class ComponentWithRepository {
+}
+
+@Component // Noncompliant {{Remove this "@Component" annotation, already implied by "@Controller".}}
+@Controller
+class ComponentWithController {
+}
+
+@Component // Noncompliant {{Remove this "@Component" annotation, already implied by "@Configuration".}}
+@Configuration
+class ComponentWithConfiguration {
+}
+
+// === RestController composition ===
+
+@Controller // Noncompliant {{Remove this "@Controller" annotation, already implied by "@RestController".}}
+@RestController
+class ControllerWithRestController {
+}
+
+@ResponseBody // Noncompliant {{Remove this "@ResponseBody" annotation, already implied by "@RestController".}}
+@RestController
+class ResponseBodyWithRestController {
+}
+
+// === SpringBootApplication composition ===
+
+@Configuration // Noncompliant {{Remove this "@Configuration" annotation, already implied by "@SpringBootApplication".}}
+@SpringBootApplication
+class ConfigurationWithSpringBootApp {
+}
+
+@EnableAutoConfiguration // Noncompliant {{Remove this "@EnableAutoConfiguration" annotation, already implied by "@SpringBootApplication".}}
+@SpringBootApplication
+class EnableAutoConfigWithSpringBootApp {
+}
+
+@ComponentScan // Noncompliant {{Remove this "@ComponentScan" annotation, already implied by "@SpringBootApplication".}}
+@SpringBootApplication
+class ComponentScanWithSpringBootApp {
+}
+
+@SpringBootConfiguration // Noncompliant {{Remove this "@SpringBootConfiguration" annotation, already implied by "@SpringBootApplication".}}
+@SpringBootApplication
+class SpringBootConfigWithSpringBootApp {
+}
+
+// === Multiple redundant annotations on same class ===
+
+@Configuration // Noncompliant {{Remove this "@Configuration" annotation, already implied by "@SpringBootApplication".}}
+@EnableAutoConfiguration // Noncompliant {{Remove this "@EnableAutoConfiguration" annotation, already implied by "@SpringBootApplication".}}
+@ComponentScan // Noncompliant {{Remove this "@ComponentScan" annotation, already implied by "@SpringBootApplication".}}
+@SpringBootApplication
+class AllRedundantWithSpringBootApp {
+}
+
+// === Spring Test redundancy ===
+
+@ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@SpringBootTest".}}
+@SpringBootTest
+class ExtendWithSpringExtAndSpringBootTest {
+  @Test
+  void test() {
+  }
+}
+
+@ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@WebMvcTest".}}
+@WebMvcTest
+class ExtendWithSpringExtAndWebMvcTest {
+}
+
+@ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@DataJpaTest".}}
+@DataJpaTest
+class ExtendWithSpringExtAndDataJpaTest {
+}
+
+@ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@WebFluxTest".}}
+@WebFluxTest
+class ExtendWithSpringExtAndWebFluxTest {
+}
+
+@Transactional // Noncompliant {{Remove this "@Transactional" annotation, already implied by "@DataJpaTest".}}
+@DataJpaTest
+class TransactionalWithDataJpaTest {
+}
+
+@ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@DataJpaTest".}}
+@Transactional // Noncompliant {{Remove this "@Transactional" annotation, already implied by "@DataJpaTest".}}
+@DataJpaTest
+class MultipleRedundantWithDataJpaTest {
+}
+
+// === Compliant cases ===
+
+@Service
+class ServiceAlone {
+}
+
+@Component
+class ComponentAlone {
+}
+
+@RestController
+class RestControllerAlone {
+}
+
+@SpringBootApplication
+class SpringBootAppAlone {
+}
+
+@Controller
+@ResponseBody
+class ControllerWithResponseBody {
+  @GetMapping("/foo")
+  public String get() {
+    return "foo";
+  }
+}
+
+@SpringBootApplication
+@ComponentScan(basePackages = "com.example.custom")
+class SpringBootAppWithCustomComponentScan {
+}
+
+@SpringBootTest
+class SpringBootTestAlone {
+  @Test
+  void test() {
+  }
+}
+
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+@SpringBootTest
+class ExtendWithMockitoAndSpringBootTest {
+  @Test
+  void test() {
+  }
+}
+
+@SpringBootTest
+@Transactional
+class TransactionalWithSpringBootTest {
+}
+
+@DataJpaTest
+class DataJpaTestAlone {
+}
+
+@ExtendWith({SpringExtension.class, org.mockito.junit.jupiter.MockitoExtension.class})
+@SpringBootTest
+class MixedExtensionsWithSpringBootTest {
+}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
@@ -221,6 +221,13 @@ class ComponentScanWithUseDefaultFiltersAndSpringBootApp {
 class ComponentWithBeanNameAndService {
 }
 
+// === Compliant: @Controller with explicit attributes (bean name) + @RestController ===
+
+@Controller("myCustomBeanName")
+@RestController
+class ControllerWithBeanNameAndRestController {
+}
+
 // === Compliant: @Configuration with explicit attributes + @SpringBootApplication ===
 
 @Configuration(proxyBeanMethods = false)

--- a/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
@@ -235,13 +235,6 @@ class ConfigurationWithProxyBeanMethodsAndSpringBootApp {
 class EnableAutoConfigWithExcludeAndSpringBootApp {
 }
 
-// === Compliant: @SpringBootConfiguration with explicit attributes + @SpringBootApplication ===
-
-@SpringBootConfiguration(proxyBeanMethods = false)
-@SpringBootApplication
-class SpringBootConfigWithProxyBeanMethodsAndSpringBootApp {
-}
-
 // === Compliant: Repeatable @ExtendWith — only SpringExtension instance reported, not MockitoExtension ===
 
 @ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@SpringBootTest".}}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
@@ -11,11 +11,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -181,4 +183,33 @@ class DataJpaTestAlone {
 @ExtendWith({SpringExtension.class, org.mockito.junit.jupiter.MockitoExtension.class})
 @SpringBootTest
 class MixedExtensionsWithSpringBootTest {
+}
+
+// === Compliant: @Transactional with custom attributes + @DataJpaTest ===
+
+@Transactional(readOnly = true)
+@DataJpaTest
+class TransactionalReadOnlyWithDataJpaTest {
+}
+
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DataJpaTest
+class TransactionalNotSupportedWithDataJpaTest {
+}
+
+// === Compliant: @ComponentScan with filters/other attributes + @SpringBootApplication ===
+
+@ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com.example.excluded"))
+@SpringBootApplication
+class ComponentScanWithExcludeFiltersAndSpringBootApp {
+}
+
+@ComponentScan(lazyInit = true)
+@SpringBootApplication
+class ComponentScanWithLazyInitAndSpringBootApp {
+}
+
+@ComponentScan(useDefaultFilters = false)
+@SpringBootApplication
+class ComponentScanWithUseDefaultFiltersAndSpringBootApp {
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
@@ -251,6 +251,32 @@ class RepeatableExtendWithSpringBootTest {
 class RepeatableComponentScanWithSpringBootApp {
 }
 
+// === @ExtendWith with single-element array syntax ===
+
+@ExtendWith({SpringExtension.class}) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@SpringBootTest".}}
+@SpringBootTest
+class ExtendWithArraySingleSpringExtension {
+}
+
+@ExtendWith({SpringExtension.class}) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@WebMvcTest".}}
+@WebMvcTest
+class ExtendWithArraySingleSpringExtensionWebMvc {
+}
+
+// === Compliant: @ExtendWith with explicit value= attribute (named parameter) ===
+
+@ExtendWith(value = SpringExtension.class)
+@SpringBootTest
+class ExtendWithNamedValueSpringExtension {
+}
+
+// === Compliant: @ExtendWith with single-element array containing non-SpringExtension ===
+
+@ExtendWith({org.mockito.junit.jupiter.MockitoExtension.class})
+@SpringBootTest
+class ExtendWithArraySingleMockitoExtension {
+}
+
 // === Records with redundant annotations ===
 
 @Component // Noncompliant {{Remove this "@Component" annotation, already implied by "@Service".}}

--- a/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/RedundantSpringAnnotationCheckSample.java
@@ -213,3 +213,54 @@ class ComponentScanWithLazyInitAndSpringBootApp {
 @SpringBootApplication
 class ComponentScanWithUseDefaultFiltersAndSpringBootApp {
 }
+
+// === Compliant: @Component with explicit attributes (bean name) ===
+
+@Component("orders")
+@Service
+class ComponentWithBeanNameAndService {
+}
+
+// === Compliant: @Configuration with explicit attributes + @SpringBootApplication ===
+
+@Configuration(proxyBeanMethods = false)
+@SpringBootApplication
+class ConfigurationWithProxyBeanMethodsAndSpringBootApp {
+}
+
+// === Compliant: @EnableAutoConfiguration with explicit attributes + @SpringBootApplication ===
+
+@EnableAutoConfiguration(exclude = Configuration.class)
+@SpringBootApplication
+class EnableAutoConfigWithExcludeAndSpringBootApp {
+}
+
+// === Compliant: @SpringBootConfiguration with explicit attributes + @SpringBootApplication ===
+
+@SpringBootConfiguration(proxyBeanMethods = false)
+@SpringBootApplication
+class SpringBootConfigWithProxyBeanMethodsAndSpringBootApp {
+}
+
+// === Compliant: Repeatable @ExtendWith — only SpringExtension instance reported, not MockitoExtension ===
+
+@ExtendWith(SpringExtension.class) // Noncompliant {{Remove this "@ExtendWith" annotation, already implied by "@SpringBootTest".}}
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+@SpringBootTest
+class RepeatableExtendWithSpringBootTest {
+}
+
+// === Compliant: Repeatable @ComponentScan with custom attributes — neither reported ===
+
+@ComponentScan("com.example.pkg1")
+@ComponentScan("com.example.pkg2")
+@SpringBootApplication
+class RepeatableComponentScanWithSpringBootApp {
+}
+
+// === Records with redundant annotations ===
+
+@Component // Noncompliant {{Remove this "@Component" annotation, already implied by "@Service".}}
+@Service
+record OrderServiceRecord(String name) {
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
@@ -51,7 +51,7 @@ public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor 
       List.of(SpringUtils.SERVICE_ANNOTATION, SpringUtils.REPOSITORY_ANNOTATION, SpringUtils.CONTROLLER_ANNOTATION, SpringUtils.CONFIGURATION_ANNOTATION),
       RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     new RedundancyRule(SpringUtils.CONTROLLER_ANNOTATION,
-      List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), null),
+      List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     // Class-level @ResponseBody only; method-level @ResponseBody in @RestController is handled by S6837
     new RedundancyRule(RESPONSE_BODY,
       List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), null),

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
@@ -1,0 +1,170 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.spring;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.QuickFixHelper;
+import org.sonar.java.checks.helpers.SpringUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.SymbolMetadata;
+import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9341")
+public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor {
+
+  private static final String RESPONSE_BODY = "org.springframework.web.bind.annotation.ResponseBody";
+  private static final String ENABLE_AUTO_CONFIGURATION = "org.springframework.boot.autoconfigure.EnableAutoConfiguration";
+  private static final String COMPONENT_SCAN = "org.springframework.context.annotation.ComponentScan";
+  private static final String SPRING_BOOT_CONFIGURATION = "org.springframework.boot.SpringBootConfiguration";
+  private static final String EXTEND_WITH = "org.junit.jupiter.api.extension.ExtendWith";
+  private static final String SPRING_EXTENSION = "org.springframework.test.context.junit.jupiter.SpringExtension";
+  private static final String WEB_MVC_TEST = "org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest";
+  private static final String DATA_JPA_TEST = "org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest";
+  private static final String WEB_FLUX_TEST = "org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest";
+
+  private static final List<RedundancyRule> REDUNDANCY_RULES = List.of(
+    new RedundancyRule(SpringUtils.COMPONENT_ANNOTATION,
+      List.of(SpringUtils.SERVICE_ANNOTATION, SpringUtils.REPOSITORY_ANNOTATION, SpringUtils.CONTROLLER_ANNOTATION, SpringUtils.CONFIGURATION_ANNOTATION), null),
+    new RedundancyRule(SpringUtils.CONTROLLER_ANNOTATION,
+      List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), null),
+    new RedundancyRule(RESPONSE_BODY,
+      List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), null),
+    new RedundancyRule(SpringUtils.CONFIGURATION_ANNOTATION,
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), null),
+    new RedundancyRule(ENABLE_AUTO_CONFIGURATION,
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), null),
+    new RedundancyRule(COMPONENT_SCAN,
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), RedundantSpringAnnotationCheck::isComponentScanWithoutCustomAttributes),
+    new RedundancyRule(SPRING_BOOT_CONFIGURATION,
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), null),
+    new RedundancyRule(EXTEND_WITH,
+      List.of(SpringUtils.SPRING_BOOT_TEST_ANNOTATION, WEB_MVC_TEST, DATA_JPA_TEST, WEB_FLUX_TEST),
+      RedundantSpringAnnotationCheck::isExtendWithSpringExtension),
+    new RedundancyRule(SpringUtils.TRANSACTIONAL_ANNOTATION,
+      List.of(DATA_JPA_TEST), null)
+  );
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    var classTree = (ClassTree) tree;
+    Map<String, AnnotationTree> annotationsByFqn = collectAnnotations(classTree);
+
+    for (RedundancyRule rule : REDUNDANCY_RULES) {
+      AnnotationTree redundantAnnotation = annotationsByFqn.get(rule.redundantFqn);
+      if (redundantAnnotation == null) {
+        continue;
+      }
+      for (String impliedByFqn : rule.impliedByFqns) {
+        AnnotationTree impliedByAnnotation = annotationsByFqn.get(impliedByFqn);
+        if (impliedByAnnotation != null && passesSpecialCondition(rule, classTree, impliedByFqn)) {
+          reportRedundancy(redundantAnnotation, impliedByAnnotation);
+          break;
+        }
+      }
+    }
+  }
+
+  private static Map<String, AnnotationTree> collectAnnotations(ClassTree classTree) {
+    Map<String, AnnotationTree> map = new HashMap<>();
+    for (AnnotationTree annotation : classTree.modifiers().annotations()) {
+      String fqn = annotation.annotationType().symbolType().fullyQualifiedName();
+      map.put(fqn, annotation);
+    }
+    return map;
+  }
+
+  private static boolean passesSpecialCondition(RedundancyRule rule, ClassTree classTree, String impliedByFqn) {
+    if (rule.specialCondition == null) {
+      return true;
+    }
+    return rule.specialCondition.test(classTree, impliedByFqn);
+  }
+
+  private void reportRedundancy(AnnotationTree redundantAnnotation, AnnotationTree impliedByAnnotation) {
+    String redundantName = simpleName(redundantAnnotation);
+    String impliedByName = simpleName(impliedByAnnotation);
+    QuickFixHelper.newIssue(context)
+      .forRule(this)
+      .onTree(redundantAnnotation)
+      .withMessage("Remove this \"@%s\" annotation, already implied by \"@%s\".", redundantName, impliedByName)
+      .withSecondaries(List.of(
+        new JavaFileScannerContext.Location("Already implied by this annotation.", impliedByAnnotation)))
+      .report();
+  }
+
+  private static String simpleName(AnnotationTree annotation) {
+    return annotation.annotationType().symbolType().name();
+  }
+
+  private static boolean isComponentScanWithoutCustomAttributes(ClassTree classTree, String impliedByFqn) {
+    SymbolMetadata metadata = classTree.symbol().metadata();
+    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(COMPONENT_SCAN);
+    if (values == null || values.isEmpty()) {
+      return true;
+    }
+    for (SymbolMetadata.AnnotationValue av : values) {
+      String name = av.name();
+      if ("value".equals(name) || "basePackages".equals(name) || "basePackageClasses".equals(name)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isExtendWithSpringExtension(ClassTree classTree, String impliedByFqn) {
+    SymbolMetadata metadata = classTree.symbol().metadata();
+    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(EXTEND_WITH);
+    if (values == null) {
+      return false;
+    }
+    for (SymbolMetadata.AnnotationValue av : values) {
+      if (isOnlySpringExtensionClass(av.value())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isOnlySpringExtensionClass(Object value) {
+    if (value instanceof Symbol symbol) {
+      return symbol.type().is(SPRING_EXTENSION);
+    }
+    if (value instanceof Object[] values) {
+      // Skip mixed arrays like @ExtendWith({SpringExtension.class, MockitoExtension.class})
+      // since the annotation cannot simply be removed
+      return values.length == 1 && values[0] instanceof Symbol symbol && symbol.type().is(SPRING_EXTENSION);
+    }
+    return false;
+  }
+
+  private record RedundancyRule(String redundantFqn, List<String> impliedByFqns,
+    BiPredicate<ClassTree, String> specialCondition) {
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
@@ -63,7 +63,7 @@ public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor 
       List.of(SpringUtils.SPRING_BOOT_TEST_ANNOTATION, WEB_MVC_TEST, DATA_JPA_TEST, WEB_FLUX_TEST),
       RedundantSpringAnnotationCheck::isExtendWithSpringExtension),
     new RedundancyRule(SpringUtils.TRANSACTIONAL_ANNOTATION,
-      List.of(DATA_JPA_TEST), null)
+      List.of(DATA_JPA_TEST), RedundantSpringAnnotationCheck::isTransactionalWithoutCustomAttributes)
   );
 
   @Override
@@ -126,16 +126,13 @@ public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor 
   private static boolean isComponentScanWithoutCustomAttributes(ClassTree classTree, String impliedByFqn) {
     SymbolMetadata metadata = classTree.symbol().metadata();
     List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(COMPONENT_SCAN);
-    if (values == null || values.isEmpty()) {
-      return true;
-    }
-    for (SymbolMetadata.AnnotationValue av : values) {
-      String name = av.name();
-      if ("value".equals(name) || "basePackages".equals(name) || "basePackageClasses".equals(name)) {
-        return false;
-      }
-    }
-    return true;
+    return values == null || values.isEmpty();
+  }
+
+  private static boolean isTransactionalWithoutCustomAttributes(ClassTree classTree, String impliedByFqn) {
+    SymbolMetadata metadata = classTree.symbol().metadata();
+    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(SpringUtils.TRANSACTIONAL_ANNOTATION);
+    return values == null || values.isEmpty();
   }
 
   private static boolean isExtendWithSpringExtension(ClassTree classTree, String impliedByFqn) {

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.SpringUtils;
@@ -155,12 +156,7 @@ public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor 
     return memberSelect.expression().symbolType().is(SPRING_EXTENSION);
   }
 
-  @FunctionalInterface
-  private interface AnnotationPredicate {
-    boolean test(AnnotationTree annotation);
-  }
-
   private record RedundancyRule(String redundantFqn, List<String> impliedByFqns,
-    AnnotationPredicate specialCondition) {
+    Predicate<AnnotationTree> specialCondition) {
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheck.java
@@ -16,19 +16,20 @@
  */
 package org.sonar.java.checks.spring;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiPredicate;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.SpringUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
-import org.sonar.plugins.java.api.semantic.Symbol;
-import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.NewArrayTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S9341")
@@ -46,65 +47,70 @@ public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor 
 
   private static final List<RedundancyRule> REDUNDANCY_RULES = List.of(
     new RedundancyRule(SpringUtils.COMPONENT_ANNOTATION,
-      List.of(SpringUtils.SERVICE_ANNOTATION, SpringUtils.REPOSITORY_ANNOTATION, SpringUtils.CONTROLLER_ANNOTATION, SpringUtils.CONFIGURATION_ANNOTATION), null),
+      List.of(SpringUtils.SERVICE_ANNOTATION, SpringUtils.REPOSITORY_ANNOTATION, SpringUtils.CONTROLLER_ANNOTATION, SpringUtils.CONFIGURATION_ANNOTATION),
+      RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     new RedundancyRule(SpringUtils.CONTROLLER_ANNOTATION,
       List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), null),
+    // Class-level @ResponseBody only; method-level @ResponseBody in @RestController is handled by S6837
     new RedundancyRule(RESPONSE_BODY,
       List.of(SpringUtils.REST_CONTROLLER_ANNOTATION), null),
     new RedundancyRule(SpringUtils.CONFIGURATION_ANNOTATION,
-      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), null),
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     new RedundancyRule(ENABLE_AUTO_CONFIGURATION,
-      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), null),
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     new RedundancyRule(COMPONENT_SCAN,
-      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), RedundantSpringAnnotationCheck::isComponentScanWithoutCustomAttributes),
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     new RedundancyRule(SPRING_BOOT_CONFIGURATION,
-      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), null),
+      List.of(SpringUtils.SPRING_BOOT_APP_ANNOTATION), RedundantSpringAnnotationCheck::hasNoExplicitAttributes),
     new RedundancyRule(EXTEND_WITH,
       List.of(SpringUtils.SPRING_BOOT_TEST_ANNOTATION, WEB_MVC_TEST, DATA_JPA_TEST, WEB_FLUX_TEST),
-      RedundantSpringAnnotationCheck::isExtendWithSpringExtension),
+      RedundantSpringAnnotationCheck::isExtendWithSpringExtensionOnly),
     new RedundancyRule(SpringUtils.TRANSACTIONAL_ANNOTATION,
-      List.of(DATA_JPA_TEST), RedundantSpringAnnotationCheck::isTransactionalWithoutCustomAttributes)
+      List.of(DATA_JPA_TEST), RedundantSpringAnnotationCheck::hasNoExplicitAttributes)
   );
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
-    return List.of(Tree.Kind.CLASS);
+    return List.of(Tree.Kind.CLASS, Tree.Kind.RECORD);
   }
 
   @Override
   public void visitNode(Tree tree) {
     var classTree = (ClassTree) tree;
-    Map<String, AnnotationTree> annotationsByFqn = collectAnnotations(classTree);
+    Map<String, List<AnnotationTree>> annotationsByFqn = collectAnnotations(classTree);
 
     for (RedundancyRule rule : REDUNDANCY_RULES) {
-      AnnotationTree redundantAnnotation = annotationsByFqn.get(rule.redundantFqn);
-      if (redundantAnnotation == null) {
+      List<AnnotationTree> redundantAnnotations = annotationsByFqn.get(rule.redundantFqn);
+      if (redundantAnnotations == null) {
         continue;
       }
-      for (String impliedByFqn : rule.impliedByFqns) {
-        AnnotationTree impliedByAnnotation = annotationsByFqn.get(impliedByFqn);
-        if (impliedByAnnotation != null && passesSpecialCondition(rule, classTree, impliedByFqn)) {
-          reportRedundancy(redundantAnnotation, impliedByAnnotation);
-          break;
+      for (AnnotationTree redundantAnnotation : redundantAnnotations) {
+        for (String impliedByFqn : rule.impliedByFqns) {
+          List<AnnotationTree> impliedByAnnotations = annotationsByFqn.get(impliedByFqn);
+          if (impliedByAnnotations != null && !impliedByAnnotations.isEmpty()
+            && passesSpecialCondition(rule, redundantAnnotation)) {
+            reportRedundancy(redundantAnnotation, impliedByAnnotations.get(0));
+            break;
+          }
         }
       }
     }
   }
 
-  private static Map<String, AnnotationTree> collectAnnotations(ClassTree classTree) {
-    Map<String, AnnotationTree> map = new HashMap<>();
+  private static Map<String, List<AnnotationTree>> collectAnnotations(ClassTree classTree) {
+    Map<String, List<AnnotationTree>> map = new HashMap<>();
     for (AnnotationTree annotation : classTree.modifiers().annotations()) {
       String fqn = annotation.annotationType().symbolType().fullyQualifiedName();
-      map.put(fqn, annotation);
+      map.computeIfAbsent(fqn, k -> new ArrayList<>()).add(annotation);
     }
     return map;
   }
 
-  private static boolean passesSpecialCondition(RedundancyRule rule, ClassTree classTree, String impliedByFqn) {
+  private static boolean passesSpecialCondition(RedundancyRule rule, AnnotationTree redundantAnnotation) {
     if (rule.specialCondition == null) {
       return true;
     }
-    return rule.specialCondition.test(classTree, impliedByFqn);
+    return rule.specialCondition.test(redundantAnnotation);
   }
 
   private void reportRedundancy(AnnotationTree redundantAnnotation, AnnotationTree impliedByAnnotation) {
@@ -123,45 +129,38 @@ public class RedundantSpringAnnotationCheck extends IssuableSubscriptionVisitor 
     return annotation.annotationType().symbolType().name();
   }
 
-  private static boolean isComponentScanWithoutCustomAttributes(ClassTree classTree, String impliedByFqn) {
-    SymbolMetadata metadata = classTree.symbol().metadata();
-    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(COMPONENT_SCAN);
-    return values == null || values.isEmpty();
+  private static boolean hasNoExplicitAttributes(AnnotationTree annotation) {
+    return annotation.arguments().isEmpty();
   }
 
-  private static boolean isTransactionalWithoutCustomAttributes(ClassTree classTree, String impliedByFqn) {
-    SymbolMetadata metadata = classTree.symbol().metadata();
-    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(SpringUtils.TRANSACTIONAL_ANNOTATION);
-    return values == null || values.isEmpty();
-  }
-
-  private static boolean isExtendWithSpringExtension(ClassTree classTree, String impliedByFqn) {
-    SymbolMetadata metadata = classTree.symbol().metadata();
-    List<SymbolMetadata.AnnotationValue> values = metadata.valuesForAnnotation(EXTEND_WITH);
-    if (values == null) {
+  private static boolean isExtendWithSpringExtensionOnly(AnnotationTree annotation) {
+    var arguments = annotation.arguments();
+    if (arguments.size() != 1) {
       return false;
     }
-    for (SymbolMetadata.AnnotationValue av : values) {
-      if (isOnlySpringExtensionClass(av.value())) {
-        return true;
-      }
+    ExpressionTree arg = arguments.get(0);
+    if (arg.is(Tree.Kind.MEMBER_SELECT)) {
+      return isSpringExtensionClassRef((MemberSelectExpressionTree) arg);
+    }
+    if (arg.is(Tree.Kind.NEW_ARRAY)) {
+      var initializers = ((NewArrayTree) arg).initializers();
+      return initializers.size() == 1
+        && initializers.get(0).is(Tree.Kind.MEMBER_SELECT)
+        && isSpringExtensionClassRef((MemberSelectExpressionTree) initializers.get(0));
     }
     return false;
   }
 
-  private static boolean isOnlySpringExtensionClass(Object value) {
-    if (value instanceof Symbol symbol) {
-      return symbol.type().is(SPRING_EXTENSION);
-    }
-    if (value instanceof Object[] values) {
-      // Skip mixed arrays like @ExtendWith({SpringExtension.class, MockitoExtension.class})
-      // since the annotation cannot simply be removed
-      return values.length == 1 && values[0] instanceof Symbol symbol && symbol.type().is(SPRING_EXTENSION);
-    }
-    return false;
+  private static boolean isSpringExtensionClassRef(MemberSelectExpressionTree memberSelect) {
+    return memberSelect.expression().symbolType().is(SPRING_EXTENSION);
+  }
+
+  @FunctionalInterface
+  private interface AnnotationPredicate {
+    boolean test(AnnotationTree annotation);
   }
 
   private record RedundancyRule(String redundantFqn, List<String> impliedByFqns,
-    BiPredicate<ClassTree, String> specialCondition) {
+    AnnotationPredicate specialCondition) {
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/spring/RedundantSpringAnnotationCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.spring;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class RedundantSpringAnnotationCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/RedundantSpringAnnotationCheckSample.java"))
+      .withCheck(new RedundantSpringAnnotationCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/spring/RedundantSpringAnnotationCheckSample.java"))
+      .withCheck(new RedundantSpringAnnotationCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9341.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9341.html
@@ -1,0 +1,82 @@
+<h2>Why is this an issue?</h2>
+<p>Some Spring annotations are composed from other annotations through meta-annotation. When you use an annotation that already includes another
+annotation's behavior, explicitly adding the parent annotation is redundant. It creates visual noise and may indicate a misunderstanding of the
+framework's annotation composition model.</p>
+<p>Common examples include:</p>
+<ul>
+  <li><code>@RestController</code> is meta-annotated with <code>@Controller</code> and <code>@ResponseBody</code></li>
+  <li><code>@Service</code>, <code>@Repository</code>, <code>@Controller</code>, and <code>@Configuration</code> are meta-annotated with
+  <code>@Component</code></li>
+  <li><code>@SpringBootApplication</code> is meta-annotated with <code>@Configuration</code>, <code>@EnableAutoConfiguration</code>, and
+  <code>@ComponentScan</code></li>
+  <li>Spring test annotations like <code>@SpringBootTest</code> already include <code>@ExtendWith(SpringExtension.class)</code></li>
+</ul>
+<h2>How to fix it in Spring</h2>
+<p>Remove the redundant parent annotation. Keep only the most specific annotation that provides the functionality you need.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@Component // Noncompliant, @Service already implies @Component
+@Service
+public class UserService {
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@Service
+public class UserService {
+}
+</pre>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+@Controller // Noncompliant, @RestController already implies @Controller
+@RestController
+public class UserController {
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+@RestController
+public class UserController {
+}
+</pre>
+<h2>How to fix it in Spring Boot</h2>
+<p>Remove <code>@Configuration</code>, <code>@EnableAutoConfiguration</code>, and <code>@ComponentScan</code> (when used without custom
+attributes) since <code>@SpringBootApplication</code> already includes all of these.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="3" data-diff-type="noncompliant">
+@Configuration // Noncompliant
+@SpringBootApplication
+public class MyApplication {
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="3" data-diff-type="compliant">
+@SpringBootApplication
+public class MyApplication {
+}
+</pre>
+<h2>How to fix it in Spring Test</h2>
+<p>Remove <code>@ExtendWith(SpringExtension.class)</code> when using specialized test annotations like <code>@SpringBootTest</code>,
+<code>@WebMvcTest</code>, <code>@DataJpaTest</code>, or <code>@WebFluxTest</code> since they already include this extension.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="4" data-diff-type="noncompliant">
+@ExtendWith(SpringExtension.class) // Noncompliant
+@SpringBootTest
+class UserServiceIntegrationTest {
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="4" data-diff-type="compliant">
+@SpringBootTest
+class UserServiceIntegrationTest {
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Spring Framework Documentation - <a href="https://docs.spring.io/spring-framework/reference/core/beans/classpath-scanning.html#beans-meta-annotations">Meta-Annotations and Composed Annotations</a></li>
+  <li>Spring Boot Documentation - <a href="https://docs.spring.io/spring-boot/reference/using/using-the-springbootapplication-annotation.html">Using the @SpringBootApplication Annotation</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9341.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9341.json
@@ -1,0 +1,23 @@
+{
+  "title": "Redundant Spring annotations should be removed",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "spring"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9341",
+  "sqKey": "S9341",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
Detect redundant Spring annotations where a more specific composed annotation already implies the parent. Covers stereotype annotations (@Component with @Service/@Repository/@Controller/@Configuration), @RestController composition, @SpringBootApplication composition, and Spring test annotation redundancies.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->
