### PR TITLE
SONARJAVA-6824: Implemented rule S9358 - Conditional expressions should not duplicate operations in both branches

### DIFF
--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9358.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9358.json
@@ -1,0 +1,9 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java": [
+129
+],
+"org.eclipse.jetty:jetty-project:jetty-jmx/src/main/java/org/eclipse/jetty/jmx/MBeanContainer.java": [
+362,
+373
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9358.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9358.json
@@ -1,0 +1,19 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java": [
+129
+],
+"org.eclipse.jetty:jetty-project:jetty-jmx/src/main/java/org/eclipse/jetty/jmx/MBeanContainer.java": [
+362,
+373
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/JavaVersion.java": [
+58
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SniX509ExtendedKeyManager.java": [
+178,
+192
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/statistic/CounterStatisticTest.java": [
+91
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9358.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9358.json
@@ -9,10 +9,6 @@
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/JavaVersion.java": [
 58
 ],
-"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/ssl/SniX509ExtendedKeyManager.java": [
-178,
-192
-],
 "org.eclipse.jetty:jetty-project:jetty-util/src/test/java/org/eclipse/jetty/util/statistic/CounterStatisticTest.java": [
 91
 ]

--- a/its/ruling/src/test/resources/guava/java-S9358.json
+++ b/its/ruling/src/test/resources/guava/java-S9358.json
@@ -3,6 +3,9 @@
 151,
 155
 ],
+"com.google.guava:guava:src/com/google/common/collect/TreeMultiset.java": [
+91
+],
 "com.google.guava:guava:src/com/google/common/hash/MessageDigestHashFunction.java": [
 156
 ]

--- a/its/ruling/src/test/resources/guava/java-S9358.json
+++ b/its/ruling/src/test/resources/guava/java-S9358.json
@@ -1,0 +1,15 @@
+{
+"com.google.guava:guava:src/com/google/common/collect/ImmutableList.java": [
+209
+],
+"com.google.guava:guava:src/com/google/common/collect/ImmutableSet.java": [
+263
+],
+"com.google.guava:guava:src/com/google/common/collect/RegularImmutableTable.java": [
+151,
+155
+],
+"com.google.guava:guava:src/com/google/common/hash/MessageDigestHashFunction.java": [
+156
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9358.json
+++ b/its/ruling/src/test/resources/guava/java-S9358.json
@@ -1,10 +1,4 @@
 {
-"com.google.guava:guava:src/com/google/common/collect/ImmutableList.java": [
-209
-],
-"com.google.guava:guava:src/com/google/common/collect/ImmutableSet.java": [
-263
-],
 "com.google.guava:guava:src/com/google/common/collect/RegularImmutableTable.java": [
 151,
 155

--- a/its/ruling/src/test/resources/sonar-server/java-S9358.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S9358.json
@@ -2,9 +2,6 @@
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/qualitygate/ConditionEvaluator.java": [
 113
 ],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualitygate/ws/ShowAction.java": [
-66
-],
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/setting/ws/ValuesAction.java": [
 247
 ]

--- a/its/ruling/src/test/resources/sonar-server/java-S9358.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S9358.json
@@ -1,0 +1,17 @@
+{
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/qualitygate/ConditionEvaluator.java": [
+113
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualitygate/QualityGateConditionsUpdater.java": [
+175
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualitygate/ws/ShowAction.java": [
+66
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualityprofile/RuleActivator.java": [
+200
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/setting/ws/ValuesAction.java": [
+247
+]
+}

--- a/its/ruling/src/test/resources/sonar-server/java-S9358.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S9358.json
@@ -2,14 +2,8 @@
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/qualitygate/ConditionEvaluator.java": [
 113
 ],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualitygate/QualityGateConditionsUpdater.java": [
-175
-],
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualitygate/ws/ShowAction.java": [
 66
-],
-"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualityprofile/RuleActivator.java": [
-200
 ],
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/setting/ws/ValuesAction.java": [
 247

--- a/its/ruling/src/test/resources/sonar-server/java-S9358.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S9358.json
@@ -2,6 +2,12 @@
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/computation/task/projectanalysis/qualitygate/ConditionEvaluator.java": [
 113
 ],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualitygate/QualityGateConditionsUpdater.java": [
+175
+],
+"org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/qualityprofile/RuleActivator.java": [
+200
+],
 "org.sonarsource.sonarqube:sonar-server:src/main/java/org/sonar/server/setting/ws/ValuesAction.java": [
 247
 ]

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckNoSemanticSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckNoSemanticSample.java
@@ -60,6 +60,15 @@ class TernaryOperatorSameOperationCheckNoSemanticSample {
     String c8 = condition ? arr[i] : otherArr[j]; // Compliant - different arrays
   }
 
