### PR TITLE
BUILD-12289 Move Linux CI jobs to WarpBuild

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -57,7 +57,7 @@ jobs:
       plugin-artifacts-sqs: "java"
       plugin-artifacts-sqc: "java"
       jira-project-key: "SONARJAVA"
-      runner-environment: "sonar-xs-public"
+      runner-environment: "warp-custom-ubuntu-24-04"
       rule-props-changed: false
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: sonar-m-public
+    runs-on: warp-custom-ubuntu-24-04
     name: Build
     permissions:
       id-token: write  # Required for Vault OIDC authentication
@@ -56,8 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         item:
-          - { runner: sonar-m-public, profile: without-sonarqube-project, sq_version: LATEST_RELEASE }
-          - { runner: sonar-m-public, profile: only-sonarqube-project, sq_version: LATEST_RELEASE }
+          - { runner: warp-custom-ubuntu-24-04, profile: without-sonarqube-project, sq_version: LATEST_RELEASE }
+          - { runner: warp-custom-ubuntu-24-04, profile: only-sonarqube-project, sq_version: LATEST_RELEASE }
           - { runner: github-windows-latest-m, profile: without-sonarqube-project, sq_version: LATEST_RELEASE }
           - { runner: github-windows-latest-m, profile: only-sonarqube-project, sq_version: LATEST_RELEASE }
     name: Ruling QA
@@ -126,7 +126,7 @@ jobs:
     name: Ruling Update and Notify
     needs: ruling-qa
     if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       contents: write
       pull-requests: write
@@ -178,7 +178,7 @@ jobs:
     needs:
       - build
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: sonar-m-public
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write
@@ -231,7 +231,7 @@ jobs:
     needs:
       - build
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: sonar-m-public
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write
@@ -278,7 +278,7 @@ jobs:
     needs:
       - build
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: sonar-l-public
+    runs-on: warp-custom-ubuntu-24-04-l
     permissions:
       id-token: write
       contents: write
@@ -313,7 +313,7 @@ jobs:
     needs:
       - build
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: sonar-m-public
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: write
@@ -398,7 +398,7 @@ jobs:
       - custom-rules-license-check
       - qa-os-win
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: sonar-s-public
+    runs-on: warp-custom-ubuntu-24-04
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,6 +306,7 @@ jobs:
         env:
           SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+          MAVEN_OPTS: "-Xmx8g"
           JAVA_TOOL_OPTIONS: "" # Set an empty value to avoid issues with runners hanging and significantly slowing down builds
 
   custom-rules-license-check:

--- a/.github/workflows/ruling-diff-comment.yml
+++ b/.github/workflows/ruling-diff-comment.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   ruling-diff-comment:
-    runs-on: ubuntu-latest
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unified-platform-dogfooding:
-    runs-on: sonar-l-public
+    runs-on: warp-custom-ubuntu-24-04-l
     name: Unified Platform Dogfooding
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Move sonar-java Linux CI jobs from ARC `sonar-*-public` labels to WarpBuild.
- `sonar-m-public` / `sonar-s-public` → `warp-custom-ubuntu-24-04`
- `sonar-l-public` → `warp-custom-ubuntu-24-04-l` (Build `test-analyze` and unified dogfooding)
- Automated-release `runner-environment` → `warp-custom-ubuntu-24-04`
- Leaves `sonar-m-docker` and remaining `sonar-xs-public` Jira/PR automations unchanged.

Parent: https://sonarsource.atlassian.net/browse/BUILD-12260
Sub-task: https://sonarsource.atlassian.net/browse/BUILD-12289

## Test plan
- [ ] Confirm Build jobs schedule on `warp-custom-ubuntu-24-04` / `warp-custom-ubuntu-24-04-l`
- [ ] Confirm build, plugin QA, ruling QA (Linux), sanity, autoscan, and promote succeed
- [ ] Watch runtime and queue time versus the previous ARC public runners