### PR TITLE
SONARJAVA-6759: Avoid overlap between S1244 and S9147 for NaN comparisons

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/FloatEquality.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FloatEquality.java
@@ -64,6 +64,9 @@ class FloatEquality {
     if (f != Float.NaN) {} // Compliant - covered by S9147
     if (Float.NaN == f) {} // Compliant - covered by S9147
     if (d == (Double.NaN)) {} // Compliant - covered by S9147
+    if (f == (Float.NaN)) {} // Compliant - covered by S9147
     if (d == NaN) {} // Compliant - covered by S9147 (static import)
+    if (Double.NaN == Double.NaN) {} // Compliant - covered by S9147 (NaN on both sides)
+    if (f == f) {} // Compliant - NaN self-test pattern
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FloatEquality.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FloatEquality.java
@@ -1,5 +1,7 @@
 package checks;
 
+import static java.lang.Double.NaN;
+
 class FloatEquality {
   void foo() {
     float f1 = 0.1f;
@@ -50,5 +52,18 @@ class FloatEquality {
     if (d1.equals(d2)) { } // Noncompliant
     if (f1.equals(f2)) { } // Noncompliant
     if (new Object().equals(f2)) { } //compliant
+  }
+
+  void nanComparisons() {
+    double d = 0.1d;
+    float f = 0.1f;
+    if (d == Double.NaN) {} // Compliant - covered by S9147
+    if (d != Double.NaN) {} // Compliant - covered by S9147
+    if (Double.NaN == d) {} // Compliant - covered by S9147
+    if (f == Float.NaN) {} // Compliant - covered by S9147
+    if (f != Float.NaN) {} // Compliant - covered by S9147
+    if (Float.NaN == f) {} // Compliant - covered by S9147
+    if (d == (Double.NaN)) {} // Compliant - covered by S9147
+    if (d == NaN) {} // Compliant - covered by S9147 (static import)
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FloatEquality.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FloatEquality.java
@@ -68,5 +68,7 @@ class FloatEquality {
     if (d == NaN) {} // Compliant - covered by S9147 (static import)
     if (Double.NaN == Double.NaN) {} // Compliant - covered by S9147 (NaN on both sides)
     if (f == f) {} // Compliant - NaN self-test pattern
+    if (d == Double.MAX_VALUE) {} // Noncompliant {{Equality tests should not be made with floating point values.}}
+    if (Double.NaN == Float.NaN) {} // Compliant - covered by S9147
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/FloatEqualityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FloatEqualityCheck.java
@@ -18,18 +18,14 @@ package org.sonar.java.checks;
 
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.SyntacticEquivalence;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
-import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
-import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
@@ -93,36 +89,8 @@ public class FloatEqualityCheck extends IssuableSubscriptionVisitor {
 
   private static boolean isNanTest(BinaryExpressionTree binaryExpressionTree) {
     return SyntacticEquivalence.areEquivalent(binaryExpressionTree.leftOperand(), binaryExpressionTree.rightOperand())
-      || isNanExpression(binaryExpressionTree.leftOperand())
-      || isNanExpression(binaryExpressionTree.rightOperand());
-  }
-
-  private static boolean isNanExpression(ExpressionTree expression) {
-    ExpressionTree expr = ExpressionUtils.skipParentheses(expression);
-    if (expr.is(Tree.Kind.MEMBER_SELECT)) {
-      MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expr;
-      if ("NaN".equals(memberSelect.identifier().name())) {
-        return isFloatingPointNan(memberSelect.identifier().symbol());
-      }
-    } else if (expr.is(Tree.Kind.IDENTIFIER)) {
-      IdentifierTree identifier = (IdentifierTree) expr;
-      if ("NaN".equals(identifier.name())) {
-        return isFloatingPointNan(identifier.symbol());
-      }
-    }
-    return false;
-  }
-
-  private static boolean isFloatingPointNan(@Nullable Symbol symbol) {
-    if (symbol == null || symbol.isUnknown()) {
-      return false;
-    }
-    Symbol owner = symbol.owner();
-    if (owner == null || owner.type() == null) {
-      return false;
-    }
-    Type ownerType = owner.type();
-    return ownerType.is("java.lang.Double") || ownerType.is("java.lang.Float");
+      || ExpressionUtils.getNanOwnerTypeName(binaryExpressionTree.leftOperand()) != null
+      || ExpressionUtils.getNanOwnerTypeName(binaryExpressionTree.rightOperand()) != null;
   }
 
   private static boolean hasFloatingType(ExpressionTree expressionTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/FloatEqualityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FloatEqualityCheck.java
@@ -18,13 +18,18 @@ package org.sonar.java.checks;
 
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.SyntacticEquivalence;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
@@ -87,7 +92,37 @@ public class FloatEqualityCheck extends IssuableSubscriptionVisitor {
 
 
   private static boolean isNanTest(BinaryExpressionTree binaryExpressionTree) {
-    return SyntacticEquivalence.areEquivalent(binaryExpressionTree.leftOperand(), binaryExpressionTree.rightOperand());
+    return SyntacticEquivalence.areEquivalent(binaryExpressionTree.leftOperand(), binaryExpressionTree.rightOperand())
+      || isNanExpression(binaryExpressionTree.leftOperand())
+      || isNanExpression(binaryExpressionTree.rightOperand());
+  }
+
+  private static boolean isNanExpression(ExpressionTree expression) {
+    ExpressionTree expr = ExpressionUtils.skipParentheses(expression);
+    if (expr.is(Tree.Kind.MEMBER_SELECT)) {
+      MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expr;
+      if ("NaN".equals(memberSelect.identifier().name())) {
+        return isFloatingPointNan(memberSelect.identifier().symbol());
+      }
+    } else if (expr.is(Tree.Kind.IDENTIFIER)) {
+      IdentifierTree identifier = (IdentifierTree) expr;
+      if ("NaN".equals(identifier.name())) {
+        return isFloatingPointNan(identifier.symbol());
+      }
+    }
+    return false;
+  }
+
+  private static boolean isFloatingPointNan(@Nullable Symbol symbol) {
+    if (symbol == null || symbol.isUnknown()) {
+      return false;
+    }
+    Symbol owner = symbol.owner();
+    if (owner == null || owner.type() == null) {
+      return false;
+    }
+    Type ownerType = owner.type();
+    return ownerType.is("java.lang.Double") || ownerType.is("java.lang.Float");
   }
 
   private static boolean hasFloatingType(ExpressionTree expressionTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/NanEqualityCheck.java
@@ -17,16 +17,10 @@
 package org.sonar.java.checks;
 
 import java.util.List;
-import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
-import org.sonar.plugins.java.api.semantic.Symbol;
-import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
-import org.sonar.plugins.java.api.tree.ExpressionTree;
-import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S9147")
@@ -40,47 +34,14 @@ public class NanEqualityCheck extends IssuableSubscriptionVisitor {
   @Override
   public void visitNode(Tree tree) {
     BinaryExpressionTree binaryExpression = (BinaryExpressionTree) tree;
-    String typeName = getNanTypeName(binaryExpression.leftOperand());
+    String typeName = ExpressionUtils.getNanOwnerTypeName(binaryExpression.leftOperand());
     if (typeName == null) {
-      typeName = getNanTypeName(binaryExpression.rightOperand());
+      typeName = ExpressionUtils.getNanOwnerTypeName(binaryExpression.rightOperand());
     }
     if (typeName != null) {
       reportIssue(binaryExpression.operatorToken(),
         String.format("Use \"%s.isNaN()\" instead of comparison with \"%s.NaN\".", typeName, typeName));
     }
-  }
-
-  @Nullable
-  private static String getNanTypeName(ExpressionTree expression) {
-    ExpressionTree expr = ExpressionUtils.skipParentheses(expression);
-    if (expr.is(Tree.Kind.MEMBER_SELECT)) {
-      MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expr;
-      if ("NaN".equals(memberSelect.identifier().name())) {
-        return resolveNanOwnerType(memberSelect.identifier().symbol());
-      }
-    } else if (expr.is(Tree.Kind.IDENTIFIER)) {
-      IdentifierTree identifier = (IdentifierTree) expr;
-      if ("NaN".equals(identifier.name())) {
-        return resolveNanOwnerType(identifier.symbol());
-      }
-    }
-    return null;
-  }
-
-  @Nullable
-  private static String resolveNanOwnerType(Symbol symbol) {
-    if (symbol.isUnknown()) {
-      return null;
-    }
-    Symbol owner = symbol.owner();
-    if (owner == null || owner.type() == null) {
-      return null;
-    }
-    Type ownerType = owner.type();
-    if (ownerType.is("java.lang.Double") || ownerType.is("java.lang.Float")) {
-      return ownerType.name();
-    }
-    return null;
   }
 
 }

--- a/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/ExpressionUtils.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -401,6 +402,39 @@ public final class ExpressionUtils {
       return ((IdentifierTree) assignment.variable()).name();
     }
     return "value";
+  }
+
+  @Nullable
+  public static String getNanOwnerTypeName(ExpressionTree expression) {
+    ExpressionTree expr = skipParentheses(expression);
+    if (expr.is(Tree.Kind.MEMBER_SELECT)) {
+      MemberSelectExpressionTree memberSelect = (MemberSelectExpressionTree) expr;
+      if ("NaN".equals(memberSelect.identifier().name())) {
+        return resolveNanOwnerType(memberSelect.identifier().symbol());
+      }
+    } else if (expr.is(Tree.Kind.IDENTIFIER)) {
+      IdentifierTree identifier = (IdentifierTree) expr;
+      if ("NaN".equals(identifier.name())) {
+        return resolveNanOwnerType(identifier.symbol());
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static String resolveNanOwnerType(Symbol symbol) {
+    if (symbol.isUnknown()) {
+      return null;
+    }
+    Symbol owner = symbol.owner();
+    if (owner == null || owner.type() == null) {
+      return null;
+    }
+    Type ownerType = owner.type();
+    if (ownerType.is("java.lang.Double") || ownerType.is("java.lang.Float")) {
+      return ownerType.name();
+    }
+    return null;
   }
 
 }

--- a/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
@@ -41,11 +41,17 @@ import org.sonar.plugins.java.api.tree.StaticInitializerTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isPrivate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.sonar.java.model.ExpressionUtils.isInvocationOnVariable;
 import static org.sonar.java.model.ExpressionUtils.skipParenthesesUpwards;
 import static org.sonar.java.model.assertions.TreeAssert.assertThat;
@@ -533,6 +539,65 @@ class ExpressionUtilsTest {
     } else {
       assertThat(actual).isEqualTo(expected);
     }
+  }
+
+  @Test
+  void getNanOwnerTypeName_identifier_not_nan() {
+    // An identifier that is not named "NaN" should return null (line 417 false branch)
+    assertNanOwnerTypeName("someVariable", null);
+  }
+
+  @Test
+  void getNanOwnerTypeName_custom_class_nan_field() {
+    // A NaN field on a custom class (not Double/Float) should return null (line 437)
+    CompilationUnitTree unit = JParserTestUtils.parse("""
+      class MyClass {
+        static double NaN = 0.0;
+      }
+      class A { Object f = MyClass.NaN; }
+      """);
+    ExpressionTree expr = ((VariableTree) ((ClassTree) unit.types().get(1)).members().get(0)).initializer();
+    assertThat(ExpressionUtils.getNanOwnerTypeName(expr)).isNull();
+  }
+
+  @Test
+  void getNanOwnerTypeName_member_select_not_nan() {
+    // A member select where the identifier is not "NaN" should return null (line 412 false branch)
+    assertNanOwnerTypeName("Double.MAX_VALUE", null);
+  }
+
+  @Test
+  void getNanOwnerTypeName_null_owner_type_via_mock() {
+    // Test resolveNanOwnerType returns null when owner.type() is null (line 431)
+    Symbol nanSymbol = mock(Symbol.class);
+    when(nanSymbol.isUnknown()).thenReturn(false);
+    Symbol ownerSymbol = mock(Symbol.class);
+    when(ownerSymbol.type()).thenReturn(null);
+    when(nanSymbol.owner()).thenReturn(ownerSymbol);
+
+    IdentifierTree identifier = mock(IdentifierTree.class);
+    when(identifier.name()).thenReturn("NaN");
+    when(identifier.symbol()).thenReturn(nanSymbol);
+    when(identifier.is(Tree.Kind.MEMBER_SELECT)).thenReturn(false);
+    when(identifier.is(Tree.Kind.IDENTIFIER)).thenReturn(true);
+
+    assertThat(ExpressionUtils.getNanOwnerTypeName(identifier)).isNull();
+  }
+
+  @Test
+  void getNanOwnerTypeName_null_owner_via_mock() {
+    // Test resolveNanOwnerType returns null when owner is null (line 431)
+    Symbol nanSymbol = mock(Symbol.class);
+    when(nanSymbol.isUnknown()).thenReturn(false);
+    when(nanSymbol.owner()).thenReturn(null);
+
+    IdentifierTree identifier = mock(IdentifierTree.class);
+    when(identifier.name()).thenReturn("NaN");
+    when(identifier.symbol()).thenReturn(nanSymbol);
+    when(identifier.is(Tree.Kind.MEMBER_SELECT)).thenReturn(false);
+    when(identifier.is(Tree.Kind.IDENTIFIER)).thenReturn(true);
+
+    assertThat(ExpressionUtils.getNanOwnerTypeName(identifier)).isNull();
   }
 
   @Test

--- a/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
@@ -41,9 +41,7 @@ import org.sonar.plugins.java.api.tree.StaticInitializerTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
-import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isPrivate;

--- a/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/model/ExpressionUtilsTest.java
@@ -471,6 +471,71 @@ class ExpressionUtilsTest {
   }
 
   @Test
+  void getNanOwnerTypeName_member_select() {
+    // Double.NaN -> "Double"
+    assertNanOwnerTypeName("Double.NaN", "Double");
+    // Float.NaN -> "Float"
+    assertNanOwnerTypeName("Float.NaN", "Float");
+    // Non-NaN member select -> null
+    assertNanOwnerTypeName("Double.MAX_VALUE", null);
+    // Parenthesized expression (Double.NaN) -> "Double"
+    assertNanOwnerTypeName("(Double.NaN)", "Double");
+    // Parenthesized expression (Float.NaN) -> "Float"
+    assertNanOwnerTypeName("(Float.NaN)", "Float");
+  }
+
+  @Test
+  void getNanOwnerTypeName_identifier_static_import() {
+    // Statically imported NaN from Double -> "Double"
+    CompilationUnitTree unit = JParserTestUtils.parse("""
+      import static java.lang.Double.NaN;
+      class A { Object f = NaN; }
+      """);
+    ExpressionTree expr = ((VariableTree) ((ClassTree) unit.types().get(0)).members().get(0)).initializer();
+    assertThat(ExpressionUtils.getNanOwnerTypeName(expr)).isEqualTo("Double");
+  }
+
+  @Test
+  void getNanOwnerTypeName_identifier_static_import_float() {
+    // Statically imported NaN from Float -> "Float"
+    CompilationUnitTree unit = JParserTestUtils.parse("""
+      import static java.lang.Float.NaN;
+      class A { Object f = NaN; }
+      """);
+    ExpressionTree expr = ((VariableTree) ((ClassTree) unit.types().get(0)).members().get(0)).initializer();
+    assertThat(ExpressionUtils.getNanOwnerTypeName(expr)).isEqualTo("Float");
+  }
+
+  @Test
+  void getNanOwnerTypeName_other_expression_types() {
+    // Literal -> null
+    assertNanOwnerTypeName("42.0", null);
+    // Method call -> null
+    assertNanOwnerTypeName("Double.valueOf(0.0)", null);
+  }
+
+  @Test
+  void getNanOwnerTypeName_unknown_nan() {
+    // Unknown class NaN field -> null (symbol is unknown)
+    CompilationUnitTree unit = JParserTestUtils.parse("""
+      class A { Object f = UnknownClass.NaN; }
+      """);
+    ExpressionTree expr = ((VariableTree) ((ClassTree) unit.types().get(0)).members().get(0)).initializer();
+    assertThat(ExpressionUtils.getNanOwnerTypeName(expr)).isNull();
+  }
+
+  private void assertNanOwnerTypeName(String code, @Nullable String expected) {
+    CompilationUnitTree unit = JParserTestUtils.parse("class A { Object f = " + code + "; }");
+    ExpressionTree expression = ((VariableTree) ((ClassTree) unit.types().get(0)).members().get(0)).initializer();
+    String actual = ExpressionUtils.getNanOwnerTypeName(expression);
+    if (expected == null) {
+      assertThat(actual).isNull();
+    } else {
+      assertThat(actual).isEqualTo(expected);
+    }
+  }
+
+  @Test
   void testAnnotationAttributeName(){
     var unit = JParserTestUtils.parse("""
       interface A {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9147.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9147.html
@@ -56,6 +56,7 @@ if (Double.isNaN(result)) {
 </ul>
 <h3>Related rules</h3>
 <ul>
+  <li>{rule:java:S1244} - Floating point numbers should not be tested for equality</li>
   <li>{rule:java:S6725} - Python equivalent: NaN should not be tested for equality</li>
   <li>{rule:java:S6679} - JavaScript equivalent: NaN should not be tested for equality</li>
   <li>{rule:java:S2688} - JavaScript: NaN should not be used in comparisons</li>


### PR DESCRIPTION
## Summary
- S1244 (`FloatEqualityCheck`) no longer raises issues when a float/double is compared to `Double.NaN` or `Float.NaN`, since this case is already covered by S9147 (`NanEqualityCheck`)
- Added S1244 as a related rule in the S9147 Rspec HTML documentation
  See rspec PR: https://github.com/SonarSource/rspec/pull/7904
- Added test cases in `FloatEquality.java` to verify NaN comparisons are compliant for S1244

## Test plan
- [x] `FloatEqualityCheckTest` passes (both with and without semantic analysis)
- [x] `NanEqualityCheckTest` passes (unchanged)
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)