### PR TITLE
SONARJAVA-6764 Implement cache for BeanDefinitionGatherer

### DIFF
--- a/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/java/it/JavaRulingTest.java
@@ -205,7 +205,8 @@ public class JavaRulingTest {
     String projectName = "guava";
     MavenBuild build = test_project("com.google.guava:guava", projectName);
     build
-      .setProperty("java.version", "17")
+      // Keep compilation and analysis on Java 17 without overriding the Java runtime version seen by the scanner.
+      .setProperty("sonar.java.source", "17")
       .setProperty("maven-bundle-plugin.version", "5.1.4")
       .setProperty("maven.javadoc.skip", "true")
       .setProperty("animal.sniffer.skip", "true")

--- a/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
@@ -19,6 +19,7 @@ package org.sonar.java.model.springcontext;
 import java.beans.Introspector;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -156,8 +157,9 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
   private static String serializeBean(BeanData bean) {
     var deps = String.join(DEP_SEPARATOR, bean.dependingBeans());
     var span = bean.textSpan();
+    var encodedName = Base64.getEncoder().encodeToString(bean.beanName().getBytes(StandardCharsets.UTF_8));
     return String.join(FIELD_SEPARATOR,
-      bean.beanName(),
+      encodedName,
       bean.type(),
       bean.beanPackage(),
       span.startLine + ":" + span.startCharacter + ":" + span.endLine + ":" + span.endCharacter,
@@ -199,15 +201,20 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
     if (content.isEmpty()) {
       return Optional.of(List.of());
     }
-    var beans = content.lines()
-      .map(line -> deserializeBean(line, ctx.getInputFile()))
-      .toList();
-    return Optional.of(beans);
+    try {
+      var beans = content.lines()
+        .map(line -> deserializeBean(line, ctx.getInputFile()))
+        .toList();
+      return Optional.of(beans);
+    } catch (RuntimeException e) {
+      LOG.trace("Failed to deserialize cached beans for '{}', will re-parse.", cacheKey);
+      return Optional.empty();
+    }
   }
 
   private static BeanData deserializeBean(String line, InputFile inputFile) {
     String[] fields = line.split("\\" + FIELD_SEPARATOR, -1);
-    String beanName = fields[0];
+    String beanName = new String(Base64.getDecoder().decode(fields[0]), StandardCharsets.UTF_8);
     String type = fields[1];
     String beanPackage = fields[2];
     String[] spanParts = fields[3].split(":");

--- a/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
@@ -196,15 +196,16 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
     if (bytes == null) {
       return Optional.empty();
     }
-    ctx.getCacheContext().getWriteCache().copyFromPrevious(cacheKey);
     String content = new String(bytes, StandardCharsets.UTF_8);
     if (content.isEmpty()) {
+      ctx.getCacheContext().getWriteCache().copyFromPrevious(cacheKey);
       return Optional.of(List.of());
     }
     try {
       var beans = content.lines()
         .map(line -> deserializeBean(line, ctx.getInputFile()))
         .toList();
+      ctx.getCacheContext().getWriteCache().copyFromPrevious(cacheKey);
       return Optional.of(beans);
     } catch (RuntimeException e) {
       LOG.trace("Failed to deserialize cached beans for '{}', will re-parse.", cacheKey);

--- a/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
@@ -17,9 +17,13 @@
 package org.sonar.java.model.springcontext;
 
 import java.beans.Introspector;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.java.reporting.AnalyzerMessage;
 import org.sonar.java.utils.PackageUtils;
@@ -52,9 +56,19 @@ import org.sonar.plugins.java.api.tree.VariableTree;
  */
 public class BeanDefinitionGatherer extends SpringContextModelGatherer {
 
+  private static final Logger LOG = LoggerFactory.getLogger(BeanDefinitionGatherer.class);
+
+  private static final String CACHE_KEY_PREFIX = "java:spring:bean-definitions:";
+  private static final String BEAN_SEPARATOR = "\n";
+  private static final String FIELD_SEPARATOR = "|";
+  private static final String DEP_SEPARATOR = ",";
+
   private static final String PRIMARY_ANNOTATION = "org.springframework.context.annotation.Primary";
 
   private final List<BeanData> collectedBeans = new ArrayList<>();
+
+  /** Beans found in the file currently being scanned, used for per-file cache writes. */
+  private final List<BeanData> beansCollectedAtFileLevel = new ArrayList<>();
 
   private record BeanData(
     String beanName,
@@ -64,6 +78,12 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
     AnalyzerMessage.TextSpan textSpan,
     boolean isPrimary,
     List<String> dependingBeans) {
+  }
+
+  @Override
+  public void setContext(JavaFileScannerContext context) {
+    beansCollectedAtFileLevel.clear();
+    super.setContext(context);
   }
 
   @Override
@@ -93,12 +113,55 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
         AnalyzerMessage.textSpanFor(classTree.simpleName()),
         meta.isAnnotatedWith(PRIMARY_ANNOTATION),
         deps));
+      beansCollectedAtFileLevel.add(new BeanData(
+        beanName, fqn, pkg,
+        context.getInputFile(),
+        AnalyzerMessage.textSpanFor(classTree.simpleName()),
+        meta.isAnnotatedWith(PRIMARY_ANNOTATION),
+        deps));
 
       // @Bean methods — only if class is a configuration/component class
       for (MethodTree method : SpringUtils.getBeanMethods(classTree)) {
         collectBeanMethod(method, pkg);
       }
     }
+  }
+
+  @Override
+  public void leaveFile(JavaFileScannerContext context) {
+    if (context.getCacheContext().isCacheEnabled()) {
+      writeToCache(context, beansCollectedAtFileLevel);
+    }
+    beansCollectedAtFileLevel.clear();
+  }
+
+  private static String cacheKey(InputFile inputFile) {
+    return CACHE_KEY_PREFIX + inputFile.key();
+  }
+
+  private static void writeToCache(JavaFileScannerContext context, List<BeanData> beans) {
+    var cacheKey = cacheKey(context.getInputFile());
+    var data = beans.stream()
+      .map(BeanDefinitionGatherer::serializeBean)
+      .collect(Collectors.joining(BEAN_SEPARATOR))
+      .getBytes(StandardCharsets.UTF_8);
+    try {
+      context.getCacheContext().getWriteCache().write(cacheKey, data);
+    } catch (IllegalArgumentException e) {
+      LOG.trace("Tried to write multiple times to cache key '{}'. Ignoring writes after the first.", cacheKey);
+    }
+  }
+
+  private static String serializeBean(BeanData bean) {
+    var deps = String.join(DEP_SEPARATOR, bean.dependingBeans());
+    var span = bean.textSpan();
+    return String.join(FIELD_SEPARATOR,
+      bean.beanName(),
+      bean.type(),
+      bean.beanPackage(),
+      span.startLine + ":" + span.startCharacter + ":" + span.endLine + ":" + span.endCharacter,
+      Boolean.toString(bean.isPrimary()),
+      deps);
   }
 
   @Override
@@ -118,9 +181,43 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
 
   @Override
   public boolean scanWithoutParsing(InputFileScannerContext ctx) {
-    // Bean data is not cached yet; force parsing so beans are
-    // always collected even for unchanged files in incremental runs.
-    return false;
+    return readFromCache(ctx).map(beans -> {
+      collectedBeans.addAll(beans);
+      return true;
+    }).orElse(false);
+  }
+
+  private static Optional<List<BeanData>> readFromCache(InputFileScannerContext ctx) {
+    var cacheKey = cacheKey(ctx.getInputFile());
+    var bytes = ctx.getCacheContext().getReadCache().readBytes(cacheKey);
+    if (bytes == null) {
+      return Optional.empty();
+    }
+    ctx.getCacheContext().getWriteCache().copyFromPrevious(cacheKey);
+    String content = new String(bytes, StandardCharsets.UTF_8);
+    if (content.isEmpty()) {
+      return Optional.of(List.of());
+    }
+    var beans = content.lines()
+      .map(line -> deserializeBean(line, ctx.getInputFile()))
+      .toList();
+    return Optional.of(beans);
+  }
+
+  private static BeanData deserializeBean(String line, InputFile inputFile) {
+    String[] fields = line.split("\\" + FIELD_SEPARATOR, -1);
+    String beanName = fields[0];
+    String type = fields[1];
+    String beanPackage = fields[2];
+    String[] spanParts = fields[3].split(":");
+    var textSpan = new AnalyzerMessage.TextSpan(
+      Integer.parseInt(spanParts[0]),
+      Integer.parseInt(spanParts[1]),
+      Integer.parseInt(spanParts[2]),
+      Integer.parseInt(spanParts[3]));
+    boolean isPrimary = Boolean.parseBoolean(fields[4]);
+    List<String> deps = fields[5].isEmpty() ? List.of() : List.of(fields[5].split(DEP_SEPARATOR));
+    return new BeanData(beanName, type, beanPackage, inputFile, textSpan, isPrimary, deps);
   }
 
   private static Optional<String> extractBeanName(SymbolMetadata meta) {
@@ -170,6 +267,12 @@ public class BeanDefinitionGatherer extends SpringContextModelGatherer {
       .toList();
 
     collectedBeans.add(new BeanData(
+      beanName, returnTypeFqn, pkg,
+      context.getInputFile(),
+      AnalyzerMessage.textSpanFor(method.simpleName()),
+      beanMeta.isAnnotatedWith(PRIMARY_ANNOTATION),
+      paramDeps));
+    beansCollectedAtFileLevel.add(new BeanData(
       beanName, returnTypeFqn, pkg,
       context.getInputFile(),
       AnalyzerMessage.textSpanFor(method.simpleName()),

--- a/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/springcontext/BeanDefinitionGatherer.java
@@ -29,6 +29,7 @@ import org.sonar.java.reporting.AnalyzerMessage;
 import org.sonar.java.utils.PackageUtils;
 import org.sonar.java.utils.SpringUtils;
 import org.sonar.plugins.java.api.InputFileScannerContext;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.ModuleScannerContext;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.tree.ClassTree;

--- a/java-frontend/src/test/java/org/sonar/java/model/springcontext/BeanDefinitionGathererTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/springcontext/BeanDefinitionGathererTest.java
@@ -18,6 +18,7 @@ package org.sonar.java.model.springcontext;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -246,8 +247,9 @@ class BeanDefinitionGathererTest extends SpringContextGathererTest {
       anyString(),
       dataCaptor.capture());
     String serialized = new String(dataCaptor.getValue(), StandardCharsets.UTF_8);
+    String encodedName = Base64.getEncoder().encodeToString("simpleComponent".getBytes(StandardCharsets.UTF_8));
     assertThat(serialized)
-      .contains("simpleComponent")
+      .contains(encodedName)
       .contains("checks.spring.context.SimpleComponent")
       .contains("checks.spring.context")
       .contains("false");
@@ -257,7 +259,8 @@ class BeanDefinitionGathererTest extends SpringContextGathererTest {
   void scanWithoutParsing_returns_true_and_restores_beans_on_cache_hit() {
     InputFile inputFile = TestUtils.inputFile(new File("src/test/files/springcontext/SimpleComponent.java"));
     String cacheKey = "java:spring:bean-definitions:" + inputFile.key();
-    String serialized = "simpleComponent|checks.spring.context.SimpleComponent|checks.spring.context|6:6:6:21|false|";
+    String encodedName = Base64.getEncoder().encodeToString("simpleComponent".getBytes(StandardCharsets.UTF_8));
+    String serialized = encodedName + "|checks.spring.context.SimpleComponent|checks.spring.context|6:6:6:21|false|";
 
     JavaReadCache readCache = mock(JavaReadCache.class);
     when(readCache.readBytes(cacheKey)).thenReturn(serialized.getBytes(StandardCharsets.UTF_8));
@@ -326,6 +329,22 @@ class BeanDefinitionGathererTest extends SpringContextGathererTest {
 
     assertThatCode(() -> scan(ctx, "src/test/files/springcontext/SimpleComponent.java"))
       .doesNotThrowAnyException();
+  }
+
+  @Test
+  void scanWithoutParsing_returns_false_on_corrupted_cache_entry() {
+    InputFile inputFile = TestUtils.inputFile(new File("src/test/files/springcontext/SimpleComponent.java"));
+    String cacheKey = "java:spring:bean-definitions:" + inputFile.key();
+
+    JavaReadCache readCache = mock(JavaReadCache.class);
+    when(readCache.readBytes(cacheKey)).thenReturn("not|valid|cache|content".getBytes(StandardCharsets.UTF_8));
+    CacheContext cacheContext = mockCacheContext(readCache, mock(JavaWriteCache.class));
+
+    InputFileScannerContext context = mock(InputFileScannerContext.class);
+    when(context.getInputFile()).thenReturn(inputFile);
+    when(context.getCacheContext()).thenReturn(cacheContext);
+
+    assertThat(gatherer.scanWithoutParsing(context)).isFalse();
   }
 
   private static CacheContext mockCacheContext(JavaReadCache readCache, JavaWriteCache writeCache) {

--- a/java-frontend/src/test/java/org/sonar/java/model/springcontext/BeanDefinitionGathererTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/springcontext/BeanDefinitionGathererTest.java
@@ -16,6 +16,8 @@
  */
 package org.sonar.java.model.springcontext;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,8 +25,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.cache.WriteCache;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.java.TestUtils;
+import org.sonar.plugins.java.api.InputFileScannerContext;
+import org.sonar.plugins.java.api.ModuleScannerContext;
+import org.sonar.plugins.java.api.caching.CacheContext;
+import org.sonar.plugins.java.api.caching.JavaReadCache;
+import org.sonar.plugins.java.api.caching.JavaWriteCache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class BeanDefinitionGathererTest extends SpringContextGathererTest {
 
@@ -209,5 +228,111 @@ class BeanDefinitionGathererTest extends SpringContextGathererTest {
     var beans = model.getBeanDefinitionRegistry().getByName("simpleComponent");
     assertThat(beans).hasSize(1);
     assertThat(beans.get(0).getBeanPackage()).isEqualTo("checks.spring.context");
+  }
+
+  // ---- Caching --------------------------------------------------------------
+
+  @Test
+  void leaveFile_writes_beans_to_cache() {
+    WriteCache writeCache = mock(WriteCache.class);
+    SensorContextTester ctx = SensorContextTester.create(new File(""));
+    ctx.setCacheEnabled(true);
+    ctx.setNextCache(writeCache);
+
+    scan(ctx, "src/test/files/springcontext/SimpleComponent.java");
+
+    var dataCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(writeCache).write(
+      anyString(),
+      dataCaptor.capture());
+    String serialized = new String(dataCaptor.getValue(), StandardCharsets.UTF_8);
+    assertThat(serialized)
+      .contains("simpleComponent")
+      .contains("checks.spring.context.SimpleComponent")
+      .contains("checks.spring.context")
+      .contains("false");
+  }
+
+  @Test
+  void scanWithoutParsing_returns_true_and_restores_beans_on_cache_hit() {
+    InputFile inputFile = TestUtils.inputFile(new File("src/test/files/springcontext/SimpleComponent.java"));
+    String cacheKey = "java:spring:bean-definitions:" + inputFile.key();
+    String serialized = "simpleComponent|checks.spring.context.SimpleComponent|checks.spring.context|6:6:6:21|false|";
+
+    JavaReadCache readCache = mock(JavaReadCache.class);
+    when(readCache.readBytes(cacheKey)).thenReturn(serialized.getBytes(StandardCharsets.UTF_8));
+    CacheContext cacheContext = mockCacheContext(readCache, mock(JavaWriteCache.class));
+
+    InputFileScannerContext context = mock(InputFileScannerContext.class);
+    when(context.getInputFile()).thenReturn(inputFile);
+    when(context.getCacheContext()).thenReturn(cacheContext);
+
+    assertThat(gatherer.scanWithoutParsing(context)).isTrue();
+
+    ModuleScannerContext moduleScannerContext = mock(ModuleScannerContext.class);
+    when(moduleScannerContext.getModuleKey()).thenReturn("");
+    gatherer.gatherSpringContextData(moduleScannerContext, model);
+
+    var beans = model.getBeanDefinitionRegistry().getByName("simpleComponent");
+    assertThat(beans).hasSize(1);
+    assertThat(beans.get(0).getType()).isEqualTo("checks.spring.context.SimpleComponent");
+    assertThat(beans.get(0).isPrimary()).isFalse();
+  }
+
+  @Test
+  void scanWithoutParsing_returns_false_on_cache_miss() {
+    InputFile inputFile = TestUtils.inputFile(new File("src/test/files/springcontext/SimpleComponent.java"));
+
+    JavaReadCache readCache = mock(JavaReadCache.class);
+    when(readCache.readBytes(anyString())).thenReturn(null);
+    CacheContext cacheContext = mockCacheContext(readCache, mock(JavaWriteCache.class));
+
+    InputFileScannerContext context = mock(InputFileScannerContext.class);
+    when(context.getInputFile()).thenReturn(inputFile);
+    when(context.getCacheContext()).thenReturn(cacheContext);
+
+    assertThat(gatherer.scanWithoutParsing(context)).isFalse();
+  }
+
+  @Test
+  void scanWithoutParsing_restores_empty_bean_list_from_cache() {
+    InputFile inputFile = TestUtils.inputFile(new File("src/test/files/springcontext/NoScanAnnotations.java"));
+    String cacheKey = "java:spring:bean-definitions:" + inputFile.key();
+
+    JavaReadCache readCache = mock(JavaReadCache.class);
+    when(readCache.readBytes(cacheKey)).thenReturn("".getBytes(StandardCharsets.UTF_8));
+    CacheContext cacheContext = mockCacheContext(readCache, mock(JavaWriteCache.class));
+
+    InputFileScannerContext context = mock(InputFileScannerContext.class);
+    when(context.getInputFile()).thenReturn(inputFile);
+    when(context.getCacheContext()).thenReturn(cacheContext);
+
+    assertThat(gatherer.scanWithoutParsing(context)).isTrue();
+
+    ModuleScannerContext moduleScannerContext = mock(ModuleScannerContext.class);
+    when(moduleScannerContext.getModuleKey()).thenReturn("");
+    gatherer.gatherSpringContextData(moduleScannerContext, model);
+
+    assertThat(model.getBeanDefinitionRegistry().getByName("noScanAnnotations")).isEmpty();
+  }
+
+  @Test
+  void duplicate_cache_write_is_silently_ignored() {
+    WriteCache writeCache = mock(WriteCache.class);
+    doThrow(new IllegalArgumentException("duplicate key")).when(writeCache).write(anyString(), any(byte[].class));
+    SensorContextTester ctx = SensorContextTester.create(new File(""));
+    ctx.setCacheEnabled(true);
+    ctx.setNextCache(writeCache);
+
+    assertThatCode(() -> scan(ctx, "src/test/files/springcontext/SimpleComponent.java"))
+      .doesNotThrowAnyException();
+  }
+
+  private static CacheContext mockCacheContext(JavaReadCache readCache, JavaWriteCache writeCache) {
+    CacheContext cacheContext = mock(CacheContext.class);
+    when(cacheContext.isCacheEnabled()).thenReturn(true);
+    when(cacheContext.getReadCache()).thenReturn(readCache);
+    when(cacheContext.getWriteCache()).thenReturn(writeCache);
+    return cacheContext;
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/model/springcontext/BeanDefinitionGathererTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/springcontext/BeanDefinitionGathererTest.java
@@ -48,12 +48,12 @@ class BeanDefinitionGathererTest extends SpringContextGathererTest {
 
   static Stream<Arguments> stereotypeAnnotationArguments() {
     return Stream.of(
-      Arguments.of("src/test/files/springcontext/SimpleComponent.java",          "simpleComponent",      "checks.spring.context.SimpleComponent"),
-      Arguments.of("src/test/files/springcontext/SimpleService.java",            "simpleService",        "checks.spring.context.SimpleService"),
-      Arguments.of("src/test/files/springcontext/SimpleRepository.java",         "simpleRepository",     "checks.spring.context.SimpleRepository"),
-      Arguments.of("src/test/files/springcontext/SimpleController.java",         "simpleController",     "checks.spring.context.SimpleController"),
-      Arguments.of("src/test/files/springcontext/SimpleRestController.java",     "simpleRestController", "checks.spring.context.SimpleRestController"),
-      Arguments.of("src/test/files/springcontext/SimpleConfiguration.java",      "simpleConfiguration",  "checks.spring.context.SimpleConfiguration"),
+      Arguments.of("src/test/files/springcontext/SimpleComponent.java", "simpleComponent", "checks.spring.context.SimpleComponent"),
+      Arguments.of("src/test/files/springcontext/SimpleService.java", "simpleService", "checks.spring.context.SimpleService"),
+      Arguments.of("src/test/files/springcontext/SimpleRepository.java", "simpleRepository", "checks.spring.context.SimpleRepository"),
+      Arguments.of("src/test/files/springcontext/SimpleController.java", "simpleController", "checks.spring.context.SimpleController"),
+      Arguments.of("src/test/files/springcontext/SimpleRestController.java", "simpleRestController", "checks.spring.context.SimpleRestController"),
+      Arguments.of("src/test/files/springcontext/SimpleConfiguration.java", "simpleConfiguration", "checks.spring.context.SimpleConfiguration"),
       Arguments.of("src/test/files/springcontext/ConfigurationWithBeanMethods.java", "simpleServiceBean", "org.springframework.context.ApplicationContext")
     );
   }
@@ -180,9 +180,9 @@ class BeanDefinitionGathererTest extends SpringContextGathererTest {
 
   static Stream<Arguments> dependencyCollectionArguments() {
     return Stream.of(
-      Arguments.of("src/test/files/springcontext/AutowiredDependencies.java",            "autowiredDependencies"),
+      Arguments.of("src/test/files/springcontext/AutowiredDependencies.java", "autowiredDependencies"),
       Arguments.of("src/test/files/springcontext/AutowiredConstructorDependencies.java", "autowiredConstructorDependencies"),
-      Arguments.of("src/test/files/springcontext/BeanMethodWithDependencies.java",       "myBean")
+      Arguments.of("src/test/files/springcontext/BeanMethodWithDependencies.java", "myBean")
     );
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Caching:**
    - Implemented caching mechanism for `BeanDefinitionGatherer` in `BeanDefinitionGatherer.java`
    - Added comprehensive unit tests covering cache hits, misses, serialization, and error handling

<sub>This will update automatically on new commits.</sub>