### PR TITLE
SONARJAVA-6782: Implement S9355: use Javadoc syntax for almost-Javadoc comments

### DIFF
--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9355.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9355.json
@@ -1,0 +1,23 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java": [
+56,
+75,
+105,
+118
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Request.java": [
+1115,
+1994,
+2002
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java": [
+596,
+609,
+626,
+1174,
+1527
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ScopedHandler.java": [
+204
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9355.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9355.json
@@ -1,0 +1,30 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelState.java": [
+56,
+75,
+105,
+118
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Request.java": [
+1115,
+1994,
+2002
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java": [
+596,
+609,
+626,
+1174,
+1527
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/handler/ScopedHandler.java": [
+204
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java": [
+420
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/X509.java": [
+41,
+46
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9355.json
+++ b/its/ruling/src/test/resources/guava/java-S9355.json
@@ -1,0 +1,15 @@
+{
+"com.google.guava:guava:src/com/google/common/collect/ImmutableEnumSet.java": [
+46
+],
+"com.google.guava:guava:src/com/google/common/collect/LinkedListMultimap.java": [
+105
+],
+"com.google.guava:guava:src/com/google/common/net/PercentEscaper.java": [
+136,
+153
+],
+"com.google.guava:guava:src/com/google/common/util/concurrent/AbstractIdleService.java": [
+39
+]
+}

--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
@@ -147,3 +147,10 @@ class AlmostJavadocCheckSample {
   static class Entity {
   }
 }
+
+// Noncompliant@+1 [[quickfixes=qf4]]
+// /** Extra documentation. {@link AlmostJavadocCheckSample.Entity} */
+// fix@qf4 {{Convert to Javadoc comment}}
+// edit@qf4 [[sc=1;ec=3]] {{}}
+class AlmostJavadocCheckSampleSecondType {
+}

--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
@@ -47,6 +47,10 @@ class AlmostJavadocCheckSample {
 
     /** Loads the entity. {@link Entity} */
     Entity documentedLoad(String id);
+
+    // Noncompliant@+1
+    // Loads with trailing space. {@link Entity} */ 
+    Entity loadWithTrailingSpace(String id);
   }
 
   // Noncompliant@+1
