### PR TITLE
SONARJAVA-6866 Fix S9358: Move conditional expressions inside operations

### DIFF
--- a/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/AssertThrowsInsteadOfTryCatchFailCheck.java
@@ -169,15 +169,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
         ", %s".formatted(contentFor(argument))
       ).orElse("");
 
-      return isTryBlock ?
-        new Replacements(
-          "assertThrows(%s, () -> ".formatted(typeClass(firstCaughtTypeInTry(tryStatement))),
-          "%s);".formatted(argumentsSuffix)
-        ) :
-        new Replacements(
-          "assertDoesNotThrow(() -> ",
-          "%s);".formatted(argumentsSuffix)
-        );
+      return new Replacements(
+        isTryBlock
+          ? "assertThrows(%s, () -> ".formatted(typeClass(firstCaughtTypeInTry(tryStatement)))
+          : "assertDoesNotThrow(() -> ",
+        "%s);".formatted(argumentsSuffix)
+      );
     }
 
     private Replacements assertJReplacement(
@@ -188,15 +185,12 @@ public class AssertThrowsInsteadOfTryCatchFailCheck extends IssuableSubscription
       var failureMessagePart = failArguments.isEmpty() ?
         "" :
         ".withFailMessage(%s)".formatted(contentFor(failArguments.get(0)));
-      return isTryBlock ?
-        new Replacements(
-          "assertThatCode(() -> ",
-          ")%s.isInstanceOf(%s);".formatted(failureMessagePart, typeClass(firstCaughtTypeInTry(tryStatement)))
-        ) :
-        new Replacements(
-          "assertThatCode(() -> ",
-          ")%s.doesNotThrowAnyException();".formatted(failureMessagePart)
-        );
+      return new Replacements(
+        "assertThatCode(() -> ",
+        isTryBlock
+          ? ")%s.isInstanceOf(%s);".formatted(failureMessagePart, typeClass(firstCaughtTypeInTry(tryStatement)))
+          : ")%s.doesNotThrowAnyException();".formatted(failureMessagePart)
+      );
     }
 
     private String contentFor(Tree tree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/security/AndroidMobileDatabaseEncryptionKeysCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/security/AndroidMobileDatabaseEncryptionKeysCheck.java
@@ -92,7 +92,7 @@ public class AndroidMobileDatabaseEncryptionKeysCheck extends IssuableSubscripti
 
   private void reportIssueIfHardCoded(MethodInvocationTree mit, String argName) {
     Arguments arguments = mit.arguments();
-    ExpressionTree passwordArg = arguments.size() == 1 ? arguments.get(0) : arguments.get(1);
+    ExpressionTree passwordArg = arguments.get(arguments.size() == 1 ? 0 : 1);
     reportIssueIfHardCoded(passwordArg, argName);
   }
 

--- a/java-frontend/src/main/java/org/sonar/java/model/JParser.java
+++ b/java-frontend/src/main/java/org/sonar/java/model/JParser.java
@@ -976,10 +976,11 @@ public class JParser {
     final InternalSyntaxToken closeParToken;
     if (tokenManager.get(openParTokenIndex).tokenType == TerminalToken.TokenNameLPAREN) {
       openParToken = createSyntaxToken(openParTokenIndex);
-      ASTNode closeParAnchor = e.arguments().isEmpty()
-        ? e.getName()
-        : (ASTNode) e.arguments().get(e.arguments().size() - 1);
-      closeParToken = firstTokenAfter(closeParAnchor, TerminalToken.TokenNameRPAREN);
+      closeParToken = firstTokenAfter(
+        e.arguments().isEmpty()
+          ? e.getName()
+          : (ASTNode) e.arguments().get(e.arguments().size() - 1),
+        TerminalToken.TokenNameRPAREN);
     } else {
       openParToken = null;
       closeParToken = null;
@@ -2738,11 +2739,10 @@ public class JParser {
     if (bound == null) {
       t = new JavaTree.WildcardTreeImpl(questionToken);
     } else {
-      Tree.Kind wildcardKind = e.isUpperBound() ? Tree.Kind.EXTENDS_WILDCARD : Tree.Kind.SUPER_WILDCARD;
-      TerminalToken boundTokenType = e.isUpperBound() ? TerminalToken.TokenNameextends : TerminalToken.TokenNamesuper;
+      boolean isUpperBound = e.isUpperBound();
       t = new JavaTree.WildcardTreeImpl(
-        wildcardKind,
-        firstTokenBefore(bound, boundTokenType),
+        isUpperBound ? Tree.Kind.EXTENDS_WILDCARD : Tree.Kind.SUPER_WILDCARD,
+        firstTokenBefore(bound, isUpperBound ? TerminalToken.TokenNameextends : TerminalToken.TokenNamesuper),
         convertType(bound)
       ).complete(questionToken);
     }


### PR DESCRIPTION
## Summary
- Move ternary expressions inside the common operation they feed, fixing 5 S9358 violations:
  - `AssertThrowsInsteadOfTryCatchFailCheck`: move ternary inside `Replacements` constructor (2 occurrences)
  - `AndroidMobileDatabaseEncryptionKeysCheck`: move ternary inside `arguments.get()` call
  - `JParser`: inline ternary into `firstTokenAfter()` and extract shared boolean to avoid duplicate `e.isUpperBound()` calls (2 occurrences)

## Test plan
- [x] `AssertThrowsInsteadOfTryCatchFailCheckTest` passes
- [x] `AndroidMobileDatabaseEncryptionKeysCheckTest` passes
- [x] `JParserTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Code improvements:**
    - Refactored `HashCodeMismatchedFieldsCheck` to use early `continue` statements for cleaner loop structure
    - Removed nested conditional checks in `LocalVariablesShouldNotSpanSwitchCaseGroupsCheck` using early return

<sub>This will update automatically on new commits.</sub>