### PR TITLE
SONARJAVA-6825: Implement rule S9360 - Constant expressions and comparisons should be simplified

### DIFF
--- a/its/ruling/src/test/resources/commons-beanutils/java-S9360.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9360.json
@@ -1,0 +1,8 @@
+{
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/ConstructorUtils.java": [
+106,
+154,
+218,
+267
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9360.json
+++ b/its/ruling/src/test/resources/eclipse-jetty-similar-to-main/java-S9360.json
@@ -1,0 +1,59 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java": [
+343,
+358,
+373,
+388,
+403
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
+1028
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java": [
+431,
+436,
+445,
+453,
+455,
+459,
+465,
+471,
+477,
+483,
+489,
+495,
+497,
+501,
+503,
+514,
+514,
+515,
+575,
+615,
+617,
+622,
+624,
+628,
+634,
+640,
+646,
+652,
+658,
+664,
+666,
+670,
+677,
+684
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java": [
+93,
+414
+],
+"org.eclipse.jetty:jetty-project:jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java": [
+94
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
+744,
+835
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9360.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9360.json
@@ -1,0 +1,75 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpStatus.java": [
+343,
+358,
+373,
+388,
+403
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/HttpURI.java": [
+1028
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java": [
+431,
+436,
+445,
+453,
+455,
+459,
+465,
+471,
+477,
+483,
+489,
+495,
+497,
+501,
+503,
+514,
+514,
+515,
+575,
+615,
+617,
+622,
+624,
+628,
+634,
+640,
+646,
+652,
+658,
+664,
+666,
+670,
+677,
+684
+],
+"org.eclipse.jetty:jetty-project:jetty-http/src/main/java/org/eclipse/jetty/http/pathmap/ServletPathSpec.java": [
+93,
+414
+],
+"org.eclipse.jetty:jetty-project:jetty-io/src/test/java/org/eclipse/jetty/io/ArrayByteBufferPoolTest.java": [
+94
+],
+"org.eclipse.jetty:jetty-project:jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java": [
+744,
+835
+],
+"org.eclipse.jetty:jetty-project:jetty-util-ajax/src/main/java/org/eclipse/jetty/util/ajax/AsyncJSON.java": [
+1275
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/StringUtil.java": [
+901,
+907,
+925,
+942,
+957,
+962,
+978
+],
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/security/Password.java": [
+117,
+132
+]
+}

--- a/its/ruling/src/test/resources/guava/java-S9360.json
+++ b/its/ruling/src/test/resources/guava/java-S9360.json
@@ -2,13 +2,12 @@
 "com.google.guava:guava:src/com/google/common/base/SmallCharMatcher.java": [
 61
 ],
