### PR TITLE
SONARJAVA-6853 S3329: fix FP when cipher.init uses a non-final variable initialized to DECRYPT_MODE

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/security/CipherBlockChainingCheckShouldDetectCustomIVFactories.java
+++ b/java-checks-test-sources/default/src/main/java/checks/security/CipherBlockChainingCheckShouldDetectCustomIVFactories.java
@@ -189,6 +189,11 @@ public class CipherBlockChainingCheckShouldDetectCustomIVFactories {
       final byte[] iv = generateRandomData(12);
       // An FP used to be raised here because iv is securely generated in a separate method, and we were not able to trace that.
       cipher.init(ENCRYPT_MODE, secretKey, new IvParameterSpec(iv)); // Compliant
+
+      // new byte[16] is not dynamically generated, so the DECRYPT_MODE suppression path must fire.
+      // No FP should be raised: opMode1's initializer resolves to DECRYPT_MODE even though opMode1 is non-final.
+      int opMode1 = Cipher.DECRYPT_MODE;
+      cipher.init(opMode1, secretKey, new IvParameterSpec(new byte[16]));
     }
 
     private byte[] generateRandomData(final int length) {

--- a/java-checks/src/main/java/org/sonar/java/checks/security/CipherBlockChainingCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/CipherBlockChainingCheck.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -191,7 +192,7 @@ public class CipherBlockChainingCheck extends AbstractMethodDetection {
       }
       // make sure it is not used for decryption - in such case you need to reuse one
       if (CIPHER_INIT.matches(methodInvocation) && methodInvocation.arguments().size() > 2) {
-        int opMode = methodInvocation.arguments().get(0).asConstant(Integer.class).orElse(-1);
+        int opMode = resolveIntConstant(methodInvocation.arguments().get(0)).orElse(-1);
         if (CIPHER_INIT_DECRYPT_MODE == opMode && isPartOfArguments(methodInvocation)) {
           hasBeenSecurelyInitialized = true;
         }
@@ -239,6 +240,21 @@ public class CipherBlockChainingCheck extends AbstractMethodDetection {
         .map(ExpressionUtils::skipParentheses)
         .map(SecureInitializationFinder::symbol)
         .anyMatch(ivParameterSymbol::equals);
+    }
+
+    private static Optional<Integer> resolveIntConstant(ExpressionTree expression) {
+      Optional<Integer> constant = expression.asConstant(Integer.class);
+      if (constant.isPresent()) {
+        return constant;
+      }
+      if (expression instanceof IdentifierTree identifierTree
+        && identifierTree.symbol() instanceof Symbol.VariableSymbol variableSymbol) {
+        var declaration = variableSymbol.declaration();
+        if (declaration != null && declaration.initializer() != null) {
+          return declaration.initializer().asConstant(Integer.class);
+        }
+      }
+      return Optional.empty();
     }
 
     private static Symbol symbol(ExpressionTree expression) {


### PR DESCRIPTION
The DECRYPT_MODE suppression in SecureInitializationFinder relied on asConstant() to resolve the operation mode, which only works for compile-time constants. A non-final variable initialized to Cipher.DECRYPT_MODE was not resolved, causing the suppression to silently fail and a FP to be raised.

Added resolveIntConstant() which falls back to inspecting the variable's declaration initializer when asConstant() returns empty.