### PR TITLE
SONARJAVA-6870: Fix FP in S9342 when zip stream is wrapped in custom OutputStream

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -1,5 +1,6 @@
 package checks;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -215,5 +216,38 @@ class EmptyArchiveEntryCheckSample {
     writer.write("data".getBytes());
     zos.closeEntry(); // Compliant - written through BufferedOutputStream wrapper
     zos.close();
+  }
+
+  void writeViaObjectMapperOnCustomOutputStream() throws IOException {
+    FileOutputStream fos = new FileOutputStream("archive.zip");
+    ZipOutputStream zos = new ZipOutputStream(fos);
+    zos.putNextEntry(new ZipEntry("data.json"));
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.writeValue(new NonClosingOutputStream(zos), new Object());
+    zos.closeEntry(); // Compliant - zos passed to custom OutputStream wrapper used by ObjectMapper
+    zos.close();
+  }
+
+  static class NonClosingOutputStream extends OutputStream {
+    private final OutputStream delegate;
+
+    NonClosingOutputStream(OutputStream delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      delegate.write(b, off, len);
+    }
+
+    @Override
+    public void close() {
+      // Do not close the delegate
+    }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -238,6 +238,29 @@ class EmptyArchiveEntryCheckSample {
     zos.close();
   }
 
+  void writeViaCustomOutputStreamWithCastInNestedStatement() throws IOException {
+    FileOutputStream fos = new FileOutputStream("archive.zip");
+    ZipOutputStream zos = new ZipOutputStream(fos);
+    zos.putNextEntry(new ZipEntry("data.json"));
+    if (System.currentTimeMillis() > 0) {
+      OutputStream out = new NonClosingOutputStream((OutputStream) zos);
+      out.write("data".getBytes());
+    }
+    zos.closeEntry(); // Compliant - zos passed via cast to constructor in nested statement
+    zos.close();
+  }
+
+  void writeViaMethodCallWithCastInNestedStatement() throws IOException {
+    FileOutputStream fos = new FileOutputStream("archive.zip");
+    ZipOutputStream zos = new ZipOutputStream(fos);
+    zos.putNextEntry(new ZipEntry("data.json"));
+    if (System.currentTimeMillis() > 0) {
+      writeContent((ZipOutputStream) (zos));
+    }
+    zos.closeEntry(); // Compliant - zos passed via cast and parentheses in nested statement
+    zos.close();
+  }
+
   void writeViaObjectMapperWithParenthesizedArgument() throws IOException {
     FileOutputStream fos = new FileOutputStream("archive.zip");
     ZipOutputStream zos = new ZipOutputStream(fos);

--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -261,6 +261,32 @@ class EmptyArchiveEntryCheckSample {
     zos.close();
   }
 
+  void writeViaCastReceiver() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("cast.txt"));
+    ((OutputStream) zos).write("data".getBytes());
+    zos.closeEntry(); // Compliant - written through cast receiver
+    zos.close();
+  }
+
+  void writeViaParenthesizedReceiver() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("paren.txt"));
+    (zos).write("data".getBytes());
+    zos.closeEntry(); // Compliant - written through parenthesized receiver
+    zos.close();
+  }
+
+  void writeViaCastReceiverInNestedStatement() throws IOException {
+    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream("archive.zip"));
+    zos.putNextEntry(new ZipEntry("nested-cast.txt"));
+    if (System.currentTimeMillis() > 0) {
+      ((OutputStream) zos).write("data".getBytes());
+    }
+    zos.closeEntry(); // Compliant - written through cast receiver in nested statement
+    zos.close();
+  }
+
   void writeViaObjectMapperWithParenthesizedArgument() throws IOException {
     FileOutputStream fos = new FileOutputStream("archive.zip");
     ZipOutputStream zos = new ZipOutputStream(fos);

--- a/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/EmptyArchiveEntryCheckSample.java
@@ -228,6 +228,26 @@ class EmptyArchiveEntryCheckSample {
     zos.close();
   }
 
+  void writeViaObjectMapperWithCastArgument() throws IOException {
+    FileOutputStream fos = new FileOutputStream("archive.zip");
+    ZipOutputStream zos = new ZipOutputStream(fos);
+    zos.putNextEntry(new ZipEntry("data.json"));
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.writeValue((OutputStream) zos, new Object());
+    zos.closeEntry(); // Compliant - zos passed via cast expression
+    zos.close();
+  }
+
+  void writeViaObjectMapperWithParenthesizedArgument() throws IOException {
+    FileOutputStream fos = new FileOutputStream("archive.zip");
+    ZipOutputStream zos = new ZipOutputStream(fos);
+    zos.putNextEntry(new ZipEntry("data.json"));
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.writeValue((zos), new Object());
+    zos.closeEntry(); // Compliant - zos passed via parenthesized expression
+    zos.close();
+  }
+
   static class NonClosingOutputStream extends OutputStream {
     private final OutputStream delegate;
 

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -163,18 +163,31 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
     return null;
   }
 
+  @CheckForNull
+  private static Symbol extractIdentifierSymbol(ExpressionTree expression) {
+    ExpressionTree unwrapped = ExpressionUtils.skipParentheses(expression);
+    while (unwrapped.is(Tree.Kind.TYPE_CAST)) {
+      unwrapped = ExpressionUtils.skipParentheses(((TypeCastTree) unwrapped).expression());
+    }
+    if (unwrapped.is(Tree.Kind.IDENTIFIER)) {
+      return ((IdentifierTree) unwrapped).symbol();
+    }
+    return null;
+  }
+
   private static void clearTrackedSymbolsUsedAsArguments(MethodInvocationTree mit, Map<Symbol, MethodInvocationTree> pendingEntries) {
     if (pendingEntries.isEmpty()) {
       return;
     }
     for (ExpressionTree arg : mit.arguments()) {
-      ExpressionTree unwrapped = ExpressionUtils.skipParentheses(arg);
-      while (unwrapped.is(Tree.Kind.TYPE_CAST)) {
-        unwrapped = ExpressionUtils.skipParentheses(((TypeCastTree) unwrapped).expression());
-      }
-      if (unwrapped.is(Tree.Kind.IDENTIFIER)) {
-        pendingEntries.remove(((IdentifierTree) unwrapped).symbol());
+      Symbol symbol = extractIdentifierSymbol(arg);
+      if (symbol != null) {
+        pendingEntries.remove(symbol);
       } else {
+        ExpressionTree unwrapped = ExpressionUtils.skipParentheses(arg);
+        while (unwrapped.is(Tree.Kind.TYPE_CAST)) {
+          unwrapped = ExpressionUtils.skipParentheses(((TypeCastTree) unwrapped).expression());
+        }
         removeUsedSymbols(unwrapped, pendingEntries);
       }
     }
@@ -206,29 +219,23 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
       if (receiver != null && pendingEntries.containsKey(receiver) && WRITE.matches(mit)) {
         usedSymbols.add(receiver);
       }
-      // Check if any tracked symbol is passed as argument
-      for (ExpressionTree arg : mit.arguments()) {
-        if (arg.is(Tree.Kind.IDENTIFIER)) {
-          Symbol argSymbol = ((IdentifierTree) arg).symbol();
-          if (pendingEntries.containsKey(argSymbol)) {
-            usedSymbols.add(argSymbol);
-          }
-        }
-      }
+      collectTrackedArgumentSymbols(mit.arguments());
       super.visitMethodInvocation(mit);
     }
 
     @Override
     public void visitNewClass(NewClassTree tree) {
-      for (ExpressionTree arg : tree.arguments()) {
-        if (arg.is(Tree.Kind.IDENTIFIER)) {
-          Symbol argSymbol = ((IdentifierTree) arg).symbol();
-          if (pendingEntries.containsKey(argSymbol)) {
-            usedSymbols.add(argSymbol);
-          }
+      collectTrackedArgumentSymbols(tree.arguments());
+      super.visitNewClass(tree);
+    }
+
+    private void collectTrackedArgumentSymbols(List<ExpressionTree> arguments) {
+      for (ExpressionTree arg : arguments) {
+        Symbol argSymbol = extractIdentifierSymbol(arg);
+        if (argSymbol != null && pendingEntries.containsKey(argSymbol)) {
+          usedSymbols.add(argSymbol);
         }
       }
-      super.visitNewClass(tree);
     }
 
     @Override

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -184,11 +184,7 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
       if (symbol != null) {
         pendingEntries.remove(symbol);
       } else {
-        ExpressionTree unwrapped = ExpressionUtils.skipParentheses(arg);
-        while (unwrapped.is(Tree.Kind.TYPE_CAST)) {
-          unwrapped = ExpressionUtils.skipParentheses(((TypeCastTree) unwrapped).expression());
-        }
-        removeUsedSymbols(unwrapped, pendingEntries);
+        removeUsedSymbols(arg, pendingEntries);
       }
     }
   }
@@ -197,9 +193,9 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
   private static Symbol getReceiverSymbol(MethodInvocationTree mit) {
     ExpressionTree methodSelect = mit.methodSelect();
     if (methodSelect.is(Tree.Kind.MEMBER_SELECT)) {
-      ExpressionTree expression = ((MemberSelectExpressionTree) methodSelect).expression();
-      if (expression.is(Tree.Kind.IDENTIFIER) && !((IdentifierTree) expression).symbol().isUnknown()) {
-        return ((IdentifierTree) expression).symbol();
+      Symbol symbol = extractIdentifierSymbol(((MemberSelectExpressionTree) methodSelect).expression());
+      if (symbol != null && !symbol.isUnknown()) {
+        return symbol;
       }
     }
     return null;

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -39,6 +39,7 @@ import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.StatementTree;
 import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TypeCastTree;
 import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S9342")
@@ -110,11 +111,13 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
     if (pendingEntries.isEmpty()) {
       return;
     }
+    removeUsedSymbols(statement, pendingEntries);
+  }
+
+  private static void removeUsedSymbols(Tree tree, Map<Symbol, MethodInvocationTree> pendingEntries) {
     TrackedSymbolVisitor visitor = new TrackedSymbolVisitor(pendingEntries);
-    statement.accept(visitor);
-    for (Symbol used : visitor.usedSymbols) {
-      pendingEntries.remove(used);
-    }
+    tree.accept(visitor);
+    visitor.usedSymbols.forEach(pendingEntries::remove);
   }
 
   @CheckForNull
@@ -165,14 +168,14 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
       return;
     }
     for (ExpressionTree arg : mit.arguments()) {
-      if (arg.is(Tree.Kind.IDENTIFIER)) {
-        pendingEntries.remove(((IdentifierTree) arg).symbol());
+      ExpressionTree unwrapped = ExpressionUtils.skipParentheses(arg);
+      while (unwrapped.is(Tree.Kind.TYPE_CAST)) {
+        unwrapped = ExpressionUtils.skipParentheses(((TypeCastTree) unwrapped).expression());
+      }
+      if (unwrapped.is(Tree.Kind.IDENTIFIER)) {
+        pendingEntries.remove(((IdentifierTree) unwrapped).symbol());
       } else {
-        TrackedSymbolVisitor visitor = new TrackedSymbolVisitor(pendingEntries);
-        arg.accept(visitor);
-        for (Symbol used : visitor.usedSymbols) {
-          pendingEntries.remove(used);
-        }
+        removeUsedSymbols(unwrapped, pendingEntries);
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/EmptyArchiveEntryCheck.java
@@ -161,10 +161,18 @@ public class EmptyArchiveEntryCheck extends IssuableSubscriptionVisitor {
   }
 
   private static void clearTrackedSymbolsUsedAsArguments(MethodInvocationTree mit, Map<Symbol, MethodInvocationTree> pendingEntries) {
+    if (pendingEntries.isEmpty()) {
+      return;
+    }
     for (ExpressionTree arg : mit.arguments()) {
       if (arg.is(Tree.Kind.IDENTIFIER)) {
-        Symbol argSymbol = ((IdentifierTree) arg).symbol();
-        pendingEntries.remove(argSymbol);
+        pendingEntries.remove(((IdentifierTree) arg).symbol());
+      } else {
+        TrackedSymbolVisitor visitor = new TrackedSymbolVisitor(pendingEntries);
+        arg.accept(visitor);
+        for (Symbol used : visitor.usedSymbols) {
+          pendingEntries.remove(used);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add test example for S9342 where `ObjectMapper.writeValue` writes to a custom `OutputStream` wrapping a `ZipOutputStream`
- Fix `clearTrackedSymbolsUsedAsArguments` to deeply scan non-identifier arguments (e.g., `new CustomOutputStream(zos)`) for tracked symbol usage, preventing false positives when the zip stream is nested inside a constructor call within a method argument

## Test plan
- [x] Existing `EmptyArchiveEntryCheckTest` passes (both with and without semantic)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)