### PR TITLE
SONARJAVA-6888: Extend S9133 with additional mathematical constants

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/HardcodedMathConstantCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/HardcodedMathConstantCheckSample.java
@@ -27,23 +27,22 @@ class HardcodedMathConstantCheckSample {
   double ln2_3 = 0.69314; // Noncompliant {{Use "Math.log(2)" instead of this approximation of the natural logarithm of 2.}}
   double ln2_4 = 0.693147; // Noncompliant {{Use "Math.log(2)" instead of this approximation of the natural logarithm of 2.}}
 
-  // sqrt(3) approximations (3+ significant digits)
-  double sqrt3_0 = 1.73; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
+  // sqrt(3) approximations (4+ significant digits required)
   double sqrt3_1 = 1.732; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
   double sqrt3_2 = 1.73205; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
   double sqrt3_3 = 1.7320508; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
 
-  // ln(10) approximations (3+ significant digits)
+  // ln(10) approximations (4+ significant digits required)
   double ln10_1 = 2.302; // Noncompliant {{Use "Math.log(10)" instead of this approximation of the natural logarithm of 10.}}
   double ln10_2 = 2.30258; // Noncompliant {{Use "Math.log(10)" instead of this approximation of the natural logarithm of 10.}}
   double ln10_3 = 2.302585; // Noncompliant {{Use "Math.log(10)" instead of this approximation of the natural logarithm of 10.}}
 
-  // log10(e) approximations (3+ significant digits)
-  double log10e_1 = 0.434; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
-  double log10e_2 = 0.43429; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
-  double log10e_3 = 0.4342944; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
+  // log10(e) approximations (4+ significant digits required)
+  double log10e_2 = 0.4343; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
+  double log10e_3 = 0.43429; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
+  double log10e_4 = 0.4342944; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
 
-  // phi (golden ratio) approximations (3+ significant digits)
+  // phi (golden ratio) approximations (4+ significant digits required)
   double phi_1 = 1.618; // Noncompliant {{Use "(1 + Math.sqrt(5)) / 2" instead of this approximation of the golden ratio.}}
   double phi_2 = 1.61803; // Noncompliant {{Use "(1 + Math.sqrt(5)) / 2" instead of this approximation of the golden ratio.}}
   double phi_3 = 1.618034; // Noncompliant {{Use "(1 + Math.sqrt(5)) / 2" instead of this approximation of the golden ratio.}}
@@ -113,6 +112,12 @@ class HardcodedMathConstantCheckSample {
   double tooImprecise3 = 2.7;
   double tooImprecise4 = 1.4;
   double tooImprecise5 = 0.69;
+
+  // Compliant - only 3 significant digits for constants requiring 4
+  double price = 2.30;
+  double measurement = 1.73;
+  double ratio = 1.62;
+  double factor = 0.434;
 
   // Compliant - outside tolerance (with 3 significant digits)
   double outsideTolerance1 = 3.16;

--- a/java-checks-test-sources/default/src/main/java/checks/HardcodedMathConstantCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/HardcodedMathConstantCheckSample.java
@@ -27,6 +27,27 @@ class HardcodedMathConstantCheckSample {
   double ln2_3 = 0.69314; // Noncompliant {{Use "Math.log(2)" instead of this approximation of the natural logarithm of 2.}}
   double ln2_4 = 0.693147; // Noncompliant {{Use "Math.log(2)" instead of this approximation of the natural logarithm of 2.}}
 
+  // sqrt(3) approximations (3+ significant digits)
+  double sqrt3_0 = 1.73; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
+  double sqrt3_1 = 1.732; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
+  double sqrt3_2 = 1.73205; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
+  double sqrt3_3 = 1.7320508; // Noncompliant {{Use "Math.sqrt(3)" instead of this approximation of the square root of 3.}}
+
+  // ln(10) approximations (3+ significant digits)
+  double ln10_1 = 2.302; // Noncompliant {{Use "Math.log(10)" instead of this approximation of the natural logarithm of 10.}}
+  double ln10_2 = 2.30258; // Noncompliant {{Use "Math.log(10)" instead of this approximation of the natural logarithm of 10.}}
+  double ln10_3 = 2.302585; // Noncompliant {{Use "Math.log(10)" instead of this approximation of the natural logarithm of 10.}}
+
+  // log10(e) approximations (3+ significant digits)
+  double log10e_1 = 0.434; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
+  double log10e_2 = 0.43429; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
+  double log10e_3 = 0.4342944; // Noncompliant {{Use "Math.log10(Math.E)" instead of this approximation of the base-10 logarithm of Euler's number.}}
+
+  // phi (golden ratio) approximations (3+ significant digits)
+  double phi_1 = 1.618; // Noncompliant {{Use "(1 + Math.sqrt(5)) / 2" instead of this approximation of the golden ratio.}}
+  double phi_2 = 1.61803; // Noncompliant {{Use "(1 + Math.sqrt(5)) / 2" instead of this approximation of the golden ratio.}}
+  double phi_3 = 1.618034; // Noncompliant {{Use "(1 + Math.sqrt(5)) / 2" instead of this approximation of the golden ratio.}}
+
   // Float literals
   float piFloat = 3.14159f; // Noncompliant {{Use "Math.PI" instead of this approximation of pi.}}
   float eFloat = 2.718f; // Noncompliant {{Use "Math.E" instead of this approximation of Euler's number.}}
@@ -68,7 +89,11 @@ class HardcodedMathConstantCheckSample {
   double compliantPi = Math.PI;
   double compliantE = Math.E;
   double compliantSqrt2 = Math.sqrt(2);
+  double compliantSqrt3 = Math.sqrt(3);
   double compliantLn2 = Math.log(2);
+  double compliantLn10 = Math.log(10);
+  double compliantLog10e = Math.log10(Math.E);
+  double compliantPhi = (1 + Math.sqrt(5)) / 2;
   double compliantStrictPi = StrictMath.PI;
   double compliantStrictE = StrictMath.E;
 

--- a/java-checks/src/main/java/org/sonar/java/checks/HardcodedMathConstantCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/HardcodedMathConstantCheck.java
@@ -31,7 +31,11 @@ public class HardcodedMathConstantCheck extends IssuableSubscriptionVisitor {
     PI(Math.PI, "Math.PI", "pi"),
     E(Math.E, "Math.E", "Euler's number"),
     SQRT2(Math.sqrt(2), "Math.sqrt(2)", "the square root of 2"),
-    LN2(Math.log(2), "Math.log(2)", "the natural logarithm of 2");
+    SQRT3(Math.sqrt(3), "Math.sqrt(3)", "the square root of 3"),
+    LN2(Math.log(2), "Math.log(2)", "the natural logarithm of 2"),
+    LN10(Math.log(10), "Math.log(10)", "the natural logarithm of 10"),
+    LOG10E(Math.log10(Math.E), "Math.log10(Math.E)", "the base-10 logarithm of Euler's number"),
+    PHI((1 + Math.sqrt(5)) / 2, "(1 + Math.sqrt(5)) / 2", "the golden ratio");
 
     final double value;
     final String replacement;

--- a/java-checks/src/main/java/org/sonar/java/checks/HardcodedMathConstantCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/HardcodedMathConstantCheck.java
@@ -25,26 +25,32 @@ import org.sonar.plugins.java.api.tree.Tree;
 @Rule(key = "S9133")
 public class HardcodedMathConstantCheck extends IssuableSubscriptionVisitor {
 
-  private static final int MIN_SIGNIFICANT_DIGITS = 3;
+  private static final int DEFAULT_MIN_SIGNIFICANT_DIGITS = 3;
 
   private enum MathConstant {
     PI(Math.PI, "Math.PI", "pi"),
     E(Math.E, "Math.E", "Euler's number"),
     SQRT2(Math.sqrt(2), "Math.sqrt(2)", "the square root of 2"),
-    SQRT3(Math.sqrt(3), "Math.sqrt(3)", "the square root of 3"),
+    SQRT3(Math.sqrt(3), "Math.sqrt(3)", "the square root of 3", 4),
     LN2(Math.log(2), "Math.log(2)", "the natural logarithm of 2"),
-    LN10(Math.log(10), "Math.log(10)", "the natural logarithm of 10"),
-    LOG10E(Math.log10(Math.E), "Math.log10(Math.E)", "the base-10 logarithm of Euler's number"),
-    PHI((1 + Math.sqrt(5)) / 2, "(1 + Math.sqrt(5)) / 2", "the golden ratio");
+    LN10(Math.log(10), "Math.log(10)", "the natural logarithm of 10", 4),
+    LOG10E(Math.log10(Math.E), "Math.log10(Math.E)", "the base-10 logarithm of Euler's number", 4),
+    PHI((1 + Math.sqrt(5)) / 2, "(1 + Math.sqrt(5)) / 2", "the golden ratio", 4);
 
     final double value;
     final String replacement;
     final String description;
+    final int minSignificantDigits;
 
     MathConstant(double value, String replacement, String description) {
+      this(value, replacement, description, DEFAULT_MIN_SIGNIFICANT_DIGITS);
+    }
+
+    MathConstant(double value, String replacement, String description, int minSignificantDigits) {
       this.value = value;
       this.replacement = replacement;
       this.description = description;
+      this.minSignificantDigits = minSignificantDigits;
     }
   }
 
@@ -76,7 +82,7 @@ public class HardcodedMathConstantCheck extends IssuableSubscriptionVisitor {
     }
 
     int significantDigits = countSignificantDigits(normalized);
-    if (significantDigits < MIN_SIGNIFICANT_DIGITS) {
+    if (significantDigits < DEFAULT_MIN_SIGNIFICANT_DIGITS) {
       return;
     }
 
@@ -85,6 +91,9 @@ public class HardcodedMathConstantCheck extends IssuableSubscriptionVisitor {
     double relativeTolerance = 5.0 * Math.pow(10, -significantDigits);
 
     for (MathConstant constant : MathConstant.values()) {
+      if (significantDigits < constant.minSignificantDigits) {
+        continue;
+      }
       double relativeError = Math.abs(absoluteValue - constant.value) / constant.value;
       if (relativeError < relativeTolerance) {
         reportIssue(tree, "Use \"" + constant.replacement + "\" instead of this approximation of " + constant.description + ".");

--- a/java-checks/src/test/java/org/sonar/java/checks/HardcodedMathConstantCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/HardcodedMathConstantCheckTest.java
@@ -31,4 +31,13 @@ class HardcodedMathConstantCheckTest {
       .verifyIssues();
   }
 
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/HardcodedMathConstantCheckSample.java"))
+      .withCheck(new HardcodedMathConstantCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9133.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9133.html
@@ -14,14 +14,18 @@ quality.</p>
 <p>Common constants that are frequently approximated include:</p>
 <ul>
   <li>π (pi): approximately 3.14159…​ - available as a predefined constant in standard mathematical libraries</li>
-  <li>e (Euler’s number): approximately 2.71828…​ - available as a predefined constant in standard mathematical libraries</li>
+  <li>e (Euler's number): approximately 2.71828…​ - available as a predefined constant in standard mathematical libraries</li>
   <li>√2: approximately 1.41421…​ - can be computed using library functions that calculate square roots of literal values</li>
+  <li>√3: approximately 1.73205…​ - can be computed using library functions that calculate square roots of literal values</li>
   <li>ln(2): approximately 0.69314…​ - can be computed using library functions that calculate natural logarithms of literal values</li>
+  <li>ln(10): approximately 2.30258…​ - can be computed using library functions that calculate natural logarithms of literal values</li>
+  <li>log₁₀(e): approximately 0.43429…​ - can be computed using library functions that calculate base-10 logarithms</li>
+  <li>φ (golden ratio): approximately 1.61803…​ - can be computed as <code>(1 + √5) / 2</code></li>
 </ul>
 <p>If a literal value happens to be close to one of these constants but represents something else entirely, such as a version number or a
 domain-specific threshold, mark the issue as won’t-fix.</p>
 <p>In Java, these constants and functions are available in the <code>Math</code> class: <code>Math.PI</code>, <code>Math.E</code>,
-<code>Math.sqrt(2)</code>, and <code>Math.log(2)</code>.</p>
+<code>Math.sqrt(2)</code>, <code>Math.sqrt(3)</code>, <code>Math.log(2)</code>, <code>Math.log(10)</code>, and <code>Math.log10(Math.E)</code>.</p>
 <h3>What is the potential impact?</h3>
 <p>Using hard-coded approximations instead of predefined constants reduces code quality in three main ways:</p>
 <ul>
@@ -34,8 +38,9 @@ domain-specific threshold, mark the issue as won’t-fix.</p>
 </ul>
 <h2>How to fix it</h2>
 <p>Replace hard-coded numeric approximations with the appropriate predefined constant from the <code>Math</code> class. For π, use
-<code>Math.PI</code>. For Euler’s number, use <code>Math.E</code>. For other common constants that don’t have direct equivalents, use mathematical
-expressions like <code>Math.sqrt(2)</code> or <code>Math.log(2)</code>.</p>
+<code>Math.PI</code>. For Euler's number, use <code>Math.E</code>. For other common constants that don't have direct equivalents, use mathematical
+expressions like <code>Math.sqrt(2)</code>, <code>Math.sqrt(3)</code>, <code>Math.log(2)</code>, <code>Math.log(10)</code>,
+<code>Math.log10(Math.E)</code>, or <code>(1 + Math.sqrt(5)) / 2</code> for the golden ratio.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9133.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9133.html
@@ -14,18 +14,14 @@ quality.</p>
 <p>Common constants that are frequently approximated include:</p>
 <ul>
   <li>π (pi): approximately 3.14159…​ - available as a predefined constant in standard mathematical libraries</li>
-  <li>e (Euler's number): approximately 2.71828…​ - available as a predefined constant in standard mathematical libraries</li>
+  <li>e (Euler’s number): approximately 2.71828…​ - available as a predefined constant in standard mathematical libraries</li>
   <li>√2: approximately 1.41421…​ - can be computed using library functions that calculate square roots of literal values</li>
-  <li>√3: approximately 1.73205…​ - can be computed using library functions that calculate square roots of literal values</li>
   <li>ln(2): approximately 0.69314…​ - can be computed using library functions that calculate natural logarithms of literal values</li>
-  <li>ln(10): approximately 2.30258…​ - can be computed using library functions that calculate natural logarithms of literal values</li>
-  <li>log₁₀(e): approximately 0.43429…​ - can be computed using library functions that calculate base-10 logarithms</li>
-  <li>φ (golden ratio): approximately 1.61803…​ - can be computed as <code>(1 + √5) / 2</code></li>
 </ul>
 <p>If a literal value happens to be close to one of these constants but represents something else entirely, such as a version number or a
 domain-specific threshold, mark the issue as won’t-fix.</p>
 <p>In Java, these constants and functions are available in the <code>Math</code> class: <code>Math.PI</code>, <code>Math.E</code>,
-<code>Math.sqrt(2)</code>, <code>Math.sqrt(3)</code>, <code>Math.log(2)</code>, <code>Math.log(10)</code>, and <code>Math.log10(Math.E)</code>.</p>
+<code>Math.sqrt(2)</code>, and <code>Math.log(2)</code>.</p>
 <h3>What is the potential impact?</h3>
 <p>Using hard-coded approximations instead of predefined constants reduces code quality in three main ways:</p>
 <ul>
@@ -38,9 +34,8 @@ domain-specific threshold, mark the issue as won’t-fix.</p>
 </ul>
 <h2>How to fix it</h2>
 <p>Replace hard-coded numeric approximations with the appropriate predefined constant from the <code>Math</code> class. For π, use
-<code>Math.PI</code>. For Euler's number, use <code>Math.E</code>. For other common constants that don't have direct equivalents, use mathematical
-expressions like <code>Math.sqrt(2)</code>, <code>Math.sqrt(3)</code>, <code>Math.log(2)</code>, <code>Math.log(10)</code>,
-<code>Math.log10(Math.E)</code>, or <code>(1 + Math.sqrt(5)) / 2</code> for the golden ratio.</p>
+<code>Math.PI</code>. For Euler’s number, use <code>Math.E</code>. For other common constants that don’t have direct equivalents, use mathematical
+expressions like <code>Math.sqrt(2)</code> or <code>Math.log(2)</code>.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">


### PR DESCRIPTION
## Summary
- Add detection for 4 new mathematical constants: √3 (`Math.sqrt(3)`), ln(10) (`Math.log(10)`), log₁₀(e) (`Math.log10(Math.E)`), and φ/golden ratio (`(1 + Math.sqrt(5)) / 2`)
- Add without-semantic test to prevent false positives when dependencies are missing
- Update rule HTML documentation to list all detected constants

## Test plan
- [x] Unit tests pass (with and without semantic)
- [ ] CI passes
- [ ] Ruling tests may need baseline updates for new detections

🤖 Generated with [Claude Code](https://claude.com/claude-code)