-"com.google.guava:guava:src/com/google/common/hash/BloomFilter.java": [
-436,
-453,
-453
-],
 "com.google.guava:guava:src/com/google/common/io/LittleEndianDataInputStream.java": [
-82
+82,
+225
+],
+"com.google.guava:guava:src/com/google/common/math/LongMath.java": [
+234
 ],
 "com.google.guava:guava:src/com/google/common/net/MediaType.java": [
 628,

--- a/its/ruling/src/test/resources/guava/java-S9360.json
+++ b/its/ruling/src/test/resources/guava/java-S9360.json
@@ -10,13 +10,6 @@
 "com.google.guava:guava:src/com/google/common/io/LittleEndianDataInputStream.java": [
 82
 ],
-"com.google.guava:guava:src/com/google/common/math/BigIntegerMath.java": [
-195,
-196
-],
-"com.google.guava:guava:src/com/google/common/math/DoubleMath.java": [
-220
-],
 "com.google.guava:guava:src/com/google/common/net/MediaType.java": [
 628,
 631,

--- a/its/ruling/src/test/resources/guava/java-S9360.json
+++ b/its/ruling/src/test/resources/guava/java-S9360.json
@@ -1,0 +1,25 @@
+{
+"com.google.guava:guava:src/com/google/common/base/SmallCharMatcher.java": [
+61
+],
+"com.google.guava:guava:src/com/google/common/hash/BloomFilter.java": [
+436,
+453,
+453
+],
+"com.google.guava:guava:src/com/google/common/io/LittleEndianDataInputStream.java": [
+82
+],
+"com.google.guava:guava:src/com/google/common/math/BigIntegerMath.java": [
+195,
+196
+],
+"com.google.guava:guava:src/com/google/common/math/DoubleMath.java": [
+220
+],
+"com.google.guava:guava:src/com/google/common/net/MediaType.java": [
+628,
+631,
+632
+]
+}

--- a/java-checks-test-sources/default/src/main/files/non-compiling/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/files/non-compiling/checks/YodaConditionCheckSample.java
@@ -1,0 +1,10 @@
+package checks;
+
+class YodaConditionCheckSample {
+
+  void unknownLiteralType() {
+    Object x = new Object();
+    if (UNKNOWN_LITERAL == x) { } // Compliant - UNKNOWN_LITERAL is not a valid literal
+  }
+
+}

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -181,6 +181,9 @@ class YodaConditionCheckSample {
     double cos = Math.cos(0.5); // Compliant
     double log = Math.log(2.0); // Compliant
     double exp = Math.exp(1.0); // Compliant
+    double cbrt = Math.cbrt(8.0); // Compliant - not exactly specified
+    double deg = Math.toDegrees(1.0); // Compliant - not exactly specified
+    double rad = Math.toRadians(90.0); // Compliant - not exactly specified
   }
 
   void testNonMathMethodCalls() {

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -79,6 +79,17 @@ class YodaConditionCheckSample {
     if (x < 5) { } // Compliant
   }
 
+  void testLessThanOrEqualGreaterThanOrEqual() {
+    int count = 0;
+    int x = 5;
+    if (0 <= count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (5 >= x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (count >= 0) { } // Compliant
+    if (x <= 5) { } // Compliant
+  }
+
   void testNonComparisonContexts() {
     int count = 0;
     int a = 1;
@@ -86,7 +97,6 @@ class YodaConditionCheckSample {
     count = 0; // Compliant - assignment
     int sum = a + 5; // Compliant - arithmetic
     int product = 5 * b; // Compliant - arithmetic
-    Object obj = Math.max(5, 10); // Compliant - method call
   }
 
   void testTernaryOperator() {
@@ -115,5 +125,48 @@ class YodaConditionCheckSample {
     Object obj2 = null;
     if (count == otherCount) { } // Compliant - both are variables
     if (obj1 == obj2) { } // Compliant - both are variables
+  }
+
+  void testConstantMathCalls() {
+    int max = Math.max(5, 10); // Noncompliant {{Replace this call to "max" with the precomputed constant value.}}
+//            ^^^^^^^^
+    int min = Math.min(3, 7); // Noncompliant {{Replace this call to "min" with the precomputed constant value.}}
+//            ^^^^^^^^
+    double sqrt = Math.sqrt(16.0); // Noncompliant {{Replace this call to "sqrt" with the precomputed constant value.}}
+//                ^^^^^^^^^
+    int abs = Math.abs(-5); // Noncompliant {{Replace this call to "abs" with the precomputed constant value.}}
+//            ^^^^^^^^
+    double pow = Math.pow(2.0, 3.0); // Noncompliant {{Replace this call to "pow" with the precomputed constant value.}}
+//               ^^^^^^^^
+    long rounded = Math.round(3.14); // Noncompliant {{Replace this call to "round" with the precomputed constant value.}}
+//                 ^^^^^^^^^^
+    double floor = Math.floor(3.7); // Noncompliant {{Replace this call to "floor" with the precomputed constant value.}}
+//                 ^^^^^^^^^^
+    double ceil = Math.ceil(3.2); // Noncompliant {{Replace this call to "ceil" with the precomputed constant value.}}
+//                ^^^^^^^^^
+  }
+
+  void testConstantMathCallsCompliant() {
+    int x = 5;
+    int y = 10;
+    int max = Math.max(x, 10); // Compliant - x is not a literal
+    int min = Math.min(3, y); // Compliant - y is not a literal
+    double sqrt = Math.sqrt(x); // Compliant - x is not a literal
+    int abs = Math.abs(x); // Compliant - x is not a literal
+    int maxVar = Math.max(x, y); // Compliant - neither is a literal
+  }
+
+  void testConstantMathCallsWithUnaryMinus() {
+    int abs = Math.abs(-10); // Noncompliant {{Replace this call to "abs" with the precomputed constant value.}}
+//            ^^^^^^^^
+    int max = Math.max(-5, -3); // Noncompliant {{Replace this call to "max" with the precomputed constant value.}}
+//            ^^^^^^^^
+    double sqrt = Math.sqrt(+4.0); // Noncompliant {{Replace this call to "sqrt" with the precomputed constant value.}}
+//                ^^^^^^^^^
+  }
+
+  void testNonMathMethodCalls() {
+    String result = String.valueOf(5); // Compliant - not a Math method
+    int hash = Integer.hashCode(42); // Compliant - not a Math method
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -63,8 +63,9 @@ class YodaConditionCheckSample {
 
   void testNestedParentheses() {
     int count = 0;
+    Object obj = new Object();
     if ((0) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
-    if (((null)) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (((null)) == obj) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
 //        ^^^^
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -1,0 +1,119 @@
+package checks;
+
+class YodaConditionCheckSample {
+
+  void testIntLiteral() {
+    int count = 0;
+    int x = 5;
+    if (0 == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (5 != x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (count == 0) { } // Compliant
+    if (x != 5) { } // Compliant
+  }
+
+  void testNullLiteral() {
+    Object obj = null;
+    Object myObject = null;
+    if (null == obj) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^
+    if (null != myObject) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^
+    if (obj == null) { } // Compliant
+    if (myObject != null) { } // Compliant
+    if (null == null) { } // Compliant
+  }
+
+  void testBooleanLiteral() {
+    boolean flag = true;
+    boolean result = false;
+    if (true == flag) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^
+    if (false != result) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^^
+    if (flag == true) { } // Compliant
+    if (result != false) { } // Compliant
+  }
+
+  void testStringLiteral() {
+    String str = "hello";
+    String value = "";
+    if ("hello" == str) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^^^^^
+    if ("" != value) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^
+    if (str == "hello") { } // Compliant
+    if (value != "") { } // Compliant
+  }
+
+  void testCharLiteral() {
+    char ch = 'a';
+    if ('a' == ch) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^
+    if (ch == 'a') { } // Compliant
+  }
+
+  void testFloatingPointLiteral() {
+    double doubleValue = 0.0;
+    if (0.0 == doubleValue) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^^
+    if (doubleValue == 0.0) { } // Compliant
+  }
+
+  void testNestedParentheses() {
+    int count = 0;
+    if ((0) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (((null)) == count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//        ^^^^
+  }
+
+  void testLessThanGreaterThan() {
+    int count = 0;
+    int x = 5;
+    if (0 < count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (5 > x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (count > 0) { } // Compliant
+    if (x < 5) { } // Compliant
+  }
+
+  void testNonComparisonContexts() {
+    int count = 0;
+    int a = 1;
+    int b = 2;
+    count = 0; // Compliant - assignment
+    int sum = a + 5; // Compliant - arithmetic
+    int product = 5 * b; // Compliant - arithmetic
+    Object obj = Math.max(5, 10); // Compliant - method call
+  }
+
+  void testTernaryOperator() {
+    boolean condition = true;
+    int result = condition ? 5 : 10; // Compliant
+    if (condition) { } // Compliant
+  }
+
+  void testArrayAccess() {
+    int[] array = {1, 2, 3};
+    if (0 == array[0]) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^
+    if (array[0] == 0) { } // Compliant
+  }
+
+  void testBothLiterals() {
+    if (0 == 0) { } // Compliant - both sides are literals
+    if (5 != 10) { } // Compliant - both sides are literals
+    if (true == false) { } // Compliant - both sides are literals
+  }
+
+  void testBothVariables() {
+    int count = 0;
+    int otherCount = 0;
+    Object obj1 = null;
+    Object obj2 = null;
+    if (count == otherCount) { } // Compliant - both are variables
+    if (obj1 == obj2) { } // Compliant - both are variables
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/YodaConditionCheckSample.java
@@ -28,10 +28,8 @@ class YodaConditionCheckSample {
   void testBooleanLiteral() {
     boolean flag = true;
     boolean result = false;
-    if (true == flag) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
-//      ^^^^
-    if (false != result) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
-//      ^^^^^
+    if (true == flag) { } // Compliant - boolean literal comparisons handled by S1125
+    if (false != result) { } // Compliant - boolean literal comparisons handled by S1125
     if (flag == true) { } // Compliant
     if (result != false) { } // Compliant
   }
@@ -72,9 +70,9 @@ class YodaConditionCheckSample {
   void testLessThanGreaterThan() {
     int count = 0;
     int x = 5;
-    if (0 < count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (0 < count) { } // Noncompliant {{Put the variable on the left side of this comparison and invert the operator.}}
 //      ^
-    if (5 > x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (5 > x) { } // Noncompliant {{Put the variable on the left side of this comparison and invert the operator.}}
 //      ^
     if (count > 0) { } // Compliant
     if (x < 5) { } // Compliant
@@ -83,9 +81,9 @@ class YodaConditionCheckSample {
   void testLessThanOrEqualGreaterThanOrEqual() {
     int count = 0;
     int x = 5;
-    if (0 <= count) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (0 <= count) { } // Noncompliant {{Put the variable on the left side of this comparison and invert the operator.}}
 //      ^
-    if (5 >= x) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+    if (5 >= x) { } // Noncompliant {{Put the variable on the left side of this comparison and invert the operator.}}
 //      ^
     if (count >= 0) { } // Compliant
     if (x <= 5) { } // Compliant
@@ -113,10 +111,23 @@ class YodaConditionCheckSample {
     if (array[0] == 0) { } // Compliant
   }
 
+  void testUnaryMinusPlusYoda() {
+    int index = 0;
+    if (-1 == index) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^
+    if (+1 == index) { } // Noncompliant {{Put the variable on the left side of this comparison.}}
+//      ^^
+    if (index == -1) { } // Compliant
+    if (index == +1) { } // Compliant
+  }
+
   void testBothLiterals() {
     if (0 == 0) { } // Compliant - both sides are literals
     if (5 != 10) { } // Compliant - both sides are literals
     if (true == false) { } // Compliant - both sides are literals
+    if (0 == -1) { } // Compliant - both sides are literals
+    if (-1 == 0) { } // Compliant - both sides are literals
+    if (-1 == -2) { } // Compliant - both sides are literals
   }
 
   void testBothVariables() {
@@ -137,8 +148,6 @@ class YodaConditionCheckSample {
 //                ^^^^^^^^^
     int abs = Math.abs(-5); // Noncompliant {{Replace this call to "abs" with the precomputed constant value.}}
 //            ^^^^^^^^
-    double pow = Math.pow(2.0, 3.0); // Noncompliant {{Replace this call to "pow" with the precomputed constant value.}}
-//               ^^^^^^^^
     long rounded = Math.round(3.14); // Noncompliant {{Replace this call to "round" with the precomputed constant value.}}
 //                 ^^^^^^^^^^
     double floor = Math.floor(3.7); // Noncompliant {{Replace this call to "floor" with the precomputed constant value.}}
@@ -164,6 +173,14 @@ class YodaConditionCheckSample {
 //            ^^^^^^^^
     double sqrt = Math.sqrt(+4.0); // Noncompliant {{Replace this call to "sqrt" with the precomputed constant value.}}
 //                ^^^^^^^^^
+  }
+
+  void testTranscendentalMathCallsCompliant() {
+    double pow = Math.pow(2.0, 3.0); // Compliant - transcendental functions excluded (result may vary across JVMs)
+    double sin = Math.sin(0.5); // Compliant
+    double cos = Math.cos(0.5); // Compliant
+    double log = Math.log(2.0); // Compliant
+    double exp = Math.exp(1.0); // Compliant
   }
 
   void testNonMathMethodCalls() {

--- a/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
@@ -20,12 +20,65 @@ import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
 
 @Rule(key = "S9360")
 public class YodaConditionCheck extends IssuableSubscriptionVisitor {
+
+  private static final String JAVA_LANG_MATH = "java.lang.Math";
+
+  private static final MethodMatchers CONSTANT_MATH_METHODS = MethodMatchers.or(
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("max", "min")
+      .addParametersMatcher("int", "int")
+      .addParametersMatcher("long", "long")
+      .addParametersMatcher("float", "float")
+      .addParametersMatcher("double", "double")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("abs", "absExact", "negateExact", "incrementExact", "decrementExact")
+      .addParametersMatcher("int")
+      .addParametersMatcher("long")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("abs")
+      .addParametersMatcher("float")
+      .addParametersMatcher("double")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("sqrt", "cbrt", "ceil", "floor", "rint", "log", "log10", "exp",
+        "sin", "cos", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh",
+        "toDegrees", "toRadians", "signum", "expm1", "log1p")
+      .addParametersMatcher("double")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("round")
+      .addParametersMatcher("float")
+      .addParametersMatcher("double")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("pow", "atan2", "IEEEremainder", "copySign")
+      .addParametersMatcher("double", "double")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("addExact", "subtractExact", "multiplyExact", "floorDiv", "floorMod")
+      .addParametersMatcher("int", "int")
+      .addParametersMatcher("long", "long")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("toIntExact")
+      .addParametersMatcher("long")
+      .build(),
+    MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
+      .names("signum")
+      .addParametersMatcher("float")
+      .build()
+  );
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -33,19 +86,53 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
       Tree.Kind.EQUAL_TO,
       Tree.Kind.NOT_EQUAL_TO,
       Tree.Kind.LESS_THAN,
-      Tree.Kind.GREATER_THAN
+      Tree.Kind.GREATER_THAN,
+      Tree.Kind.LESS_THAN_OR_EQUAL_TO,
+      Tree.Kind.GREATER_THAN_OR_EQUAL_TO,
+      Tree.Kind.METHOD_INVOCATION
     );
   }
 
   @Override
   public void visitNode(Tree tree) {
-    BinaryExpressionTree binaryExpression = (BinaryExpressionTree) tree;
+    if (tree.is(Tree.Kind.METHOD_INVOCATION)) {
+      checkConstantMathCall((MethodInvocationTree) tree);
+    } else {
+      checkYodaCondition((BinaryExpressionTree) tree);
+    }
+  }
+
+  private void checkYodaCondition(BinaryExpressionTree binaryExpression) {
     ExpressionTree left = ExpressionUtils.skipParentheses(binaryExpression.leftOperand());
     ExpressionTree right = ExpressionUtils.skipParentheses(binaryExpression.rightOperand());
 
     if (isLiteral(left) && !isLiteral(right)) {
       reportIssue(left, "Put the variable on the left side of this comparison.");
     }
+  }
+
+  private void checkConstantMathCall(MethodInvocationTree methodInvocation) {
+    if (CONSTANT_MATH_METHODS.matches(methodInvocation) && allArgumentsAreLiterals(methodInvocation)) {
+      reportIssue(methodInvocation.methodSelect(),
+        String.format("Replace this call to \"%s\" with the precomputed constant value.", methodInvocation.methodSymbol().name()));
+    }
+  }
+
+  private static boolean allArgumentsAreLiterals(MethodInvocationTree methodInvocation) {
+    return methodInvocation.arguments().stream().allMatch(YodaConditionCheck::isNumericLiteral);
+  }
+
+  private static boolean isNumericLiteral(ExpressionTree tree) {
+    ExpressionTree expr = ExpressionUtils.skipParentheses(tree);
+    if (expr.is(Tree.Kind.UNARY_MINUS, Tree.Kind.UNARY_PLUS)) {
+      expr = ExpressionUtils.skipParentheses(((UnaryExpressionTree) expr).expression());
+    }
+    return expr.is(
+      Tree.Kind.INT_LITERAL,
+      Tree.Kind.LONG_LITERAL,
+      Tree.Kind.FLOAT_LITERAL,
+      Tree.Kind.DOUBLE_LITERAL
+    );
   }
 
   private static boolean isLiteral(ExpressionTree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
@@ -31,14 +31,16 @@ import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
 public class YodaConditionCheck extends IssuableSubscriptionVisitor {
 
   private static final String JAVA_LANG_MATH = "java.lang.Math";
+  private static final String FLOAT = "float";
+  private static final String DOUBLE = "double";
 
   private static final MethodMatchers CONSTANT_MATH_METHODS = MethodMatchers.or(
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
       .names("max", "min")
       .addParametersMatcher("int", "int")
       .addParametersMatcher("long", "long")
-      .addParametersMatcher("float", "float")
-      .addParametersMatcher("double", "double")
+      .addParametersMatcher(FLOAT, FLOAT)
+      .addParametersMatcher(DOUBLE, DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
       .names("abs", "absExact", "negateExact", "incrementExact", "decrementExact")
@@ -47,23 +49,21 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
       .names("abs")
-      .addParametersMatcher("float")
-      .addParametersMatcher("double")
+      .addParametersMatcher(FLOAT)
+      .addParametersMatcher(DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
-      .names("sqrt", "cbrt", "ceil", "floor", "rint", "log", "log10", "exp",
-        "sin", "cos", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh",
-        "toDegrees", "toRadians", "signum", "expm1", "log1p")
-      .addParametersMatcher("double")
+      .names("sqrt", "cbrt", "ceil", "floor", "rint", "toDegrees", "toRadians", "signum")
+      .addParametersMatcher(DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
       .names("round")
-      .addParametersMatcher("float")
-      .addParametersMatcher("double")
+      .addParametersMatcher(FLOAT)
+      .addParametersMatcher(DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
-      .names("pow", "atan2", "IEEEremainder", "copySign")
-      .addParametersMatcher("double", "double")
+      .names("copySign")
+      .addParametersMatcher(DOUBLE, DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
       .names("addExact", "subtractExact", "multiplyExact", "floorDiv", "floorMod")
@@ -76,7 +76,7 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
       .names("signum")
-      .addParametersMatcher("float")
+      .addParametersMatcher(FLOAT)
       .build()
   );
 
@@ -107,7 +107,12 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
     ExpressionTree right = ExpressionUtils.skipParentheses(binaryExpression.rightOperand());
 
     if (isLiteral(left) && !isLiteral(right)) {
-      reportIssue(left, "Put the variable on the left side of this comparison.");
+      if (binaryExpression.is(Tree.Kind.LESS_THAN, Tree.Kind.GREATER_THAN,
+        Tree.Kind.LESS_THAN_OR_EQUAL_TO, Tree.Kind.GREATER_THAN_OR_EQUAL_TO)) {
+        reportIssue(left, "Put the variable on the left side of this comparison and invert the operator.");
+      } else {
+        reportIssue(left, "Put the variable on the left side of this comparison.");
+      }
     }
   }
 
@@ -136,12 +141,15 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
   }
 
   private static boolean isLiteral(ExpressionTree tree) {
-    return tree.is(
+    ExpressionTree expr = tree;
+    if (expr.is(Tree.Kind.UNARY_MINUS, Tree.Kind.UNARY_PLUS)) {
+      expr = ExpressionUtils.skipParentheses(((UnaryExpressionTree) expr).expression());
+    }
+    return expr.is(
       Tree.Kind.INT_LITERAL,
       Tree.Kind.LONG_LITERAL,
       Tree.Kind.FLOAT_LITERAL,
       Tree.Kind.DOUBLE_LITERAL,
-      Tree.Kind.BOOLEAN_LITERAL,
       Tree.Kind.CHAR_LITERAL,
       Tree.Kind.STRING_LITERAL,
       Tree.Kind.NULL_LITERAL

--- a/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
@@ -53,7 +53,7 @@ public class YodaConditionCheck extends IssuableSubscriptionVisitor {
       .addParametersMatcher(DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)
-      .names("sqrt", "cbrt", "ceil", "floor", "rint", "toDegrees", "toRadians", "signum")
+      .names("sqrt", "ceil", "floor", "rint", "signum")
       .addParametersMatcher(DOUBLE)
       .build(),
     MethodMatchers.create().ofTypes(JAVA_LANG_MATH)

--- a/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/YodaConditionCheck.java
@@ -1,0 +1,63 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.BinaryExpressionTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9360")
+public class YodaConditionCheck extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(
+      Tree.Kind.EQUAL_TO,
+      Tree.Kind.NOT_EQUAL_TO,
+      Tree.Kind.LESS_THAN,
+      Tree.Kind.GREATER_THAN
+    );
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    BinaryExpressionTree binaryExpression = (BinaryExpressionTree) tree;
+    ExpressionTree left = ExpressionUtils.skipParentheses(binaryExpression.leftOperand());
+    ExpressionTree right = ExpressionUtils.skipParentheses(binaryExpression.rightOperand());
+
+    if (isLiteral(left) && !isLiteral(right)) {
+      reportIssue(left, "Put the variable on the left side of this comparison.");
+    }
+  }
+
+  private static boolean isLiteral(ExpressionTree tree) {
+    return tree.is(
+      Tree.Kind.INT_LITERAL,
+      Tree.Kind.LONG_LITERAL,
+      Tree.Kind.FLOAT_LITERAL,
+      Tree.Kind.DOUBLE_LITERAL,
+      Tree.Kind.BOOLEAN_LITERAL,
+      Tree.Kind.CHAR_LITERAL,
+      Tree.Kind.STRING_LITERAL,
+      Tree.Kind.NULL_LITERAL
+    );
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/YodaConditionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/YodaConditionCheckTest.java
@@ -33,15 +33,6 @@ class YodaConditionCheckTest {
   }
 
   @Test
-  void no_issue_without_semantic() {
-    CheckVerifier.newVerifier()
-      .onFile(mainCodeSourcesPath("checks/YodaConditionCheckSample.java"))
-      .withCheck(new YodaConditionCheck())
-      .withoutSemantic()
-      .verifyIssues();
-  }
-
-  @Test
   void test_non_compiling() {
     CheckVerifier.newVerifier()
       .onFile(nonCompilingTestSourcesPath("checks/YodaConditionCheckSample.java"))

--- a/java-checks/src/test/java/org/sonar/java/checks/YodaConditionCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/YodaConditionCheckTest.java
@@ -1,0 +1,51 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+import static org.sonar.java.checks.verifier.TestUtils.nonCompilingTestSourcesPath;
+
+class YodaConditionCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/YodaConditionCheckSample.java"))
+      .withCheck(new YodaConditionCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void no_issue_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/YodaConditionCheckSample.java"))
+      .withCheck(new YodaConditionCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+
+  @Test
+  void test_non_compiling() {
+    CheckVerifier.newVerifier()
+      .onFile(nonCompilingTestSourcesPath("checks/YodaConditionCheckSample.java"))
+      .withCheck(new YodaConditionCheck())
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
@@ -12,9 +12,9 @@ visible to readers.</p>
 <p><strong>Yoda Conditions</strong></p>
 <p>Yoda conditions place the constant on the left side of a comparison: <code>0 == count</code> instead of <code>count == 0</code>. This pattern
 originated in C programming to prevent accidental assignment (single equals operator) instead of comparison (double equals operator).</p>
-<p>In modern type-safe languages, this defensive technique is unnecessary. Type systems that distinguish between assignment and comparison contexts
-will reject code that attempts assignment where a boolean expression is expected. For example, attempting to assign a numeric value in a conditional
-expression produces a compiler error in languages with strong type checking.</p>
+<p>In Java, this defensive technique is largely unnecessary. The compiler rejects assignment in conditional contexts for non-boolean types (for example,
+<code>if (count = 0)</code> does not compile when <code>count</code> is an <code>int</code>). While <code>if (flag = true)</code> does compile for
+boolean variables, that case is better addressed by removing the redundant boolean comparison entirely.</p>
 <p>Placing constants on the left reduces readability. Natural language flows from subject to comparison: "Is the count zero?" translates more
 naturally to <code>count == 0</code> than to <code>0 == count</code>.</p>
 <p>By following conventional comparison order, code becomes more intuitive for developers to read and maintain.</p>
@@ -43,9 +43,8 @@ public class Example {
         }
 
         Object obj = null;
-        boolean flag = true;
-        if (null == obj &amp;&amp; true == flag) { // Noncompliant
-            System.out.println("Both conditions met");
+        if (null == obj) { // Noncompliant
+            System.out.println("Condition met");
         }
     }
 }
@@ -63,9 +62,8 @@ public class Example {
         }
 
         Object obj = null;
-        boolean flag = true;
-        if (obj == null &amp;&amp; flag == true) { // Natural comparison order
-            System.out.println("Both conditions met");
+        if (obj == null) { // Natural comparison order
+            System.out.println("Condition met");
         }
     }
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.html
@@ -1,0 +1,79 @@
+<p>This rule raises an issue when code contains operations on constants that can be precomputed, or when comparisons place constants on the left side
+(Yoda conditions).</p>
+<h2>Why is this an issue?</h2>
+<p>Code that works with constants can often be simplified to improve readability and, in some cases, performance.</p>
+<p><strong>Constant Function Calls</strong></p>
+<p>When all arguments to a deterministic function are compile-time constants, the result is also a constant. For example, a function that returns the
+maximum of two numbers when called with literal values <code>5</code> and <code>10</code> always returns <code>10</code>. Computing this value at
+runtime is unnecessary and makes the code less clear.</p>
+<p>Mathematical functions that compute maximum values, minimum values, square roots, and absolute values produce predictable results when given
+constant inputs. Replacing these calls with their precomputed values eliminates function call overhead and makes the intended value immediately
+visible to readers.</p>
+<p><strong>Yoda Conditions</strong></p>
+<p>Yoda conditions place the constant on the left side of a comparison: <code>0 == count</code> instead of <code>count == 0</code>. This pattern
+originated in C programming to prevent accidental assignment (single equals operator) instead of comparison (double equals operator).</p>
+<p>In modern type-safe languages, this defensive technique is unnecessary. Type systems that distinguish between assignment and comparison contexts
+will reject code that attempts assignment where a boolean expression is expected. For example, attempting to assign a numeric value in a conditional
+expression produces a compiler error in languages with strong type checking.</p>
+<p>Placing constants on the left reduces readability. Natural language flows from subject to comparison: "Is the count zero?" translates more
+naturally to <code>count == 0</code> than to <code>0 == count</code>.</p>
+<p>By following conventional comparison order, code becomes more intuitive for developers to read and maintain.</p>
+<h3>What is the potential impact?</h3>
+<p>The impact on code quality is primarily related to maintainability:</p>
+<ul>
+  <li><strong>Readability</strong>: Simplified constant expressions and natural comparison order make code easier to understand</li>
+  <li><strong>Performance</strong>: Precomputing constant values eliminates unnecessary method calls at runtime, though the performance gain is
+  typically negligible in modern compilers and runtime environments with optimization</li>
+  <li><strong>Maintainability</strong>: Clear, conventional code patterns reduce cognitive load for developers</li>
+</ul>
+<h2>How to fix it</h2>
+<p>For constant method calls, replace the method invocation with the precomputed result. For Yoda conditions, reverse the comparison to place the
+variable on the left and the constant on the right.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+public class Example {
+    public void calculate() {
+        int max = Math.max(5, 10); // Noncompliant
+        double result = Math.sqrt(16.0) + Math.abs(-5); // Noncompliant
+
+        int count = 0;
+        if (0 == count) { // Noncompliant
+            return;
+        }
+
+        Object obj = null;
+        boolean flag = true;
+        if (null == obj &amp;&amp; true == flag) { // Noncompliant
+            System.out.println("Both conditions met");
+        }
+    }
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+public class Example {
+    public void calculate() {
+        int max = 10; // Precomputed constant
+        double result = 4.0 + 5; // Precomputed constants
+
+        int count = 0;
+        if (count == 0) { // Natural comparison order
+            return;
+        }
+
+        Object obj = null;
+        boolean flag = true;
+        if (obj == null &amp;&amp; flag == true) { // Natural comparison order
+            System.out.println("Both conditions met");
+        }
+    }
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html">Math (Java Platform SE 8)</a></li>
+  <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26">Assignment Operators</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9360.json
@@ -1,0 +1,25 @@
+{
+  "title": "Constant expressions and comparisons should be simplified",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "confusing",
+    "convention",
+    "clarity"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9360",
+  "sqKey": "S9360",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
## Summary
- Implements rule S9360: Constant expressions and comparisons should be simplified
- **Yoda conditions**: Detects comparisons where a literal is on the left side (`0 == count`, `null != obj`) and suggests putting the variable on the left
- **Constant Math calls**: Detects calls to deterministic `Math` methods where all arguments are compile-time literals (`Math.max(5, 10)`, `Math.sqrt(16.0)`, `Math.abs(-5)`) and suggests replacing with precomputed values
- Covers all comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
- Handles unary minus/plus in Math call arguments (e.g., `Math.abs(-10)`)
- Uses `MethodMatchers` for type-safe Math method detection with semantic analysis

## Test plan
- [x] Unit tests pass (2 tests: with semantic, non-compiling)
- [x] Sonar way profile test passes
- [ ] Ruling QA CI checks pass (ruling expectation files will be auto-generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)