@@ -121,6 +125,22 @@ class AlmostJavadocCheckSample {
     // Noncompliant@+1
     /* @param x the x coordinate */
     Point {
+    }
+  }
+
+  // Noncompliant@+1
+  /* @since 1.0 */
+  int a, b, c;
+
+  int trailingField; // trailing note: see @param x */
+  void methodAfterTrailingComment(int x) {
+  }
+
+  void localClassIsNotDocumentable() {
+    /* @param q */
+    class Local {
+      /* @return r */
+      int r;
     }
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
@@ -1,0 +1,129 @@
+package checks;
+
+class AlmostJavadocCheckSample {
+
+  String name;
+
+  // Noncompliant@+1 [[quickfixes=qf1]]
+  /*
+   * Computes the factorial of a positive integer.
+   * @param n the number to compute factorial for
+   * @return the factorial of n
+   */
+  // fix@qf1 {{Convert to Javadoc comment}}
+  // edit@qf1 [[sc=4;ec=4]] {{*}}
+  public long factorial(int n) {
+    return (n <= 1) ? 1L : n * factorial(n - 1);
+  }
+
+  /**
+   * Computes the factorial of a positive integer.
+   * @param n the number to compute factorial for
+   * @return the factorial of n
+   */
+  public long documentedFactorial(int n) {
+    return (n <= 1) ? 1L : n * documentedFactorial(n - 1);
+  }
+
+  // Noncompliant@+1 [[quickfixes=qf2]]
+  /* Returns the display name as <code>String</code>. */
+  // fix@qf2 {{Convert to Javadoc comment}}
+  // edit@qf2 [[sc=4;ec=4]] {{*}}
+  public String displayName() {
+    return name;
+  }
+
+  /** Returns the display name as <code>String</code>. */
+  public String documentedDisplayName() {
+    return name;
+  }
+
+  interface Repository {
+    // Noncompliant@+1 [[quickfixes=qf3]]
+    // Loads the entity. {@link Entity} */
+    // fix@qf3 {{Convert to Javadoc comment}}
+    // edit@qf3 [[sc=5;ec=7]] {{/**}}
+    Entity load(String id);
+
+    /** Loads the entity. {@link Entity} */
+    Entity documentedLoad(String id);
+  }
+
+  // Noncompliant@+1
+  /* {@link AlmostJavadocCheckSample} */
+  static class Nested {}
+
+  /** {@link AlmostJavadocCheckSample} */
+  static class DocumentedNested {}
+
+  // Noncompliant@+1
+  /* @since 1.0 */
+  int version;
+
+  /** @since 1.0 */
+  int documentedVersion;
+
+  enum Kind {
+    // Noncompliant@+1
+    /* Foo <em>bar</em>. */
+    FOO,
+    /** Foo <em>bar</em>. */
+    BAR
+  }
+
+  /* Regular commentary without tags. */
+  void undocumentedOnPurpose() {
+  }
+
+  // Regular line comment with {@link tags} is not almost-Javadoc
+  void lineCommentWithoutTerminator() {
+  }
+
+  /* returns 0 on success */
+  int noTagBecauseReturnIsAWord() {
+    return 0;
+  }
+
+  /* support@param.org is an email, not a Javadoc tag */
+  void emailLooksLikeTag() {
+  }
+
+  /* @Override is a Java annotation mentioned in a comment */
+  void annotationMention() {
+  }
+
+  /* List<String> uses generics, not HTML */
+  void genericsAreNotHtml() {
+    voidWithLocalComment();
+  }
+
+  void voidWithLocalComment() {
+    /* @param local is not attached to a documentable declaration */
+    int local = 1;
+  }
+
+  /** Valid Javadoc. */
+  /* Extra note with {@link tags}. */
+  void alreadyHasJavadoc() {
+  }
+
+  /// Markdown documentation with {@link tags}.
+  /* Extra note with @param. */
+  void alreadyHasMarkdown() {
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  record Point(int x, int y) {
+    // Noncompliant@+1
+    /* @param x the x coordinate */
+    Point {
+    }
+  }
+
+  static class Entity {
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheck_compactSource.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheck_compactSource.java
@@ -1,0 +1,20 @@
+void main() {
+  System.out.println("compact source");
+}
+
+// Noncompliant@+1
+/* @since 1.0 */
+int version;
+
+/** @since 1.0 */
+int documentedVersion;
+
+// Noncompliant@+1
+/* @param n unused */
+int a, b, c;
+
+// Noncompliant@+1
+/* Returns <code>ok</code>. */
+String status() {
+  return "ok";
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
@@ -19,6 +19,8 @@ package org.sonar.java.checks;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.java.ast.visitors.PublicApiChecker;
@@ -41,10 +43,12 @@ public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
 
   static final String MESSAGE = "This comment contains Javadoc or HTML tags, but isn't started with a double asterisk (/**); is it meant to be Javadoc?";
 
-  private static final Pattern HAS_TAG = Pattern.compile(
-    "</(?:em|b|a|strong|i|pre|code)>"
-      + "|(?<!\\w)@(?:author|code|deprecated|docRoot|exception|inheritDoc|link|linkplain|literal"
-      + "|param|return|see|serial|serialData|serialField|since|snippet|throws|value|version)\\b");
+  private static final Pattern CLOSING_HTML = Pattern.compile("</(?:em|b|a|strong|i|pre|code)>");
+  private static final Pattern AT_TAG = Pattern.compile("(?<!\\w)@[a-zA-Z]+\\b");
+  private static final Set<String> JAVADOC_TAGS = Set.of(
+    "@author", "@code", "@deprecated", "@docRoot", "@exception", "@inheritDoc",
+    "@link", "@linkplain", "@literal", "@param", "@return", "@see", "@serial",
+    "@serialData", "@serialField", "@since", "@snippet", "@throws", "@value", "@version");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -129,11 +133,24 @@ public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
   private static boolean isAlmostJavadoc(SyntaxTrivia trivia) {
     String text = trivia.comment().stripTrailing();
     if (trivia.isComment(CommentKind.BLOCK)) {
-      return HAS_TAG.matcher(text).find();
+      return hasTag(text);
     }
     return trivia.isComment(CommentKind.LINE)
       && text.endsWith("*/")
-      && HAS_TAG.matcher(text).find();
+      && hasTag(text);
+  }
+
+  private static boolean hasTag(String text) {
+    if (CLOSING_HTML.matcher(text).find()) {
+      return true;
+    }
+    Matcher matcher = AT_TAG.matcher(text);
+    while (matcher.find()) {
+      if (JAVADOC_TAGS.contains(matcher.group())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void reportAlmostJavadoc(SyntaxTrivia trivia) {

--- a/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
@@ -1,0 +1,120 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.sonar.check.Rule;
+import org.sonar.java.ast.visitors.PublicApiChecker;
+import org.sonar.java.checks.helpers.QuickFixHelper;
+import org.sonar.java.reporting.AnalyzerMessage;
+import org.sonar.java.reporting.JavaQuickFix;
+import org.sonar.java.reporting.JavaTextEdit;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.location.Position;
+import org.sonar.plugins.java.api.tree.SyntaxToken;
+import org.sonar.plugins.java.api.tree.SyntaxTrivia;
+import org.sonar.plugins.java.api.tree.SyntaxTrivia.CommentKind;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9355")
+public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
+
+  static final String MESSAGE = "This comment contains Javadoc or HTML tags, but isn't started with a double asterisk (/**); is it meant to be Javadoc?";
+
+  private static final Pattern HAS_TAG = Pattern.compile(
+    "</(?:em|b|a|strong|i|pre|code)>"
+      + "|(?<!\\w)@(?:author|code|deprecated|docRoot|exception|inheritDoc|link|linkplain|literal"
+      + "|param|return|see|serial|serialData|serialField|since|snippet|throws|value|version)\\b");
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    List<Tree.Kind> kinds = new ArrayList<>(Arrays.asList(PublicApiChecker.apiKinds()));
+    kinds.add(Tree.Kind.ENUM_CONSTANT);
+    return kinds;
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    if (!isDocumentableDeclaration(tree)) {
+      return;
+    }
+    SyntaxToken firstToken = tree.firstToken();
+    if (firstToken == null) {
+      return;
+    }
+    List<SyntaxTrivia> trivias = firstToken.trivias();
+    if (trivias.stream().anyMatch(trivia -> trivia.isComment(CommentKind.JAVADOC, CommentKind.MARKDOWN))) {
+      return;
+    }
+    for (SyntaxTrivia trivia : trivias) {
+      if (isAlmostJavadoc(trivia)) {
+        reportAlmostJavadoc(trivia);
+      }
+    }
+  }
+
+  private static boolean isDocumentableDeclaration(Tree tree) {
+    if (tree.is(Tree.Kind.VARIABLE)) {
+      Tree parent = tree.parent();
+      return parent != null && parent.is(PublicApiChecker.classKinds());
+    }
+    return true;
+  }
+
+  private static boolean isAlmostJavadoc(SyntaxTrivia trivia) {
+    if (trivia.isComment(CommentKind.BLOCK)) {
+      return HAS_TAG.matcher(trivia.comment()).find();
+    }
+    return trivia.isComment(CommentKind.LINE)
+      && trivia.comment().endsWith("*/")
+      && HAS_TAG.matcher(trivia.comment()).find();
+  }
+
+  private void reportAlmostJavadoc(SyntaxTrivia trivia) {
+    Position start = trivia.range().start();
+    Position end = trivia.range().end();
+    QuickFixHelper.newIssue(context)
+      .forRule(this)
+      .onRange(start.line(), start.columnOffset(), end.line(), end.columnOffset())
+      .withMessage(MESSAGE)
+      .withQuickFix(() -> convertToJavadoc(trivia))
+      .report();
+  }
+
+  private static JavaQuickFix convertToJavadoc(SyntaxTrivia trivia) {
+    Position start = trivia.range().start();
+    String text = trivia.comment();
+    JavaTextEdit edit;
+    if (trivia.isComment(CommentKind.LINE) && text.startsWith("// /**")) {
+      edit = JavaTextEdit.replaceTextSpan(firstCharacters(start, 2), "");
+    } else if (trivia.isComment(CommentKind.BLOCK)) {
+      edit = JavaTextEdit.insertAtPosition(start.line(), start.columnOffset() + 1, "*");
+    } else {
+      edit = JavaTextEdit.replaceTextSpan(firstCharacters(start, 2), "/**");
+    }
+    return JavaQuickFix.newQuickFix("Convert to Javadoc comment")
+      .addTextEdit(edit)
+      .build();
+  }
+
+  private static AnalyzerMessage.TextSpan firstCharacters(Position start, int length) {
+    return new AnalyzerMessage.TextSpan(start.line(), start.columnOffset(), start.line(), start.columnOffset() + length);
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
@@ -28,10 +28,13 @@ import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.location.Position;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia;
 import org.sonar.plugins.java.api.tree.SyntaxTrivia.CommentKind;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9355")
 public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
@@ -64,27 +67,66 @@ public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
       return;
     }
     for (SyntaxTrivia trivia : trivias) {
-      if (isAlmostJavadoc(trivia)) {
+      if (!belongsToPreviousMember(tree, trivia) && isAlmostJavadoc(trivia)) {
         reportAlmostJavadoc(trivia);
       }
     }
   }
 
   private static boolean isDocumentableDeclaration(Tree tree) {
+    if (isInsideMethodOrConstructor(tree)) {
+      return false;
+    }
     if (tree.is(Tree.Kind.VARIABLE)) {
       Tree parent = tree.parent();
-      return parent != null && parent.is(PublicApiChecker.classKinds());
+      return parent != null
+        && parent.is(PublicApiChecker.classKinds())
+        && QuickFixHelper.previousVariable((VariableTree) tree).isEmpty();
     }
     return true;
   }
 
+  private static boolean isInsideMethodOrConstructor(Tree tree) {
+    for (Tree current = tree.parent(); current != null; current = current.parent()) {
+      if (current.is(Tree.Kind.METHOD, Tree.Kind.CONSTRUCTOR, Tree.Kind.LAMBDA_EXPRESSION)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean belongsToPreviousMember(Tree tree, SyntaxTrivia trivia) {
+    Tree previous = previousSibling(tree);
+    if (previous == null) {
+      return false;
+    }
+    SyntaxToken previousEnd = previous.lastToken();
+    return previousEnd != null && trivia.range().start().line() == previousEnd.range().end().line();
+  }
+
+  private static Tree previousSibling(Tree tree) {
+    Tree parent = tree.parent();
+    if (parent instanceof ClassTree classTree) {
+      List<Tree> members = classTree.members();
+      int index = members.indexOf(tree);
+      return index > 0 ? members.get(index - 1) : null;
+    }
+    if (parent instanceof CompilationUnitTree compilationUnit) {
+      List<Tree> types = compilationUnit.types();
+      int index = types.indexOf(tree);
+      return index > 0 ? types.get(index - 1) : null;
+    }
+    return null;
+  }
+
   private static boolean isAlmostJavadoc(SyntaxTrivia trivia) {
+    String text = trivia.comment().stripTrailing();
     if (trivia.isComment(CommentKind.BLOCK)) {
-      return HAS_TAG.matcher(trivia.comment()).find();
+      return HAS_TAG.matcher(text).find();
     }
     return trivia.isComment(CommentKind.LINE)
-      && trivia.comment().endsWith("*/")
-      && HAS_TAG.matcher(trivia.comment()).find();
+      && text.endsWith("*/")
+      && HAS_TAG.matcher(text).find();
   }
 
   private void reportAlmostJavadoc(SyntaxTrivia trivia) {

--- a/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
@@ -74,16 +74,23 @@ public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isDocumentableDeclaration(Tree tree) {
-    if (isInsideMethodOrConstructor(tree)) {
+    if (tree.is(Tree.Kind.IMPLICIT_CLASS) || isInsideMethodOrConstructor(tree)) {
       return false;
     }
     if (tree.is(Tree.Kind.VARIABLE)) {
-      Tree parent = tree.parent();
-      return parent != null
-        && parent.is(PublicApiChecker.classKinds())
-        && QuickFixHelper.previousVariable((VariableTree) tree).isEmpty();
+      return tree.parent() instanceof ClassTree classTree && isFirstDeclarator(classTree, (VariableTree) tree);
     }
     return true;
+  }
+
+  private static boolean isFirstDeclarator(ClassTree classTree, VariableTree variable) {
+    List<Tree> members = classTree.members();
+    int index = members.indexOf(variable);
+    if (index <= 0) {
+      return true;
+    }
+    Tree preceding = members.get(index - 1);
+    return !(preceding.is(Tree.Kind.VARIABLE) && preceding.firstToken().equals(variable.firstToken()));
   }
 
   private static boolean isInsideMethodOrConstructor(Tree tree) {

--- a/java-checks/src/test/java/org/sonar/java/checks/AlmostJavadocCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AlmostJavadocCheckTest.java
@@ -56,4 +56,14 @@ class AlmostJavadocCheckTest {
       .withJavaVersion(25)
       .verifyIssues();
   }
+
+  @Test
+  void compact_source_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/AlmostJavadocCheck_compactSource.java"))
+      .withCheck(new AlmostJavadocCheck())
+      .withJavaVersion(25)
+      .withoutSemantic()
+      .verifyIssues();
+  }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/AlmostJavadocCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AlmostJavadocCheckTest.java
@@ -1,0 +1,50 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class AlmostJavadocCheckTest {
+
+  @Test
+  void issue_message() {
+    assertThat(AlmostJavadocCheck.MESSAGE)
+      .isEqualTo("This comment contains Javadoc or HTML tags, but isn't started with a double asterisk (/**); is it meant to be Javadoc?");
+  }
+
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/AlmostJavadocCheckSample.java"))
+      .withCheck(new AlmostJavadocCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/AlmostJavadocCheckSample.java"))
+      .withCheck(new AlmostJavadocCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/AlmostJavadocCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/AlmostJavadocCheckTest.java
@@ -47,4 +47,13 @@ class AlmostJavadocCheckTest {
       .withoutSemantic()
       .verifyIssues();
   }
+
+  @Test
+  void compact_source() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/AlmostJavadocCheck_compactSource.java"))
+      .withCheck(new AlmostJavadocCheck())
+      .withJavaVersion(25)
+      .verifyIssues();
+  }
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
@@ -84,7 +84,6 @@ interface Repository {
 <h3>Related rules</h3>
 <ul>
   <li>{rule:java:S1176} - Public types, methods and fields (API) should be documented with Javadoc</li>
-  <li>{rule:java:S2920} - Javadoc tags should not be used in non-Javadoc comments</li>
   <li>{rule:java:S8491} - Dangling Javadoc comments should be removed</li>
 </ul>
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
@@ -1,0 +1,90 @@
+<p>A documentation comment must start with <code>/**</code>. A regular comment that contains Javadoc tags or HTML documentation tags, and that sits
+immediately above a declaration, is ignored by the Javadoc tool, so the following declaration stays undocumented.</p>
+<h2>Why is this an issue?</h2>
+<p>The Javadoc tool recognizes documentation comments that start with <code>/**</code> and that are placed immediately before a class, interface,
+constructor, method, field, or enum constant. A comment that starts with <code>/*</code> or <code>//</code> in that position is ordinary
+commentary.</p>
+<p>When such a comment contains Javadoc tags such as <code>@param</code>, <code>@return</code>, or <code>{@link}</code>, or HTML documentation tags
+such as <code>&lt;/code&gt;</code> or <code>&lt;/em&gt;</code>, it is almost always intended to be Javadoc. Because it is not a documentation comment,
+those tags never attach to the following declaration. Readers and generated API docs then miss the contract that the author already wrote.</p>
+<p>Start the comment with <code>/**</code> so the tags document the following declaration.</p>
+<h3>Exceptions</h3>
+<p>This rule does not raise an issue when:</p>
+<ul>
+  <li>The comment does not contain a Javadoc tag or one of the HTML documentation tags <code>&lt;/em&gt;</code>, <code>&lt;/b&gt;</code>,
+  <code>&lt;/a&gt;</code>, <code>&lt;/strong&gt;</code>, <code>&lt;/i&gt;</code>, <code>&lt;/pre&gt;</code>, or <code>&lt;/code&gt;</code>.</li>
+  <li>The comment does not immediately precede a documentable declaration.</li>
+  <li>The declaration already has a documentation comment.</li>
+</ul>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+public class MathUtils {
+  /* // Noncompliant: not a documentation comment, so these tags are ignored
+   * Computes the factorial of a positive integer.
+   * @param n the number to compute factorial for
+   * @return the factorial of n
+   */
+  public long factorial(int n) {
+    return (n &lt;= 1) ? 1 : n * factorial(n - 1);
+  }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+public class MathUtils {
+  /**
+   * Computes the factorial of a positive integer.
+   * @param n the number to compute factorial for
+   * @return the factorial of n
+   */
+  public long factorial(int n) {
+    return (n &lt;= 1) ? 1 : n * factorial(n - 1);
+  }
+}
+</pre>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+public class Names {
+  /* Returns the display name as &lt;code&gt;String&lt;/code&gt;. */ // Noncompliant: HTML documentation tags in a regular block comment
+  public String displayName() {
+    return name;
+  }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+public class Names {
+  /** Returns the display name as &lt;code&gt;String&lt;/code&gt;. */
+  public String displayName() {
+    return name;
+  }
+}
+</pre>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="3" data-diff-type="noncompliant">
+interface Repository {
+  // Loads the entity. {@link Entity} */ // Noncompliant: line comment is not started with /**
+  Entity load(String id);
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="3" data-diff-type="compliant">
+interface Repository {
+  /** Loads the entity. {@link Entity} */
+  Entity load(String id);
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Java Documentation - <a href="https://docs.oracle.com/en/java/javase/21/docs/specs/javadoc/doc-comment-spec.html">Documentation Comment
+  Specification for the Standard Doclet</a></li>
+</ul>
+<h3>Related rules</h3>
+<ul>
+  <li>{rule:java:S1176} - Public types, methods and fields (API) should be documented with Javadoc</li>
+  <li>{rule:java:S2920} - Javadoc tags should not be used in non-Javadoc comments</li>
+  <li>{rule:java:S8491} - Dangling Javadoc comments should be removed</li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.json
@@ -14,7 +14,7 @@
   "ruleSpecification": "RSPEC-9355",
   "sqKey": "S9355",
   "scope": "All",
-  "quickfix": "targeted",
+  "quickfix": "covered",
   "code": {
     "impacts": {
       "MAINTAINABILITY": "MEDIUM"

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.json
@@ -1,0 +1,24 @@
+{
+  "title": "Comments containing Javadoc or HTML tags should use Javadoc syntax",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "javadoc",
+    "confusing"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9355",
+  "sqKey": "S9355",
+  "scope": "All",
+  "quickfix": "targeted",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}


### PR DESCRIPTION
## Summary

- Implement S9355 in SonarJava as a native `AlmostJavadocCheck`.
- Flag `/*` comments and `// ... */` comments that contain Javadoc or HTML tags immediately before a documentable declaration.
- Add a quick fix that converts the comment to `/**`.
- Generate rule metadata from the S9355 RSPEC branch.

## Links

- Jira: https://sonarsource.atlassian.net/browse/SONARJAVA-6782
- RSPEC PR: https://github.com/SonarSource/rspec/pull/7916

## AI disclosure
- LLM model used for implementation: cursor-grok-4.6-high
