### PR TITLE
SONARJAVA-6769 Implement new rule S9342: Archive entries should not be empty

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -1,8 +1,10 @@
 package checks;
 
+import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
@@ -187,6 +189,31 @@ class EmptyArchiveEntryCheckSample {
     pw.println("content via wrapper");
     pw.flush();
     zos.closeEntry(); // Compliant - written through wrapper
+    zos.close();
+  }
+
+  void qualifiedHelperMethodCall() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("helper.txt"));
+    this.writeContent(zos);
+    zos.closeEntry(); // Compliant - stream passed to qualified helper method
+    zos.close();
+  }
+
+  void directoryEntryViaVariable() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    ZipEntry directory = new ZipEntry("dir/");
+    zos.putNextEntry(directory);
+    zos.closeEntry(); // Compliant - directory entry via variable
+    zos.close();
+  }
+
+  void writeViaBufferedOutputStream() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("file.txt"));
+    OutputStream writer = new BufferedOutputStream(zos);
+    writer.write("data".getBytes());
+    zos.closeEntry(); // Compliant - written through BufferedOutputStream wrapper
     zos.close();
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -172,4 +172,21 @@ class EmptyArchiveEntryCheckSample {
     zos.closeEntry(); // Compliant - no preceding putNextEntry tracked
     zos.close();
   }
