### PR TITLE
SONARJAVA-6860 Upgrade the minimum Java version to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ To run tests locally follow these instructions.
 ### Java versions
 
 You need `Java 26` to compile and run the Unit Tests of the project and `Java 21` run most Integration Tests (ITs).
-Ruling test on Guava project require `Java 17`.
 Note that `Java 21` can be used to build and test all modules except under `java-checks-test-sources` (as they require `Java 26`).
 If you are adding or moving rule test samples, see [java-checks-test-sources/README.md](java-checks-test-sources/README.md)
 for guidance on when samples belong in the dedicated test-source modules instead of `java-checks/src/test/files`.

--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -109,8 +109,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>21</source>
+          <target>21</target>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
   <properties>
     <license.title>SonarQube Java</license.title>
 
-    <jdk.min.version>17</jdk.min.version>
+    <jdk.min.version>21</jdk.min.version>
 
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -169,7 +169,7 @@
           <requiredForLanguages>java,jsp,kotlin</requiredForLanguages>
           <sonarLintSupported>true</sonarLintSupported>
           <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
-          <jreMinVersion>17</jreMinVersion>
+          <jreMinVersion>21</jreMinVersion>
           <archive>
             <manifestEntries>
               <Implementation-Version>${project.version}</Implementation-Version>

--- a/sonar-java-plugin/src/main/resources/static/documentation.md
+++ b/sonar-java-plugin/src/main/resources/static/documentation.md
@@ -38,20 +38,20 @@ Key | Value
 ## Project's specific JDK
 
 In some situations, you might have to analyze a project built with a different version of Java than the one executing the analysis.
-The most common case is to run the analysis with **Java 17**, while the project itself uses **Java 11** or before for its build.
+The most common case is to run the analysis with **Java 21**, while the project itself uses **Java 17** or before for its build.
 
 If this is your case, you will need to set the `sonar.java.jdkHome` property manually to point the appropriate JDK (see below).
 By doing this you will specify which JDK classes the analyzer must refer to during the analysis.
 Not setting this property, while it would have been required, usually leads to inconsistent or even impossible to fix issues being reported, especially in relation with native JDK classes.
 
 When setting `sonar.java.jdkHome`, you need to provide the path to the JDK directory used by the project being analyzed, if different from the Java runtime executing the analysis.
-For example, for a Java 11 project, by setting it as follows: `sonar.java.jdkHome=/usr/lib/jvm/jdk11.0.22`
+For example, for a Java 17 project, by setting it as follows: `sonar.java.jdkHome=/usr/lib/jvm/jdk17.0.11`
 
 ```bash
-# Here maven uses the default version of Java on the system but we specify that we want to analyze a Java 11 project.
+# Here maven uses the default version of Java on the system but we specify that we want to analyze a Java 17 project.
 mvn clean verify sonar:sonar \
   # other analysis parameters
-  -Dsonar.java.jdkHome=/usr/lib/jvm/jdk11.0.22/
+  -Dsonar.java.jdkHome=/usr/lib/jvm/jdk17.0.11/
   # other analysis parameters
 ```
 This option can of course be added to your `sonar.properties` configuration.
@@ -150,6 +150,11 @@ where `src/main/webapp` is the directory which contains `.jsp` or Thymeleaf's `.
 The tutorial [Writing Custom Java Rules 101](https://redirect.sonarsource.com/doc/java-custom-rules-guide.html) will help to quickly start writing custom rules for Java.
 
 ### API changes
+
+#### **8.41**
+
+**Breaking**  
+The Java analyzer now requires `Java 21` to run.
 
 #### **8.22**
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
    - Upgraded minimum JDK version to `21` in `pom.xml` and custom rules example
    - Updated minimum JRE version to `21` in `sonar-java-plugin/pom.xml`
- **Documentation:**
    - Updated documentation to reflect Java 21 runtime requirement and sample JDK home paths

<sub>This will update automatically on new commits.</sub>