### PR TITLE
SONARJAVA-6820: Fix S9355: ignore Eclipse (non-Javadoc) override comments

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
@@ -121,6 +121,35 @@ class AlmostJavadocCheckSample {
     return name;
   }
 
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object other) {
+    return this == other;
+  }
+
+  /* (non-Javadoc)
+   * @param ignored this Eclipse stub still contains a Javadoc tag
+   */
+  public void eclipseMarkerWithoutSee(int ignored) {
+  }
+
+  // Noncompliant@+1
+  /* @see java.lang.Object#clone() */
+  public Object seeWithoutEclipseMarker() {
+    return this;
+  }
+
   record Point(int x, int y) {
     // Noncompliant@+1
     /* @param x the x coordinate */

--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
@@ -159,11 +159,6 @@ class AlmostJavadocCheckSample {
   public void eclipseMarkerLineComment() {
   }
 
-  /* (non-Javadoc) returns </code> */
-  public String eclipseMarkerWithHtml() {
-    return name;
-  }
-
   record Point(int x, int y) {
     // Noncompliant@+1
     /* @param x the x coordinate */

--- a/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/AlmostJavadocCheckSample.java
@@ -150,6 +150,20 @@ class AlmostJavadocCheckSample {
     return this;
   }
 
+  // Noncompliant@+1
+  /* (non-javadoc) @see java.lang.Object#wait() */
+  public void lowercaseMarkerLookalike() {
+  }
+
+  // (non-Javadoc) {@link Object} */
+  public void eclipseMarkerLineComment() {
+  }
+
+  /* (non-Javadoc) returns </code> */
+  public String eclipseMarkerWithHtml() {
+    return name;
+  }
+
   record Point(int x, int y) {
     // Noncompliant@+1
     /* @param x the x coordinate */

--- a/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AlmostJavadocCheck.java
@@ -132,6 +132,9 @@ public class AlmostJavadocCheck extends IssuableSubscriptionVisitor {
 
   private static boolean isAlmostJavadoc(SyntaxTrivia trivia) {
     String text = trivia.comment().stripTrailing();
+    if (text.contains("(non-Javadoc)")) {
+      return false;
+    }
     if (trivia.isComment(CommentKind.BLOCK)) {
       return hasTag(text);
     }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
@@ -76,29 +76,6 @@ interface Repository {
   Entity load(String id);
 }
 </pre>
-<h4>Noncompliant code example</h4>
-<pre data-diff-id="4" data-diff-type="noncompliant">
-class Value {
-  /* @see java.lang.Object#hashCode() */ // Noncompliant: @see tag in a regular comment
-  @Override
-  public int hashCode() {
-    return 0;
-  }
-}
-</pre>
-<h4>Compliant solution</h4>
-<pre data-diff-id="4" data-diff-type="compliant">
-class Value {
-  /*
-   * (non-Javadoc)
-   * @see java.lang.Object#hashCode()
-   */
-  @Override
-  public int hashCode() {
-    return 0;
-  }
-}
-</pre>
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9355.html
@@ -15,6 +15,7 @@ those tags never attach to the following declaration. Readers and generated API 
   <code>&lt;/a&gt;</code>, <code>&lt;/strong&gt;</code>, <code>&lt;/i&gt;</code>, <code>&lt;/pre&gt;</code>, or <code>&lt;/code&gt;</code>.</li>
   <li>The comment does not immediately precede a documentable declaration.</li>
   <li>The declaration already has a documentation comment.</li>
+  <li>The comment contains the Eclipse <code>(non-Javadoc)</code> marker.</li>
 </ul>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
@@ -73,6 +74,29 @@ interface Repository {
 interface Repository {
   /** Loads the entity. {@link Entity} */
   Entity load(String id);
+}
+</pre>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="4" data-diff-type="noncompliant">
+class Value {
+  /* @see java.lang.Object#hashCode() */ // Noncompliant: @see tag in a regular comment
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="4" data-diff-type="compliant">
+class Value {
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return 0;
+  }
 }
 </pre>
 <h2>Resources</h2>


### PR DESCRIPTION
## Summary

- Stop raising S9355 when a comment contains the Eclipse `(non-Javadoc)` marker.
- The marker alone is enough; `@see` is not required.
- Keep flagging a regular `@see` comment that is not an Eclipse stub.
- Refresh the generated S9355 description from the RSPEC branch.

## Links

- Jira: https://sonarsource.atlassian.net/browse/SONARJAVA-6820
- RSPEC PR: https://github.com/SonarSource/rspec/pull/7936

## AI disclosure
- LLM model used for implementation: cursor-grok-4.6-high
