### PR TITLE
JAVASE-241 Remove Bean Validation @NotNull annotaions from nullability configuration to fix FPs

### DIFF
--- a/java-checks-test-sources/default/src/main/java/annotations/nullability/no_default/NullabilityAtMethodLevel.java
+++ b/java-checks-test-sources/default/src/main/java/annotations/nullability/no_default/NullabilityAtMethodLevel.java
@@ -71,6 +71,7 @@ public class NullabilityAtMethodLevel {
     return new Object();
   }
 
+
 }
 
 abstract class NullabilityAtMethodLevelParent {

--- a/java-checks-test-sources/default/src/main/java/annotations/nullability/no_default/NullabilityAtVariableLevel.java
+++ b/java-checks-test-sources/default/src/main/java/annotations/nullability/no_default/NullabilityAtVariableLevel.java
@@ -104,8 +104,6 @@ public class NullabilityAtVariableLevel {
   Object id1031_type_NON_NULL_level_VARIABLE;
   @javax.annotation.Nonnull
   Object id1032_type_NON_NULL_level_VARIABLE;
-  @javax.validation.constraints.NotNull
-  Object id1033_type_NON_NULL_level_VARIABLE;
   @lombok.NonNull
   Object id1034_type_NON_NULL_level_VARIABLE;
   @org.checkerframework.checker.nullness.compatqual.NonNullDecl

--- a/java-checks-test-sources/default/src/main/java/checks/EqualsParametersMarkedNonNullCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EqualsParametersMarkedNonNullCheckSample.java
@@ -41,17 +41,6 @@ public class EqualsParametersMarkedNonNullCheckSample {
     }
   }
 
-  static class F {
-    public boolean equals(
-      @javax.validation.constraints.NotNull // Noncompliant {{"equals" method parameters should not be marked "@NotNull".}} [[quickfixes=qf2]]
-//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      java.lang.Object object) {
-      // fix@qf2 {{Remove "@NotNull"}}
-      // edit@qf2 [[sc=7;ec=7;el=+2]] {{}}
-      return false;
-    }
-  }
-
   @org.eclipse.jdt.annotation.NonNullByDefault
   static class G {
     public boolean equals(Object object) { // Compliant

--- a/java-checks-test-sources/default/src/main/java/checks/S2638_ChangeMethodContractCheck/noPackageInfo/ChangeMethodContractCheck.java
+++ b/java-checks-test-sources/default/src/main/java/checks/S2638_ChangeMethodContractCheck/noPackageInfo/ChangeMethodContractCheck.java
@@ -186,38 +186,6 @@ class ChangeMethodContractCheck_WithMetaAnnotations {
   }
 }
 
-/**
- * Not null with arguments is inconsistently supported. See SONARJAVA-3803.
- */
-class ChangeMethodContractCheck_NonnullWithArguments {
-
-  class Parent {
-    @javax.validation.constraints.NotNull(groups = { ChangeMethodContractCheck.class })
-    String annotatedNotNullWithArg(Object a) { return "null"; }
-
-    @javax.validation.constraints.NotNull
-    String annotatedNotNullWithoutArg(Object a) { return "null"; }
-
-    void argAnnotatedNoNullWithArg(@javax.validation.constraints.NotNull(groups = { ChangeMethodContractCheck.class }) Object a) { }
-    void argAnnotatedNoNullWithoutArg(@javax.validation.constraints.NotNull Object a) { }
-  }
-
-  class Child extends Parent {
-    // Parent is not strictly not null (NotNull with arguments).
-    @Override
-    @javax.annotation.CheckForNull
-    String annotatedNotNullWithArg(Object a) { return null; }
-
-    @Override
-    // This one is a TP though.
-    @javax.annotation.CheckForNull
-    String annotatedNotNullWithoutArg(Object a) { return null; } // Noncompliant {{Fix the incompatibility of the annotation @CheckForNull to honor @NotNull of the overridden method.}}
-
-    // It works correctly for arguments though.
-    void argAnnotatedNoNullWithArg(@javax.annotation.CheckForNull Object a) { }
-    void argAnnotatedNoNullWithoutArg(@javax.annotation.CheckForNull Object a) { }
-  }
-}
 
 /**
  * javax.annotation.Nonnull with argument when=When.MAYBE or when=When.UNKNOWN is actually Nullable.

--- a/java-checks-test-sources/default/src/main/java/checks/jspecify/RedundantNullabilityAnnotationsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/jspecify/RedundantNullabilityAnnotationsCheckSample.java
@@ -2,7 +2,6 @@ package checks.jspecify;
 
 import java.util.List;
 import javax.annotation.meta.When;
-import javax.validation.constraints.NotNull;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
@@ -18,11 +17,6 @@ class RedundantNullabilityAnnotationsCheckSampleB {
 
   public void methodNonNullParam(@javax.annotation.Nonnull(when= When.ALWAYS) Object o) { // Noncompliant {{Remove redundant annotation @Nonnull(when=ALWAYS) as inside scope annotation @NullMarked at class level.}}
     // ...
-  }
-
-  @NotNull // Noncompliant {{Remove redundant annotation @NotNull as inside scope annotation @NullMarked at class level.}}
-  public Integer methodJXNonNullReturn(Object o) {
-    return 0;
   }
 
   @javax.annotation.Nonnull(when= When.ALWAYS) // Noncompliant {{Remove redundant annotation @Nonnull(when=ALWAYS) as inside scope annotation @NullMarked at class level.}}

--- a/java-checks/src/main/java/org/sonar/java/checks/ChangeMethodContractCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/ChangeMethodContractCheck.java
@@ -83,9 +83,11 @@ public class ChangeMethodContractCheck extends IssuableSubscriptionVisitor {
 
   private void compareNullability(TypeTree tree, SymbolMetadata upperBound, SymbolMetadata lowerBound, boolean overriddenIsLowerBound) {
     // Check current level
-    if (upperBound.nullabilityData().isNullable(PACKAGE, false, false)
-        && lowerBound.nullabilityData().isNonNull(PACKAGE, false, false)) {
-      reportIssue(tree, lowerBound.nullabilityData(), upperBound.nullabilityData(), overriddenIsLowerBound);
+    NullabilityData upperData = upperBound.nullabilityData();
+    NullabilityData lowerData = lowerBound.nullabilityData();
+    if (upperData.isNullable(PACKAGE, false, false)
+        && lowerData.isNonNull(PACKAGE, false, false)) {
+      reportIssue(tree, lowerData, upperData, overriddenIsLowerBound);
     }
 
     // Check type parameters

--- a/java-frontend/src/main/java/org/sonar/java/model/JSymbolMetadataNullabilityHelper.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JSymbolMetadataNullabilityHelper.java
@@ -119,8 +119,6 @@ public class JSymbolMetadataNullabilityHelper {
     "edu.umd.cs.findbugs.annotations.NonNull",
     "io.reactivex.annotations.NonNull",
     "io.reactivex.rxjava3.annotations.NonNull",
-    "javax.validation.constraints.NotNull",
-    "jakarta.validation.constraints.NotNull",
     "lombok.NonNull",
     "org.checkerframework.checker.nullness.compatqual.NonNullDecl",
     "org.checkerframework.checker.nullness.compatqual.NonNullType",


### PR DESCRIPTION
javax.validation.constraints.NotNull and jakarta.validation.constraints.NotNull are runtime constraints, not static nullability guarantees. Removing both of them from nullability status configuration gives consistent, conservative treatment.

Rules fixed as a direct consequence:
- S4454: @NotNull on equals() parameter no longer fires
- S6539: @NotNull inside @NullMarked no longer flagged as redundant
- S2583/S2589 from java-symbolic-execution no longer raised for these annotations


