### PR TITLE
SONARJAVA-6874 S9351: Fix FPs on null checks and normalized scales

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/BigDecimalEqualsCheckGuavaSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/BigDecimalEqualsCheckGuavaSample.java
@@ -14,6 +14,11 @@ class BigDecimalEqualsCheckGuavaSample {
 
     // Compliant
     res = com.google.common.base.Objects.equal(s, "hello");
+    res = com.google.common.base.Objects.equal(null, s);
+    res = com.google.common.base.Objects.equal(s, null);
+    res = com.google.common.base.Objects.equal(null, a);
+    res = com.google.common.base.Objects.equal(a, null);
+    res = com.google.common.base.Objects.equal(a.setScale(2), b.setScale(2));
   }
 
   static class AccountWithGuavaEquals {

--- a/java-checks-test-sources/default/src/main/java/checks/BigDecimalEqualsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/BigDecimalEqualsCheckSample.java
@@ -84,6 +84,7 @@ class BigDecimalEqualsCheckSample {
 
     void testCustom(MyBigDecimal other) {
       boolean r = this.equals(other); // Noncompliant
+      r = this.setScale(2).equals(other.setScale(2));
     }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/BigDecimalEqualsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/BigDecimalEqualsCheckSample.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 
 class BigDecimalEqualsCheckSample {
 
-  void method(BigDecimal a, BigDecimal b, Object o, String s) {
+  private static final int SCALE = 2;
+
+  void method(BigDecimal a, BigDecimal b, Object o, String s, int runtimeScaleA, int runtimeScaleB) {
     boolean res;
 
     res = a.equals(b); // Noncompliant [["BigDecimal.equals()" compares scale as well as value; use "compareTo() == 0" for numerical comparison.]]
@@ -18,6 +20,11 @@ class BigDecimalEqualsCheckSample {
 //                ^^^^^^
     res = Objects.equals(a, o); // Noncompliant
     res = Objects.equals(o, a); // Noncompliant
+    res = a.setScale(2).equals(b); // Noncompliant
+    res = a.equals(b.setScale(2)); // Noncompliant
+    res = a.setScale(2).equals(b.setScale(3)); // Noncompliant
+    res = a.setScale(runtimeScaleA).equals(b.setScale(runtimeScaleB)); // Noncompliant
+    res = Objects.equals(a.setScale(2), b); // Noncompliant
 
     // Compliant
     res = a.compareTo(b) == 0;
@@ -26,6 +33,16 @@ class BigDecimalEqualsCheckSample {
     res = s.equals(a);
     res = s.equals("hello");
     res = Objects.equals(s, "hello");
+    res = Objects.equals(null, s);
+    res = Objects.equals(s, null);
+    res = Objects.equals(null, a);
+    res = Objects.equals(a, null);
+    res = Objects.equals((null), s);
+    res = a.setScale(2).equals(b.setScale(2));
+    res = a.setScale(2, java.math.RoundingMode.UP).equals(b.setScale(2, java.math.RoundingMode.DOWN));
+    res = a.setScale(SCALE, java.math.RoundingMode.HALF_UP).equals(b.setScale(SCALE, java.math.RoundingMode.HALF_UP));
+    res = (a.setScale(2)).equals((b.setScale(2)));
+    res = Objects.equals(a.setScale(2), b.setScale(2));
   }
 
   static class Account {

--- a/java-checks/src/main/java/org/sonar/java/checks/BigDecimalEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/BigDecimalEqualsCheck.java
@@ -18,6 +18,7 @@ package org.sonar.java.checks;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.MethodTreeUtils;
 import org.sonar.java.model.ExpressionUtils;
@@ -25,6 +26,8 @@ import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.MethodMatchers;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.Arguments;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -48,6 +51,14 @@ public class BigDecimalEqualsCheck extends IssuableSubscriptionVisitor {
     .addParametersMatcher(JAVA_LANG_OBJECT, JAVA_LANG_OBJECT)
     .build();
 
+  private static final MethodMatchers SET_SCALE = MethodMatchers.create()
+    .ofTypes(BIG_DECIMAL)
+    .names("setScale")
+    .addParametersMatcher("int")
+    .addParametersMatcher("int", "int")
+    .addParametersMatcher("int", "java.math.RoundingMode")
+    .build();
+
   @Override
   public List<Tree.Kind> nodesToVisit() {
     return Collections.singletonList(Tree.Kind.METHOD_INVOCATION);
@@ -60,15 +71,43 @@ public class BigDecimalEqualsCheck extends IssuableSubscriptionVisitor {
       return;
     }
     if (INSTANCE_EQUALS.matches(mit)) {
-      reportIssue(ExpressionUtils.methodName(mit), MESSAGE);
+      if (!hasSameKnownScale(mit)) {
+        reportIssue(ExpressionUtils.methodName(mit), MESSAGE);
+      }
     } else if (STATIC_EQUALS.matches(mit)) {
       Arguments arguments = mit.arguments();
       Type firstType = arguments.get(0).symbolType();
       Type secondType = arguments.get(1).symbolType();
-      if (isBigDecimal(firstType) || isBigDecimal(secondType)) {
+      if (!hasNullArgument(arguments)
+        && (isBigDecimal(firstType) || isBigDecimal(secondType))
+        && !hasSameKnownScale(arguments.get(0), arguments.get(1))) {
         reportIssue(ExpressionUtils.methodName(mit), MESSAGE);
       }
     }
+  }
+
+  private static boolean hasNullArgument(Arguments arguments) {
+    return arguments.stream().anyMatch(ExpressionUtils::isNullLiteral);
+  }
+
+  private static boolean hasSameKnownScale(MethodInvocationTree invocation) {
+    if (invocation.methodSelect() instanceof MemberSelectExpressionTree memberSelect) {
+      return hasSameKnownScale(memberSelect.expression(), invocation.arguments().get(0));
+    }
+    return false;
+  }
+
+  private static boolean hasSameKnownScale(ExpressionTree first, ExpressionTree second) {
+    Optional<Integer> firstScale = setScale(first);
+    return firstScale.isPresent() && firstScale.equals(setScale(second));
+  }
+
+  private static Optional<Integer> setScale(ExpressionTree expression) {
+    ExpressionTree unwrapped = ExpressionUtils.skipParentheses(expression);
+    if (unwrapped instanceof MethodInvocationTree invocation && SET_SCALE.matches(invocation)) {
+      return invocation.arguments().get(0).asConstant(Integer.class);
+    }
+    return Optional.empty();
   }
 
   private static boolean isBigDecimal(Type type) {

--- a/java-checks/src/main/java/org/sonar/java/checks/BigDecimalEqualsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/BigDecimalEqualsCheck.java
@@ -104,7 +104,7 @@ public class BigDecimalEqualsCheck extends IssuableSubscriptionVisitor {
 
   private static Optional<Integer> setScale(ExpressionTree expression) {
     ExpressionTree unwrapped = ExpressionUtils.skipParentheses(expression);
-    if (unwrapped instanceof MethodInvocationTree invocation && SET_SCALE.matches(invocation)) {
+    if (unwrapped instanceof MethodInvocationTree invocation && SET_SCALE.matches(invocation.methodSymbol())) {
       return invocation.arguments().get(0).asConstant(Integer.class);
     }
     return Optional.empty();


### PR DESCRIPTION
Fixes [SONARJAVA-6874](https://sonarsource.atlassian.net/browse/SONARJAVA-6874).

## Summary

- Ignore `Objects.equals` and Guava `Objects.equal` calls when either operand is a null literal.
- Ignore equality comparisons between two resolved `BigDecimal.setScale` calls with the same compile-time scale.
- Keep one-sided, differing-scale, runtime-scale, and unresolved cases noncompliant.

## Test

- `mvn -pl java-checks -Dtest=BigDecimalEqualsCheckTest test`

[RC-289]: https://sonarsource.atlassian.net/browse/RC-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SONARJAVA-6874]: https://sonarsource.atlassian.net/browse/SONARJAVA-6874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