### PR TITLE
SONARJAVA-6783: Implement rule S9345 Classes with throwing constructors should be protected against Finalizer attacks

### DIFF
--- a/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
@@ -1,32 +1,41 @@
 {
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueChangeClosure.java": [
-79
+134
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java": [
-110
+164
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformer.java": [
-71
+119
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java": [
-78
+97
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java": [
-44
+85,
+151,
+197
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/MethodUtils.java": [
-1304
+1319
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/ResultSetDynaClass.java": [
-82
+100,
+128,
+159
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/RowSetDynaClass.java": [
-66
+101,
+123,
+148,
+176,
+206,
+236
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/SuppressPropertiesBeanIntrospector.java": [
-38
+62
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/converters/ArrayConverter.java": [
-129
+150
 ]
 }

--- a/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
@@ -1,0 +1,32 @@
+{
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueChangeClosure.java": [
+79
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java": [
+110
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformer.java": [
+71
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java": [
+78
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java": [
+44
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/MethodUtils.java": [
+1304
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/ResultSetDynaClass.java": [
+82
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/RowSetDynaClass.java": [
+66
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/SuppressPropertiesBeanIntrospector.java": [
+38
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/converters/ArrayConverter.java": [
+129
+]
+}

--- a/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
@@ -1,4 +1,7 @@
 {
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BaseDynaBeanMapDecorator.java": [
+78
+],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueChangeClosure.java": [
 134
 ],

--- a/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9345.json
@@ -2,17 +2,37 @@
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BaseDynaBeanMapDecorator.java": [
 78
 ],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPredicate.java": [
+49
+],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueChangeClosure.java": [
+117,
 134
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanPropertyValueEqualsPredicate.java": [
+149,
 164
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanToPropertyValueTransformer.java": [
+103,
 119
 ],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BeanUtilsBean.java": [
+111,
+124,
+136
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/ConvertUtilsBean.java": [
+158
+],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/FluentPropertyBeanIntrospector.java": [
-97
+97,
+110
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/LazyDynaBean.java": [
+172,
+181,
+192
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/MappedPropertyDescriptor.java": [
 85,
@@ -21,6 +41,9 @@
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/MethodUtils.java": [
 1319
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/PropertyUtilsBean.java": [
+128
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/ResultSetDynaClass.java": [
 100,
@@ -40,5 +63,61 @@
 ],
 "commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/converters/ArrayConverter.java": [
 150
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/BaseLocaleConverter.java": [
+70,
+83,
+97,
+111
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/LocaleBeanUtilsBean.java": [
+92,
+104,
+118
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/LocaleConvertUtilsBean.java": [
+118
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/converters/DateLocaleConverter.java": [
+69,
+82,
+94,
+107,
+120,
+134,
+148,
+162,
+175,
+189,
+204,
+219
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/converters/DecimalLocaleConverter.java": [
+59,
+72,
+84,
+97,
+110,
+124,
+138,
+152,
+165,
+179,
+193,
+208
+],
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/locale/converters/StringLocaleConverter.java": [
+63,
+76,
+88,
+101,
+114,
+128,
+142,
+156,
+169,
+183,
+197,
+212
 ]
 }

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9345.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9345.json
@@ -11,6 +11,9 @@
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
 76
 ],
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java": [
+51
+],
 "org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
 90
 ],

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9345.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9345.json
@@ -1,0 +1,35 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java": [
+28
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java": [
+32
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/PrecompressedHttpContent.java": [
+30
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
+39
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
+273
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
+29
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
+33
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java": [
+83
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServletPathMapping.java": [
+38
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9345.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9345.json
@@ -1,35 +1,35 @@
 {
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java": [
-28
+37
 ],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java": [
-32
+125
 ],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/PrecompressedHttpContent.java": [
-30
+36
 ],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
-41
+76
 ],
 "org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
-39
+90
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
-273
+303
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java": [
-41
+68
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
-29
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
 33
 ],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
+54
+],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java": [
-83
+370
 ],
 "org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServletPathMapping.java": [
-38
+47
 ]
 }

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9345.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9345.json
@@ -1,107 +1,120 @@
 {
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java": [
-28
+37
 ],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java": [
-32
+125
 ],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/PrecompressedHttpContent.java": [
-30
-],
-"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
-41
-],
-"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
-39
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
-273
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java": [
-41
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
-29
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
-33
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java": [
-83
-],
-"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServletPathMapping.java": [
-38
-],
-"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONPojoConvertorFactory.java": [
-29
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java": [
-49
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ClassLoadingObjectInputStream.java": [
-32
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/CountingCallback.java": [
-41
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java": [
-26
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java": [
-39
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/InetAddressPattern.java": [
-110,
-191,
-236
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartOutputStream.java": [
-29
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartWriter.java": [
-28
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiReleaseJarFile.java": [
-38,
-154
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java": [
-70
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/QuotedStringTokenizer.java": [
-37
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java": [
-51
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/Uptime.java": [
 36
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/FileDestroyable.java": [
-32
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
+76
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java": [
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
+90
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
+303
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java": [
+68
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
+33
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
+54
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java": [
+370
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServletPathMapping.java": [
+47
+],
+"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONPojoConvertorFactory.java": [
+46
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java": [
+126
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ClassLoadingObjectInputStream.java": [
+48,
 53
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java": [
-43
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/CountingCallback.java": [
+45
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateValidator.java": [
-55
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/KeyStoreScanner.java": [
-40
-],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/X509.java": [
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java": [
 37
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java": [
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java": [
+85
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/InetAddressPattern.java": [
+115,
+198,
+241
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartOutputStream.java": [
+43,
+53
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartWriter.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiReleaseJarFile.java": [
+55,
+68,
+162
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java": [
+98
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/QuotedStringTokenizer.java": [
+52
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java": [
+79,
+91,
+104,
+120,
+140,
+151
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/Uptime.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/FileDestroyable.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java": [
+279,
+331
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java": [
+89
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateValidator.java": [
+86
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/KeyStoreScanner.java": [
 48
 ],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/X509.java": [
+67
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java": [
+126
+],
 "org.eclipse.jetty:jetty-project:jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlAppendable.java": [
-30
+38,
+43,
+48,
+53,
+58
 ],
 "org.eclipse.jetty:jetty-project:jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java": [
-87
+224
 ]
 }

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9345.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9345.json
@@ -11,6 +11,9 @@
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
 76
 ],
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/AbstractConnection.java": [
+51
+],
 "org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
 90
 ],

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9345.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9345.json
@@ -1,0 +1,107 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HostPortHttpField.java": [
+28
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpCookie.java": [
+32
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/PrecompressedHttpContent.java": [
+30
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/UriTemplatePathSpec.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-io/src/main/java/org/eclipse/jetty/io/ArrayByteBufferPool.java": [
+39
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/CustomRequestLog.java": [
+273
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/Dispatcher.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/EncodingHttpWriter.java": [
+29
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/HttpChannelListeners.java": [
+33
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/MultiPartFormInputStream.java": [
+83
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/main/java/org/eclipse/jetty/server/ServletPathMapping.java": [
+38
+],
+"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/JSONPojoConvertorFactory.java": [
+29
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/BlockingArrayQueue.java": [
+49
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ClassLoadingObjectInputStream.java": [
+32
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/CountingCallback.java": [
+41
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java": [
+26
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/IncludeExcludeSet.java": [
+39
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/InetAddressPattern.java": [
+110,
+191,
+236
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartOutputStream.java": [
+29
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiPartWriter.java": [
+28
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/MultiReleaseJarFile.java": [
+38,
+154
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java": [
+70
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/QuotedStringTokenizer.java": [
+37
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/RolloverFileOutputStream.java": [
+51
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/Uptime.java": [
+36
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/component/FileDestroyable.java": [
+32
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java": [
+53
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceCollection.java": [
+43
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/CertificateValidator.java": [
+55
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/KeyStoreScanner.java": [
+40
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/X509.java": [
+37
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java": [
+48
+],
+"org.eclipse.jetty:jetty-project:jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlAppendable.java": [
+30
+],
+"org.eclipse.jetty:jetty-project:jetty-xml/src/main/java/org/eclipse/jetty/xml/XmlConfiguration.java": [
+87
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9345.json
+++ b/its/ruling/src/test/resources/guava/java-S9345.json
@@ -1,0 +1,8 @@
+{
+"com.google.guava:guava:src/com/google/common/base/FinalizableReferenceQueue.java": [
+94
+],
+"com.google.guava:guava:src/com/google/common/io/MultiReader.java": [
+33
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9345.json
+++ b/its/ruling/src/test/resources/guava/java-S9345.json
@@ -1,8 +1,8 @@
 {
 "com.google.guava:guava:src/com/google/common/base/FinalizableReferenceQueue.java": [
-94
+159
 ],
 "com.google.guava:guava:src/com/google/common/io/MultiReader.java": [
-33
+37
 ]
 }

--- a/its/ruling/src/test/resources/sonar-server/java-S9345.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S9345.json
@@ -1,23 +1,23 @@
 {
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/source/ReportIterator.java": [
-33
-],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/issue/index/IssueIteratorForSingleChunk.java": [
-53
-],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/platform/web/MasterServletFilter.java": [
-42
-],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/plugins/UpdateCenterClient.java": [
-64
-],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/user/SecurityRealmFactory.java": [
 38
 ],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/issue/index/IssueIteratorForSingleChunk.java": [