+
+  void zipDirectoryEntry() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("dir/"));
+    zos.closeEntry(); // Compliant - directory entry
+    zos.close();
+  }
+
+  void writeViaWrapper() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("wrapped.txt"));
+    java.io.PrintWriter pw = new java.io.PrintWriter(zos);
+    pw.println("content via wrapper");
+    pw.flush();
+    zos.closeEntry(); // Compliant - written through wrapper
+    zos.close();
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -1,0 +1,175 @@
+package checks;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+class EmptyArchiveEntryCheckSample {
+
+  void emptyZipEntry() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("empty.txt"));
+//      ^^^^^^^^^^^^>
+    zos.closeEntry(); // Noncompliant {{Write content to this archive entry; it is empty.}}
+//      ^^^^^^^^^^
+    zos.close();
+  }
+
+  void multipleEntriesOneEmpty() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("file.txt"));
+    zos.write("content".getBytes());
+    zos.closeEntry(); // Compliant - content written
+
+    zos.putNextEntry(new ZipEntry("empty.txt"));
+//      ^^^^^^^^^^^^>
+    zos.closeEntry(); // Noncompliant
+//      ^^^^^^^^^^
+    zos.close();
+  }
+
+  void emptyEntryInLoop(String[] names) throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    for (String name : names) {
+      zos.putNextEntry(new ZipEntry(name));
+//        ^^^^^^^^^^^^>
+      zos.closeEntry(); // Noncompliant
+//        ^^^^^^^^^^
+    }
+    zos.close();
+  }
+
+  void emptyJarEntry() throws IOException {
+    JarOutputStream jos = new JarOutputStream(new FileOutputStream("app.jar"));
+    jos.putNextEntry(new JarEntry("empty.class"));
+//      ^^^^^^^^^^^^>
+    jos.closeEntry(); // Noncompliant
+//      ^^^^^^^^^^
+    jos.close();
+  }
+
+  void jarWithZipEntry() throws IOException {
+    JarOutputStream jos = new JarOutputStream(new FileOutputStream("app.jar"));
+    jos.putNextEntry(new ZipEntry("empty.txt"));
+//      ^^^^^^^^^^^^>
+    jos.closeEntry(); // Noncompliant
+//      ^^^^^^^^^^
+    jos.close();
+  }
+
+  void zipWithContent() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("file.txt"));
+    zos.write("Hello, World!".getBytes());
+    zos.closeEntry(); // Compliant
+    zos.close();
+  }
+
+  void writeFromFile() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("data.bin"));
+    FileInputStream fis = new FileInputStream("data.bin");
+    byte[] buffer = new byte[1024];
+    int len;
+    while ((len = fis.read(buffer)) > 0) {
+      zos.write(buffer, 0, len);
+    }
+    fis.close();
+    zos.closeEntry(); // Compliant
+    zos.close();
+  }
+
+  void writeByteArray() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("data.txt"));
+    byte[] data = "content".getBytes();
+    zos.write(data, 0, data.length);
+    zos.closeEntry(); // Compliant
+    zos.close();
+  }
+
+  void jarWithContent() throws IOException {
+    JarOutputStream jos = new JarOutputStream(new FileOutputStream("app.jar"));
+    jos.putNextEntry(new JarEntry("META-INF/MANIFEST.MF"));
+    jos.write("Manifest-Version: 1.0\n".getBytes());
+    jos.closeEntry(); // Compliant
+    jos.close();
+  }
+
+  void multipleJarEntriesAllWithContent() throws IOException {
+    JarOutputStream jos = new JarOutputStream(new FileOutputStream("app.jar"));
+    jos.putNextEntry(new JarEntry("a.class"));
+    jos.write(new byte[]{1, 2, 3});
+    jos.closeEntry(); // Compliant
+
+    jos.putNextEntry(new JarEntry("b.class"));
+    jos.write(new byte[]{4, 5, 6});
+    jos.closeEntry(); // Compliant
+    jos.close();
+  }
+
+  void writeSingleByte() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("byte.txt"));
+    zos.write(65);
+    zos.closeEntry(); // Compliant
+    zos.close();
+  }
+
+  void writeInIfBlock() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("conditional.txt"));
+    if (System.currentTimeMillis() > 0) {
+      zos.write("data".getBytes());
+    }
+    zos.closeEntry(); // Compliant - write is in a conditional block
+    zos.close();
+  }
+
+  void helperMethodWithStream() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("helper.txt"));
+    writeContent(zos);
+    zos.closeEntry(); // Compliant - stream passed to helper method
+    zos.close();
+  }
+
+  private void writeContent(ZipOutputStream zos) throws IOException {
+    zos.write("content".getBytes());
+  }
+
+  void twoStreamsIndependent() throws IOException {
+    ZipOutputStream zos1 = new ZipOutputStream(new FileOutputStream("a.zip"));
+    ZipOutputStream zos2 = new ZipOutputStream(new FileOutputStream("b.zip"));
+
+    zos1.putNextEntry(new ZipEntry("file.txt"));
+    zos2.putNextEntry(new ZipEntry("file.txt"));
+    zos1.write("content".getBytes());
+    zos1.closeEntry(); // Compliant - zos1 has content
+
+    zos2.putNextEntry(new ZipEntry("empty.txt"));
+//       ^^^^^^^^^^^^>
+    zos2.closeEntry(); // Noncompliant
+//       ^^^^^^^^^^
+
+    zos1.close();
+    zos2.close();
+  }
+
+  void noCloseEntry() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("file.txt"));
+    // No closeEntry - no issue raised (putNextEntry without closeEntry is not flagged)
+    zos.close();
+  }
+
+  void closeEntryWithoutPutNextEntry() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.closeEntry(); // Compliant - no preceding putNextEntry tracked
+    zos.close();
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -174,11 +174,8 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
     ExpressionTree methodSelect = mit.methodSelect();
     if (methodSelect.is(Tree.Kind.MEMBER_SELECT)) {
       ExpressionTree expression = ((MemberSelectExpressionTree) methodSelect).expression();
-      if (expression.is(Tree.Kind.IDENTIFIER)) {
-        Symbol symbol = ((IdentifierTree) expression).symbol();
-        if (!symbol.isUnknown()) {
-          return symbol;
-        }
+      if (expression.is(Tree.Kind.IDENTIFIER) && !((IdentifierTree) expression).symbol().isUnknown()) {
+        return ((IdentifierTree) expression).symbol();
       }
     }
     return null;

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -1,0 +1,169 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.CheckForNull;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BlockTree;
+import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.StatementTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9342")
+public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
+
+  private static final MethodMatchers PUT_NEXT_ENTRY = MethodMatchers.create()
+    .ofSubTypes("java.util.zip.ZipOutputStream")
+    .names("putNextEntry")
+    .addParametersMatcher("java.util.zip.ZipEntry")
+    .build();
+
+  private static final MethodMatchers CLOSE_ENTRY = MethodMatchers.create()
+    .ofSubTypes("java.util.zip.ZipOutputStream")
+    .names("closeEntry")
+    .addWithoutParametersMatcher()
+    .build();
+
+  private static final MethodMatchers WRITE = MethodMatchers.create()
+    .ofSubTypes("java.io.OutputStream")
+    .names("write")
+    .withAnyParameters()
+    .build();
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.BLOCK);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    Map<Symbol, MethodInvocationTree> pendingEntries = new HashMap<>();
+    for (StatementTree statement : ((BlockTree) tree).body()) {
+      MethodInvocationTree mit = extractMethodInvocation(statement);
+      if (mit != null) {
+        handleMethodInvocation(mit, pendingEntries);
+      } else {
+        scanForTrackedSymbolUsage(statement, pendingEntries);
+      }
+    }
+  }
+
+  private void handleMethodInvocation(MethodInvocationTree mit, Map<Symbol, MethodInvocationTree> pendingEntries) {
+    Symbol receiver = getReceiverSymbol(mit);
+    if (receiver == null) {
+      return;
+    }
+    if (PUT_NEXT_ENTRY.matches(mit)) {
+      pendingEntries.put(receiver, mit);
+    } else if (CLOSE_ENTRY.matches(mit)) {
+      MethodInvocationTree putNextEntry = pendingEntries.remove(receiver);
+      if (putNextEntry != null) {
+        reportIssue(ExpressionUtils.methodName(mit), "Write content to this archive entry; it is empty.",
+          Collections.singletonList(new JavaFileScannerContext.Location("Entry opened here", ExpressionUtils.methodName(putNextEntry))), null);
+      }
+    } else if (WRITE.matches(mit)) {
+      pendingEntries.remove(receiver);
+    }
+  }
+
+  private static void scanForTrackedSymbolUsage(StatementTree statement, Map<Symbol, MethodInvocationTree> pendingEntries) {
+    if (pendingEntries.isEmpty()) {
+      return;
+    }
+    TrackedSymbolVisitor visitor = new TrackedSymbolVisitor(pendingEntries);
+    statement.accept(visitor);
+    for (Symbol used : visitor.usedSymbols) {
+      pendingEntries.remove(used);
+    }
+  }
+
+  @CheckForNull
+  private static MethodInvocationTree extractMethodInvocation(StatementTree statement) {
+    if (statement.is(Tree.Kind.EXPRESSION_STATEMENT)) {
+      ExpressionTree expression = ((ExpressionStatementTree) statement).expression();
+      if (expression.is(Tree.Kind.METHOD_INVOCATION)) {
+        return (MethodInvocationTree) expression;
+      }
+    }
+    return null;
+  }
+
+  @CheckForNull
+  private static Symbol getReceiverSymbol(MethodInvocationTree mit) {
+    ExpressionTree methodSelect = mit.methodSelect();
+    if (methodSelect.is(Tree.Kind.MEMBER_SELECT)) {
+      ExpressionTree expression = ((MemberSelectExpressionTree) methodSelect).expression();
+      if (expression.is(Tree.Kind.IDENTIFIER)) {
+        Symbol symbol = ((IdentifierTree) expression).symbol();
+        if (!symbol.isUnknown()) {
+          return symbol;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static class TrackedSymbolVisitor extends BaseTreeVisitor {
+    private final Map<Symbol, MethodInvocationTree> pendingEntries;
+    private final List<Symbol> usedSymbols = new ArrayList<>();
+
+    TrackedSymbolVisitor(Map<Symbol, MethodInvocationTree> pendingEntries) {
+      this.pendingEntries = pendingEntries;
+    }
+
+    @Override
+    public void visitMethodInvocation(MethodInvocationTree mit) {
+      Symbol receiver = getReceiverSymbol(mit);
+      if (receiver != null && pendingEntries.containsKey(receiver)) {
+        if (WRITE.matches(mit)) {
+          usedSymbols.add(receiver);
+        }
+      }
+      // Check if any tracked symbol is passed as argument
+      for (ExpressionTree arg : mit.arguments()) {
+        if (arg.is(Tree.Kind.IDENTIFIER)) {
+          Symbol argSymbol = ((IdentifierTree) arg).symbol();
+          if (pendingEntries.containsKey(argSymbol)) {
+            usedSymbols.add(argSymbol);
+          }
+        }
+      }
+      super.visitMethodInvocation(mit);
+    }
+
+    @Override
+    public void visitIdentifier(IdentifierTree tree) {
+      // Intentionally not clearing state for simple identifier references;
+      // only method calls (write or passing as argument) should clear state.
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -33,8 +33,10 @@ import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.ExpressionStatementTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
@@ -66,6 +68,9 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
 
   @Override
   public void visitNode(Tree tree) {
+    if (context.getSemanticModel() == null) {
+      return;
+    }
     Map<Symbol, MethodInvocationTree> pendingEntries = new HashMap<>();
     for (StatementTree statement : ((BlockTree) tree).body()) {
       MethodInvocationTree mit = extractMethodInvocation(statement);
@@ -80,10 +85,13 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
   private void handleMethodInvocation(MethodInvocationTree mit, Map<Symbol, MethodInvocationTree> pendingEntries) {
     Symbol receiver = getReceiverSymbol(mit);
     if (receiver == null) {
+      clearTrackedSymbolsUsedAsArguments(mit, pendingEntries);
       return;
     }
     if (PUT_NEXT_ENTRY.matches(mit)) {
-      pendingEntries.put(receiver, mit);
+      if (!isDirectoryEntry(mit)) {
+        pendingEntries.put(receiver, mit);
+      }
     } else if (CLOSE_ENTRY.matches(mit)) {
       MethodInvocationTree putNextEntry = pendingEntries.remove(receiver);
       if (putNextEntry != null) {
@@ -115,6 +123,27 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
       }
     }
     return null;
+  }
+
+  private static boolean isDirectoryEntry(MethodInvocationTree putNextEntry) {
+    if (putNextEntry.arguments().size() == 1 && putNextEntry.arguments().get(0).is(Tree.Kind.NEW_CLASS)) {
+      NewClassTree newClass = (NewClassTree) putNextEntry.arguments().get(0);
+      if (newClass.arguments().size() == 1 && newClass.arguments().get(0).is(Tree.Kind.STRING_LITERAL)) {
+        String value = ((LiteralTree) newClass.arguments().get(0)).value();
+        // value includes quotes, e.g. "\"dir/\""
+        return value.endsWith("/\"");
+      }
+    }
+    return false;
+  }
+
+  private static void clearTrackedSymbolsUsedAsArguments(MethodInvocationTree mit, Map<Symbol, MethodInvocationTree> pendingEntries) {
+    for (ExpressionTree arg : mit.arguments()) {
+      if (arg.is(Tree.Kind.IDENTIFIER)) {
+        Symbol argSymbol = ((IdentifierTree) arg).symbol();
+        pendingEntries.remove(argSymbol);
+      }
+    }
   }
 
   @CheckForNull
@@ -158,6 +187,19 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
         }
       }
       super.visitMethodInvocation(mit);
+    }
+
+    @Override
+    public void visitNewClass(NewClassTree tree) {
+      for (ExpressionTree arg : tree.arguments()) {
+        if (arg.is(Tree.Kind.IDENTIFIER)) {
+          Symbol argSymbol = ((IdentifierTree) arg).symbol();
+          if (pendingEntries.containsKey(argSymbol)) {
+            usedSymbols.add(argSymbol);
+          }
+        }
+      }
+      super.visitNewClass(tree);
     }
 
     @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -39,6 +39,7 @@ import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9342")
 public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
@@ -100,6 +101,8 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
       }
     } else if (WRITE.matches(mit)) {
       pendingEntries.remove(receiver);
+    } else {
+      clearTrackedSymbolsUsedAsArguments(mit, pendingEntries);
     }
   }
 
@@ -126,15 +129,35 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isDirectoryEntry(MethodInvocationTree putNextEntry) {
-    if (putNextEntry.arguments().size() == 1 && putNextEntry.arguments().get(0).is(Tree.Kind.NEW_CLASS)) {
-      NewClassTree newClass = (NewClassTree) putNextEntry.arguments().get(0);
-      if (newClass.arguments().size() == 1 && newClass.arguments().get(0).is(Tree.Kind.STRING_LITERAL)) {
-        String value = ((LiteralTree) newClass.arguments().get(0)).value();
-        // value includes quotes, e.g. "\"dir/\""
-        return value.endsWith("/\"");
-      }
+    if (putNextEntry.arguments().size() != 1) {
+      return false;
+    }
+    ExpressionTree argument = putNextEntry.arguments().get(0);
+    NewClassTree newClass = resolveNewClass(argument);
+    if (newClass != null && newClass.arguments().size() == 1 && newClass.arguments().get(0).is(Tree.Kind.STRING_LITERAL)) {
+      String value = ((LiteralTree) newClass.arguments().get(0)).value();
+      // value includes quotes, e.g. "\"dir/\""
+      return value.endsWith("/\"");
     }
     return false;
+  }
+
+  @CheckForNull
+  private static NewClassTree resolveNewClass(ExpressionTree expression) {
+    if (expression.is(Tree.Kind.NEW_CLASS)) {
+      return (NewClassTree) expression;
+    }
+    if (expression.is(Tree.Kind.IDENTIFIER)) {
+      Symbol symbol = ((IdentifierTree) expression).symbol();
+      Tree declaration = symbol.declaration();
+      if (declaration != null && declaration.is(Tree.Kind.VARIABLE)) {
+        ExpressionTree initializer = ((VariableTree) declaration).initializer();
+        if (initializer != null && initializer.is(Tree.Kind.NEW_CLASS)) {
+          return (NewClassTree) initializer;
+        }
+      }
+    }
+    return null;
   }
 
   private static void clearTrackedSymbolsUsedAsArguments(MethodInvocationTree mit, Map<Symbol, MethodInvocationTree> pendingEntries) {

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -172,10 +172,8 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
     @Override
     public void visitMethodInvocation(MethodInvocationTree mit) {
       Symbol receiver = getReceiverSymbol(mit);
-      if (receiver != null && pendingEntries.containsKey(receiver)) {
-        if (WRITE.matches(mit)) {
-          usedSymbols.add(receiver);
-        }
+      if (receiver != null && pendingEntries.containsKey(receiver) && WRITE.matches(mit)) {
+        usedSymbols.add(receiver);
       }
       // Check if any tracked symbol is passed as argument
       for (ExpressionTree arg : mit.arguments()) {

--- a/java-checks/src/test/java/org/sonar/java/checks/EmptyArchiveEntryCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/EmptyArchiveEntryCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class EmptyArchiveEntryCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/EmptyArchiveEntryCheckSample.java"))
+      .withCheck(new EmptyArchiveEntryCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/EmptyArchiveEntryCheckSample.java"))
+      .withCheck(new EmptyArchiveEntryCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9342.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9342.html
@@ -1,0 +1,48 @@
+<p>An issue is raised when an operation that closes an archive entry is called immediately after an operation that opens or begins a new
+entry in an archive output stream, without writing any content in between.</p>
+<h2>Why is this an issue?</h2>
+<p>When creating archive files (ZIP or JAR), entries are added using a three-step process:</p>
+<ol>
+  <li>Call an API method to declare the start of a new entry</li>
+  <li>Write the entry's content using output stream methods</li>
+  <li>Call an API method to finalize the entry</li>
+</ol>
+<p>Skipping the second step creates an empty entry in the archive. This is almost always a mistake.</p>
+<p>Empty archive entries serve no useful purpose. In ZIP files, they waste space by storing metadata for entries with no content. In JAR files,
+empty entries can cause runtime errors when the application expects to load classes or resources that don't exist.</p>
+<p>In Java, this specifically refers to calling <code>closeEntry()</code> immediately after <code>putNextEntry()</code> on a
+<code>ZipOutputStream</code> or <code>JarOutputStream</code>.</p>
+<h3>What is the potential impact?</h3>
+<ul>
+  <li><strong>Build failures</strong>: Archive files with empty code file entries will fail when the runtime attempts to load those code
+  modules</li>
+  <li><strong>Missing resources</strong>: Applications expecting configuration files, images, or other resources will fail when these entries are
+  empty</li>
+  <li><strong>Confusion and debugging time</strong>: Developers may spend time investigating why expected files aren't working, not realizing they
+  exist but are empty</li>
+</ul>
+<h2>How to fix it</h2>
+<p>Write content to the archive entry between <code>putNextEntry()</code> and <code>closeEntry()</code> using the <code>write()</code> method.
+The content can come from a byte array, file, or any other source.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+zos.putNextEntry(new ZipEntry("empty.txt"));
+zos.closeEntry(); // Noncompliant - no content written
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+zos.putNextEntry(new ZipEntry("file.txt"));
+zos.write("Hello, World!".getBytes());
+zos.closeEntry();
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Java Platform SE 8 Documentation - <a
+  href="https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipOutputStream.html">ZipOutputStream (Java Platform SE 8)</a></li>
+  <li>Java Platform SE 8 Documentation - <a
+  href="https://docs.oracle.com/javase/8/docs/api/java/util/jar/JarOutputStream.html">JarOutputStream (Java Platform SE 8)</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9342.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9342.json
@@ -1,0 +1,23 @@
+{
+  "title": "Archive entries should not be empty",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "suspicious"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9342",
+  "sqKey": "S9342",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
Detect empty archive entries where closeEntry() is called on a ZipOutputStream or JarOutputStream after putNextEntry() without any intervening write() call, which creates useless empty entries in the archive.


