### PR TITLE
SONARJAVA-6770 Integrate TestFileClassifier from analyzer-commons

### DIFF
--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -95,7 +95,8 @@ public final class JavaFileTypeClassifier {
    * <ul>
    *   <li>Directory segments: {@code test}, {@code tests}, {@code testing}, {@code Test},
    *       {@code Tests}, {@code __tests__}</li>
-   *   <li>Maven integration-test source trees: {@code src/it/java}, {@code src/its/java}</li>
+   *   <li>Maven integration-test source trees: {@code src/it/java}, {@code src/its/java},
+   *       {@code src/IT/java}, {@code src/ITS/java}</li>
    *   <li>Filename suffixes: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT},
    *       {@code ITCase}, {@code Spec}, {@code Specs}</li>
    * </ul>
@@ -111,6 +112,8 @@ public final class JavaFileTypeClassifier {
     // Maven integration test source trees
     "**/it/java/**",
     "**/its/java/**",
+    "**/IT/java/**",
+    "**/ITS/java/**",
     // Filename suffix patterns
     "**/*Test.java",
     "**/*Tests.java",

--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -17,14 +17,16 @@
 package org.sonar.java.utils;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
+import java.util.concurrent.atomic.AtomicReference;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.config.Configuration;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonarsource.analyzer.commons.appsec.TestFileClassifier;
 
 /**
  * Enriches test scope determination beyond the platform's {@link InputFile.Type}.
@@ -36,13 +38,18 @@ import org.sonar.plugins.java.api.tree.Tree;
  * <p>This classifier combines three signals:
  * <ol>
  *   <li>Platform truth: {@link InputFile#type()} from the Sonar scanner</li>
- *   <li>Naming conventions: file name patterns like {@code FooTest}, {@code FooIT}, {@code FooSpec}</li>
- *   <li>AST annotations: class-level test framework annotations ({@code @RunWith}, {@code @SpringBootTest}, etc.)</li>
+ *   <li>Path and naming heuristics: delegated to {@link TestFileClassifier} from
+ *       sonar-analyzer-commons, extended with Java-specific path conventions</li>
+ *   <li>AST annotations: class-level test framework annotations ({@code @RunWith},
+ *       {@code @SpringBootTest}, etc.)</li>
  * </ol>
  *
- * <p>A file is considered a test file if <em>any</em> signal indicates it — the platform type
+ * <p>A file is considered a test file if <em>any</em> signal indicates it. The platform type
  * takes priority when {@code TEST}, but a {@code MAIN}-typed file can be upgraded to test scope
- * by the naming or annotation signals.
+ * by the path, naming, or annotation signals.
+ *
+ * <p>The path/naming heuristic is only applied when {@code sonar.tests} is not configured; if it
+ * is configured the platform already classifies test files as {@link InputFile.Type#TEST}.
  *
  * <p>Usage example in a check's {@code scanFile} method:
  * <pre>{@code
@@ -81,19 +88,52 @@ public final class JavaFileTypeClassifier {
   );
 
   /**
-   * Path substrings that indicate a file lives in an integration-test source tree,
-   * following the Maven convention of {@code src/it/java} or {@code src/its/java}.
+   * {@link org.sonar.api.utils.WildcardPattern}-compatible path patterns for test file detection,
+   * passed to {@link TestFileClassifier#of(Configuration, String...)}.
+   *
+   * <p>Covers:
+   * <ul>
+   *   <li>Directory segments: {@code test}, {@code tests}, {@code testing}, {@code Test},
+   *       {@code Tests}, {@code __tests__}</li>
+   *   <li>Maven integration-test source trees: {@code src/it/java}, {@code src/its/java}</li>
+   *   <li>Filename suffixes: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT},
+   *       {@code ITCase}, {@code Spec}, {@code Specs}</li>
+   *   <li>Filename prefix: {@code Test}</li>
+   * </ul>
    */
-  private static final List<String> TEST_PATH_SUBPATHS = List.of("src/it/java", "src/its/java");
+  private static final String[] JAVA_TEST_PATTERNS = {
+    // Directory segment patterns (superset of commons defaults + testing + Java-specific)
+    "**/Test/**",
+    "**/Tests/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/testing/**",
+    "**/__tests__/**",
+    // Maven integration test source trees
+    "**/it/java/**",
+    "**/its/java/**",
+    // Filename suffix patterns
+    "**/*Test.java",
+    "**/*Tests.java",
+    "**/*TestCase.java",
+    "**/*IT.java",
+    "**/*ITCase.java",
+    "**/*Spec.java",
+    "**/*Specs.java",
+    // Filename prefix pattern
+    "**/Test*.java"
+  };
 
   /**
-   * Matches file names (without {@code .java} extension) that follow standard test naming conventions
-   * by suffix: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT}, {@code ITCase}, {@code Spec}, {@code Specs}
-   * (e.g. {@code FooTest}, {@code FooSpec}, {@code FooIT}).
+   * Cached {@link TestFileClassifier} for the most recently seen {@link Configuration}.
+   * In practice there is exactly one {@link Configuration} per analysis run, so a single
+   * cached entry avoids recompiling WildcardPatterns for every analyzed file.
+   * The {@link AtomicReference} ensures the config+classifier pair is always observed
+   * consistently. A race on simultaneous updates is benign: both threads produce an
+   * identical classifier for the same config.
    */
-  private static final Pattern TEST_NAME_PATTERN = Pattern.compile(
-    "^[A-Z]\\w*(Test|Tests|TestCase|IT|ITCase|Spec|Specs)$"
-  );
+  private static final AtomicReference<Map.Entry<Configuration, TestFileClassifier>> CLASSIFIER_REF =
+    new AtomicReference<>();
 
   private JavaFileTypeClassifier() {
     // utility class
@@ -101,14 +141,13 @@ public final class JavaFileTypeClassifier {
 
   /**
    * Returns {@code true} if the file should be treated as test code.
-   * Combines all three signals (platform type, naming, AST annotations) with OR semantics.
+   * Combines all signals (platform type, path/naming heuristics, AST annotations) with OR semantics.
    *
    * @param context the current file scanner context
    */
   public static boolean isTestFile(JavaFileScannerContext context) {
     return isPlatformTestFile(context)
-      || hasTestNamingConvention(context)
-      || hasTestPathSegment(context)
+      || getClassifier(context.getConfiguration()).looksLikeTestFile(context.getInputFile())
       || hasTestFrameworkAnnotation(context);
   }
 
@@ -120,32 +159,6 @@ public final class JavaFileTypeClassifier {
    */
   static boolean isPlatformTestFile(JavaFileScannerContext context) {
     return context.getInputFile().type() == InputFile.Type.TEST;
-  }
-
-  /**
-   * Returns {@code true} if the file name (without {@code .java} extension) matches
-   * {@link #TEST_NAME_PATTERN}.
-   *
-   * @param context the current file scanner context
-   */
-  static boolean hasTestNamingConvention(JavaFileScannerContext context) {
-    String filename = context.getInputFile().filename();
-    String baseName = filename.endsWith(".java") ? filename.substring(0, filename.length() - 5) : filename;
-    return TEST_NAME_PATTERN.matcher(baseName).matches();
-  }
-
-  /**
-   * Returns {@code true} if the file's URI path contains a known integration-test source tree
-   * substring: {@code src/it/java} or {@code src/its/java}.
-   *
-   * <p>This covers the Maven convention of placing integration tests under
-   * {@code src/it/java} or {@code src/its/java}.
-   *
-   * @param context the current file scanner context
-   */
-  static boolean hasTestPathSegment(JavaFileScannerContext context) {
-    String path = context.getInputFile().uri().getPath().toLowerCase(Locale.ROOT);
-    return TEST_PATH_SUBPATHS.stream().anyMatch(path::contains);
   }
 
   /**
@@ -175,5 +188,15 @@ public final class JavaFileTypeClassifier {
     return metadata.annotations().stream()
       .map(ann -> ann.symbol().type().fullyQualifiedName())
       .anyMatch(fqn -> TEST_ANNOTATION_PACKAGE_PREFIXES.stream().anyMatch(fqn::startsWith));
+  }
+
+  private static TestFileClassifier getClassifier(Configuration config) {
+    var entry = CLASSIFIER_REF.get();
+    if (entry == null || entry.getKey() != config) {
+      var fresh = Map.entry(config, TestFileClassifier.of(config, JAVA_TEST_PATTERNS));
+      CLASSIFIER_REF.compareAndSet(entry, fresh);
+      entry = CLASSIFIER_REF.get();
+    }
+    return entry.getValue();
   }
 }

--- a/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
+++ b/java-frontend/src/main/java/org/sonar/java/utils/JavaFileTypeClassifier.java
@@ -98,7 +98,6 @@ public final class JavaFileTypeClassifier {
    *   <li>Maven integration-test source trees: {@code src/it/java}, {@code src/its/java}</li>
    *   <li>Filename suffixes: {@code Test}, {@code Tests}, {@code TestCase}, {@code IT},
    *       {@code ITCase}, {@code Spec}, {@code Specs}</li>
-   *   <li>Filename prefix: {@code Test}</li>
    * </ul>
    */
   private static final String[] JAVA_TEST_PATTERNS = {
@@ -119,9 +118,7 @@ public final class JavaFileTypeClassifier {
     "**/*IT.java",
     "**/*ITCase.java",
     "**/*Spec.java",
-    "**/*Specs.java",
-    // Filename prefix pattern
-    "**/Test*.java"
+    "**/*Specs.java"
   };
 
   /**

--- a/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
@@ -19,17 +19,25 @@ package org.sonar.java.utils;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.config.Configuration;
 import org.sonar.java.TestUtils;
 import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.test.classpath.TestClasspathUtils;
 import org.sonar.java.testing.VisitorsBridgeForTests;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class JavaFileTypeClassifierTest {
+
+  /**
+   * A {@link Configuration} that does not declare {@code sonar.tests}, so the path/naming
+   * heuristic in {@link org.sonarsource.analyzer.commons.appsec.TestFileClassifier} is active.
+   */
+  private static final Configuration NO_SONAR_TESTS_CONFIG = new MapSettings().asConfig();
 
   // -------------------------------------------------------------------------
   // isPlatformTestFile
@@ -45,80 +53,6 @@ class JavaFileTypeClassifierTest {
   void isPlatformTestFile_returnsFalse_forMainType() {
     JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("Foo.java", InputFile.Type.MAIN));
     assertThat(JavaFileTypeClassifier.isPlatformTestFile(context)).isFalse();
-  }
-
-  // -------------------------------------------------------------------------
-  // hasTestNamingConvention
-  // -------------------------------------------------------------------------
-
-  @Test
-  void hasTestNamingConvention_recognizesSuffixes() {
-    assertNamingConvention(true, "FooTest.java");
-    assertNamingConvention(true, "FooTests.java");
-    assertNamingConvention(true, "FooTestCase.java");
-    assertNamingConvention(true, "FooIT.java");
-    assertNamingConvention(true, "FooITCase.java");
-    assertNamingConvention(true, "FooSpec.java");
-    assertNamingConvention(true, "FooSpecs.java");
-  }
-
-  @Test
-  void hasTestNamingConvention_returnsFalse_forProductionNames() {
-    assertNamingConvention(false, "Foo.java");
-    assertNamingConvention(false, "FooService.java");
-    assertNamingConvention(false, "FooController.java");
-    // Lower-case 'test' in the middle is not a match
-    assertNamingConvention(false, "MyTestedCode.java");
-    // Prefix-only conventions are not recognized
-    assertNamingConvention(false, "TestFoo.java");
-    assertNamingConvention(false, "ITFoo.java");
-  }
-
-  private void assertNamingConvention(boolean expected, String filename) {
-    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile(filename, InputFile.Type.MAIN));
-    assertThat(JavaFileTypeClassifier.hasTestNamingConvention(context))
-      .as("Expected hasTestNamingConvention=%s for '%s'", expected, filename)
-      .isEqualTo(expected);
-  }
-
-  // -------------------------------------------------------------------------
-  // hasTestPathSegment
-  // -------------------------------------------------------------------------
-
-  @Test
-  void hasTestPathSegment_returnsTrue_forItSegment() {
-    assertPathSegment(true, "src/it/java/Foo.java");
-  }
-
-  @Test
-  void hasTestPathSegment_returnsTrue_forItsSegment() {
-    assertPathSegment(true, "src/its/java/Foo.java");
-  }
-
-  @Test
-  void hasTestPathSegment_isCaseInsensitive() {
-    assertPathSegment(true, "src/IT/java/Foo.java");
-    assertPathSegment(true, "src/ITS/java/Foo.java");
-  }
-
-  @Test
-  void hasTestPathSegment_returnsFalse_forMainPath() {
-    assertPathSegment(false, "src/main/java/Foo.java");
-    assertPathSegment(false, "src/test/java/Foo.java");
-  }
-
-  @Test
-  void hasTestPathSegment_returnsFalse_whenSegmentIsSubstring() {
-    // "itself" or "iteration" should not match — only exact segment
-    assertPathSegment(false, "src/itself/java/Foo.java");
-    assertPathSegment(false, "src/iteration/java/Foo.java");
-  }
-
-  private void assertPathSegment(boolean expected, String relativePath) {
-    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile(relativePath, InputFile.Type.MAIN));
-    assertThat(JavaFileTypeClassifier.hasTestPathSegment(context))
-      .as("Expected hasTestPathSegment=%s for '%s'", expected, relativePath)
-      .isEqualTo(expected);
   }
 
   // -------------------------------------------------------------------------
@@ -171,43 +105,117 @@ class JavaFileTypeClassifierTest {
   }
 
   // -------------------------------------------------------------------------
-  // isTestFile (combined signal)
+  // isTestFile — platform signal
   // -------------------------------------------------------------------------
 
   @Test
   void isTestFile_returnsTrue_whenPlatformSaysTest() {
-    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("Foo.java", InputFile.Type.TEST));
+    JavaFileScannerContext context = contextWithInputFileAndConfig(
+      TestUtils.emptyInputFile("Foo.java", InputFile.Type.TEST), NO_SONAR_TESTS_CONFIG);
     assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
   }
 
+  // -------------------------------------------------------------------------
+  // isTestFile — filename suffix conventions
+  // -------------------------------------------------------------------------
+
   @Test
-  void isTestFile_returnsTrue_whenPathSegmentMatches_evenIfPlatformSaysMain() {
-    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("src/it/java/Foo.java", InputFile.Type.MAIN));
-    assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
+  void isTestFile_recognizes_testFileSuffixes() {
+    assertIsTestFile(true, "FooTest.java");
+    assertIsTestFile(true, "FooTests.java");
+    assertIsTestFile(true, "FooTestCase.java");
+    assertIsTestFile(true, "FooIT.java");
+    assertIsTestFile(true, "FooITCase.java");
+    assertIsTestFile(true, "FooSpec.java");
+    assertIsTestFile(true, "FooSpecs.java");
   }
 
   @Test
-  void isTestFile_returnsTrue_whenNamingMatches_evenIfPlatformSaysMain() {
-    JavaFileScannerContext context = contextWithInputFile(TestUtils.emptyInputFile("FooTest.java", InputFile.Type.MAIN));
-    // fileParsed() not set → defaults to false (Mockito default for boolean), no AST signal
-    assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
+  void isTestFile_recognizes_TestPrefix() {
+    assertIsTestFile(true, "TestFoo.java");
+    assertIsTestFile(true, "TestBar.java");
   }
+
+  @Test
+  void isTestFile_returnsFalse_forProductionNames() {
+    assertIsTestFile(false, "Foo.java");
+    assertIsTestFile(false, "FooService.java");
+    assertIsTestFile(false, "FooController.java");
+  }
+
+  // -------------------------------------------------------------------------
+  // isTestFile — path/directory segment conventions
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isTestFile_recognizes_mavenTestPath() {
+    assertIsTestFile(true, "src/test/java/Foo.java");
+  }
+
+  @Test
+  void isTestFile_recognizes_mavenItPath() {
+    assertIsTestFile(true, "src/it/java/Foo.java");
+  }
+
+  @Test
+  void isTestFile_recognizes_mavenItsPath() {
+    assertIsTestFile(true, "src/its/java/Foo.java");
+  }
+
+  @Test
+  void isTestFile_recognizes_testDirectorySegment() {
+    assertIsTestFile(true, "src/test/Foo.java");
+    assertIsTestFile(true, "modules/core/test/Foo.java");
+  }
+
+  @Test
+  void isTestFile_recognizes_testsDirectorySegment() {
+    assertIsTestFile(true, "src/tests/Foo.java");
+  }
+
+  @Test
+  void isTestFile_recognizes_testingDirectorySegment() {
+    assertIsTestFile(true, "src/testing/Foo.java");
+  }
+
+  @Test
+  void isTestFile_returnsFalse_forProductionPath() {
+    assertIsTestFile(false, "src/main/java/Foo.java");
+  }
+
+  // -------------------------------------------------------------------------
+  // isTestFile — no signal
+  // -------------------------------------------------------------------------
 
   @Test
   void isTestFile_returnsFalse_whenNoSignal() {
     JavaFileScannerContext context = mock(JavaFileScannerContext.class);
     when(context.getInputFile()).thenReturn(TestUtils.emptyInputFile("Foo.java", InputFile.Type.MAIN));
+    when(context.getConfiguration()).thenReturn(NO_SONAR_TESTS_CONFIG);
     when(context.fileParsed()).thenReturn(false);
     assertThat(JavaFileTypeClassifier.isTestFile(context)).isFalse();
   }
 
   // -------------------------------------------------------------------------
-  // Helper
+  // Helpers
   // -------------------------------------------------------------------------
 
+  private static void assertIsTestFile(boolean expected, String filename) {
+    JavaFileScannerContext context = contextWithInputFileAndConfig(
+      TestUtils.emptyInputFile(filename, InputFile.Type.MAIN), NO_SONAR_TESTS_CONFIG);
+    assertThat(JavaFileTypeClassifier.isTestFile(context))
+      .as("Expected isTestFile=%s for '%s'", expected, filename)
+      .isEqualTo(expected);
+  }
+
   private static JavaFileScannerContext contextWithInputFile(InputFile inputFile) {
+    return contextWithInputFileAndConfig(inputFile, NO_SONAR_TESTS_CONFIG);
+  }
+
+  private static JavaFileScannerContext contextWithInputFileAndConfig(InputFile inputFile, Configuration config) {
     JavaFileScannerContext context = mock(JavaFileScannerContext.class);
     when(context.getInputFile()).thenReturn(inputFile);
+    when(context.getConfiguration()).thenReturn(config);
     return context;
   }
 }

--- a/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
@@ -135,6 +135,8 @@ class JavaFileTypeClassifierTest {
     assertIsTestFile(false, "Foo.java");
     assertIsTestFile(false, "FooService.java");
     assertIsTestFile(false, "FooController.java");
+    assertIsTestFile(false, "TestUtils.java");
+    assertIsTestFile(false, "TestHelper.java");
   }
 
   // -------------------------------------------------------------------------
@@ -147,28 +149,18 @@ class JavaFileTypeClassifierTest {
   }
 
   @Test
-  void isTestFile_recognizes_mavenItPath() {
+  void isTestFile_recognizes_mavenITPaths() {
     assertIsTestFile(true, "src/it/java/Foo.java");
-  }
-
-  @Test
-  void isTestFile_recognizes_mavenItsPath() {
     assertIsTestFile(true, "src/its/java/Foo.java");
+    assertIsTestFile(true, "src/IT/java/Foo.java");
+    assertIsTestFile(true, "src/ITS/java/Foo.java");
   }
 
   @Test
-  void isTestFile_recognizes_testDirectorySegment() {
+  void isTestFile_recognizes_testDirectorySegments() {
     assertIsTestFile(true, "src/test/Foo.java");
     assertIsTestFile(true, "modules/core/test/Foo.java");
-  }
-
-  @Test
-  void isTestFile_recognizes_testsDirectorySegment() {
     assertIsTestFile(true, "src/tests/Foo.java");
-  }
-
-  @Test
-  void isTestFile_recognizes_testingDirectorySegment() {
     assertIsTestFile(true, "src/testing/Foo.java");
   }
 

--- a/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
@@ -178,6 +178,39 @@ class JavaFileTypeClassifierTest {
   }
 
   // -------------------------------------------------------------------------
+  // isTestFile — sonar.tests configured: path/naming heuristic disabled
+  // -------------------------------------------------------------------------
+
+  @Test
+  void isTestFile_withSonarTestsConfigured_ignoresNamingAndPathSignals() {
+    // When sonar.tests is set, TestFileClassifier suppresses the heuristic because
+    // the platform already classifies test files as InputFile.Type.TEST.
+    // Names and paths that would otherwise trigger the heuristic must return false.
+    var config = new MapSettings().setProperty("sonar.tests", "src/test/java").asConfig();
+
+    assertIsTestFileWithConfig(false, "FooTest.java", config);
+    assertIsTestFileWithConfig(false, "src/test/java/Foo.java", config);
+    assertIsTestFileWithConfig(false, "src/it/java/Foo.java", config);
+  }
+
+  @Test
+  void isTestFile_withSonarTestsConfigured_platformTypeStillApplies() {
+    var config = new MapSettings().setProperty("sonar.tests", "src/test/java").asConfig();
+
+    // InputFile.Type.TEST is checked before the heuristic and is always authoritative.
+    var context = contextWithInputFileAndConfig(
+      TestUtils.emptyInputFile("Foo.java", InputFile.Type.TEST), config);
+    assertThat(JavaFileTypeClassifier.isTestFile(context)).isTrue();
+  }
+
+  @Test
+  void isTestFile_withSonarTestsConfigured_annotationSignalStillApplies() {
+    // hasTestFrameworkAnnotation() reads the AST, not the configuration —
+    // it must keep working regardless of whether sonar.tests is set.
+    assertAnnotationSignal(true, "src/test/files/utils/SampleWithRunWith.java");
+  }
+
+  // -------------------------------------------------------------------------
   // isTestFile — no signal
   // -------------------------------------------------------------------------
 
@@ -193,6 +226,14 @@ class JavaFileTypeClassifierTest {
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  private static void assertIsTestFileWithConfig(boolean expected, String filename, Configuration config) {
+    JavaFileScannerContext context = contextWithInputFileAndConfig(
+      TestUtils.emptyInputFile(filename, InputFile.Type.MAIN), config);
+    assertThat(JavaFileTypeClassifier.isTestFile(context))
+      .as("Expected isTestFile=%s for '%s' with sonar.tests config", expected, filename)
+      .isEqualTo(expected);
+  }
 
   private static void assertIsTestFile(boolean expected, String filename) {
     JavaFileScannerContext context = contextWithInputFileAndConfig(

--- a/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
+++ b/java-frontend/src/test/java/org/sonar/java/utils/JavaFileTypeClassifierTest.java
@@ -131,12 +131,6 @@ class JavaFileTypeClassifierTest {
   }
 
   @Test
-  void isTestFile_recognizes_TestPrefix() {
-    assertIsTestFile(true, "TestFoo.java");
-    assertIsTestFile(true, "TestBar.java");
-  }
-
-  @Test
   void isTestFile_returnsFalse_forProductionNames() {
     assertIsTestFile(false, "Foo.java");
     assertIsTestFile(false, "FooService.java");


### PR DESCRIPTION
Delegate path/naming heuristics to TestFileClassifier from sonar-analyzer-commons and extend it with Java-specific signals (IT paths, filename suffixes).

- Remove hasTestNamingConvention() and hasTestPathSegment(); replaced by TestFileClassifier.of() with JAVA_TEST_PATTERNS covering test/tests/testing directory segments, src/it/java, src/its/java, *Test/*Spec/*IT suffixes.
- Cache the TestFileClassifier per Configuration via AtomicReference so WildcardPatterns are compiled once per analysis run, not once per file.
- Keep isPlatformTestFile() and hasTestFrameworkAnnotation() unchanged; public API isTestFile(context) is backward-compatible.