+  void testNewClassWithClassBody() {
+    String a = "a";
+    String b = "b";
+
+    // Anonymous class body - Compliant even without semantics
+    Object ac1 = condition ? new Foo(a) { } : new Foo(b) { }; // Compliant - anonymous class bodies
+    Object ac2 = condition ? new Foo(a) { } : new Foo(b); // Compliant - one has class body
+  }
+
   // Private methods used in ternary
   private String foo(String s) { return s; }
   private String foo(String s, String t) { return s + t; }

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckNoSemanticSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckNoSemanticSample.java
@@ -1,0 +1,78 @@
+package checks;
+
+import java.util.function.Function;
+
+class TernaryOperatorSameOperationCheckNoSemanticSample {
+
+  boolean condition;
+  boolean other;
+  TernaryOperatorSameOperationCheckNoSemanticSample obj;
+  TernaryOperatorSameOperationCheckNoSemanticSample obj2;
+
+  void testMethodInvocations() {
+    String a = "a";
+    String b = "b";
+    String x = "x";
+    String y = "y";
+
+    // Method invocations - Noncompliant
+    String m1 = condition ? foo(a) : foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
+
+    String m2 = condition ? this.foo(a) : this.foo(b); // Noncompliant
+    String m3 = condition ? obj.foo(a) : obj.foo(b); // Noncompliant
+
+    // Method invocations with multiple args where some differ - Noncompliant
+    String m5 = condition ? foo(a, x) : foo(b, x); // Noncompliant
+
+    // Method invocations with multiple args where all differ - Compliant
+    String m6 = condition ? foo(a, x) : foo(b, y); // Compliant - more than one argument differs
+
+    // Method invocations - Compliant (different operations or same arguments)
+    String c1 = condition ? foo(a) : bar(b); // Compliant - different methods
+    String c2 = condition ? foo(a) : foo(a); // Compliant - same arguments
+    String c3 = condition ? foo(a) : foo(a, b); // Compliant - different number of arguments
+  }
+
+  void testNewClass() {
+    String a = "a";
+    String b = "b";
+
+    // New class - Noncompliant
+    Object n1 = condition ? new Foo(a) : new Foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
+
+    // New class - Compliant
+    Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant - different classes
+    Object c5 = condition ? new Foo(a) : new Foo(a); // Compliant - same arguments
+    Object c6 = condition ? new Foo(a) : new Foo(a, b); // Compliant - different arguments count
+  }
+
+  void testArrayAccess() {
+    String[] arr = new String[10];
+    String[] otherArr = new String[10];
+    int i = 0;
+    int j = 1;
+
+    // Array access - Noncompliant
+    String a1 = condition ? arr[i] : arr[j]; // Noncompliant {{Move the conditional expression inside this operation.}}
+
+    // Array access - Compliant
+    String c7 = condition ? arr[i] : arr[i]; // Compliant - same index
+    String c8 = condition ? arr[i] : otherArr[j]; // Compliant - different arrays
+  }
+
+  // Private methods used in ternary
+  private String foo(String s) { return s; }
+  private String foo(String s, String t) { return s + t; }
+  private String bar(String s) { return s; }
+  private String noArg() { return ""; }
+
+  private static class Foo {
+    Foo(String s) {}
+    Foo(String s, String t) {}
+  }
+
+  private static class Bar {
+    Bar(String s) {}
+  }
+
+}

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -155,6 +155,28 @@ class TernaryOperatorSameOperationCheckSample {
     Object ac2 = condition ? new Foo(a) { } : new Foo(b); // Compliant - one has class body
   }
 
+  void testQualifiedInstantiations() {
+    String a = "a";
+    String b = "b";
+
+    // Qualified instantiation with same enclosing expression - Noncompliant
+    Object qi1 = condition ? obj.new Inner(a) : obj.new Inner(b); // Noncompliant
+
+    // Qualified instantiation with different enclosing expression - Compliant
+    Object qi2 = condition ? obj.new Inner(a) : obj2.new Inner(b); // Compliant - different enclosing expressions
+
+    // Mixed: unqualified vs qualified - Compliant
+    Object qi3 = condition ? new Inner(a) : obj.new Inner(b); // Compliant - one has enclosing, other doesn't
+  }
+
+  void testNonIdentifierReceiver() {
+    String a = "a";
+    String b = "b";
+
+    // Non-identifier receiver (method call as receiver) - Noncompliant
+    Object nir1 = condition ? getObj().foo(a) : getObj().foo(b); // Noncompliant
+  }
+
   // Private methods used in ternary
   private String foo(String s) { return s; }
   private String foo(String s, String t) { return s + t; }