+114
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/platform/web/MasterServletFilter.java": [
+48
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/plugins/UpdateCenterClient.java": [
+75
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/user/SecurityRealmFactory.java": [
+43
+],
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/util/ObjectInputStreamIterator.java": [
-31
+35
 ],
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/util/cache/DiskCache.java": [
-37
+42
 ]
 }

--- a/its/ruling/src/test/resources/sonar-server/java-S9345.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S9345.json
@@ -1,0 +1,23 @@
+{
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/source/ReportIterator.java": [
+33
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/issue/index/IssueIteratorForSingleChunk.java": [
+53
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/platform/web/MasterServletFilter.java": [
+42
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/plugins/UpdateCenterClient.java": [
+64
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/user/SecurityRealmFactory.java": [
+38
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/util/ObjectInputStreamIterator.java": [
+31
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/util/cache/DiskCache.java": [
+37
+]
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/FinalizerAttackCheckSample.java
@@ -1,0 +1,36 @@
+package checks;
+
+class FinalizerAttackCheckSample {
+
+  // --- Noncompliant: sealed class permitting an unknown type (unresolvable) ---
+  // When the permitted type cannot be resolved, the class is conservatively treated as safely sealed.
+  // However, this sealed class also permits a non-sealed type that IS resolvable.
+
+  static sealed class SealedWithUnknown permits UnknownType, KnownNonSealed { // Secondary {{Non-final class}}
+    public SealedWithUnknown(String s) throws Exception { // Noncompliant
+      if (s == null) throw new Exception();
+    }
+  }
+
+  static non-sealed class KnownNonSealed extends SealedWithUnknown { // Secondary {{Non-final class}}
+    KnownNonSealed(String s) throws Exception { // Noncompliant
+      super(s);
+    }
+  }
+
+  // --- Compliant: sealed class permitting only unknown types (conservatively safe) ---
+
+  static sealed class SealedWithOnlyUnknown permits AnotherUnknownType {
+    public SealedWithOnlyUnknown(String s) throws Exception {
+      if (s == null) throw new Exception();
+    }
+  }
+
+  // --- Noncompliant: non-final class with throwing constructor (basic case) ---
+
+  static class BasicThrowing { // Secondary {{Non-final class}}
+    public BasicThrowing() throws Exception { // Noncompliant
+      throw new Exception();
+    }
+  }
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/FinalizerAttackCheckSample.java
@@ -18,10 +18,10 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  // --- Compliant: sealed class permitting only unknown types (conservatively safe) ---
+  // --- Noncompliant: sealed class permitting only unknown types (conservatively unsafe) ---
 
-  static sealed class SealedWithOnlyUnknown permits AnotherUnknownType {
-    public SealedWithOnlyUnknown(String s) throws Exception {
+  static sealed class SealedWithOnlyUnknown permits AnotherUnknownType { // Secondary {{Non-final class}}
+    public SealedWithOnlyUnknown(String s) throws Exception { // Noncompliant
       if (s == null) throw new Exception();
     }
   }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -611,4 +611,94 @@ class FinalizerAttackCheckSample {
       throw new Exception();
     }
   }
+
+  // --- Compliant: sealed class with all sealed children (no non-sealed in hierarchy) ---
+
+  static sealed class SealedAllSealed permits SealedChildA {
+    public SealedAllSealed(String s) throws Exception {
+      if (s == null) throw new Exception();
+    }
+  }
+
+  static final class SealedChildA extends SealedAllSealed {
+    SealedChildA(String s) throws Exception {
+      super(s);
+    }
+  }
+
+  // --- Compliant: field initializer calls method (no direct throw in expression) ---
+
+  static class FieldInitMethodCallOnly {
+    private final Object value = initOrThrow();
+
+    private static Object initOrThrow() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // --- Compliant: abstract class with private constructor and throwing initializer ---
+
+  static abstract class AbstractPrivateCtorThrowingInit {
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    private AbstractPrivateCtorThrowingInit() {
+    }
+  }
+
+  // --- Noncompliant: class with multiple constructors, one private one public, throwing initializer ---
+
+  static class MixedCtorsThrowingInit { // Secondary {{Non-final class}}
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    private MixedCtorsThrowingInit(int x) {
+    }
+
+    public MixedCtorsThrowingInit(String s) { // Noncompliant
+    }
+  }
+
+  // --- Compliant: class with final finalize() and throwing field initializer calls method ---
+
+  static class FinalFinalizerFieldInit {
+    private final Object value = computeValue();
+
+    private static Object computeValue() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected final void finalize() {
+    }
+  }
+
+  // --- Compliant: class with only private constructor, throwing initializer, no default ctor ---
+
+  static class PrivateCtorOnlyThrowInit {
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    private PrivateCtorOnlyThrowInit(String s) {
+    }
+  }
+
+  // --- Noncompliant: nested inner class with throwing constructor ---
+
+  static class OuterClass {
+    static class InnerVulnerable { // Secondary {{Non-final class}}
+      public InnerVulnerable(String s) throws Exception { // Noncompliant
+        if (s == null) throw new Exception();
+      }
+    }
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -244,7 +244,7 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  // --- Compliant: field initializer calls a method that may throw, but no direct throw statement ---
+  // --- Compliant: field initializer calls a method that throws unchecked exception (no throws clause) ---
 
   static class FieldInitializerMethodCall {
     private final Object value = computeValue();
@@ -253,6 +253,7 @@ class FinalizerAttackCheckSample {
       throw new UnsupportedOperationException();
     }
   }
+
 
   // --- Compliant: instance initializer throws but has explicit private constructor ---
 
@@ -425,6 +426,28 @@ class FinalizerAttackCheckSample {
 
   static final class DeepSealedGrandchild extends DeepSealedChild {
     public DeepSealedGrandchild(String data) throws Exception {
+      super(data);
+    }
+  }
+
+  // --- Noncompliant: sealed class with deep hierarchy ending in non-sealed ---
+
+  static sealed class DeepSealedNonSealedBottom permits DeepSealedMid { // Secondary {{Non-final class}}
+    public DeepSealedNonSealedBottom(String data) throws Exception { // Noncompliant
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+  }
+
+  static sealed class DeepSealedMid extends DeepSealedNonSealedBottom permits DeepSealedOpen { // Secondary {{Non-final class}}
+    public DeepSealedMid(String data) throws Exception { // Noncompliant
+      super(data);
+    }
+  }
+
+  static non-sealed class DeepSealedOpen extends DeepSealedMid { // Secondary {{Non-final class}}
+    public DeepSealedOpen(String data) throws Exception { // Noncompliant
       super(data);
     }
   }
@@ -665,7 +688,7 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  // --- Compliant: class with final finalize() and throwing field initializer calls method ---
+  // --- Compliant: class with final empty finalize() and throwing field initializer calls method ---
 
   static class FinalFinalizerFieldInit {
     private final Object value = computeValue();
@@ -676,6 +699,21 @@ class FinalizerAttackCheckSample {
 
     @Override
     protected final void finalize() {
+    }
+  }
+
+  // --- Noncompliant: class with final finalize() but non-empty body (can still resurrect object) ---
+
+  static class FinalFinalizerNonEmpty { // Secondary {{Non-final class}}
+    public FinalFinalizerNonEmpty(String data) throws Exception { // Noncompliant
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+
+    @Override
+    protected final void finalize() {
+      System.out.println("leaked");
     }
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -4,10 +4,10 @@ class FinalizerAttackCheckSample {
 
   // --- Noncompliant: non-final class with throwing constructor ---
 
-  static class SecurityService { // Noncompliant {{Make this class "final" or make the throwing constructors "private".}}
+  static class SecurityService { // Secondary {{Non-final class}}
     private final String token;
 
-    public SecurityService(String token) throws IllegalArgumentException {
+    public SecurityService(String token) throws IllegalArgumentException { // Noncompliant {{Make this class "final" or make this throwing constructor "private".}}
       if (token == null) {
         throw new IllegalArgumentException("Invalid token");
       }
@@ -15,24 +15,24 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  static class AuthProvider { // Noncompliant
-    public AuthProvider(String credentials) throws Exception {
+  static class AuthProvider { // Secondary {{Non-final class}}
+    public AuthProvider(String credentials) throws Exception { // Noncompliant
       if (credentials.isEmpty()) {
         throw new Exception("Bad credentials");
       }
     }
   }
 
-  static class ResourceLoader { // Noncompliant
-    ResourceLoader(String path) {
+  static class ResourceLoader { // Secondary {{Non-final class}}
+    ResourceLoader(String path) { // Noncompliant
       if (path == null) {
         throw new NullPointerException();
       }
     }
   }
 
-  static class MultiConstructorService { // Noncompliant
-    MultiConstructorService(int id) throws Exception {
+  static class MultiConstructorService { // Secondary {{Non-final class}}
+    MultiConstructorService(int id) throws Exception { // Noncompliant
       if (id < 0) {
         throw new Exception("Negative id");
       }
@@ -42,16 +42,16 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  static class ProtectedConstructorService { // Noncompliant
-    protected ProtectedConstructorService(String data) throws Exception {
+  static class ProtectedConstructorService { // Secondary {{Non-final class}}
+    protected ProtectedConstructorService(String data) throws Exception { // Noncompliant
       if (data == null) {
         throw new Exception("Null data");
       }
     }
   }
 
-  static class ThrowsClauseOnly { // Noncompliant
-    public ThrowsClauseOnly() throws Exception {
+  static class ThrowsClauseOnly { // Secondary {{Non-final class}}
+    public ThrowsClauseOnly() throws Exception { // Noncompliant
     }
   }
 
@@ -142,8 +142,8 @@ class FinalizerAttackCheckSample {
 
   // --- Noncompliant: throw in constructor body without throws clause ---
 
-  static class ConfigLoader { // Noncompliant
-    public ConfigLoader(String config) {
+  static class ConfigLoader { // Secondary {{Non-final class}}
+    public ConfigLoader(String config) { // Noncompliant
       if (config == null) {
         throw new IllegalStateException("Missing config");
       }
@@ -163,8 +163,8 @@ class FinalizerAttackCheckSample {
 
   // --- Noncompliant: nested throw in try block within constructor ---
 
-  static class DatabaseConnection { // Noncompliant
-    public DatabaseConnection(String url) {
+  static class DatabaseConnection { // Secondary {{Non-final class}}
+    public DatabaseConnection(String url) { // Noncompliant
       try {
         if (url == null) {
           throw new RuntimeException("Null URL");

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -134,6 +134,22 @@ class FinalizerAttackCheckSample {
     }
   }
 
+  // --- Compliant: sealed class (cannot be subclassed by attackers) ---
+
+  static sealed class SealedService permits AllowedSubclass {
+    public SealedService(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+  }
+
+  static final class AllowedSubclass extends SealedService {
+    public AllowedSubclass(String data) throws Exception {
+      super(data);
+    }
+  }
+
   // --- Compliant: inner interface (no constructors) ---
 
   interface Service {

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -453,4 +453,64 @@ class FinalizerAttackCheckSample {
       }
     }
   }
+
+  // --- Compliant: field initializer calls method (no direct throw in initializer) ---
+
+  static class FieldInitializerIndirectThrow2 {
+    private final Object value = throwingInit();
+
+    private static Object throwingInit() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // --- Compliant: field initializer is a method call (no direct throw in initializer expression) ---
+
+  static class FieldInitWithExplicitConstructor {
+    private final Object data = initField();
+
+    public FieldInitWithExplicitConstructor() {
+    }
+
+    private Object initField() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // --- Compliant: abstract class with non-throwing constructor and no initializers ---
+
+  static abstract class AbstractNoThrow {
+    public AbstractNoThrow() {
+    }
+  }
+
+  // --- Compliant: sealed class with only sealed/final subclasses (resolved via symbolType) ---
+
+  static sealed class SealedResolved permits ResolvedFinalChild {
+    public SealedResolved(String s) throws Exception {
+      if (s == null) throw new Exception();
+    }
+  }
+
+  static final class ResolvedFinalChild extends SealedResolved {
+    ResolvedFinalChild(String s) throws Exception {
+      super(s);
+    }
+  }
+
+  // --- Noncompliant: class with multiple constructors, some throwing ---
+
+  static class PartiallyVulnerable { // Secondary {{Non-final class}}
+    PartiallyVulnerable(int x) throws Exception { // Noncompliant
+      if (x < 0) throw new Exception();
+    }
+
+    private PartiallyVulnerable(String s) throws Exception {
+      if (s == null) throw new Exception();
+    }
+
+    PartiallyVulnerable(double d) {
+      // compliant: non-throwing
+    }
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -276,4 +276,94 @@ class FinalizerAttackCheckSample {
       }
     }
   }
+
+  // --- Compliant: field initializer calls a method, no direct throw in initializer expression ---
+
+  static class FieldInitializerIndirectThrow {
+    private final Object data = check(null);
+
+    private static Object check(Object o) {
+      if (o == null) {
+        throw new IllegalArgumentException();
+      }
+      return o;
+    }
+  }
+
+  // --- Noncompliant: non-final finalize() does not protect ---
+
+  static class NonFinalFinalize { // Secondary {{Non-final class}}
+    public NonFinalFinalize(String data) throws Exception { // Noncompliant
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+
+    @Override
+    protected void finalize() {
+      // non-final finalize does NOT protect
+    }
+  }
+
+  // --- Compliant: throw only inside lambda in constructor ---
+
+  static class ThrowInLambda {
+    public ThrowInLambda() {
+      Runnable r = () -> {
+        throw new RuntimeException("in lambda");
+      };
+    }
+  }
+
+  // --- Compliant: throw only inside anonymous class in constructor ---
+
+  static class ThrowInAnonymousClass {
+    public ThrowInAnonymousClass() {
+      Runnable r = new Runnable() {
+        @Override
+        public void run() {
+          throw new RuntimeException("in anon");
+        }
+      };
+    }
+  }
+
+  // --- Noncompliant: multiple throwing instance initializers, no explicit constructor ---
+
+  static class MultipleThrowingInitializers { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
+    { // Secondary {{Throwing initializer}}
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init block 1");
+      }
+    }
+    { // Secondary {{Throwing initializer}}
+      if (System.currentTimeMillis() == 1) {
+        throw new RuntimeException("init block 2");
+      }
+    }
+  }
+
+  // --- Compliant: local class inside a constructor ---
+
+  static class EnclosingWithLocalInConstructor {
+    EnclosingWithLocalInConstructor() {
+      class InnerLocal {
+        InnerLocal() throws Exception {
+          throw new Exception("local in ctor");
+        }
+      }
+    }
+  }
+
+  // --- Compliant: field initializer without throw ---
+
+  static class FieldInitializerNoThrow {
+    private final String data = "hello";
+  }
+
+  // --- Compliant: field without initializer ---
+
+  static class FieldNoInitializer {
+    private String data;
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -92,10 +92,10 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  // --- Compliant: abstract class ---
+  // --- Noncompliant: abstract class with throwing constructor (attacker can subclass) ---
 
-  static abstract class AbstractService {
-    public AbstractService(String data) throws Exception {
+  static abstract class AbstractService { // Secondary {{Non-final class}}
+    public AbstractService(String data) throws Exception { // Noncompliant
       if (data == null) {
         throw new Exception("Null");
       }
@@ -134,18 +134,34 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  // --- Compliant: sealed class (cannot be subclassed by attackers) ---
+  // --- Compliant: sealed class whose permitted subclasses are all final/sealed ---
 
-  static sealed class SealedService permits AllowedSubclass {
-    public SealedService(String data) throws Exception {
+  static sealed class SealedServiceAllFinal permits AllowedSubclass {
+    public SealedServiceAllFinal(String data) throws Exception {
       if (data == null) {
         throw new Exception("Null");
       }
     }
   }
 
-  static final class AllowedSubclass extends SealedService {
+  static final class AllowedSubclass extends SealedServiceAllFinal {
     public AllowedSubclass(String data) throws Exception {
+      super(data);
+    }
+  }
+
+  // --- Noncompliant: sealed class with a non-sealed permitted subclass ---
+
+  static sealed class SealedServiceWithNonSealed permits OpenSubclass { // Secondary {{Non-final class}}
+    public SealedServiceWithNonSealed(String data) throws Exception { // Noncompliant
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+  }
+
+  static non-sealed class OpenSubclass extends SealedServiceWithNonSealed { // Secondary {{Non-final class}}
+    public OpenSubclass(String data) throws Exception { // Noncompliant
       super(data);
     }
   }
@@ -200,6 +216,64 @@ class FinalizerAttackCheckSample {
 
     private PrivateOnlyThrowers(int i) {
       throw new IllegalArgumentException();
+    }
+  }
+
+  // --- Compliant: class declares final finalize() method ---
+
+  static class ProtectedByFinalizer {
+    public ProtectedByFinalizer(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+
+    @Override
+    protected final void finalize() {
+      // prevents finalizer attack
+    }
+  }
+
+  // --- Noncompliant: instance initializer throws, no explicit constructor ---
+
+  static class InitializerThrower { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
+    { // Secondary {{Throwing initializer}}
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+  }
+
+  // --- Compliant: field initializer calls a method that may throw, but no direct throw statement ---
+
+  static class FieldInitializerMethodCall {
+    private final Object value = computeValue();
+
+    private static Object computeValue() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // --- Compliant: instance initializer throws but has explicit private constructor ---
+
+  static class InitializerWithPrivateConstructor {
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    private InitializerWithPrivateConstructor() {
+    }
+  }
+
+  // --- Compliant: local class (cannot be subclassed from outside) ---
+
+  void someMethod() {
+    class LocalClass {
+      LocalClass() throws Exception {
+        throw new Exception("local");
+      }
     }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -513,4 +513,102 @@ class FinalizerAttackCheckSample {
       // compliant: non-throwing
     }
   }
+
+  // --- Compliant: abstract class with no throwing constructor and no throwing initializer ---
+
+  static abstract class AbstractSafeClass {
+    public AbstractSafeClass(String data) {
+      // no throw
+    }
+
+    abstract void doWork();
+  }
+
+  // --- Noncompliant: abstract class with constructor that has throws clause only ---
+
+  static abstract class AbstractThrowsClause { // Secondary {{Non-final class}}
+    protected AbstractThrowsClause() throws Exception { // Noncompliant
+    }
+  }
+
+  // --- Compliant: sealed class with sealed child (not non-sealed) ---
+
+  static sealed class SealedWithSealedChild permits SealedChild {
+    public SealedWithSealedChild(String s) throws Exception {
+      if (s == null) throw new Exception();
+    }
+  }
+
+  static sealed class SealedChild extends SealedWithSealedChild permits FinalGrandchild {
+    public SealedChild(String s) throws Exception {
+      super(s);
+    }
+  }
+
+  static final class FinalGrandchild extends SealedChild {
+    public FinalGrandchild(String s) throws Exception {
+      super(s);
+    }
+  }
+
+  // --- Compliant: abstract class with only abstract methods ---
+
+  static abstract class AbstractMethodOnly {
+    abstract void compute();
+  }
+
+  // --- Compliant: field initializer without direct throw ---
+
+  static class FieldInitializerSafe {
+    private final String value = String.valueOf(42);
+
+    public FieldInitializerSafe() {
+    }
+  }
+
+  // --- Compliant: field initializer is anonymous class with throw (skipped by visitor) ---
+
+  static class FieldInitAnonymousThrow {
+    private final Runnable action = new Runnable() {
+      @Override
+      public void run() {
+        throw new RuntimeException("in anon in field init");
+      }
+    };
+  }
+
+  // --- Noncompliant: non-final, non-private constructors where one has throw and one has throws clause ---
+
+  static class BothThrowAndThrowsClause { // Secondary {{Non-final class}}
+    public BothThrowAndThrowsClause(int x) { // Noncompliant
+      if (x < 0) {
+        throw new IllegalArgumentException();
+      }
+    }
+
+    protected BothThrowAndThrowsClause(String s) throws Exception { // Noncompliant
+    }
+  }
+
+  // --- Noncompliant: finalize(Object) is not zero-arg finalize, does not protect ---
+
+  static class WrongFinalizeSignature { // Secondary {{Non-final class}}
+    public WrongFinalizeSignature(String s) throws Exception { // Noncompliant
+      if (s == null) throw new Exception();
+    }
+
+    protected final void finalize(Object obj) {
+      // wrong signature, does not protect
+    }
+  }
+
+  // --- Noncompliant: class with field without initializer but throwing constructor ---
+
+  static class FieldWithoutInitializer { // Secondary {{Non-final class}}
+    private Object data;
+
+    public FieldWithoutInitializer() throws Exception { // Noncompliant
+      throw new Exception();
+    }
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -4,7 +4,7 @@ class FinalizerAttackCheckSample {
 
   // --- Noncompliant: non-final class with throwing constructor ---
 
-  class SecurityService { // Noncompliant {{Make this class "final" or make the throwing constructors "private".}}
+  static class SecurityService { // Noncompliant {{Make this class "final" or make the throwing constructors "private".}}
     private final String token;
 
     public SecurityService(String token) throws IllegalArgumentException {
@@ -15,7 +15,7 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  class AuthProvider { // Noncompliant
+  static class AuthProvider { // Noncompliant
     public AuthProvider(String credentials) throws Exception {
       if (credentials.isEmpty()) {
         throw new Exception("Bad credentials");
@@ -23,7 +23,7 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  class ResourceLoader { // Noncompliant
+  static class ResourceLoader { // Noncompliant
     ResourceLoader(String path) {
       if (path == null) {
         throw new NullPointerException();
@@ -31,7 +31,7 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  class MultiConstructorService { // Noncompliant
+  static class MultiConstructorService { // Noncompliant
     MultiConstructorService(int id) throws Exception {
       if (id < 0) {
         throw new Exception("Negative id");
@@ -42,7 +42,7 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  class ProtectedConstructorService { // Noncompliant
+  static class ProtectedConstructorService { // Noncompliant
     protected ProtectedConstructorService(String data) throws Exception {
       if (data == null) {
         throw new Exception("Null data");
@@ -50,14 +50,14 @@ class FinalizerAttackCheckSample {
     }
   }
 
-  class ThrowsClauseOnly { // Noncompliant
+  static class ThrowsClauseOnly { // Noncompliant
     public ThrowsClauseOnly() throws Exception {
     }
   }
 
   // --- Compliant: final class ---
 
-  final class SecureService {
+  static final class SecureService {
     public SecureService(String token) throws IllegalArgumentException {
       if (token == null) {
         throw new IllegalArgumentException("Invalid token");
@@ -67,7 +67,7 @@ class FinalizerAttackCheckSample {
 
   // --- Compliant: all constructors private (factory pattern) ---
 
-  class FactoryService {
+  static class FactoryService {
     private FactoryService(String data) {
     }
 
@@ -81,20 +81,20 @@ class FinalizerAttackCheckSample {
 
   // --- Compliant: no throwing constructor ---
 
-  class SafeService {
+  static class SafeService {
     public SafeService(String data) {
       // no throw
     }
   }
 
-  class NoConstructor {
+  static class NoConstructor {
     void doSomething() {
     }
   }
 
   // --- Compliant: abstract class ---
 
-  abstract class AbstractService {
+  static abstract class AbstractService {
     public AbstractService(String data) throws Exception {
       if (data == null) {
         throw new Exception("Null");
@@ -104,7 +104,7 @@ class FinalizerAttackCheckSample {
 
   // --- Compliant: private throwing constructor, public non-throwing constructor ---
 
-  class MixedConstructors {
+  static class MixedConstructors {
     private MixedConstructors(String data) throws Exception {
       if (data == null) {
         throw new Exception("Null");
@@ -142,7 +142,7 @@ class FinalizerAttackCheckSample {
 
   // --- Noncompliant: throw in constructor body without throws clause ---
 
-  class ConfigLoader { // Noncompliant
+  static class ConfigLoader { // Noncompliant
     public ConfigLoader(String config) {
       if (config == null) {
         throw new IllegalStateException("Missing config");
@@ -152,7 +152,7 @@ class FinalizerAttackCheckSample {
 
   // --- Compliant: throw in a method, not in constructor ---
 
-  class Processor {
+  static class Processor {
     public Processor() {
     }
 
@@ -163,7 +163,7 @@ class FinalizerAttackCheckSample {
 
   // --- Noncompliant: nested throw in try block within constructor ---
 
-  class DatabaseConnection { // Noncompliant
+  static class DatabaseConnection { // Noncompliant
     public DatabaseConnection(String url) {
       try {
         if (url == null) {
@@ -177,7 +177,7 @@ class FinalizerAttackCheckSample {
 
   // --- Compliant: all throwing constructors are private ---
 
-  class PrivateOnlyThrowers {
+  static class PrivateOnlyThrowers {
     private PrivateOnlyThrowers(String s) throws Exception {
       throw new Exception();
     }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -366,4 +366,91 @@ class FinalizerAttackCheckSample {
   static class FieldNoInitializer {
     private String data;
   }
+
+  // --- Noncompliant: explicit non-private constructor AND throwing initializer ---
+
+  static class ConstructorAndThrowingInitializer { // Secondary {{Non-final class}}
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    public ConstructorAndThrowingInitializer(String data) throws Exception { // Noncompliant
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+  }
+
+  // --- Noncompliant: explicit non-throwing constructor AND throwing initializer (constructor is still a vector) ---
+
+  static class NonThrowingConstructorWithThrowingInit { // Secondary {{Non-final class}}
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    public NonThrowingConstructorWithThrowingInit() { // Noncompliant
+      // non-throwing, but the initializer block throws during construction
+    }
+  }
+
+  // --- Noncompliant: abstract class with throwing initializer, no constructor ---
+
+  static abstract class AbstractWithThrowingInitializer { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
+    { // Secondary {{Throwing initializer}}
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("abstract init");
+      }
+    }
+  }
+
+  // --- Compliant: sealed class with all final + sealed subclasses (deep hierarchy) ---
+
+  static sealed class DeepSealedParent permits DeepSealedChild {
+    public DeepSealedParent(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+  }
+
+  static sealed class DeepSealedChild extends DeepSealedParent permits DeepSealedGrandchild {
+    public DeepSealedChild(String data) throws Exception {
+      super(data);
+    }
+  }
+
+  static final class DeepSealedGrandchild extends DeepSealedChild {
+    public DeepSealedGrandchild(String data) throws Exception {
+      super(data);
+    }
+  }
+
+  // --- Compliant: class with final finalize() and throwing initializer ---
+
+  static class FinalFinalizerWithThrowingInit {
+    {
+      if (System.currentTimeMillis() == 0) {
+        throw new RuntimeException("init");
+      }
+    }
+
+    @Override
+    protected final void finalize() {
+      // prevents finalizer attack
+    }
+  }
+
+  // --- Compliant: class with only static initializer that throws ---
+
+  static class StaticInitializerThrower {
+    static {
+      if (System.getenv("MISSING") == null) {
+        throw new RuntimeException("static init");
+      }
+    }
+  }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSample.java
@@ -1,0 +1,189 @@
+package checks;
+
+class FinalizerAttackCheckSample {
+
+  // --- Noncompliant: non-final class with throwing constructor ---
+
+  class SecurityService { // Noncompliant {{Make this class "final" or make the throwing constructors "private".}}
+    private final String token;
+
+    public SecurityService(String token) throws IllegalArgumentException {
+      if (token == null) {
+        throw new IllegalArgumentException("Invalid token");
+      }
+      this.token = token;
+    }
+  }
+
+  class AuthProvider { // Noncompliant
+    public AuthProvider(String credentials) throws Exception {
+      if (credentials.isEmpty()) {
+        throw new Exception("Bad credentials");
+      }
+    }
+  }
+
+  class ResourceLoader { // Noncompliant
+    ResourceLoader(String path) {
+      if (path == null) {
+        throw new NullPointerException();
+      }
+    }
+  }
+
+  class MultiConstructorService { // Noncompliant
+    MultiConstructorService(int id) throws Exception {
+      if (id < 0) {
+        throw new Exception("Negative id");
+      }
+    }
+
+    MultiConstructorService(String name) {
+    }
+  }
+
+  class ProtectedConstructorService { // Noncompliant
+    protected ProtectedConstructorService(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null data");
+      }
+    }
+  }
+
+  class ThrowsClauseOnly { // Noncompliant
+    public ThrowsClauseOnly() throws Exception {
+    }
+  }
+
+  // --- Compliant: final class ---
+
+  final class SecureService {
+    public SecureService(String token) throws IllegalArgumentException {
+      if (token == null) {
+        throw new IllegalArgumentException("Invalid token");
+      }
+    }
+  }
+
+  // --- Compliant: all constructors private (factory pattern) ---
+
+  class FactoryService {
+    private FactoryService(String data) {
+    }
+
+    public static FactoryService create(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null");
+      }
+      return new FactoryService(data);
+    }
+  }
+
+  // --- Compliant: no throwing constructor ---
+
+  class SafeService {
+    public SafeService(String data) {
+      // no throw
+    }
+  }
+
+  class NoConstructor {
+    void doSomething() {
+    }
+  }
+
+  // --- Compliant: abstract class ---
+
+  abstract class AbstractService {
+    public AbstractService(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+  }
+
+  // --- Compliant: private throwing constructor, public non-throwing constructor ---
+
+  class MixedConstructors {
+    private MixedConstructors(String data) throws Exception {
+      if (data == null) {
+        throw new Exception("Null");
+      }
+    }
+
+    public MixedConstructors(int id) {
+    }
+  }
+
+  // --- Compliant: enum (implicitly final) ---
+
+  enum Status {
+    ACTIVE, INACTIVE;
+
+    Status() {
+    }
+  }
+
+  // --- Compliant: record (implicitly final) ---
+
+  record Credential(String value) {
+    Credential {
+      if (value == null) {
+        throw new IllegalArgumentException("Null value");
+      }
+    }
+  }
+
+  // --- Compliant: inner interface (no constructors) ---
+
+  interface Service {
+    void execute();
+  }
+
+  // --- Noncompliant: throw in constructor body without throws clause ---
+
+  class ConfigLoader { // Noncompliant
+    public ConfigLoader(String config) {
+      if (config == null) {
+        throw new IllegalStateException("Missing config");
+      }
+    }
+  }
+
+  // --- Compliant: throw in a method, not in constructor ---
+
+  class Processor {
+    public Processor() {
+    }
+
+    public void process() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  // --- Noncompliant: nested throw in try block within constructor ---
+
+  class DatabaseConnection { // Noncompliant
+    public DatabaseConnection(String url) {
+      try {
+        if (url == null) {
+          throw new RuntimeException("Null URL");
+        }
+      } catch (Exception e) {
+        throw new RuntimeException("Connection failed", e);
+      }
+    }
+  }
+
+  // --- Compliant: all throwing constructors are private ---
+
+  class PrivateOnlyThrowers {
+    private PrivateOnlyThrowers(String s) throws Exception {
+      throw new Exception();
+    }
+
+    private PrivateOnlyThrowers(int i) {
+      throw new IllegalArgumentException();
+    }
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSemanticSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSemanticSample.java
@@ -1,0 +1,49 @@
+package checks;
+
+class FinalizerAttackCheckSemanticSample {
+
+  // --- Noncompliant: field initializer calls a method that declares checked exception ---
+
+  static class FieldInitializerCheckedThrow { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
+    private final Object value = loadValue(); // Secondary {{Throwing initializer}}
+
+    private static Object loadValue() throws Exception {
+      return new Object();
+    }
+  }
+
+  // --- Noncompliant: field initializer constructs an object whose constructor declares checked exception ---
+
+  static final class ThrowingConstructorTarget {
+    public ThrowingConstructorTarget(String s) throws Exception {
+      if (s == null) throw new Exception();
+    }
+  }
+
+  static class FieldInitializerNewThrows { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
+    private final ThrowingConstructorTarget svc = new ThrowingConstructorTarget("token"); // Secondary {{Throwing initializer}}
+  }
+
+  // --- Noncompliant: field initializer with explicit constructor, method declares checked exception ---
+
+  static class FieldInitWithCheckedAndCtor { // Secondary {{Non-final class}}
+    private final Object data = initField();
+
+    public FieldInitWithCheckedAndCtor() { // Noncompliant
+    }
+
+    private static Object initField() throws Exception {
+      return new Object();
+    }
+  }
+
+  // --- Compliant: field initializer calls method with no declared exceptions ---
+
+  static class FieldInitNoDeclaredThrows {
+    private final Object value = compute();
+
+    private static Object compute() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSemanticSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/FinalizerAttackCheckSemanticSample.java
@@ -4,8 +4,11 @@ class FinalizerAttackCheckSemanticSample {
 
   // --- Noncompliant: field initializer calls a method that declares checked exception ---
 
-  static class FieldInitializerCheckedThrow { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
-    private final Object value = loadValue(); // Secondary {{Throwing initializer}}
+  static class FieldInitializerCheckedThrow { // Secondary {{Non-final class}}
+    private final Object value = loadValue();
+
+    FieldInitializerCheckedThrow() throws Exception { // Noncompliant {{Make this class "final" or make this throwing constructor "private".}}
+    }
 
     private static Object loadValue() throws Exception {
       return new Object();
@@ -20,8 +23,11 @@ class FinalizerAttackCheckSemanticSample {
     }
   }
 
-  static class FieldInitializerNewThrows { // Noncompliant {{Make this class "final" or add a private constructor, because initializers can throw.}}
-    private final ThrowingConstructorTarget svc = new ThrowingConstructorTarget("token"); // Secondary {{Throwing initializer}}
+  static class FieldInitializerNewThrows { // Secondary {{Non-final class}}
+    private final ThrowingConstructorTarget svc = new ThrowingConstructorTarget("token");
+
+    FieldInitializerNewThrows() throws Exception { // Noncompliant {{Make this class "final" or make this throwing constructor "private".}}
+    }
   }
 
   // --- Noncompliant: field initializer with explicit constructor, method declares checked exception ---
@@ -29,7 +35,7 @@ class FinalizerAttackCheckSemanticSample {
   static class FieldInitWithCheckedAndCtor { // Secondary {{Non-final class}}
     private final Object data = initField();
 
-    public FieldInitWithCheckedAndCtor() { // Noncompliant
+    public FieldInitWithCheckedAndCtor() throws Exception { // Noncompliant
     }
 
     private static Object initField() throws Exception {

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -1,0 +1,92 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.Collections;
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ModifiersUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.BlockTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Modifier;
+import org.sonar.plugins.java.api.tree.ThrowStatementTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
+@Rule(key = "S9345")
+public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Kind> nodesToVisit() {
+    return Collections.singletonList(Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ClassTree classTree = (ClassTree) tree;
+    if (ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.FINAL) ||
+      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.ABSTRACT)) {
+      return;
+    }
+    for (Tree member : classTree.members()) {
+      if (member.is(Kind.CONSTRUCTOR) && isVulnerableConstructor((MethodTree) member)) {
+        reportIssue(classTree.simpleName(), "Make this class \"final\" or make the throwing constructors \"private\".");
+        return;
+      }
+    }
+  }
+
+  private static boolean isVulnerableConstructor(MethodTree constructor) {
+    if (ModifiersUtils.hasModifier(constructor.modifiers(), Modifier.PRIVATE)) {
+      return false;
+    }
+    return !constructor.throwsClauses().isEmpty() || containsThrowStatement(constructor);
+  }
+
+  private static boolean containsThrowStatement(MethodTree constructor) {
+    BlockTree block = constructor.block();
+    if (block == null) {
+      return false;
+    }
+    ThrowStatementVisitor visitor = new ThrowStatementVisitor();
+    block.accept(visitor);
+    return visitor.hasThrow;
+  }
+
+  private static class ThrowStatementVisitor extends BaseTreeVisitor {
+    boolean hasThrow;
+
+    @Override
+    public void visitThrowStatement(ThrowStatementTree tree) {
+      hasThrow = true;
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // skip nested classes
+    }
+
+    @Override
+    public void visitLambdaExpression(LambdaExpressionTree tree) {
+      // skip lambdas
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -23,7 +23,6 @@ import org.sonar.check.Rule;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
-import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -70,10 +70,7 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     for (Tree member : classTree.members()) {
       if (member.is(Kind.CONSTRUCTOR)) {
         hasExplicitConstructor = true;
-      } else if (member.is(Kind.INITIALIZER) && containsThrowStatementInBlock((BlockTree) member)) {
-        throwingInitializers.add(member);
-        hasThrowingInitializers = true;
-      } else if (member.is(Kind.VARIABLE) && hasThrowingFieldInitializer((VariableTree) member)) {
+      } else if (isThrowingInitializer(member)) {
         throwingInitializers.add(member);
         hasThrowingInitializers = true;
       }
@@ -108,6 +105,11 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     reportIssue(classTree.simpleName(),
       "Make this class \"final\" or add a private constructor, because initializers can throw.",
       locations, null);
+  }
+
+  private static boolean isThrowingInitializer(Tree member) {
+    return (member.is(Kind.INITIALIZER) && containsThrowStatementInBlock((BlockTree) member))
+      || (member.is(Kind.VARIABLE) && hasThrowingFieldInitializer((VariableTree) member));
   }
 
   private static boolean isLocalClass(ClassTree classTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -176,18 +176,18 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
       if (classTree.simpleName() != null && name.equals(classTree.simpleName().name())) {
         return classTree;
       }
-      for (Tree member : classTree.members()) {
-        ClassTree found = findClassInTree(member, name);
-        if (found != null) {
-          return found;
-        }
-      }
+      return findClassInChildren(classTree.members(), name);
     } else if (tree.is(Kind.COMPILATION_UNIT)) {
-      for (Tree child : ((CompilationUnitTree) tree).types()) {
-        ClassTree found = findClassInTree(child, name);
-        if (found != null) {
-          return found;
-        }
+      return findClassInChildren(((CompilationUnitTree) tree).types(), name);
+    }
+    return null;
+  }
+
+  private static ClassTree findClassInChildren(List<? extends Tree> children, String name) {
+    for (Tree child : children) {
+      ClassTree found = findClassInTree(child, name);
+      if (found != null) {
+        return found;
       }
     }
     return null;

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -16,21 +16,28 @@
  */
 package org.sonar.java.checks;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
+import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.CompilationUnitTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Modifier;
 import org.sonar.plugins.java.api.tree.ThrowStatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
+import org.sonar.plugins.java.api.tree.TypeTree;
+import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9345")
 public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
@@ -45,20 +52,136 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     ClassTree classTree = (ClassTree) tree;
     if (classTree.simpleName() == null ||
       ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.FINAL) ||
-      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.ABSTRACT) ||
-      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.SEALED)) {
+      isLocalClass(classTree) ||
+      isSafelySealedClass(classTree) ||
+      hasFinalFinalizer(classTree)) {
       return;
     }
     List<JavaFileScannerContext.Location> secondaryLocations = Collections.singletonList(
       new JavaFileScannerContext.Location("Non-final class", classTree.simpleName()));
+
+    boolean hasExplicitConstructor = false;
+    List<Tree> throwingInitializers = new ArrayList<>();
+
     for (Tree member : classTree.members()) {
-      if (member.is(Kind.CONSTRUCTOR) && isVulnerableConstructor((MethodTree) member)) {
-        MethodTree constructor = (MethodTree) member;
-        reportIssue(constructor.simpleName(),
-          "Make this class \"final\" or make this throwing constructor \"private\".",
-          secondaryLocations, null);
+      if (member.is(Kind.CONSTRUCTOR)) {
+        hasExplicitConstructor = true;
+        if (isVulnerableConstructor((MethodTree) member)) {
+          MethodTree constructor = (MethodTree) member;
+          reportIssue(constructor.simpleName(),
+            "Make this class \"final\" or make this throwing constructor \"private\".",
+            secondaryLocations, null);
+        }
+      } else if (member.is(Kind.INITIALIZER) && containsThrowStatementInBlock((BlockTree) member)) {
+        throwingInitializers.add(member);
+      } else if (member.is(Kind.VARIABLE) && hasThrowingFieldInitializer((VariableTree) member)) {
+        throwingInitializers.add(member);
       }
     }
+
+    if (!hasExplicitConstructor && !throwingInitializers.isEmpty()) {
+      List<JavaFileScannerContext.Location> locations = new ArrayList<>();
+      for (Tree init : throwingInitializers) {
+        locations.add(new JavaFileScannerContext.Location("Throwing initializer", init));
+      }
+      reportIssue(classTree.simpleName(),
+        "Make this class \"final\" or add a private constructor, because initializers can throw.",
+        locations, null);
+    }
+  }
+
+  private static boolean isLocalClass(ClassTree classTree) {
+    Tree parent = classTree.parent();
+    while (parent != null) {
+      if (parent.is(Kind.METHOD, Kind.CONSTRUCTOR)) {
+        return true;
+      }
+      if (parent.is(Kind.CLASS, Kind.ENUM, Kind.INTERFACE, Kind.RECORD, Kind.ANNOTATION_TYPE)) {
+        return false;
+      }
+      parent = parent.parent();
+    }
+    return false;
+  }
+
+  private static boolean isSafelySealedClass(ClassTree classTree) {
+    if (!ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.SEALED)) {
+      return false;
+    }
+    for (TypeTree permitted : classTree.permittedTypes()) {
+      Type permittedType = permitted.symbolType();
+      if (!permittedType.isUnknown()) {
+        Symbol.TypeSymbol permittedSymbol = permittedType.symbol();
+        ClassTree permittedDecl = permittedSymbol.declaration();
+        if (permittedDecl != null && ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED)) {
+          return false;
+        }
+      } else {
+        ClassTree permittedDecl = findClassByName(classTree, getSimpleName(permitted));
+        if (permittedDecl != null && ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private static String getSimpleName(TypeTree typeTree) {
+    if (typeTree.is(Kind.IDENTIFIER)) {
+      return ((IdentifierTree) typeTree).name();
+    }
+    return "";
+  }
+
+  private static ClassTree findClassByName(ClassTree context, String name) {
+    if (name.isEmpty()) {
+      return null;
+    }
+    Tree parent = context.parent();
+    while (parent != null && !parent.is(Kind.COMPILATION_UNIT)) {
+      parent = parent.parent();
+    }
+    if (parent == null) {
+      return null;
+    }
+    return findClassInTree(parent, name);
+  }
+
+  private static ClassTree findClassInTree(Tree tree, String name) {
+    if (tree.is(Kind.CLASS, Kind.INTERFACE)) {
+      ClassTree classTree = (ClassTree) tree;
+      if (classTree.simpleName() != null && name.equals(classTree.simpleName().name())) {
+        return classTree;
+      }
+      for (Tree member : classTree.members()) {
+        ClassTree found = findClassInTree(member, name);
+        if (found != null) {
+          return found;
+        }
+      }
+    } else if (tree.is(Kind.COMPILATION_UNIT)) {
+      for (Tree child : ((CompilationUnitTree) tree).types()) {
+        ClassTree found = findClassInTree(child, name);
+        if (found != null) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static boolean hasFinalFinalizer(ClassTree classTree) {
+    for (Tree member : classTree.members()) {
+      if (member.is(Kind.METHOD)) {
+        MethodTree method = (MethodTree) member;
+        if ("finalize".equals(method.simpleName().name()) &&
+          method.parameters().isEmpty() &&
+          ModifiersUtils.hasModifier(method.modifiers(), Modifier.FINAL)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static boolean isVulnerableConstructor(MethodTree constructor) {
@@ -68,13 +191,26 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     return !constructor.throwsClauses().isEmpty() || containsThrowStatement(constructor);
   }
 
-  private static boolean containsThrowStatement(MethodTree constructor) {
-    BlockTree block = constructor.block();
+  private static boolean containsThrowStatement(MethodTree method) {
+    BlockTree block = method.block();
     if (block == null) {
       return false;
     }
+    return containsThrowStatementInBlock(block);
+  }
+
+  private static boolean containsThrowStatementInBlock(BlockTree block) {
     ThrowStatementVisitor visitor = new ThrowStatementVisitor();
     block.accept(visitor);
+    return visitor.hasThrow;
+  }
+
+  private static boolean hasThrowingFieldInitializer(VariableTree variable) {
+    if (variable.initializer() == null) {
+      return false;
+    }
+    ThrowStatementVisitor visitor = new ThrowStatementVisitor();
+    variable.initializer().accept(visitor);
     return visitor.hasThrow;
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -130,21 +130,24 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
       return false;
     }
     for (TypeTree permitted : classTree.permittedTypes()) {
-      Type permittedType = permitted.symbolType();
-      if (!permittedType.isUnknown()) {
-        Symbol.TypeSymbol permittedSymbol = permittedType.symbol();
-        ClassTree permittedDecl = permittedSymbol.declaration();
-        if (permittedDecl != null && ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED)) {
-          return false;
-        }
-      } else {
-        ClassTree permittedDecl = findClassByName(classTree, getSimpleName(permitted));
-        if (permittedDecl != null && ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED)) {
-          return false;
-        }
+      if (isNonSealedPermittedType(classTree, permitted)) {
+        return false;
       }
     }
     return true;
+  }
+
+  private static boolean isNonSealedPermittedType(ClassTree context, TypeTree permitted) {
+    ClassTree permittedDecl = resolvePermittedDeclaration(context, permitted);
+    return permittedDecl != null && ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED);
+  }
+
+  private static ClassTree resolvePermittedDeclaration(ClassTree context, TypeTree permitted) {
+    Type permittedType = permitted.symbolType();
+    if (!permittedType.isUnknown()) {
+      return permittedType.symbol().declaration();
+    }
+    return findClassByName(context, getSimpleName(permitted));
   }
 
   private static String getSimpleName(TypeTree typeTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -18,11 +18,14 @@ package org.sonar.java.checks;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;
@@ -30,8 +33,11 @@ import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Modifier;
+import org.sonar.plugins.java.api.tree.NewClassTree;
+import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.ThrowStatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.Tree.Kind;
@@ -127,20 +133,41 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isSafelySealedClass(ClassTree classTree) {
+    return isSafelySealedClass(classTree, new HashSet<>());
+  }
+
+  private static boolean isSafelySealedClass(ClassTree classTree, Set<ClassTree> visited) {
     if (!ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.SEALED)) {
       return false;
     }
+    if (!visited.add(classTree)) {
+      return true;
+    }
     for (TypeTree permitted : classTree.permittedTypes()) {
-      if (isNonSealedPermittedType(classTree, permitted)) {
+      if (!isSafePermittedType(classTree, permitted, visited)) {
         return false;
       }
     }
     return true;
   }
 
-  private static boolean isNonSealedPermittedType(ClassTree context, TypeTree permitted) {
+  private static boolean isSafePermittedType(ClassTree context, TypeTree permitted, Set<ClassTree> visited) {
     ClassTree permittedDecl = resolvePermittedDeclaration(context, permitted);
-    return permittedDecl != null && ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED);
+    if (permittedDecl == null) {
+      // Unresolved permitted type: conservatively treat as unsafe
+      return false;
+    }
+    if (ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.NON_SEALED)) {
+      return false;
+    }
+    if (ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.FINAL)) {
+      return true;
+    }
+    if (ModifiersUtils.hasModifier(permittedDecl.modifiers(), Modifier.SEALED)) {
+      return isSafelySealedClass(permittedDecl, visited);
+    }
+    // Neither final, sealed, nor non-sealed — treat as unsafe
+    return false;
   }
 
   private static ClassTree resolvePermittedDeclaration(ClassTree context, TypeTree permitted) {
@@ -201,12 +228,22 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
         MethodTree method = (MethodTree) member;
         if ("finalize".equals(method.simpleName().name()) &&
           method.parameters().isEmpty() &&
-          ModifiersUtils.hasModifier(method.modifiers(), Modifier.FINAL)) {
+          ModifiersUtils.hasModifier(method.modifiers(), Modifier.FINAL) &&
+          hasEmptyBody(method)) {
           return true;
         }
       }
     }
     return false;
+  }
+
+  private static boolean hasEmptyBody(MethodTree method) {
+    BlockTree body = method.block();
+    if (body == null) {
+      return true;
+    }
+    List<StatementTree> statements = body.body();
+    return statements.isEmpty();
   }
 
   private static boolean isVulnerableConstructor(MethodTree constructor, boolean hasThrowingInitializers) {
@@ -234,9 +271,9 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     if (variable.initializer() == null) {
       return false;
     }
-    ThrowStatementVisitor visitor = new ThrowStatementVisitor();
+    ThrowingExpressionVisitor visitor = new ThrowingExpressionVisitor();
     variable.initializer().accept(visitor);
-    return visitor.hasThrow;
+    return visitor.hasThrowing;
   }
 
   private static class ThrowStatementVisitor extends BaseTreeVisitor {
@@ -255,6 +292,48 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     @Override
     public void visitLambdaExpression(LambdaExpressionTree tree) {
       // skip lambdas
+    }
+  }
+
+  private static class ThrowingExpressionVisitor extends BaseTreeVisitor {
+    boolean hasThrowing;
+
+    @Override
+    public void visitThrowStatement(ThrowStatementTree tree) {
+      hasThrowing = true;
+    }
+
+    @Override
+    public void visitMethodInvocation(MethodInvocationTree tree) {
+      if (canThrowCheckedException(tree.methodSymbol())) {
+        hasThrowing = true;
+      }
+      super.visitMethodInvocation(tree);
+    }
+
+    @Override
+    public void visitNewClass(NewClassTree tree) {
+      if (canThrowCheckedException(tree.methodSymbol())) {
+        hasThrowing = true;
+      }
+      super.visitNewClass(tree);
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // skip nested classes
+    }
+
+    @Override
+    public void visitLambdaExpression(LambdaExpressionTree tree) {
+      // skip lambdas
+    }
+
+    private static boolean canThrowCheckedException(Symbol.MethodSymbol methodSymbol) {
+      if (methodSymbol.isUnknown()) {
+        return false;
+      }
+      return !methodSymbol.thrownTypes().isEmpty();
     }
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -65,29 +65,39 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
 
   private void checkMembers(ClassTree classTree, List<JavaFileScannerContext.Location> secondaryLocations) {
     boolean hasExplicitConstructor = false;
+    boolean hasThrowingInitializers = false;
     List<Tree> throwingInitializers = new ArrayList<>();
 
     for (Tree member : classTree.members()) {
       if (member.is(Kind.CONSTRUCTOR)) {
         hasExplicitConstructor = true;
-        reportVulnerableConstructor((MethodTree) member, secondaryLocations);
       } else if (member.is(Kind.INITIALIZER) && containsThrowStatementInBlock((BlockTree) member)) {
         throwingInitializers.add(member);
+        hasThrowingInitializers = true;
       } else if (member.is(Kind.VARIABLE) && hasThrowingFieldInitializer((VariableTree) member)) {
         throwingInitializers.add(member);
+        hasThrowingInitializers = true;
       }
     }
 
-    if (!hasExplicitConstructor && !throwingInitializers.isEmpty()) {
+    if (hasExplicitConstructor) {
+      reportVulnerableConstructors(classTree, hasThrowingInitializers, secondaryLocations);
+    } else if (hasThrowingInitializers) {
       reportThrowingInitializers(classTree, throwingInitializers);
     }
   }
 
-  private void reportVulnerableConstructor(MethodTree constructor, List<JavaFileScannerContext.Location> secondaryLocations) {
-    if (isVulnerableConstructor(constructor)) {
-      reportIssue(constructor.simpleName(),
-        "Make this class \"final\" or make this throwing constructor \"private\".",
-        secondaryLocations, null);
+  private void reportVulnerableConstructors(ClassTree classTree, boolean hasThrowingInitializers,
+    List<JavaFileScannerContext.Location> secondaryLocations) {
+    for (Tree member : classTree.members()) {
+      if (member.is(Kind.CONSTRUCTOR)) {
+        MethodTree constructor = (MethodTree) member;
+        if (isVulnerableConstructor(constructor, hasThrowingInitializers)) {
+          reportIssue(constructor.simpleName(),
+            "Make this class \"final\" or make this throwing constructor \"private\".",
+            secondaryLocations, null);
+        }
+      }
     }
   }
 
@@ -195,11 +205,11 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     return false;
   }
 
-  private static boolean isVulnerableConstructor(MethodTree constructor) {
+  private static boolean isVulnerableConstructor(MethodTree constructor, boolean hasThrowingInitializers) {
     if (ModifiersUtils.hasModifier(constructor.modifiers(), Modifier.PRIVATE)) {
       return false;
     }
-    return !constructor.throwsClauses().isEmpty() || containsThrowStatement(constructor);
+    return hasThrowingInitializers || !constructor.throwsClauses().isEmpty() || containsThrowStatement(constructor);
   }
 
   private static boolean containsThrowStatement(MethodTree method) {

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -60,18 +60,17 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     List<JavaFileScannerContext.Location> secondaryLocations = Collections.singletonList(
       new JavaFileScannerContext.Location("Non-final class", classTree.simpleName()));
 
+    checkMembers(classTree, secondaryLocations);
+  }
+
+  private void checkMembers(ClassTree classTree, List<JavaFileScannerContext.Location> secondaryLocations) {
     boolean hasExplicitConstructor = false;
     List<Tree> throwingInitializers = new ArrayList<>();
 
     for (Tree member : classTree.members()) {
       if (member.is(Kind.CONSTRUCTOR)) {
         hasExplicitConstructor = true;
-        if (isVulnerableConstructor((MethodTree) member)) {
-          MethodTree constructor = (MethodTree) member;
-          reportIssue(constructor.simpleName(),
-            "Make this class \"final\" or make this throwing constructor \"private\".",
-            secondaryLocations, null);
-        }
+        reportVulnerableConstructor((MethodTree) member, secondaryLocations);
       } else if (member.is(Kind.INITIALIZER) && containsThrowStatementInBlock((BlockTree) member)) {
         throwingInitializers.add(member);
       } else if (member.is(Kind.VARIABLE) && hasThrowingFieldInitializer((VariableTree) member)) {
@@ -80,14 +79,26 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
     }
 
     if (!hasExplicitConstructor && !throwingInitializers.isEmpty()) {
-      List<JavaFileScannerContext.Location> locations = new ArrayList<>();
-      for (Tree init : throwingInitializers) {
-        locations.add(new JavaFileScannerContext.Location("Throwing initializer", init));
-      }
-      reportIssue(classTree.simpleName(),
-        "Make this class \"final\" or add a private constructor, because initializers can throw.",
-        locations, null);
+      reportThrowingInitializers(classTree, throwingInitializers);
     }
+  }
+
+  private void reportVulnerableConstructor(MethodTree constructor, List<JavaFileScannerContext.Location> secondaryLocations) {
+    if (isVulnerableConstructor(constructor)) {
+      reportIssue(constructor.simpleName(),
+        "Make this class \"final\" or make this throwing constructor \"private\".",
+        secondaryLocations, null);
+    }
+  }
+
+  private void reportThrowingInitializers(ClassTree classTree, List<Tree> throwingInitializers) {
+    List<JavaFileScannerContext.Location> locations = new ArrayList<>();
+    for (Tree init : throwingInitializers) {
+      locations.add(new JavaFileScannerContext.Location("Throwing initializer", init));
+    }
+    reportIssue(classTree.simpleName(),
+      "Make this class \"final\" or add a private constructor, because initializers can throw.",
+      locations, null);
   }
 
   private static boolean isLocalClass(ClassTree classTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -43,8 +43,10 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
   @Override
   public void visitNode(Tree tree) {
     ClassTree classTree = (ClassTree) tree;
-    if (ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.FINAL) ||
-      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.ABSTRACT)) {
+    if (classTree.simpleName() == null ||
+      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.FINAL) ||
+      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.ABSTRACT) ||
+      ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.SEALED)) {
       return;
     }
     List<JavaFileScannerContext.Location> secondaryLocations = Collections.singletonList(

--- a/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/FinalizerAttackCheck.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.BlockTree;
 import org.sonar.plugins.java.api.tree.ClassTree;
@@ -46,10 +47,14 @@ public class FinalizerAttackCheck extends IssuableSubscriptionVisitor {
       ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.ABSTRACT)) {
       return;
     }
+    List<JavaFileScannerContext.Location> secondaryLocations = Collections.singletonList(
+      new JavaFileScannerContext.Location("Non-final class", classTree.simpleName()));
     for (Tree member : classTree.members()) {
       if (member.is(Kind.CONSTRUCTOR) && isVulnerableConstructor((MethodTree) member)) {
-        reportIssue(classTree.simpleName(), "Make this class \"final\" or make the throwing constructors \"private\".");
-        return;
+        MethodTree constructor = (MethodTree) member;
+        reportIssue(constructor.simpleName(),
+          "Make this class \"final\" or make this throwing constructor \"private\".",
+          secondaryLocations, null);
       }
     }
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.java.checks.verifier.CheckVerifier;
 
 import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
 
 class FinalizerAttackCheckTest {
 
@@ -37,6 +38,14 @@ class FinalizerAttackCheckTest {
       .onFile(mainCodeSourcesPath("checks/FinalizerAttackCheckSample.java"))
       .withCheck(new FinalizerAttackCheck())
       .withoutSemantic()
+      .verifyIssues();
+  }
+
+  @Test
+  void test_non_compiling() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/FinalizerAttackCheckSample.java"))
+      .withCheck(new FinalizerAttackCheck())
       .verifyIssues();
   }
 

--- a/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
@@ -31,4 +31,13 @@ class FinalizerAttackCheckTest {
       .verifyIssues();
   }
 
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FinalizerAttackCheckSample.java"))
+      .withCheck(new FinalizerAttackCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
@@ -42,6 +42,14 @@ class FinalizerAttackCheckTest {
   }
 
   @Test
+  void test_semantic_only() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FinalizerAttackCheckSemanticSample.java"))
+      .withCheck(new FinalizerAttackCheck())
+      .verifyIssues();
+  }
+
+  @Test
   void test_non_compiling() {
     CheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/FinalizerAttackCheckSample.java"))

--- a/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/FinalizerAttackCheckTest.java
@@ -1,0 +1,34 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class FinalizerAttackCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/FinalizerAttackCheckSample.java"))
+      .withCheck(new FinalizerAttackCheck())
+      .verifyIssues();
+  }
+
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.html
@@ -1,0 +1,68 @@
+<h2>Why is this an issue?</h2>
+<p>When a constructor throws an exception, you might expect the object construction to fail completely and no reference to the object to exist. However,
+finalization or cleanup mechanisms can be exploited to obtain a reference to a partially-constructed object.</p>
+<p>Here's how a Finalizer attack works:</p>
+<ol>
+  <li>An attacker creates a malicious derived class that overrides the cleanup/finalization method</li>
+  <li>The attacker attempts to instantiate this derived class</li>
+  <li>If the parent constructor throws an exception during initialization, the object is not fully constructed</li>
+  <li>Despite the exception, the garbage collector will eventually call the finalization method on the partially-constructed object</li>
+  <li>The malicious cleanup method can store a reference to the object being finalized, effectively "resurrecting" the broken object</li>
+  <li>The attacker now has access to an object that bypassed security checks or validation logic in the constructor</li>
+</ol>
+<p>This vulnerability is particularly dangerous for security-sensitive classes where the constructor performs authentication or authorization checks,
+input validation, resource allocation with security constraints, or initialization of security-critical fields.</p>
+<h2>How to fix it</h2>
+<p>The simplest solution is to declare the class as <code>final</code>. This prevents attackers from creating malicious subclasses that override the
+<code>finalize()</code> method.</p>
+<p>However, some frameworks such as Spring or JPA/Hibernate require non-final classes. In such cases, use a <strong>factory method with a private
+constructor</strong> to ensure the object is fully validated before any reference is exposed. Since the constructor is private, no malicious subclass
+can be created, achieving the same protection as <code>final</code>.</p>
+<h3>Noncompliant code example</h3>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+public class SecuritySensitiveClass {
+    private final String credentials;
+
+    public SecuritySensitiveClass(String credentials) throws AuthenticationException {
+        if (!isValid(credentials)) {
+            throw new AuthenticationException("Invalid credentials"); // Noncompliant
+        }
+        this.credentials = credentials;
+    }
+
+    private boolean isValid(String credentials) {
+        return credentials != null &amp;&amp; credentials.length() &gt; 10;
+    }
+}
+</pre>
+<h3>Compliant solution</h3>
+<pre data-diff-id="1" data-diff-type="compliant">
+public final class SecuritySensitiveClass { // Compliant: class is final
+    private final String credentials;
+
+    public SecuritySensitiveClass(String credentials) throws AuthenticationException {
+        if (!isValid(credentials)) {
+            throw new AuthenticationException("Invalid credentials");
+        }
+        this.credentials = credentials;
+    }
+
+    private boolean isValid(String credentials) {
+        return credentials != null &amp;&amp; credentials.length() &gt; 10;
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://www.oracle.com/java/technologies/javase/seccodeguide.html">Secure Coding Guidelines for Java
+  SE</a></li>
+  <li>Java Language Specification - <a
+  href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-12.html#jls-12.6">Finalization of Class Instances</a></li>
+</ul>
+<h3>Standards</h3>
+<ul>
+  <li>CWE - <a href="https://cwe.mitre.org/data/definitions/586.html">CWE-586: Explicit Call to Finalize()</a></li>
+  <li>CERT - <a href="https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions">CERT-OBJ11-J: Be
+  wary of letting constructors throw exceptions</a></li>
+</ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.html
@@ -62,7 +62,6 @@ public final class SecuritySensitiveClass { // Compliant: class is final
 </ul>
 <h3>Standards</h3>
 <ul>
-  <li>CWE - <a href="https://cwe.mitre.org/data/definitions/586.html">CWE-586: Explicit Call to Finalize()</a></li>
   <li>CERT - <a href="https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions">CERT-OBJ11-J: Be
   wary of letting constructors throw exceptions</a></li>
 </ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.json
@@ -1,0 +1,32 @@
+{
+  "title": "Classes with throwing constructors should be protected against Finalizer attacks",
+  "type": "VULNERABILITY",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "cert",
+    "cwe",
+    "serialization"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9345",
+  "sqKey": "S9345",
+  "scope": "Main",
+  "defaultQualityProfiles": [
+    "Sonar way"
+  ],
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "SECURITY": "HIGH"
+    },
+    "attribute": "COMPLETE"
+  },
+  "securityStandards": {
+    "CWE": [586],
+    "CERT": ["OBJ11-J."]
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9345.json
@@ -7,9 +7,7 @@
     "constantCost": "5min"
   },
   "tags": [
-    "cert",
-    "cwe",
-    "serialization"
+    "cert"
   ],
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-9345",
@@ -26,7 +24,6 @@
     "attribute": "COMPLETE"
   },
   "securityStandards": {
-    "CWE": [586],
     "CERT": ["OBJ11-J."]
   }
 }


### PR DESCRIPTION
## Summary
- Implement new rule S9345 that detects classes with throwing constructors vulnerable to Finalizer attacks
- Non-compliant: non-final class with public/protected/package-private constructor that has a `throws` clause or contains `throw` statements
- Compliant: `final` classes, classes with only `private` throwing constructors (factory pattern), enums, records, sealed classes (where all permitted subclasses are final/sealed), classes with `final finalize()` method, and local classes

## Review feedback addressed (commit 09126f5)
All 6 findings from @nathsou have been addressed:
- **[P1]** Handle instance/field initializers and classes with no explicit constructor
- **[P1]** Abstract classes are no longer exempt (attacker can subclass)
- **[P1]** Sealed classes with non-sealed subclasses are correctly flagged
- **[P2]** Classes with `protected final void finalize() {}` recognized as safe
- **[P2]** Removed inaccurate CWE-586 mapping, kept CERT OBJ11-J reference
- **[P3]** Local classes are excluded (cannot be subclassed from outside)

## Test plan
- [x] Unit test with `CheckVerifier` covering noncompliant and compliant patterns
- [x] Test without semantic analysis
- [x] Ruling results updated
- [ ] CI passes