### PR TITLE
SONARJAVA-5397 Support the import of custom checkstyle issues

### DIFF
--- a/external-reports/src/main/java/org/sonar/java/externalreport/CheckstyleXmlReportReader.java
+++ b/external-reports/src/main/java/org/sonar/java/externalreport/CheckstyleXmlReportReader.java
@@ -112,6 +112,10 @@ class CheckstyleXmlReportReader {
     String source = getAttributeValue(element, SOURCE);
     String line = getAttributeValue(element, LINE);
     String message = getAttributeValue(element, MESSAGE);
+    if (source.isEmpty()) {
+      LOG.debug("Unexpected error without rule key (missing 'source' attribute).");
+      return;
+    }
     if (message.isEmpty()) {
       LOG.debug("Unexpected error without message for rule: '{}'", source);
       return;

--- a/external-reports/src/main/java/org/sonar/java/externalreport/CheckstyleXmlReportReader.java
+++ b/external-reports/src/main/java/org/sonar/java/externalreport/CheckstyleXmlReportReader.java
@@ -112,15 +112,11 @@ class CheckstyleXmlReportReader {
     String source = getAttributeValue(element, SOURCE);
     String line = getAttributeValue(element, LINE);
     String message = getAttributeValue(element, MESSAGE);
-    if (!source.startsWith(CHECKSTYLE_PREFIX)) {
-      LOG.debug("Unexpected rule key without '{}' prefix: '{}'", CHECKSTYLE_PREFIX, source);
-      return;
-    }
     if (message.isEmpty()) {
       LOG.debug("Unexpected error without message for rule: '{}'", source);
       return;
     }
-    String key = source.substring(CHECKSTYLE_PREFIX.length());
+    String key = source.startsWith(CHECKSTYLE_PREFIX) ? source.substring(CHECKSTYLE_PREFIX.length()) : source;
     consumer.onError(context, inputFile, key, line, message);
   }
 

--- a/external-reports/src/test/java/org/sonar/java/externalreport/CheckstyleSensorTest.java
+++ b/external-reports/src/test/java/org/sonar/java/externalreport/CheckstyleSensorTest.java
@@ -155,7 +155,7 @@ class CheckstyleSensorTest {
   @Test
   void issues_when_xml_file_has_errors() throws IOException {
     List<ExternalIssue> externalIssues = executeSensorImporting("checkstyle-with-errors.xml");
-    assertThat(externalIssues).hasSize(1);
+    assertThat(externalIssues).hasSize(2);
 
     ExternalIssue first = externalIssues.get(0);
     assertThat(first.primaryLocation().inputComponent().key()).isEqualTo("checkstyle-project:Main.java");
@@ -165,13 +165,22 @@ class CheckstyleSensorTest {
     assertThat(first.primaryLocation().message()).isEqualTo("Error at file level with an unknown rule key.");
     assertThat(first.primaryLocation().textRange()).isNull();
 
+    ExternalIssue second = externalIssues.get(1);
+    assertThat(second.primaryLocation().inputComponent().key()).isEqualTo("checkstyle-project:A.java");
+    assertThat(second.engineId()).isEqualTo("checkstyle");
+    assertThat(second.ruleId()).isEqualTo("com.example.CustomCheck");
+    assertThat(second.ruleKey().rule()).isEqualTo("com.example.CustomCheck");
+    assertThat(second.type()).isEqualTo(RuleType.CODE_SMELL);
+    assertThat(second.severity()).isEqualTo(Severity.MAJOR);
+    assertThat(second.primaryLocation().message()).isEqualTo("Custom rule issue.");
+    assertThat(second.primaryLocation().textRange().start().line()).isEqualTo(1);
+
     assertThat(logTester.logs(Level.ERROR)).isEmpty();
     assertThat(onlyOneLogElement(logTester.logs(Level.WARN)))
       .startsWith("No input file found for '")
       .endsWith("not-existing-file.java'. No checkstyle issues will be imported on this file.");
-    assertThat(logTester.logs(Level.DEBUG)).containsExactlyInAnyOrder(
-      "Unexpected error without message for rule: 'com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck'",
-      "Unexpected rule key without 'com.puppycrawl.tools.checkstyle.checks.' prefix: 'invalid-format'");
+    assertThat(logTester.logs(Level.DEBUG)).containsExactly(
+      "Unexpected error without message for rule: 'com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck'");
   }
 
   private List<ExternalIssue> executeSensorImporting(@Nullable String fileName) throws IOException {

--- a/external-reports/src/test/resources/checkstyle/checkstyle-with-errors.xml
+++ b/external-reports/src/test/resources/checkstyle/checkstyle-with-errors.xml
@@ -12,6 +12,6 @@
 	<error message="Error at file level with an unknown rule key." source="com.puppycrawl.tools.checkstyle.checks.UnknownRuleKey" />
 </file>
 <file name="${PROJECT_DIR}A.java">
-	<error line="1" column="1" severity="error" message="Unsupported rule key format." source="invalid-format" />
+	<error line="1" column="1" severity="error" message="Custom rule issue." source="com.example.CustomCheck" />
 </file>
 </checkstyle>


### PR DESCRIPTION
----
## Summary by Gitar

- **External Reports:**
    - Added support for importing custom checkstyle issues without the standard prefix in `CheckstyleXmlReportReader.java`

<sub>This will update automatically on new commits.</sub>