@@ -163,6 +185,7 @@ class TernaryOperatorSameOperationCheckSample {
   private String noArg() { return ""; }
   private Object overloaded(int i) { return i; }
   private Object overloaded(String s) { return s; }
+  private TernaryOperatorSameOperationCheckSample getObj() { return this; }
 
   private static class StaticClass {
     static String foo(String s) { return s; }
@@ -180,6 +203,10 @@ class TernaryOperatorSameOperationCheckSample {
   private static class OverloadedCtor {
     OverloadedCtor(int i) {}
     OverloadedCtor(String s) {}
+  }
+
+  class Inner {
+    Inner(String s) {}
   }
 
 }

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -80,7 +80,7 @@ class TernaryOperatorSameOperationCheckSample {
 
     // Multiple different operations - Compliant
     String c10 = condition ? foo(a) : bar(b); // Compliant
-    String c11 = condition ? new Foo(a) : new Bar(b); // Compliant
+    Object c11 = condition ? new Foo(a) : new Bar(b); // Compliant
   }
 
   // Private methods used in ternary

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -1,10 +1,13 @@
 package checks;
 
+import java.util.function.Function;
+
 class TernaryOperatorSameOperationCheckSample {
 
   boolean condition;
   boolean other;
   TernaryOperatorSameOperationCheckSample obj;
+  TernaryOperatorSameOperationCheckSample obj2;
 
   void testMethodInvocations() {
     String a = "a";
@@ -24,9 +27,30 @@ class TernaryOperatorSameOperationCheckSample {
     String m5 = condition ? foo(a, x) : foo(b, x); // Noncompliant
 
     // Method invocations - Compliant (different operations or same arguments)
-    String c1 = condition ? foo(a) : bar(b); // Compliant
-    String c2 = condition ? foo(a) : foo(a); // Compliant (same arguments)
-    String c3 = condition ? foo(a) : foo(a, b); // Compliant (different number of arguments)
+    String c1 = condition ? foo(a) : bar(b); // Compliant - different methods
+    String c2 = condition ? foo(a) : foo(a); // Compliant - same arguments
+    String c3 = condition ? foo(a) : foo(a, b); // Compliant - different number of arguments
+  }
+
+  void testMethodInvocationsEdgeCases() {
+    String a = "a";
+    String b = "b";
+
+    // No-arg methods - Compliant (no arguments to differ)
+    String e1 = condition ? noArg() : noArg(); // Compliant
+
+    // Different receivers - Compliant
+    String e2 = condition ? obj.foo(a) : obj2.foo(b); // Compliant - different receiver objects
+
+    // Different kinds in true/false - Compliant
+    Object e3 = condition ? foo(a) : new Foo(b); // Compliant - method vs constructor
+    Object e4 = condition ? a : b; // Compliant - simple identifiers, not method/new/array
+
+    // String literal - Compliant
+    String e5 = condition ? "hello" : "world"; // Compliant
+
+    // Numeric literal - Compliant
+    int e6 = condition ? 1 : 2; // Compliant
   }
 
   void testNewClass() {
@@ -40,9 +64,9 @@ class TernaryOperatorSameOperationCheckSample {
     Object n2 = condition ? new Foo(a, b) : new Foo(b, b); // Noncompliant
 
     // New class - Compliant
-    Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant (different classes)
-    Object c5 = condition ? new Foo(a) : new Foo(a); // Compliant (same arguments)
-    Object c6 = condition ? new Foo(a) : new Foo(a, b); // Compliant (different arguments count)
+    Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant - different classes
+    Object c5 = condition ? new Foo(a) : new Foo(a); // Compliant - same arguments
+    Object c6 = condition ? new Foo(a) : new Foo(a, b); // Compliant - different arguments count
   }
 
   void testArrayAccess() {
@@ -55,8 +79,8 @@ class TernaryOperatorSameOperationCheckSample {
     String a1 = condition ? arr[i] : arr[j]; // Noncompliant {{Move the conditional expression inside this operation.}}
 
     // Array access - Compliant
-    String c7 = condition ? arr[i] : arr[i]; // Compliant (same index)
-    String c8 = condition ? arr[i] : otherArr[j]; // Compliant (different arrays)
+    String c7 = condition ? arr[i] : arr[i]; // Compliant - same index
+    String c8 = condition ? arr[i] : otherArr[j]; // Compliant - different arrays
   }
 
   void testNestedTernary() {
@@ -64,23 +88,41 @@ class TernaryOperatorSameOperationCheckSample {
     String y = "y";
     String z = "z";
 
-    // Nested ternary - Noncompliant (outer ternary)
+    // Nested ternary - Noncompliant (outer ternary has same operation after parentheses skip)
     String n3 = condition ? (other ? foo(x) : foo(y)) : foo(z); // Noncompliant {{Move the conditional expression inside this operation.}}
 
     // Nested ternary - Compliant (inner ternary is not same operation)
     String c9 = condition ? (other ? foo(x) : bar(x)) : foo(z); // Compliant
   }
 
+  void testMemberSelectEdgeCases() {
+    String a = "a";
+    String b = "b";
+
+    // Same receiver, different method names - Compliant
+    String ms1 = condition ? obj.foo(a) : obj.bar(b); // Compliant - different method names
+
+    // Method invocation vs member select method invocation - Compliant
+    String ms2 = condition ? foo(a) : obj.foo(b); // Compliant - identifier vs member select
+  }
+
   void testOther() {
     String a = "a";
     String b = "b";
 
-    // Method reference - Compliant (different method references)
-    java.util.function.Function<String, String> f1 = condition ? this::foo : this::method; // Compliant
+    // Method reference - Compliant
+    Function<String, String> f1 = condition ? this::foo : this::method; // Compliant
 
     // Multiple different operations - Compliant
     String c10 = condition ? foo(a) : bar(b); // Compliant
     Object c11 = condition ? new Foo(a) : new Bar(b); // Compliant
+
+    // Array access vs method invocation - Compliant
+    String[] arr = {a, b};
+    Object o1 = condition ? arr[0] : foo(b); // Compliant - different expression kinds
+
+    // New class vs array access - Compliant
+    Object o2 = condition ? new Foo(a) : arr[0]; // Compliant - different expression kinds
   }
 
   // Private methods used in ternary
@@ -88,6 +130,7 @@ class TernaryOperatorSameOperationCheckSample {
   private String foo(String s, String t) { return s + t; }
   private String bar(String s) { return s; }
   private String method(String s) { return s; }
+  private String noArg() { return ""; }
 
   private static class StaticClass {
     static String foo(String s) { return s; }
@@ -101,4 +144,5 @@ class TernaryOperatorSameOperationCheckSample {
   private static class Bar {
     Bar(String s) {}
   }
+
 }

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -1,0 +1,67 @@
+package checks;
+
+class TernaryOperatorSameOperationCheckSample {
+
+  boolean condition;
+  String result;
+  String[] array;
+
+  // Method invocations - Noncompliant
+  String m1 = condition ? foo(a) : foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
+
+  String m2 = condition ? this.foo(a) : this.foo(b); // Noncompliant
+  String m3 = condition ? obj.foo(a) : obj.foo(b); // Noncompliant
+  String m4 = condition ? StaticClass.foo(a) : StaticClass.foo(b); // Noncompliant
+
+  // Method invocations - Compliant (different operations or same arguments)
+  String c1 = condition ? foo(a) : bar(b); // Compliant
+  String c2 = condition ? foo(a) : foo(a); // Compliant (same arguments)
+  String c3 = condition ? foo(a) : foo(a, b); // Compliant (different number of arguments)
+
+  // New class - Noncompliant
+  Object n1 = condition ? new Foo(a) : new Foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
+
+  // New class - Compliant
+  Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant (different classes)
+  Object c5 = condition ? new Foo(a) : new Foo(a); // Compliant (same arguments)
+  Object c6 = condition ? new Foo(a) : new Foo(a, b); // Compliant (different arguments)
+
+  // Array access - Noncompliant
+  String[] arr = new String[10];
+  String a1 = condition ? arr[a] : arr[b]; // Noncompliant {{Move the conditional expression inside this operation.}}
+
+  // Array access - Compliant
+  String c7 = condition ? arr[a] : arr[a]; // Compliant (same index)
+  String c8 = condition ? arr[a] : otherArr[b]; // Compliant (different arrays)
+
+  // Nested ternary - Noncompliant (outer ternary)
+  String n3 = condition ? (other ? foo(x) : foo(y)) : foo(z); // Noncompliant {{Move the conditional expression inside this operation.}}
+
+  // Nested ternary - Compliant (inner ternary is not same operation)
+  String c9 = condition ? (other ? foo(x) : bar(x)) : foo(z); // Compliant
+
+  // Method reference - Compliant (different method references)
+  java.util.function.Function<String, String> f1 = condition ? this::foo : this::method; // Compliant
+
+  // Multiple different operations - Compliant
+  String c10 = condition ? foo(a) : bar(b); // Compliant
+  String c11 = condition ? new Foo(a) : new Bar(b); // Compliant
+
+  // Private methods used in ternary
+  private String foo(String s) { return s; }
+  private String foo(String s, String t) { return s + t; }
+  private void method(String a, String b) {}
+
+  private static class StaticClass {
+    static String foo(String s) { return s; }
+  }
+
+  private static class Foo {
+    Foo(String s) {}
+    Foo(String s, String t) {}
+  }
+
+  private static class Bar {
+    Bar(String s) {}
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -131,12 +131,38 @@ class TernaryOperatorSameOperationCheckSample {
     Object o2 = condition ? new Foo(a) : arr[0]; // Compliant - different expression kinds
   }
 
+  void testOverloadedMethods() {
+    // Overloaded methods with different parameter types - Compliant (different method symbols)
+    Object ov1 = condition ? overloaded(1) : overloaded("x"); // Compliant - different overloads
+    Object ov2 = condition ? this.overloaded(1) : this.overloaded("x"); // Compliant - different overloads
+
+    // Same overload, different arguments - Noncompliant
+    Object ov3 = condition ? overloaded(1) : overloaded(2); // Noncompliant
+    Object ov4 = condition ? overloaded("a") : overloaded("b"); // Noncompliant
+  }
+
+  void testOverloadedConstructors() {
+    // Overloaded constructors with different parameter types - Compliant (different constructor symbols)
+    Object oc1 = condition ? new OverloadedCtor(1) : new OverloadedCtor("x"); // Compliant - different constructors
+  }
+
+  void testNewClassWithClassBody() {
+    String a = "a";
+    String b = "b";
+
+    // Anonymous class body - Compliant (class bodies make each instantiation unique)
+    Object ac1 = condition ? new Foo(a) { } : new Foo(b) { }; // Compliant - anonymous class bodies
+    Object ac2 = condition ? new Foo(a) { } : new Foo(b); // Compliant - one has class body
+  }
+
   // Private methods used in ternary
   private String foo(String s) { return s; }
   private String foo(String s, String t) { return s + t; }
   private String bar(String s) { return s; }
   private String method(String s) { return s; }
   private String noArg() { return ""; }
+  private Object overloaded(int i) { return i; }
+  private Object overloaded(String s) { return s; }
 
   private static class StaticClass {
     static String foo(String s) { return s; }
@@ -149,6 +175,11 @@ class TernaryOperatorSameOperationCheckSample {
 
   private static class Bar {
     Bar(String s) {}
+  }
+
+  private static class OverloadedCtor {
+    OverloadedCtor(int i) {}
+    OverloadedCtor(String s) {}
   }
 
 }

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -26,6 +26,9 @@ class TernaryOperatorSameOperationCheckSample {
     // Method invocations with multiple args where some differ - Noncompliant
     String m5 = condition ? foo(a, x) : foo(b, x); // Noncompliant
 
+    // Method invocations with multiple args where all differ - Compliant
+    String m6 = condition ? foo(a, x) : foo(b, y); // Compliant - more than one argument differs
+
     // Method invocations - Compliant (different operations or same arguments)
     String c1 = condition ? foo(a) : bar(b); // Compliant - different methods
     String c2 = condition ? foo(a) : foo(a); // Compliant - same arguments
@@ -62,6 +65,9 @@ class TernaryOperatorSameOperationCheckSample {
 
     // New class with multiple args where some differ - Noncompliant
     Object n2 = condition ? new Foo(a, b) : new Foo(b, b); // Noncompliant
+
+    // New class with multiple args where all differ - Compliant
+    Object n3 = condition ? new Foo(a, a) : new Foo(b, b); // Compliant - more than one argument differs
 
     // New class - Compliant
     Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant - different classes

--- a/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/TernaryOperatorSameOperationCheckSample.java
@@ -3,54 +3,91 @@ package checks;
 class TernaryOperatorSameOperationCheckSample {
 
   boolean condition;
-  String result;
-  String[] array;
+  boolean other;
+  TernaryOperatorSameOperationCheckSample obj;
 
-  // Method invocations - Noncompliant
-  String m1 = condition ? foo(a) : foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
+  void testMethodInvocations() {
+    String a = "a";
+    String b = "b";
+    String x = "x";
+    String y = "y";
+    String z = "z";
 
-  String m2 = condition ? this.foo(a) : this.foo(b); // Noncompliant
-  String m3 = condition ? obj.foo(a) : obj.foo(b); // Noncompliant
-  String m4 = condition ? StaticClass.foo(a) : StaticClass.foo(b); // Noncompliant
+    // Method invocations - Noncompliant
+    String m1 = condition ? foo(a) : foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
 
-  // Method invocations - Compliant (different operations or same arguments)
-  String c1 = condition ? foo(a) : bar(b); // Compliant
-  String c2 = condition ? foo(a) : foo(a); // Compliant (same arguments)
-  String c3 = condition ? foo(a) : foo(a, b); // Compliant (different number of arguments)
+    String m2 = condition ? this.foo(a) : this.foo(b); // Noncompliant
+    String m3 = condition ? obj.foo(a) : obj.foo(b); // Noncompliant
+    String m4 = condition ? StaticClass.foo(a) : StaticClass.foo(b); // Noncompliant
 
-  // New class - Noncompliant
-  Object n1 = condition ? new Foo(a) : new Foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
+    // Method invocations with multiple args where some differ - Noncompliant
+    String m5 = condition ? foo(a, x) : foo(b, x); // Noncompliant
 
-  // New class - Compliant
-  Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant (different classes)
-  Object c5 = condition ? new Foo(a) : new Foo(a); // Compliant (same arguments)
-  Object c6 = condition ? new Foo(a) : new Foo(a, b); // Compliant (different arguments)
+    // Method invocations - Compliant (different operations or same arguments)
+    String c1 = condition ? foo(a) : bar(b); // Compliant
+    String c2 = condition ? foo(a) : foo(a); // Compliant (same arguments)
+    String c3 = condition ? foo(a) : foo(a, b); // Compliant (different number of arguments)
+  }
 
-  // Array access - Noncompliant
-  String[] arr = new String[10];
-  String a1 = condition ? arr[a] : arr[b]; // Noncompliant {{Move the conditional expression inside this operation.}}
+  void testNewClass() {
+    String a = "a";
+    String b = "b";
 
-  // Array access - Compliant
-  String c7 = condition ? arr[a] : arr[a]; // Compliant (same index)
-  String c8 = condition ? arr[a] : otherArr[b]; // Compliant (different arrays)
+    // New class - Noncompliant
+    Object n1 = condition ? new Foo(a) : new Foo(b); // Noncompliant {{Move the conditional expression inside this operation.}}
 
-  // Nested ternary - Noncompliant (outer ternary)
-  String n3 = condition ? (other ? foo(x) : foo(y)) : foo(z); // Noncompliant {{Move the conditional expression inside this operation.}}
+    // New class with multiple args where some differ - Noncompliant
+    Object n2 = condition ? new Foo(a, b) : new Foo(b, b); // Noncompliant
 
-  // Nested ternary - Compliant (inner ternary is not same operation)
-  String c9 = condition ? (other ? foo(x) : bar(x)) : foo(z); // Compliant
+    // New class - Compliant
+    Object c4 = condition ? new Foo(a) : new Bar(b); // Compliant (different classes)
+    Object c5 = condition ? new Foo(a) : new Foo(a); // Compliant (same arguments)
+    Object c6 = condition ? new Foo(a) : new Foo(a, b); // Compliant (different arguments count)
+  }
 
-  // Method reference - Compliant (different method references)
-  java.util.function.Function<String, String> f1 = condition ? this::foo : this::method; // Compliant
+  void testArrayAccess() {
+    String[] arr = new String[10];
+    String[] otherArr = new String[10];
+    int i = 0;
+    int j = 1;
 
-  // Multiple different operations - Compliant
-  String c10 = condition ? foo(a) : bar(b); // Compliant
-  String c11 = condition ? new Foo(a) : new Bar(b); // Compliant
+    // Array access - Noncompliant
+    String a1 = condition ? arr[i] : arr[j]; // Noncompliant {{Move the conditional expression inside this operation.}}
+
+    // Array access - Compliant
+    String c7 = condition ? arr[i] : arr[i]; // Compliant (same index)
+    String c8 = condition ? arr[i] : otherArr[j]; // Compliant (different arrays)
+  }
+
+  void testNestedTernary() {
+    String x = "x";
+    String y = "y";
+    String z = "z";
+
+    // Nested ternary - Noncompliant (outer ternary)
+    String n3 = condition ? (other ? foo(x) : foo(y)) : foo(z); // Noncompliant {{Move the conditional expression inside this operation.}}
+
+    // Nested ternary - Compliant (inner ternary is not same operation)
+    String c9 = condition ? (other ? foo(x) : bar(x)) : foo(z); // Compliant
+  }
+
+  void testOther() {
+    String a = "a";
+    String b = "b";
+
+    // Method reference - Compliant (different method references)
+    java.util.function.Function<String, String> f1 = condition ? this::foo : this::method; // Compliant
+
+    // Multiple different operations - Compliant
+    String c10 = condition ? foo(a) : bar(b); // Compliant
+    String c11 = condition ? new Foo(a) : new Bar(b); // Compliant
+  }
 
   // Private methods used in ternary
   private String foo(String s) { return s; }
   private String foo(String s, String t) { return s + t; }
-  private void method(String a, String b) {}
+  private String bar(String s) { return s; }
+  private String method(String s) { return s; }
 
   private static class StaticClass {
     static String foo(String s) { return s; }

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -21,15 +21,13 @@ import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
-import org.sonar.plugins.java.api.tree.ArrayDimensionTree;
+import org.sonar.plugins.java.api.tree.ConditionalExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.TypeArguments;
-import org.sonar.plugins.java.api.tree.TypeTree;
 
 @Rule(key = "S9358")
 public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisitor {
@@ -41,7 +39,7 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
 
   @Override
   public void visitNode(Tree tree) {
-    var conditional = (org.sonar.plugins.java.api.tree.ConditionalExpressionTree) tree;
+    var conditional = (ConditionalExpressionTree) tree;
     var trueExpr = ExpressionUtils.skipParentheses(conditional.trueExpression());
     var falseExpr = ExpressionUtils.skipParentheses(conditional.falseExpression());
 
@@ -51,10 +49,6 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
   }
 
   private static boolean hasSameOperationStructure(ExpressionTree left, ExpressionTree right) {
-    if (left == null || right == null) {
-      return false;
-    }
-
     if (left.is(Tree.Kind.METHOD_INVOCATION) && right.is(Tree.Kind.METHOD_INVOCATION)) {
       return sameMethodInvocation((MethodInvocationTree) left, (MethodInvocationTree) right);
     }
@@ -68,23 +62,8 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
   }
 
   private static boolean sameMethodInvocation(MethodInvocationTree left, MethodInvocationTree right) {
-    if (!sameMethodSelect(left.methodSelect(), right.methodSelect())) {
-      return false;
-    }
-
-    var leftArgs = (List<ExpressionTree>) left.arguments();
-    var rightArgs = (List<ExpressionTree>) right.arguments();
-    if (leftArgs.size() != rightArgs.size()) {
-      return false;
-    }
-
-    boolean anyDifferent = false;
-    for (int i = 0; i < leftArgs.size(); i++) {
-      if (!sameExpression(leftArgs.get(i), rightArgs.get(i))) {
-        anyDifferent = true;
-      }
-    }
-    return anyDifferent;
+    return sameMethodSelect(left.methodSelect(), right.methodSelect())
+      && hasExactlyOneArgumentDifference(left.arguments(), right.arguments());
   }
 
   private static boolean sameMethodSelect(ExpressionTree left, ExpressionTree right) {
@@ -100,7 +79,7 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
     if (left.is(Tree.Kind.IDENTIFIER)) {
       return sameIdentifier((IdentifierTree) left, (IdentifierTree) right);
     }
-    return left.toString().equals(right.toString());
+    return sameTree(left, right);
   }
 
   private static boolean sameIdentifier(IdentifierTree left, IdentifierTree right) {
@@ -111,25 +90,16 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
     if (!sameTree(left.identifier(), right.identifier())) {
       return false;
     }
+    return hasExactlyOneArgumentDifference(left.arguments(), right.arguments());
+  }
 
-    var leftTypeArgs = left.typeArguments();
-    var rightTypeArgs = right.typeArguments();
-    if ((leftTypeArgs == null) != (rightTypeArgs == null)) {
-      return false;
-    }
-    if (leftTypeArgs != null && !sameTypeArguments(leftTypeArgs, rightTypeArgs)) {
-      return false;
-    }
-
-    var leftArgs = (List<ExpressionTree>) left.arguments();
-    var rightArgs = (List<ExpressionTree>) right.arguments();
+  private static boolean hasExactlyOneArgumentDifference(List<? extends ExpressionTree> leftArgs, List<? extends ExpressionTree> rightArgs) {
     if (leftArgs.size() != rightArgs.size()) {
       return false;
     }
-
     boolean anyDifferent = false;
     for (int i = 0; i < leftArgs.size(); i++) {
-      if (!sameExpression(leftArgs.get(i), rightArgs.get(i))) {
+      if (!sameTree(leftArgs.get(i), rightArgs.get(i))) {
         anyDifferent = true;
       }
     }
@@ -137,54 +107,14 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
   }
 
   private static boolean sameArrayAccess(ArrayAccessExpressionTree left, ArrayAccessExpressionTree right) {
-    if (!sameExpression(left.expression(), right.expression())) {
-      return false;
-    }
-    var leftIndex = getArrayIndex(left);
-    var rightIndex = getArrayIndex(right);
-    if (leftIndex == null || rightIndex == null) {
-      return false;
-    }
-    return !sameExpression(leftIndex, rightIndex);
-  }
-
-  private static ExpressionTree getArrayIndex(ArrayAccessExpressionTree arrayAccess) {
-    var dimension = arrayAccess.dimension();
-    if (dimension != null && dimension.expression() != null) {
-      return dimension.expression();
-    }
-    return null;
-  }
-
-  private static boolean sameExpression(ExpressionTree left, ExpressionTree right) {
-    if (left == null || right == null) {
-      return false;
-    }
-    if (!left.is(right.kind())) {
-      return false;
-    }
-    return left.toString().equals(right.toString());
+    return sameTree(left.expression(), right.expression())
+      && !sameTree(left.dimension().expression(), right.dimension().expression());
   }
 
   private static boolean sameTree(Tree left, Tree right) {
-    if (left == null || right == null) {
-      return false;
-    }
     if (!left.is(right.kind())) {
       return false;
     }
     return left.toString().equals(right.toString());
-  }
-
-  private static boolean sameTypeArguments(TypeArguments left, TypeArguments right) {
-    if (left.size() != right.size()) {
-      return false;
-    }
-    for (int i = 0; i < left.size(); i++) {
-      if (!left.get(i).toString().equals(right.get(i).toString())) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -19,6 +19,7 @@ package org.sonar.java.checks;
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
+import org.sonar.java.model.SyntacticEquivalence;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
@@ -144,9 +145,6 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
   }
 
   private static boolean sameTree(Tree left, Tree right) {
-    if (!left.is(right.kind())) {
-      return false;
-    }
-    return left.toString().equals(right.toString());
+    return SyntacticEquivalence.areEquivalent(left, right);
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -97,13 +97,13 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
     if (leftArgs.size() != rightArgs.size()) {
       return false;
     }
-    boolean anyDifferent = false;
+    int differences = 0;
     for (int i = 0; i < leftArgs.size(); i++) {
       if (!sameTree(leftArgs.get(i), rightArgs.get(i))) {
-        anyDifferent = true;
+        differences++;
       }
     }
-    return anyDifferent;
+    return differences == 1;
   }
 
   private static boolean sameArrayAccess(ArrayAccessExpressionTree left, ArrayAccessExpressionTree right) {

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
 import org.sonar.plugins.java.api.tree.ConditionalExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
@@ -62,8 +63,20 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
   }
 
   private static boolean sameMethodInvocation(MethodInvocationTree left, MethodInvocationTree right) {
-    return sameMethodSelect(left.methodSelect(), right.methodSelect())
-      && hasExactlyOneArgumentDifference(left.arguments(), right.arguments());
+    if (!sameMethodSelect(left.methodSelect(), right.methodSelect())) {
+      return false;
+    }
+    if (!hasExactlyOneArgumentDifference(left.arguments(), right.arguments())) {
+      return false;
+    }
+    return sameMethodSymbol(left.methodSymbol(), right.methodSymbol());
+  }
+
+  private static boolean sameMethodSymbol(Symbol.MethodSymbol left, Symbol.MethodSymbol right) {
+    if (left.isUnknown() || right.isUnknown()) {
+      return true;
+    }
+    return left.equals(right);
   }
 
   private static boolean sameMethodSelect(ExpressionTree left, ExpressionTree right) {
@@ -90,7 +103,26 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
     if (!sameTree(left.identifier(), right.identifier())) {
       return false;
     }
-    return hasExactlyOneArgumentDifference(left.arguments(), right.arguments());
+    if (!hasExactlyOneArgumentDifference(left.arguments(), right.arguments())) {
+      return false;
+    }
+    if (!sameMethodSymbol(left.methodSymbol(), right.methodSymbol())) {
+      return false;
+    }
+    if (left.classBody() != null || right.classBody() != null) {
+      return false;
+    }
+    return sameNullableTree(left.enclosingExpression(), right.enclosingExpression());
+  }
+
+  private static boolean sameNullableTree(Tree left, Tree right) {
+    if (left == null && right == null) {
+      return true;
+    }
+    if (left == null || right == null) {
+      return false;
+    }
+    return sameTree(left, right);
   }
 
   private static boolean hasExactlyOneArgumentDifference(List<? extends ExpressionTree> leftArgs, List<? extends ExpressionTree> rightArgs) {

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -18,6 +18,7 @@ package org.sonar.java.checks;
 
 import java.util.List;
 import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
 import org.sonar.plugins.java.api.tree.ArrayDimensionTree;
@@ -41,8 +42,8 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
   @Override
   public void visitNode(Tree tree) {
     var conditional = (org.sonar.plugins.java.api.tree.ConditionalExpressionTree) tree;
-    var trueExpr = conditional.trueExpression();
-    var falseExpr = conditional.falseExpression();
+    var trueExpr = ExpressionUtils.skipParentheses(conditional.trueExpression());
+    var falseExpr = ExpressionUtils.skipParentheses(conditional.falseExpression());
 
     if (hasSameOperationStructure(trueExpr, falseExpr)) {
       reportIssue(conditional, "Move the conditional expression inside this operation.");
@@ -77,12 +78,13 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
       return false;
     }
 
+    boolean anyDifferent = false;
     for (int i = 0; i < leftArgs.size(); i++) {
-      if (sameExpression(leftArgs.get(i), rightArgs.get(i))) {
-        return false;
+      if (!sameExpression(leftArgs.get(i), rightArgs.get(i))) {
+        anyDifferent = true;
       }
     }
-    return true;
+    return anyDifferent;
   }
 
   private static boolean sameMethodSelect(ExpressionTree left, ExpressionTree right) {
@@ -125,12 +127,13 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
       return false;
     }
 
+    boolean anyDifferent = false;
     for (int i = 0; i < leftArgs.size(); i++) {
-      if (sameExpression(leftArgs.get(i), rightArgs.get(i))) {
-        return false;
+      if (!sameExpression(leftArgs.get(i), rightArgs.get(i))) {
+        anyDifferent = true;
       }
     }
-    return true;
+    return anyDifferent;
   }
 
   private static boolean sameArrayAccess(ArrayAccessExpressionTree left, ArrayAccessExpressionTree right) {

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -1,0 +1,187 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.ArrayAccessExpressionTree;
+import org.sonar.plugins.java.api.tree.ArrayDimensionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.NewClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TypeArguments;
+import org.sonar.plugins.java.api.tree.TypeTree;
+
+@Rule(key = "S9358")
+public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.CONDITIONAL_EXPRESSION);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    var conditional = (org.sonar.plugins.java.api.tree.ConditionalExpressionTree) tree;
+    var trueExpr = conditional.trueExpression();
+    var falseExpr = conditional.falseExpression();
+
+    if (hasSameOperationStructure(trueExpr, falseExpr)) {
+      reportIssue(conditional, "Move the conditional expression inside this operation.");
+    }
+  }
+
+  private static boolean hasSameOperationStructure(ExpressionTree left, ExpressionTree right) {
+    if (left == null || right == null) {
+      return false;
+    }
+
+    if (left.is(Tree.Kind.METHOD_INVOCATION) && right.is(Tree.Kind.METHOD_INVOCATION)) {
+      return sameMethodInvocation((MethodInvocationTree) left, (MethodInvocationTree) right);
+    }
+    if (left.is(Tree.Kind.NEW_CLASS) && right.is(Tree.Kind.NEW_CLASS)) {
+      return sameNewClass((NewClassTree) left, (NewClassTree) right);
+    }
+    if (left.is(Tree.Kind.ARRAY_ACCESS_EXPRESSION) && right.is(Tree.Kind.ARRAY_ACCESS_EXPRESSION)) {
+      return sameArrayAccess((ArrayAccessExpressionTree) left, (ArrayAccessExpressionTree) right);
+    }
+    return false;
+  }
+
+  private static boolean sameMethodInvocation(MethodInvocationTree left, MethodInvocationTree right) {
+    if (!sameMethodSelect(left.methodSelect(), right.methodSelect())) {
+      return false;
+    }
+
+    var leftArgs = (List<ExpressionTree>) left.arguments();
+    var rightArgs = (List<ExpressionTree>) right.arguments();
+    if (leftArgs.size() != rightArgs.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < leftArgs.size(); i++) {
+      if (sameExpression(leftArgs.get(i), rightArgs.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean sameMethodSelect(ExpressionTree left, ExpressionTree right) {
+    if (!left.is(right.kind())) {
+      return false;
+    }
+    if (left.is(Tree.Kind.MEMBER_SELECT)) {
+      var leftMember = (MemberSelectExpressionTree) left;
+      var rightMember = (MemberSelectExpressionTree) right;
+      return sameMethodSelect(leftMember.expression(), rightMember.expression())
+          && sameIdentifier(leftMember.identifier(), rightMember.identifier());
+    }
+    if (left.is(Tree.Kind.IDENTIFIER)) {
+      return sameIdentifier((IdentifierTree) left, (IdentifierTree) right);
+    }
+    return left.toString().equals(right.toString());
+  }
+
+  private static boolean sameIdentifier(IdentifierTree left, IdentifierTree right) {
+    return left.name().equals(right.name());
+  }
+
+  private static boolean sameNewClass(NewClassTree left, NewClassTree right) {
+    if (!sameTree(left.identifier(), right.identifier())) {
+      return false;
+    }
+
+    var leftTypeArgs = left.typeArguments();
+    var rightTypeArgs = right.typeArguments();
+    if ((leftTypeArgs == null) != (rightTypeArgs == null)) {
+      return false;
+    }
+    if (leftTypeArgs != null && !sameTypeArguments(leftTypeArgs, rightTypeArgs)) {
+      return false;
+    }
+
+    var leftArgs = (List<ExpressionTree>) left.arguments();
+    var rightArgs = (List<ExpressionTree>) right.arguments();
+    if (leftArgs.size() != rightArgs.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < leftArgs.size(); i++) {
+      if (sameExpression(leftArgs.get(i), rightArgs.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean sameArrayAccess(ArrayAccessExpressionTree left, ArrayAccessExpressionTree right) {
+    if (!sameExpression(left.expression(), right.expression())) {
+      return false;
+    }
+    var leftIndex = getArrayIndex(left);
+    var rightIndex = getArrayIndex(right);
+    if (leftIndex == null || rightIndex == null) {
+      return false;
+    }
+    return !sameExpression(leftIndex, rightIndex);
+  }
+
+  private static ExpressionTree getArrayIndex(ArrayAccessExpressionTree arrayAccess) {
+    var dimension = arrayAccess.dimension();
+    if (dimension != null && dimension.expression() != null) {
+      return dimension.expression();
+    }
+    return null;
+  }
+
+  private static boolean sameExpression(ExpressionTree left, ExpressionTree right) {
+    if (left == null || right == null) {
+      return false;
+    }
+    if (!left.is(right.kind())) {
+      return false;
+    }
+    return left.toString().equals(right.toString());
+  }
+
+  private static boolean sameTree(Tree left, Tree right) {
+    if (left == null || right == null) {
+      return false;
+    }
+    if (!left.is(right.kind())) {
+      return false;
+    }
+    return left.toString().equals(right.toString());
+  }
+
+  private static boolean sameTypeArguments(TypeArguments left, TypeArguments right) {
+    if (left.size() != right.size()) {
+      return false;
+    }
+    for (int i = 0; i < left.size(); i++) {
+      if (!left.get(i).toString().equals(right.get(i).toString())) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/TernaryOperatorSameOperationCheck.java
@@ -113,17 +113,15 @@ public class TernaryOperatorSameOperationCheck extends IssuableSubscriptionVisit
     if (left.classBody() != null || right.classBody() != null) {
       return false;
     }
-    return sameNullableTree(left.enclosingExpression(), right.enclosingExpression());
-  }
-
-  private static boolean sameNullableTree(Tree left, Tree right) {
-    if (left == null && right == null) {
+    var leftEnclosing = left.enclosingExpression();
+    var rightEnclosing = right.enclosingExpression();
+    if (leftEnclosing == null && rightEnclosing == null) {
       return true;
     }
-    if (left == null || right == null) {
+    if (leftEnclosing == null || rightEnclosing == null) {
       return false;
     }
-    return sameTree(left, right);
+    return sameTree(leftEnclosing, rightEnclosing);
   }
 
   private static boolean hasExactlyOneArgumentDifference(List<? extends ExpressionTree> leftArgs, List<? extends ExpressionTree> rightArgs) {

--- a/java-checks/src/test/java/org/sonar/java/checks/TernaryOperatorSameOperationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/TernaryOperatorSameOperationCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class TernaryOperatorSameOperationCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/TernaryOperatorSameOperationCheckSample.java"))
+      .withCheck(new TernaryOperatorSameOperationCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/TernaryOperatorSameOperationCheckSample.java"))
+      .withCheck(new TernaryOperatorSameOperationCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/TernaryOperatorSameOperationCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/TernaryOperatorSameOperationCheckTest.java
@@ -34,7 +34,7 @@ class TernaryOperatorSameOperationCheckTest {
   @Test
   void test_without_semantic() {
     CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/TernaryOperatorSameOperationCheckSample.java"))
+      .onFile(mainCodeSourcesPath("checks/TernaryOperatorSameOperationCheckNoSemanticSample.java"))
       .withCheck(new TernaryOperatorSameOperationCheck())
       .withoutSemantic()
       .verifyIssues();

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9358.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9358.html
@@ -1,0 +1,51 @@
+<p>An issue is raised when a conditional expression (with a condition determining which of two alternative expressions to evaluate) performs the same
+operation on both branches, differing only in the arguments.</p>
+<p>In Java, this refers to the ternary operator with the syntax <code>condition ? trueExpr : falseExpr</code>.</p>
+<h2>Why is this an issue?</h2>
+<p>When both branches of a ternary operator apply the same function call or operation to different values, the code contains unnecessary duplication.
+This pattern makes the code harder to read because the common operation is stated twice instead of once.</p>
+<p>Consider this example:</p>
+<pre>
+message = isError ? formatMessage(errorText) : formatMessage(warningText)
+</pre>
+<p>Here, the message formatting function appears in both branches. This duplication obscures the actual difference between the branches (the input
+value) and makes the code longer than necessary.</p>
+<p>By moving the condition inside the function call, you highlight what actually varies:</p>
+<pre>
+message = formatMessage(isError ? errorText : warningText)
+</pre>
+<p>This refactored version:</p>
+<ul>
+  <li>Eliminates repetition of the function call</li>
+  <li>Makes the variable part (the condition) more visible</li>
+  <li>Reduces the overall line length</li>
+  <li>Improves readability by following the DRY (Don’t Repeat Yourself) principle</li>
+</ul>
+<p>This pattern applies to function calls, object creation, array access, and other operations that are identical in both branches.</p>
+<h3>What is the potential impact?</h3>
+<p>This issue has a minor impact on code maintainability:</p>
+<ul>
+  <li><strong>Readability</strong>: Duplicated operations make code harder to scan and understand quickly</li>
+  <li><strong>Maintenance burden</strong>: If the operation needs to change, developers must update it in two places instead of one</li>
+  <li><strong>Code size</strong>: Unnecessary duplication increases the code footprint without adding value</li>
+</ul>
+<h2>How to fix it</h2>
+<p>Move the ternary operator inside the common method call or operation. The condition should determine which argument is passed, not which method is
+called.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+String result = condition ? foo(a) : foo(b); // Noncompliant
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+String result = foo(condition ? a : b);
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/expressions.html">The Java Tutorials -
+  Expressions, Statements, and Blocks</a></li>
+  <li>Refactoring Guru - <a href="https://refactoring.guru/simplifying-conditional-expressions">Simplifying Conditional Expressions</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9358.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9358.json
@@ -1,0 +1,25 @@
+{
+  "title": "Conditional expressions should not duplicate operations in both branches",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "clumsy",
+    "redundant",
+    "confusing"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-9358",
+  "sqKey": "S9358",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
This PR implements rule S9358 which detects when a ternary operator applies the same operation (method invocation, object creation, or array access) to different arguments in both branches.

Such patterns can be refactored by moving the condition inside the operation for better readability:



The rule handles:
- Method invocations with same method name and different arguments
- Object creation ( vs )
- Array access ( vs )

Test cases cover both compliant and non-compliant scenarios including edge cases like nested ternaries, chained method calls, and generic type arguments.