### PR TITLE
BUILD-12290 Move Windows GitHub-hosted jobs to WarpBuild

### DIFF
--- a/.github/actions/upload-actual/action.yml
+++ b/.github/actions/upload-actual/action.yml
@@ -33,6 +33,7 @@ runs:
       if: runner.os != 'Windows'
 
     - name: Generate Diff Report
+      if: runner.os != 'Windows'
       shell: bash
       env:
         IT_DIR: ${{ inputs.it-dir }}
@@ -46,6 +47,7 @@ runs:
         npx diff2html-cli --input file --style side --file "target/diff_${NAME}.html" -- "target/test.diff"
 
     - name: Upload Diff Report
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: diff_${{ inputs.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,8 @@ jobs:
         item:
           - { runner: warp-custom-ubuntu-24-04, profile: without-sonarqube-project, sq_version: LATEST_RELEASE }
           - { runner: warp-custom-ubuntu-24-04, profile: only-sonarqube-project, sq_version: LATEST_RELEASE }
-          - { runner: github-windows-latest-m, profile: without-sonarqube-project, sq_version: LATEST_RELEASE }
-          - { runner: github-windows-latest-m, profile: only-sonarqube-project, sq_version: LATEST_RELEASE }
+          - { runner: warp-custom-windows-2022-l, profile: without-sonarqube-project, sq_version: LATEST_RELEASE }
+          - { runner: warp-custom-windows-2022-m, profile: only-sonarqube-project, sq_version: LATEST_RELEASE }
     name: Ruling QA
     needs:
       - build
@@ -71,6 +71,9 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
     steps:
+      - name: Config Git
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf input
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
@@ -108,11 +111,17 @@ jobs:
       - name: Run ruling tests
         shell: bash # Set explicitly so Bash is used on Windows runners too.
         env:
-          MAVEN_OPTS: "-Xmx3g"
+          MAVEN_OPTS: "-Xmx3g -Dfile.encoding=UTF-8"
+          JAVA_TOOL_OPTIONS: ""
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
         run: |
           cd its/ruling
-          mvn package ${MAVEN_OUTPUT_ARGS} "-Pit-ruling,${{ matrix.item.profile }}" -Dsonar.runtimeVersion=${{ matrix.item.sq_version }} -Dmaven.test.redirectTestOutputToFile=false -Dparallel=methods -DuseUnlimitedThreads=true
+          extra_args=()
+          # Nested Maven builds share ~/.m2; Windows denies concurrent writes to *.lastUpdated.
+          if [[ "${RUNNER_OS}" != "Windows" ]]; then
+            extra_args+=(-Dparallel=methods -DuseUnlimitedThreads=true)
+          fi
+          mvn package ${MAVEN_OUTPUT_ARGS} "-Pit-ruling,${{ matrix.item.profile }}" -Dsonar.runtimeVersion=${{ matrix.item.sq_version }} -Dmaven.test.redirectTestOutputToFile=false "${extra_args[@]}"
       - name: Upload Actual Results On Failure
         if: failure()
         uses: ./.github/actions/upload-actual
@@ -364,7 +373,7 @@ jobs:
   qa-os-win:
     name: Build and Unit Test on Windows
     # No dependency on build step, because we do not need the build number.
-    runs-on: github-windows-latest-m
+    runs-on: warp-custom-windows-2022-m
     permissions:
       id-token: write  # Required for Vault OIDC authentication
       contents: write  # Required for repository access and tagging
@@ -387,6 +396,9 @@ jobs:
           use-develocity: ${{ env.USE_DEVELOCITY }}
           develocity-url: ${{ env.DEVELOCITY_URL }}
       - name: Run Maven
+        env:
+          JAVA_TOOL_OPTIONS: ""
+          MAVEN_OPTS: "-Xmx8g"
         run: mvn clean verify --batch-mode
 
   promote:


### PR DESCRIPTION
## Summary
- Move the Windows CI jobs to WarpBuild:
  - `qa-os-win` and the `only-sonarqube-project` ruling profile use `warp-custom-windows-2022-m`.
  - The full `without-sonarqube-project` ruling profile uses `warp-custom-windows-2022-l`, which provides the capacity required by that analysis.
- Preserve the existing ruling profiles, Maven goals, SonarQube runtime, and expected ruling dumps.
- Use Windows-safe workflow settings: LF checkout, explicit Java 21 for ruling, cleared inherited JVM options, an 8 GiB Maven heap for the Windows unit-test job, and serial nested Maven execution to avoid local-repository write races.

## Behavior and trade-offs
- The full Windows ruling profile remains functionally equivalent, but uses the large runner and runs its nested Maven tests without method-level parallelism. This can increase capacity usage and elapsed time.
- On a Windows ruling failure, the raw actual-results artifact is still uploaded. The optional HTML diff report is skipped because its generator adds a separate npm dependency step to the failure path.
- No source analysis scope, quality profiles, expected ruling results, or release behavior is changed.

## Validation
- [x] Windows unit tests pass on `warp-custom-windows-2022-m`.
- [x] Windows `only-sonarqube-project` ruling passes on `warp-custom-windows-2022-m`.
- [x] Windows `without-sonarqube-project` ruling passes on `warp-custom-windows-2022-l`.
- [x] Linux ruling, plugin QA, sanity, Test Analyze, custom-rules/license, SCA, quality analysis, and required security checks pass.

The full ruling profile needs the large runner: the medium runner made 3 GiB available to the scanner, while the large runner completed with the shared expected ruling results.

Parent: https://sonarsource.atlassian.net/browse/BUILD-12260  
Sub-task: https://sonarsource.atlassian.net/browse/BUILD-12290