### PR TITLE
SONARJAVA-6825: Implemented rule S9360 - Comparisons should not use Yoda conditions

### DIFF
--- a/its/ruling/src/test/resources/commons-beanutils/java-S9360.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9360.json
@@ -1,0 +1,8 @@
+{
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/ConstructorUtils.java": [
+106,
+154,
+218,
+267
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9360.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9360.json
@@ -1,0 +1,59 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java": [
+343,
+358,
+373,
+388,
+403
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
+1028
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java": [
+431,
+436,
+445,
+453,
+455,
+459,
+465,
+471,
+477,
+483,
+489,
+495,
+497,
+501,
+503,
+514,
+514,
+515,
+575,
+615,
+617,
+622,
+624,
+628,
+634,
+640,
+646,
+652,
+658,
+664,
+666,
+670,
+677,
+684
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java": [
+93,
+414
+],
+"org.eclipse.jetty:jetty-project:jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java": [
+94
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
+744,
+835
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9360.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9360.json
@@ -1,4 +1,11 @@
 {
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java": [
+343,
+358,
+373,
+388,
+403
+],
 "org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
 1028
 ],
@@ -48,6 +55,9 @@
 "org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
 744,
 835
+],
+"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/AsyncJSON.java": [
+1275
 ],
 "org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java": [
 901,

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9360.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9360.json
@@ -1,0 +1,65 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
+1028
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java": [
+431,
+436,
+445,
+453,
+455,
+459,
+465,
+471,
+477,
+483,
+489,
+495,
+497,
+501,
+503,
+514,
+514,
+515,
+575,
+615,
+617,
+622,
+624,
+628,
+634,
+640,
+646,
+652,
+658,
+664,
+666,
+670,
+677,
+684
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java": [
+93,
+414
+],
+"org.eclipse.jetty:jetty-project:jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java": [
+94
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
+744,
+835
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java": [
+901,
+907,
+925,
+942,
+957,
+962,
+978
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java": [
+117,
+132
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9360.json
+++ b/its/ruling/src/test/resources/guava/java-S9360.json
@@ -1,0 +1,13 @@
+{
+"com.google.guava:guava:src/com/google/common/base/SmallCharMatcher.java": [
+61
+],
+"com.google.guava:guava:src/com/google/common/io/LittleEndianDataInputStream.java": [
+82
+],
+"com.google.guava:guava:src/com/google/common/net/MediaType.java": [
+628,
+631,
+632
+]
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/YodaConditionCheckSample.java
@@ -1,0 +1,10 @@
+package checks;
+
+class YodaConditionCheckSample {
+
+  void unknownLiteralType() {
+    Object x = new Object();
+    if (UNKNOWN_LITERAL == x) { } // Compliant - UNKNOWN_LITERAL is not a valid literal
+  }
+
+}

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -1,0 +1,119 @@
+package checks;
+
+class YodaConditionCheckSample {
+
+  void testIntLiteral() {
+    int count = 0;
+    int x = 5;
+    if (0 == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (5 != x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (count == 0) { } // Compliant
+    if (x != 5) { } // Compliant
+  }
+
+  void testNullLiteral() {
+    Object obj = null;
+    Object myObject = null;
+    if (null == obj) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^
+    if (null != myObject) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^
+    if (obj == null) { } // Compliant
+    if (myObject != null) { } // Compliant
+    if (null == null) { } // Compliant
+  }
+
+  void testBooleanLiteral() {
+    boolean flag = true;
+    boolean result = false;
+    if (true == flag) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^
+    if (false != result) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^^
+    if (flag == true) { } // Compliant
+    if (result != false) { } // Compliant
+  }
+
+  void testStringLiteral() {
+    String str = "hello";
+    String value = "";
+    if ("hello" == str) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^^^^
+    if ("" != value) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^
+    if (str == "hello") { } // Compliant
+    if (value != "") { } // Compliant
+  }
+
+  void testCharLiteral() {
+    char ch = 'a';
+    if ('a' == ch) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^
+    if (ch == 'a') { } // Compliant
+  }
+
+  void testFloatingPointLiteral() {
+    double doubleValue = 0.0;
+    if (0.0 == doubleValue) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^
+    if (doubleValue == 0.0) { } // Compliant
+  }
+
+  void testNestedParentheses() {
+    int count = 0;
+    if ((0) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (((null)) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//        ^^^^
+  }
+
+  void testLessThanGreaterThan() {
+    int count = 0;
+    int x = 5;
+    if (0 < count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (5 > x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (count > 0) { } // Compliant
+    if (x < 5) { } // Compliant
+  }
+
+  void testNonComparisonContexts() {
+    int count = 0;
+    int a = 1;
+    int b = 2;
+    count = 0; // Compliant - assignment
+    int sum = a + 5; // Compliant - arithmetic
+    int product = 5 * b; // Compliant - arithmetic
+    Object obj = Math.max(5, 10); // Compliant - method call
+  }
+
+  void testTernaryOperator() {
+    boolean condition = true;
+    int result = condition ? 5 : 10; // Compliant
+    if (condition) { } // Compliant
+  }
+
+  void testArrayAccess() {
+    int[] array = {1, 2, 3};
+    if (0 == array[0]) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (array[0] == 0) { } // Compliant
+  }
+
+  void testBothLiterals() {
+    if (0 == 0) { } // Compliant - both sides are literals
+    if (5 != 10) { } // Compliant - both sides are literals
+    if (true == false) { } // Compliant - both sides are literals
+  }
+
+  void testBothVariables() {
+    int count = 0;
+    int otherCount = 0;
+    Object obj1 = null;
+    Object obj2 = null;
+    if (count == otherCount) { } // Compliant - both are variables
+    if (obj1 == obj2) { } // Compliant - both are variables
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -63,20 +63,32 @@ class YodaConditionCheckSample {
 
   void testNestedParentheses() {
     int count = 0;
+    Object obj = null;
     if ((0) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
-    if (((null)) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (((null)) == obj) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
 //        ^^^^
   }
 
   void testLessThanGreaterThan() {
     int count = 0;
     int x = 5;
-    if (0 < count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (0 < count) { } // Noncompliant {{Put the variable on the left side of this comparison and reverse the operator.}}
 //      ^
-    if (5 > x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (5 > x) { } // Noncompliant {{Put the variable on the left side of this comparison and reverse the operator.}}
 //      ^
     if (count > 0) { } // Compliant
     if (x < 5) { } // Compliant
+  }
+
+  void testLessThanOrEqualGreaterThanOrEqual() {
+    int count = 0;
+    int x = 5;
+    if (0 <= count) { } // Noncompliant {{Put the variable on the left side of this comparison and reverse the operator.}}
+//      ^
+    if (5 >= x) { } // Noncompliant {{Put the variable on the left side of this comparison and reverse the operator.}}
+//      ^
+    if (count >= 0) { } // Compliant
+    if (x <= 5) { } // Compliant
   }
 
   void testNonComparisonContexts() {

--- a/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
@@ -27,13 +27,18 @@ import org.sonar.plugins.java.api.tree.Tree;
 @Rule(key = "S9360")
 public class YodaConditionCheck extends IssuableSubscriptionVisitor {
 
+  private static final String MESSAGE = "Put the variable on the left side of this comparison.";
+  private static final String MESSAGE_WITH_REVERSE = "Put the variable on the left side of this comparison and reverse the operator.";
+
   @Override
   public List<Tree.Kind> nodesToVisit() {
     return List.of(
       Tree.Kind.EQUAL_TO,
       Tree.Kind.NOT_EQUAL_TO,
       Tree.Kind.LESS_THAN,
-      Tree.Kind.GREATER_THAN
+      Tree.Kind.GREATER_THAN,
+      Tree.Kind.LESS_THAN_OR_EQUAL_TO,
+      Tree.Kind.GREATER_THAN_OR_EQUAL_TO
     );
   }
 
@@ -44,8 +49,17 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
     ExpressionTree right = ExpressionUtils.skipParentheses(binaryExpression.rightOperand());
 
     if (isLiteral(left) && !isLiteral(right)) {
-      reportIssue(left, "Put the variable on the left side of this comparison.");
+      reportIssue(left, isRelationalOperator(tree) ? MESSAGE_WITH_REVERSE : MESSAGE);
     }
+  }
+
+  private static boolean isRelationalOperator(Tree tree) {
+    return tree.is(
+      Tree.Kind.LESS_THAN,
+      Tree.Kind.GREATER_THAN,
+      Tree.Kind.LESS_THAN_OR_EQUAL_TO,
+      Tree.Kind.GREATER_THAN_OR_EQUAL_TO
+    );
   }
 
   private static boolean isLiteral(ExpressionTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
@@ -1,0 +1,63 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9360")
+public class YodaConditionCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(
+      Tree.Kind.EQUAL_TO,
+      Tree.Kind.NOT_EQUAL_TO,
+      Tree.Kind.LESS_THAN,
+      Tree.Kind.GREATER_THAN
+    );
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    BinaryExpressionTree binaryExpression = (BinaryExpressionTree) tree;
+    ExpressionTree left = ExpressionUtils.skipParentheses(binaryExpression.leftOperand());
+    ExpressionTree right = ExpressionUtils.skipParentheses(binaryExpression.rightOperand());
+
+    if (isLiteral(left) && !isLiteral(right)) {
+      reportIssue(left, "Put the variable on the left side of this comparison.");
+    }
+  }
+
+  private static boolean isLiteral(ExpressionTree tree) {
+    return tree.is(
+      Tree.Kind.INT_LITERAL,
+      Tree.Kind.LONG_LITERAL,
+      Tree.Kind.FLOAT_LITERAL,
+      Tree.Kind.DOUBLE_LITERAL,
+      Tree.Kind.BOOLEAN_LITERAL,
+      Tree.Kind.CHAR_LITERAL,
+      Tree.Kind.STRING_LITERAL,
+      Tree.Kind.NULL_LITERAL
+    );
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/YodaConditionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/YodaConditionCheckTest.java
@@ -1,0 +1,51 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
+
+class YodaConditionCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/YodaConditionCheckSample.java"))
+      .withCheck(new YodaConditionCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void no_issue_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/YodaConditionCheckSample.java"))
+      .withCheck(new YodaConditionCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+
+  @Test
+  void test_non_compiling() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/YodaConditionCheckSample.java"))
+      .withCheck(new YodaConditionCheck())
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
@@ -1,0 +1,79 @@
+<p>This rule raises an issue when code contains operations on constants that can be precomputed, or when comparisons place constants on the left side
+(Yoda conditions).</p>
+<h2>Why is this an issue?</h2>
+<p>Code that works with constants can often be simplified to improve readability and, in some cases, performance.</p>
+<p><strong>Constant Function Calls</strong></p>
+<p>When all arguments to a deterministic function are compile-time constants, the result is also a constant. For example, a function that returns the
+maximum of two numbers when called with literal values <code>5</code> and <code>10</code> always returns <code>10</code>. Computing this value at
+runtime is unnecessary and makes the code less clear.</p>
+<p>Mathematical functions that compute maximum values, minimum values, square roots, and absolute values produce predictable results when given
+constant inputs. Replacing these calls with their precomputed values eliminates function call overhead and makes the intended value immediately
+visible to readers.</p>
+<p><strong>Yoda Conditions</strong></p>
+<p>Yoda conditions place the constant on the left side of a comparison: <code>0 == count</code> instead of <code>count == 0</code>. This pattern
+originated in C programming to prevent accidental assignment (single equals operator) instead of comparison (double equals operator).</p>
+<p>In modern type-safe languages, this defensive technique is unnecessary. Type systems that distinguish between assignment and comparison contexts
+will reject code that attempts assignment where a boolean expression is expected. For example, attempting to assign a numeric value in a conditional
+expression produces a compiler error in languages with strong type checking.</p>
+<p>Placing constants on the left reduces readability. Natural language flows from subject to comparison: "Is the count zero?" translates more
+naturally to <code>count == 0</code> than to <code>0 == count</code>.</p>
+<p>By following conventional comparison order, code becomes more intuitive for developers to read and maintain.</p>
+<h3>What is the potential impact?</h3>
+<p>The impact on code quality is primarily related to maintainability:</p>
+<ul>
+  <li><strong>Readability</strong>: Simplified constant expressions and natural comparison order make code easier to understand</li>
+  <li><strong>Performance</strong>: Precomputing constant values eliminates unnecessary method calls at runtime, though the performance gain is
+  typically negligible in modern compilers and runtime environments with optimization</li>
+  <li><strong>Maintainability</strong>: Clear, conventional code patterns reduce cognitive load for developers</li>
+</ul>
+<h2>How to fix it</h2>
+<p>For constant method calls, replace the method invocation with the precomputed result. For Yoda conditions, reverse the comparison to place the
+variable on the left and the constant on the right.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+public class Example {
+    public void calculate() {
+        int max = Math.max(5, 10); // Noncompliant
+        double result = Math.sqrt(16.0) + Math.abs(-5); // Noncompliant
+
+        int count = 0;
+        if (0 == count) { // Noncompliant
+            return;
+        }
+
+        Object obj = null;
+        boolean flag = true;
+        if (null == obj &amp;&amp; true == flag) { // Noncompliant
+            System.out.println("Both conditions met");
+        }
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+public class Example {
+    public void calculate() {
+        int max = 10; // Precomputed constant
+        double result = 4.0 + 5; // Precomputed constants
+
+        int count = 0;
+        if (count == 0) { // Natural comparison order
+            return;
+        }
+
+        Object obj = null;
+        boolean flag = true;
+        if (obj == null &amp;&amp; flag == true) { // Natural comparison order
+            System.out.println("Both conditions met");
+        }
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html">Math (Java Platform SE 8)</a></li>
+  <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26">Assignment Operators</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
@@ -1,15 +1,5 @@
-<p>This rule raises an issue when code contains operations on constants that can be precomputed, or when comparisons place constants on the left side
-(Yoda conditions).</p>
+<p>This rule raises an issue when comparisons place constants on the left side (Yoda conditions).</p>
 <h2>Why is this an issue?</h2>
-<p>Code that works with constants can often be simplified to improve readability and, in some cases, performance.</p>
-<p><strong>Constant Function Calls</strong></p>
-<p>When all arguments to a deterministic function are compile-time constants, the result is also a constant. For example, a function that returns the
-maximum of two numbers when called with literal values <code>5</code> and <code>10</code> always returns <code>10</code>. Computing this value at
-runtime is unnecessary and makes the code less clear.</p>
-<p>Mathematical functions that compute maximum values, minimum values, square roots, and absolute values produce predictable results when given
-constant inputs. Replacing these calls with their precomputed values eliminates function call overhead and makes the intended value immediately
-visible to readers.</p>
-<p><strong>Yoda Conditions</strong></p>
 <p>Yoda conditions place the constant on the left side of a comparison: <code>0 == count</code> instead of <code>count == 0</code>. This pattern
 originated in C programming to prevent accidental assignment (single equals operator) instead of comparison (double equals operator).</p>
 <p>In modern type-safe languages, this defensive technique is unnecessary. Type systems that distinguish between assignment and comparison contexts
@@ -21,22 +11,16 @@ naturally to <code>count == 0</code> than to <code>0 == count</code>.</p>
 <h3>What is the potential impact?</h3>
 <p>The impact on code quality is primarily related to maintainability:</p>
 <ul>
-  <li><strong>Readability</strong>: Simplified constant expressions and natural comparison order make code easier to understand</li>
-  <li><strong>Performance</strong>: Precomputing constant values eliminates unnecessary method calls at runtime, though the performance gain is
-  typically negligible in modern compilers and runtime environments with optimization</li>
+  <li><strong>Readability</strong>: Natural comparison order makes code easier to understand</li>
   <li><strong>Maintainability</strong>: Clear, conventional code patterns reduce cognitive load for developers</li>
 </ul>
 <h2>How to fix it</h2>
-<p>For constant method calls, replace the method invocation with the precomputed result. For Yoda conditions, reverse the comparison to place the
-variable on the left and the constant on the right.</p>
+<p>Reverse the comparison to place the variable on the left and the constant on the right.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 public class Example {
-    public void calculate() {
-        int max = Math.max(5, 10); // Noncompliant
-        double result = Math.sqrt(16.0) + Math.abs(-5); // Noncompliant
-
+    public void check() {
         int count = 0;
         if (0 == count) { // Noncompliant
             return;
@@ -53,10 +37,7 @@ public class Example {
 <h4>Compliant solution</h4>
 <pre data-diff-id="1" data-diff-type="compliant">
 public class Example {
-    public void calculate() {
-        int max = 10; // Precomputed constant
-        double result = 4.0 + 5; // Precomputed constants
-
+    public void check() {
         int count = 0;
         if (count == 0) { // Natural comparison order
             return;
@@ -64,7 +45,7 @@ public class Example {
 
         Object obj = null;
         boolean flag = true;
-        if (obj == null &amp;&amp; flag == true) { // Natural comparison order
+        if (obj == null &amp;&amp; flag) { // Natural comparison order
             System.out.println("Both conditions met");
         }
     }
@@ -73,7 +54,5 @@ public class Example {
 <h2>Resources</h2>
 <h3>Documentation</h3>
 <ul>
-  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html">Math (Java Platform SE 8)</a></li>
   <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26">Assignment Operators</a></li>
 </ul>
-

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.json
@@ -1,5 +1,5 @@
 {
-  "title": "Constant expressions and comparisons should be simplified",
+  "title": "Comparisons should not use Yoda conditions",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.json
@@ -1,0 +1,25 @@
+{
+  "title": "Constant expressions and comparisons should be simplified",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "confusing",
+    "convention",
+    "clarity"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9360",
+  "sqKey": "S9360",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
This PR implements rule S9360 'Constant expressions and comparisons should be simplified'.

The rule detects **Yoda conditions** where a constant literal appears on the left side of a comparison operator.

## What the rule detects

- `0 == count` → should be `count == 0`
- `null == obj` → should be `obj == null`
- `true == flag` → should be `flag == true`
- `5 != x` → should be `x != 5`
- `0 < count` → should be `count > 0`
- `5 > x` → should be `x < 5`

## Supported operators

- `==` (equality)
- `!=` (inequality)
- `<` (less than)
- `>` (greater than)

## Supported literal types

- Integer literals (`0`, `5`, `42`)
- Long literals (`0L`, `5L`)
- Floating-point literals (`0.0`, `3.14`)
- Boolean literals (`true`, `false`)
- Character literals (`'a'`)
- String literals (`"hello"`, `""`)
- Null literal (`null`)

## Edge cases handled

- Nested parentheses: `((0)) == count` is detected
- Both operands are literals: `0 == 0` is compliant (nothing to swap)
- Both operands are variables: `count == otherCount` is compliant
- Non-comparison contexts: assignments, arithmetic, method calls are ignored

## Implementation details

- Uses `IssuableSubscriptionVisitor` pattern
- Subscribes to `EQUAL_TO`, `NOT_EQUAL_TO`, `LESS_THAN`, `GREATER_THAN` tree kinds
- Uses `ExpressionUtils.skipParentheses()` to handle nested parentheses
- Reports issue on the literal (left operand) with message "Put the variable on the left side of this comparison."

## Test coverage

- All literal types with `==` and `!=` operators
- Less than and greater than operators
- Nested parentheses handling
- Non-comparison contexts (assignments, arithmetic, method calls)
- Edge cases: both literals, both variables, ternary operators
