### PR TITLE
SONARJAVA-6788: Implement S9361: Duplicate keys or elements should not be passed to immutable collection factory methods

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
@@ -1,0 +1,124 @@
+package checks;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import static java.util.Map.entry;
+
+class DuplicateImmutableCollectionArgumentsCheckSample {
+
+  private static final String CONST_A = "keyA";
+  private static final String CONST_B = "keyB";
+  private static final String CONST_A_ALIAS = "keyA";
+
+  void testMapOf() {
+    Map<String, Integer> empty = Map.of(); // Compliant
+    Map<String, Integer> single = Map.of("a", 1); // Compliant
+    Map<String, Integer> distinct = Map.of("a", 1, "b", 2, "c", 3); // Compliant
+
+    Map<String, Integer> duplicateLiteral = Map.of(
+      "timeout", 30,
+      "retries", 3,
+      "timeout", 60 // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<String, Integer> multipleDuplicates = Map.of(
+      "k1", 1,
+      "k2", 2,
+      "k1", 3, // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+      "k2", 4, // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+      "k1", 5  // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-4]]
+    );
+
+    Map<String, Integer> duplicateConstants = Map.of(
+      CONST_A, 1,
+      CONST_B, 2,
+      CONST_A_ALIAS, 3 // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<Integer, String> duplicateIntKeys = Map.of(
+      1, "one",
+      2, "two",
+      1, "uno" // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<Boolean, String> duplicateBoolKeys = Map.of(
+      true, "yes",
+      false, "no",
+      true, "oui" // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+  }
+
+  void testMapOfVariables(String varKey1, String varKey2) {
+    Map<String, Integer> distinctVars = Map.of(varKey1, 1, varKey2, 2); // Compliant
+    Map<String, Integer> sameVar = Map.of(
+      varKey1, 1,
+      varKey2, 2,
+      varKey1, 3 // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+  }
+
+  void testMapOfEntries() {
+    Map<String, String> empty = Map.ofEntries(); // Compliant
+    Map<String, String> single = Map.ofEntries(Map.entry("a", "b")); // Compliant
+    Map<String, String> distinct = Map.ofEntries(
+      Map.entry("k1", "v1"),
+      Map.entry("k2", "v2"),
+      entry("k3", "v3")
+    ); // Compliant
+
+    Map<String, String> duplicateEntries = Map.ofEntries(
+      Map.entry("host", "localhost"),
+      Map.entry("port", "8080"),
+      Map.entry("host", "remotehost") // Noncompliant {{Remove or rename this duplicate key; "Map.ofEntries" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<String, String> duplicateStaticImport = Map.ofEntries(
+      entry("user", "admin"),
+      entry("user", "guest") // Noncompliant {{Remove or rename this duplicate key; "Map.ofEntries" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-1]]
+    );
+  }
+
+  void testSetOf() {
+    Set<String> empty = Set.of(); // Compliant
+    Set<String> single = Set.of("a"); // Compliant
+    Set<String> distinct = Set.of("a", "b", "c"); // Compliant
+
+    Set<String> duplicateStrings = Set.of(
+      "read",
+      "write",
+      "read" // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+
+    Set<Integer> duplicateNumbers = Set.of(
+      10,
+      20,
+      10 // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+
+    Set<String> duplicateConsts = Set.of(
+      CONST_A,
+      CONST_B,
+      CONST_A // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+
+    Set<String> multipleSetDuplicates = Set.of(
+      "x",
+      "x", // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-1]]
+      "x"  // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+  }
+
+  void testSetOfVariables(String v1, String v2) {
+    Set<String> distinctVars = Set.of(v1, v2); // Compliant
+    Set<String> duplicateVars = Set.of(
+      v1,
+      v2,
+      v1 // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+  }
+
+  void testListOfPermitsDuplicates() {
+    List<String> list = List.of("dup", "dup", "dup"); // Compliant: List.of allows duplicates
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
@@ -184,6 +184,17 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
     List<String> list = List.of("dup", "dup", "dup"); // Compliant: List.of allows duplicates
   }
 
+  static class CyclicDeclarations {
+    static int a = b;
+    static int b = a;
+    int selfRef = selfRef;
+
+    void testCyclic() {
+      Map<Integer, String> map = Map.of(a, "a", b, "b"); // Compliant
+      Set<Integer> set = Set.of(selfRef, 1); // Compliant
+    }
+  }
+
   private String generateId() {
     return UUID.randomUUID().toString();
   }

--- a/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
@@ -3,6 +3,7 @@ package checks;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import static java.util.Map.entry;
 
 class DuplicateImmutableCollectionArgumentsCheckSample {
@@ -10,6 +11,16 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
   private static final String CONST_A = "keyA";
   private static final String CONST_B = "keyB";
   private static final String CONST_A_ALIAS = "keyA";
+
+  private static final int INT_A = 1;
+  private static final int INT_B = 2;
+  private static final int INT_A_ALIAS = 1;
+
+  enum Color {
+    RED, GREEN, BLUE
+  }
+
+  private static final Color RED_ALIAS = Color.RED;
 
   void testMapOf() {
     Map<String, Integer> empty = Map.of(); // Compliant
@@ -36,9 +47,27 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
       CONST_A_ALIAS, 3 // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
     );
 
+    Map<String, Integer> duplicateConstAndLiteral = Map.of(
+      CONST_A, 1,
+      CONST_B, 2,
+      "keyA", 3 // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
     Map<Integer, String> duplicateIntKeys = Map.of(
       1, "one",
       2, "two",
+      1, "uno" // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<Integer, String> duplicateAliasedInts = Map.of(
+      INT_A, "one",
+      INT_B, "two",
+      INT_A_ALIAS, "uno" // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<Integer, String> duplicateIntAndConst = Map.of(
+      INT_A, "one",
+      INT_B, "two",
       1, "uno" // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
     );
 
@@ -46,6 +75,12 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
       true, "yes",
       false, "no",
       true, "oui" // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
+    );
+
+    Map<String, Integer> parenthesizedKeys = Map.of(
+      ("key"), 1,
+      "other", 2,
+      "key", 3 // Noncompliant {{Remove or rename this duplicate key; "Map.of" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-2]]
     );
   }
 
@@ -77,6 +112,9 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
       entry("user", "admin"),
       entry("user", "guest") // Noncompliant {{Remove or rename this duplicate key; "Map.ofEntries" throws an "IllegalArgumentException" at runtime when keys are duplicated.}} [[secondary=-1]]
     );
+
+    Map.Entry<String, String> entryVariable = Map.entry("dynamic", "val");
+    Map<String, String> entryVarMap = Map.ofEntries(entryVariable); // Compliant
   }
 
   void testSetOf() {
@@ -90,6 +128,12 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
       "read" // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
     );
 
+    Set<String> duplicateConcat = Set.of(
+      "ab",
+      "cd",
+      "a" + "b" // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+
     Set<Integer> duplicateNumbers = Set.of(
       10,
       20,
@@ -100,6 +144,18 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
       CONST_A,
       CONST_B,
       CONST_A // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+
+    Set<Color> duplicateEnums = Set.of(
+      Color.RED,
+      Color.GREEN,
+      Color.RED // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
+    );
+
+    Set<Color> duplicateAliasedEnums = Set.of(
+      Color.RED,
+      Color.BLUE,
+      RED_ALIAS // Noncompliant {{Remove or replace this duplicate element; "Set.of" throws an "IllegalArgumentException" at runtime when elements are duplicated.}} [[secondary=-2]]
     );
 
     Set<String> multipleSetDuplicates = Set.of(
@@ -118,7 +174,17 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
     );
   }
 
+  void testNonDeterministicExpressionsAreCompliant() {
+    Set<Object> newObjects = Set.of(new Object(), new Object()); // Compliant: each instance is distinct
+    Set<String> methodCalls = Set.of(generateId(), generateId()); // Compliant: methods can return distinct values
+    Set<UUID> randomUuids = Set.of(UUID.randomUUID(), UUID.randomUUID()); // Compliant
+  }
+
   void testListOfPermitsDuplicates() {
     List<String> list = List.of("dup", "dup", "dup"); // Compliant: List.of allows duplicates
+  }
+
+  private String generateId() {
+    return UUID.randomUUID().toString();
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/DuplicateImmutableCollectionArgumentsCheckSample.java
@@ -185,13 +185,25 @@ class DuplicateImmutableCollectionArgumentsCheckSample {
   }
 
   static class CyclicDeclarations {
-    static int a = b;
-    static int b = a;
-    int selfRef = selfRef;
+    int a;
+    int b;
+    int self;
+
+    void setA() {
+      a = b;
+    }
+
+    void setB() {
+      b = a;
+    }
+
+    void setSelf() {
+      self = self;
+    }
 
     void testCyclic() {
       Map<Integer, String> map = Map.of(a, "a", b, "b"); // Compliant
-      Set<Integer> set = Set.of(selfRef, 1); // Compliant
+      Set<Integer> set = Set.of(self, 1); // Compliant
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
@@ -47,20 +47,22 @@ public class DuplicateImmutableCollectionArgumentsCheck extends IssuableSubscrip
   private static final String FIRST_KEY_SECONDARY_MESSAGE = "First occurrence of this key.";
   private static final String FIRST_ELEMENT_SECONDARY_MESSAGE = "First occurrence of this element.";
 
+  private static final String JAVA_UTIL_MAP = "java.util.Map";
+
   private static final MethodMatchers MAP_OF = MethodMatchers.create()
-    .ofTypes("java.util.Map")
+    .ofTypes(JAVA_UTIL_MAP)
     .names("of")
     .withAnyParameters()
     .build();
 
   private static final MethodMatchers MAP_OF_ENTRIES = MethodMatchers.create()
-    .ofTypes("java.util.Map")
+    .ofTypes(JAVA_UTIL_MAP)
     .names("ofEntries")
     .withAnyParameters()
     .build();
 
   private static final MethodMatchers MAP_ENTRY = MethodMatchers.create()
-    .ofTypes("java.util.Map")
+    .ofTypes(JAVA_UTIL_MAP)
     .names("entry")
     .addParametersMatcher(MethodMatchers.ANY, MethodMatchers.ANY)
     .build();

--- a/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
@@ -1,0 +1,160 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.java.checks.helpers.ExpressionsHelper;
+import org.sonar.java.model.SyntacticEquivalence;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.tree.Arguments;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9361")
+public class DuplicateImmutableCollectionArgumentsCheck extends IssuableSubscriptionVisitor {
+
+  private static final String MAP_OF_MESSAGE = "Remove or rename this duplicate key; \"Map.of\" throws an \"IllegalArgumentException\" at runtime when keys are duplicated.";
+  private static final String MAP_OF_ENTRIES_MESSAGE = "Remove or rename this duplicate key; \"Map.ofEntries\" throws an \"IllegalArgumentException\" at runtime when keys are duplicated.";
+  private static final String SET_OF_MESSAGE = "Remove or replace this duplicate element; \"Set.of\" throws an \"IllegalArgumentException\" at runtime when elements are duplicated.";
+
+  private static final String FIRST_KEY_SECONDARY_MESSAGE = "First occurrence of this key.";
+  private static final String FIRST_ELEMENT_SECONDARY_MESSAGE = "First occurrence of this element.";
+
+  private static final MethodMatchers MAP_OF = MethodMatchers.create()
+    .ofTypes("java.util.Map")
+    .names("of")
+    .withAnyParameters()
+    .build();
+
+  private static final MethodMatchers MAP_OF_ENTRIES = MethodMatchers.create()
+    .ofTypes("java.util.Map")
+    .names("ofEntries")
+    .withAnyParameters()
+    .build();
+
+  private static final MethodMatchers MAP_ENTRY = MethodMatchers.create()
+    .ofTypes("java.util.Map")
+    .names("entry")
+    .addParametersMatcher(MethodMatchers.ANY, MethodMatchers.ANY)
+    .build();
+
+  private static final MethodMatchers SET_OF = MethodMatchers.create()
+    .ofTypes("java.util.Set")
+    .names("of")
+    .withAnyParameters()
+    .build();
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.METHOD_INVOCATION);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    MethodInvocationTree mit = (MethodInvocationTree) tree;
+    if (MAP_OF.matches(mit)) {
+      checkMapOf(mit);
+    } else if (MAP_OF_ENTRIES.matches(mit)) {
+      checkMapOfEntries(mit);
+    } else if (SET_OF.matches(mit)) {
+      checkSetOf(mit);
+    }
+  }
+
+  private void checkMapOf(MethodInvocationTree mit) {
+    Arguments arguments = mit.arguments();
+    List<ExpressionTree> keys = new ArrayList<>();
+    for (int i = 0; i < arguments.size(); i += 2) {
+      keys.add(ExpressionUtils.skipParentheses(arguments.get(i)));
+    }
+    checkDuplicates(keys, MAP_OF_MESSAGE, FIRST_KEY_SECONDARY_MESSAGE);
+  }
+
+  private void checkMapOfEntries(MethodInvocationTree mit) {
+    List<ExpressionTree> keys = new ArrayList<>();
+    for (ExpressionTree arg : mit.arguments()) {
+      ExpressionTree unwrapped = ExpressionUtils.skipParentheses(arg);
+      if (unwrapped.is(Tree.Kind.METHOD_INVOCATION)) {
+        MethodInvocationTree entryMit = (MethodInvocationTree) unwrapped;
+        if (MAP_ENTRY.matches(entryMit) && entryMit.arguments().size() == 2) {
+          keys.add(ExpressionUtils.skipParentheses(entryMit.arguments().get(0)));
+        }
+      }
+    }
+    checkDuplicates(keys, MAP_OF_ENTRIES_MESSAGE, FIRST_KEY_SECONDARY_MESSAGE);
+  }
+
+  private void checkSetOf(MethodInvocationTree mit) {
+    List<ExpressionTree> elements = new ArrayList<>();
+    for (ExpressionTree arg : mit.arguments()) {
+      elements.add(ExpressionUtils.skipParentheses(arg));
+    }
+    checkDuplicates(elements, SET_OF_MESSAGE, FIRST_ELEMENT_SECONDARY_MESSAGE);
+  }
+
+  private void checkDuplicates(List<ExpressionTree> expressions, String message, String secondaryMessage) {
+    List<ExpressionTree> seen = new ArrayList<>();
+    for (ExpressionTree expr : expressions) {
+      ExpressionTree firstOccurrence = findFirstEquivalent(seen, expr);
+      if (firstOccurrence != null) {
+        reportIssue(
+          expr,
+          message,
+          Collections.singletonList(new JavaFileScannerContext.Location(secondaryMessage, firstOccurrence)),
+          null
+        );
+      } else {
+        seen.add(expr);
+      }
+    }
+  }
+
+  private static ExpressionTree findFirstEquivalent(List<ExpressionTree> seen, ExpressionTree target) {
+    for (ExpressionTree prior : seen) {
+      if (areEquivalent(prior, target)) {
+        return prior;
+      }
+    }
+    return null;
+  }
+
+  private static boolean areEquivalent(ExpressionTree expr1, ExpressionTree expr2) {
+    ExpressionTree e1 = ExpressionUtils.skipParentheses(expr1);
+    ExpressionTree e2 = ExpressionUtils.skipParentheses(expr2);
+
+    String str1 = ExpressionsHelper.getConstantValueAsString(e1).value();
+    String str2 = ExpressionsHelper.getConstantValueAsString(e2).value();
+    if (str1 != null && str2 != null) {
+      return str1.equals(str2);
+    }
+
+    Boolean bool1 = ExpressionsHelper.getConstantValueAsBoolean(e1).value();
+    Boolean bool2 = ExpressionsHelper.getConstantValueAsBoolean(e2).value();
+    if (bool1 != null && bool2 != null) {
+      return bool1.equals(bool2);
+    }
+
+    return SyntacticEquivalence.areEquivalentIncludingSameVariables(e1, e2);
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
@@ -18,8 +18,10 @@ package org.sonar.java.checks;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.ExpressionsHelper;
 import org.sonar.java.model.ExpressionUtils;
@@ -37,9 +39,10 @@ import org.sonar.plugins.java.api.tree.Tree;
 @Rule(key = "S9361")
 public class DuplicateImmutableCollectionArgumentsCheck extends IssuableSubscriptionVisitor {
 
-  private static final String MAP_OF_MESSAGE = "Remove or rename this duplicate key; \"Map.of\" throws an \"IllegalArgumentException\" at runtime when keys are duplicated.";
-  private static final String MAP_OF_ENTRIES_MESSAGE = "Remove or rename this duplicate key; \"Map.ofEntries\" throws an \"IllegalArgumentException\" at runtime when keys are duplicated.";
-  private static final String SET_OF_MESSAGE = "Remove or replace this duplicate element; \"Set.of\" throws an \"IllegalArgumentException\" at runtime when elements are duplicated.";
+  private static final String MESSAGE_TEMPLATE = "Remove or %s this duplicate %s; \"%s\" throws an \"IllegalArgumentException\" at runtime when %s are duplicated.";
+  private static final String MAP_OF_MESSAGE = String.format(MESSAGE_TEMPLATE, "rename", "key", "Map.of", "keys");
+  private static final String MAP_OF_ENTRIES_MESSAGE = String.format(MESSAGE_TEMPLATE, "rename", "key", "Map.ofEntries", "keys");
+  private static final String SET_OF_MESSAGE = String.format(MESSAGE_TEMPLATE, "replace", "element", "Set.of", "elements");
 
   private static final String FIRST_KEY_SECONDARY_MESSAGE = "First occurrence of this key.";
   private static final String FIRST_ELEMENT_SECONDARY_MESSAGE = "First occurrence of this element.";
@@ -170,13 +173,17 @@ public class DuplicateImmutableCollectionArgumentsCheck extends IssuableSubscrip
   }
 
   private static ExpressionTree resolveExpression(ExpressionTree expression) {
+    return resolveExpression(expression, new HashSet<>());
+  }
+
+  private static ExpressionTree resolveExpression(ExpressionTree expression, Set<Symbol> visited) {
     ExpressionTree current = ExpressionUtils.skipParentheses(expression);
     if (current.is(Tree.Kind.IDENTIFIER)) {
       Symbol symbol = ((IdentifierTree) current).symbol();
-      if (!symbol.isUnknown()) {
+      if (!symbol.isUnknown() && visited.add(symbol)) {
         ExpressionTree singleWrite = ExpressionsHelper.getSingleWriteUsage(symbol);
         if (singleWrite != null) {
-          return resolveExpression(singleWrite);
+          return resolveExpression(singleWrite, visited);
         }
       }
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheck.java
@@ -19,15 +19,18 @@ package org.sonar.java.checks;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.sonar.check.Rule;
-import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.checks.helpers.ExpressionsHelper;
+import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.SyntacticEquivalence;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.JavaFileScannerContext;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.Arguments;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;
 
@@ -140,8 +143,14 @@ public class DuplicateImmutableCollectionArgumentsCheck extends IssuableSubscrip
   }
 
   private static boolean areEquivalent(ExpressionTree expr1, ExpressionTree expr2) {
-    ExpressionTree e1 = ExpressionUtils.skipParentheses(expr1);
-    ExpressionTree e2 = ExpressionUtils.skipParentheses(expr2);
+    ExpressionTree e1 = resolveExpression(expr1);
+    ExpressionTree e2 = resolveExpression(expr2);
+
+    Optional<Object> const1 = e1.asConstant();
+    Optional<Object> const2 = e2.asConstant();
+    if (const1.isPresent() && const2.isPresent()) {
+      return const1.get().equals(const2.get());
+    }
 
     String str1 = ExpressionsHelper.getConstantValueAsString(e1).value();
     String str2 = ExpressionsHelper.getConstantValueAsString(e2).value();
@@ -155,6 +164,22 @@ public class DuplicateImmutableCollectionArgumentsCheck extends IssuableSubscrip
       return bool1.equals(bool2);
     }
 
-    return SyntacticEquivalence.areEquivalentIncludingSameVariables(e1, e2);
+    return ExpressionsHelper.alwaysReturnSameValue(e1)
+      && ExpressionsHelper.alwaysReturnSameValue(e2)
+      && SyntacticEquivalence.areEquivalentIncludingSameVariables(e1, e2);
+  }
+
+  private static ExpressionTree resolveExpression(ExpressionTree expression) {
+    ExpressionTree current = ExpressionUtils.skipParentheses(expression);
+    if (current.is(Tree.Kind.IDENTIFIER)) {
+      Symbol symbol = ((IdentifierTree) current).symbol();
+      if (!symbol.isUnknown()) {
+        ExpressionTree singleWrite = ExpressionsHelper.getSingleWriteUsage(symbol);
+        if (singleWrite != null) {
+          return resolveExpression(singleWrite);
+        }
+      }
+    }
+    return current;
   }
 }

--- a/java-checks/src/test/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/DuplicateImmutableCollectionArgumentsCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class DuplicateImmutableCollectionArgumentsCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/DuplicateImmutableCollectionArgumentsCheckSample.java"))
+      .withCheck(new DuplicateImmutableCollectionArgumentsCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/DuplicateImmutableCollectionArgumentsCheckSample.java"))
+      .withCheck(new DuplicateImmutableCollectionArgumentsCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.html
@@ -8,9 +8,12 @@ an <code>IllegalArgumentException</code> is thrown at runtime during collection 
 contract. Because the factory methods validate their arguments at initialization time, duplicate entries cause an immediate runtime crash when the
 collection is constructed.</p>
 <h2>How to fix it</h2>
-<p>Review the arguments passed to the factory method: * For <code>Map.of()</code> and <code>Map.ofEntries()</code>, remove the redundant key-value
-pair or replace the duplicate key with the intended distinct key. * For <code>Set.of()</code>, remove the duplicated element or replace it with the
-intended distinct element.</p>
+<p>Review the arguments passed to the factory method:</p>
+<ul>
+  <li>For <code>Map.of()</code> and <code>Map.ofEntries()</code>, remove the redundant key-value pair or replace the duplicate key with the intended
+  distinct key.</li>
+  <li>For <code>Set.of()</code>, remove the duplicated element or replace it with the intended distinct element.</li>
+</ul>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.html
@@ -1,0 +1,89 @@
+<p>Java 9 introduced immutable collection factory methods: <code>Map.of()</code>, <code>Map.ofEntries()</code>, and <code>Set.of()</code>. Unlike
+mutable collections such as <code>HashMap</code> (where duplicate keys overwrite previous entries) or <code>HashSet</code> (where duplicate elements
+are ignored), these static factory methods disallow duplicate keys and elements.</p>
+<p>When duplicate keys are passed to <code>Map.of()</code> or <code>Map.ofEntries()</code>, or duplicate elements are passed to <code>Set.of()</code>,
+an <code>IllegalArgumentException</code> is thrown at runtime during collection creation.</p>
+<h2>Why is this an issue?</h2>
+<p>Passing duplicate keys or duplicate elements to immutable collection factories is almost always a copy-paste error or a misunderstanding of the API
+contract. Because the factory methods validate their arguments at initialization time, duplicate entries cause an immediate runtime crash when the
+collection is constructed.</p>
+<h2>How to fix it</h2>
+<p>Review the arguments passed to the factory method: * For <code>Map.of()</code> and <code>Map.ofEntries()</code>, remove the redundant key-value
+pair or replace the duplicate key with the intended distinct key. * For <code>Set.of()</code>, remove the duplicated element or replace it with the
+intended distinct element.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+import java.util.Map;
+import java.util.Set;
+
+class CollectionFactoryExamples {
+
+  void createMap() {
+    Map&lt;String, Integer&gt; config = Map.of(
+      "timeout", 30,
+      "retries", 3,
+      "timeout", 60 // Noncompliant: "timeout" is duplicated
+    );
+  }
+
+  void createEntriesMap() {
+    Map&lt;String, String&gt; endpoints = Map.ofEntries(
+      Map.entry("auth", "https://auth.example.com"),
+      Map.entry("api", "https://api.example.com"),
+      Map.entry("auth", "https://auth2.example.com") // Noncompliant: "auth" is duplicated
+    );
+  }
+
+  void createSet() {
+    Set&lt;String&gt; permissions = Set.of(
+      "read",
+      "write",
+      "read" // Noncompliant: "read" is duplicated
+    );
+  }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+import java.util.Map;
+import java.util.Set;
+
+class CollectionFactoryExamples {
+
+  void createMap() {
+    Map&lt;String, Integer&gt; config = Map.of(
+      "timeout", 30,
+      "retries", 3,
+      "port", 60
+    );
+  }
+
+  void createEntriesMap() {
+    Map&lt;String, String&gt; endpoints = Map.ofEntries(
+      Map.entry("auth", "https://auth.example.com"),
+      Map.entry("api", "https://api.example.com"),
+      Map.entry("admin", "https://auth2.example.com")
+    );
+  }
+
+  void createSet() {
+    Set&lt;String&gt; permissions = Set.of(
+      "read",
+      "write",
+      "execute"
+    );
+  }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Java Documentation - <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Map.html#of(K,V)">Method Map.of</a></li>
+  <li>Java Documentation - <a
+  href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Map.html#ofEntries(java.util.Map.Entry…​)">Method
+  Map.ofEntries</a></li>
+  <li>Java Documentation - <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Set.html#of(E…​)">Method Set.of</a></li>
+  <li>{rule:java:S4143} - Map values should not be replaced unconditionally</li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.html
@@ -1,8 +1,7 @@
-<p>Java 9 introduced immutable collection factory methods: <code>Map.of()</code>, <code>Map.ofEntries()</code>, and <code>Set.of()</code>. Unlike
-mutable collections such as <code>HashMap</code> (where duplicate keys overwrite previous entries) or <code>HashSet</code> (where duplicate elements
-are ignored), these static factory methods disallow duplicate keys and elements.</p>
-<p>When duplicate keys are passed to <code>Map.of()</code> or <code>Map.ofEntries()</code>, or duplicate elements are passed to <code>Set.of()</code>,
-an <code>IllegalArgumentException</code> is thrown at runtime during collection creation.</p>
+<p>Passing duplicate keys to <code>Map.of()</code> or <code>Map.ofEntries()</code>, or duplicate elements to <code>Set.of()</code>, throws an
+<code>IllegalArgumentException</code> at runtime during collection creation.</p>
+<p>Unlike mutable collections such as <code>HashMap</code> (where duplicate keys overwrite previous entries) or <code>HashSet</code> (where duplicate
+elements are ignored), these static factory methods disallow duplicate keys and elements.</p>
 <h2>Why is this an issue?</h2>
 <p>Passing duplicate keys or duplicate elements to immutable collection factories is almost always a copy-paste error or a misunderstanding of the API
 contract. Because the factory methods validate their arguments at initialization time, duplicate entries cause an immediate runtime crash when the
@@ -87,6 +86,9 @@ class CollectionFactoryExamples {
   href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Map.html#ofEntries(java.util.Map.Entry…​)">Method
   Map.ofEntries</a></li>
   <li>Java Documentation - <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Set.html#of(E…​)">Method Set.of</a></li>
+</ul>
+<h3>Related rules</h3>
+<ul>
   <li>{rule:java:S4143} - Map values should not be replaced unconditionally</li>
 </ul>
 

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9361.json
@@ -1,0 +1,23 @@
+{
+  "title": "Duplicate keys or elements should not be passed to immutable collection factory methods",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "bad-practice"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9361",
+  "sqKey": "S9361",
+  "scope": "Main",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "LOGICAL"
+  }
+}


### PR DESCRIPTION
## Summary

- Implement S9361 (DuplicateImmutableCollectionArgumentsCheck) in SonarJava.
- Flag duplicate keys in `Map.of(...)` and `Map.ofEntries(...)`.
- Flag duplicate elements in `Set.of(...)`.
- Add comprehensive test samples and `.withoutSemantic()` check verifier tests.
- Add generated rule metadata and Sonar way profile entry.

## Links

- Jira: https://sonarsource.atlassian.net/browse/SONARJAVA-6788
- RSPEC PR: https://github.com/SonarSource/rspec/pull/7943

## AI disclosure
- LLM model used for implementation: gemini-3.7-flash-high
