### PR TITLE
SONARJAVA-6687 S2129 Java: add BigDecimal(String) to exceptions

### DIFF
--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2129.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S2129.html
@@ -29,6 +29,8 @@ BigDecimal bigDecimal = new BigDecimal("42.0");
 <h3>Exceptions</h3>
 <p><code>BigDecimal</code> constructor with a <code>double</code> argument is ignored as using <code>valueOf</code> instead might change the resulting
 value. See {rule:java:S2111}.</p>
+<p><code>BigDecimal</code> constructor with a <code>String</code> argument is also ignored because <code>BigDecimal.valueOf</code> does not accept a
+<code>String</code>, leaving no equivalent alternative.</p>
 <h2>Resources</h2>
 <ul>
   <li><a href="https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html">Oracle - Learning the Java Language</a> - Autoboxing and


### PR DESCRIPTION
BigDecimal.valueOf has no String overload, so new BigDecimal(String) has no equivalent alternative and should not be flagged.

