### PR TITLE
SONARJAVA-6891 Remove redundant logging dependency handling

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -63,17 +63,6 @@
         "/^org\\.apache\\.tomcat(?:\\.|:)/"
       ],
       "allowedVersions": "/^9\\./"
-    },
-    {
-      "description": "Major SLF4J version changes can create incompatibilities, so we prefer to update it manually.",
-      "matchPackageNames": [
-        "org.slf4j:**",
-        "org.slf4j"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "enabled": false
     }
   ]
 }

--- a/check-list/pom.xml
+++ b/check-list/pom.xml
@@ -23,11 +23,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>java-checks</artifactId>
         <version>${project.version}</version>

--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -28,6 +28,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>sonar-java-plugin</artifactId>
       <type>sonar-plugin</type>

--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -28,11 +28,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>sonar-java-plugin</artifactId>
       <type>sonar-plugin</type>

--- a/docs/java-custom-rules-example/pom.xml
+++ b/docs/java-custom-rules-example/pom.xml
@@ -27,6 +27,8 @@
       <version>10.12.0.2522</version>
       <scope>provided</scope>
     </dependency>
+    <!-- This example targets Plugin API 10.12, while its tests use v14 fixtures.
+         Keep this direct dependency so the centrally managed SLF4J 2 version wins in both scopes. -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/external-reports/pom.xml
+++ b/external-reports/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <scope>test</scope>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -23,7 +23,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -21,6 +21,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.18</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <scope>test</scope>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -21,11 +21,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <scope>test</scope>

--- a/its/vibebot/pom.xml
+++ b/its/vibebot/pom.xml
@@ -11,6 +11,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>21</maven.compiler.release>
+    <!-- Standalone project: keep aligned with the SLF4J version provided by the Plugin API. -->
     <slf4j.version>2.0.18</slf4j.version>
   </properties>
   <dependencies>

--- a/java-checks-aws/pom.xml
+++ b/java-checks-aws/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <scope>test</scope>

--- a/java-checks-common/pom.xml
+++ b/java-checks-common/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-frontend</artifactId>
       <version>${project.version}</version>

--- a/java-checks/pom.xml
+++ b/java-checks/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <scope>test</scope>

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -35,6 +35,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.6.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.scanner.engine</groupId>
       <artifactId>plugin-api-scanner-impl</artifactId>
       <scope>test</scope>

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -30,11 +30,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <scope>test</scope>

--- a/java-frontend/pom.xml
+++ b/java-frontend/pom.xml
@@ -30,14 +30,23 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api-test-fixtures</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.6.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java-jsp/pom.xml
+++ b/java-jsp/pom.xml
@@ -20,11 +20,6 @@
       <artifactId>sonar-plugin-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-frontend</artifactId>
       <version>${project.version}</version>

--- a/java-surefire/pom.xml
+++ b/java-surefire/pom.xml
@@ -20,11 +20,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-frontend</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,10 @@
     <jacoco-agent-jar>org.jacoco.agent-${version.jacoco.plugin}-runtime.jar</jacoco-agent-jar>
     <mockito-agent-jar>mockito-core-${mockito-core.version}.jar</mockito-agent-jar>
 
+    <!-- Keep direct logging dependencies aligned with the versions provided by the Plugin API. -->
+    <slf4j.version>2.0.18</slf4j.version>
+    <logback.version>1.6.3</logback.version>
+
   </properties>
 
   <distributionManagement>
@@ -272,6 +276,22 @@
         <artifactId>assertj-core</artifactId>
         <version>3.27.7</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,8 +112,6 @@
     <jacoco-agent-jar>org.jacoco.agent-${version.jacoco.plugin}-runtime.jar</jacoco-agent-jar>
     <mockito-agent-jar>mockito-core-${mockito-core.version}.jar</mockito-agent-jar>
 
-    <!-- The product must work with the SLF4J provided in the Plugin API. -->
-    <slf4j.version>2.0.18</slf4j.version>
   </properties>
 
   <distributionManagement>
@@ -276,12 +274,6 @@
         <scope>test</scope>
       </dependency>
 
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>test</scope>
-      </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>

--- a/sonar-java-plugin/pom.xml
+++ b/sonar-java-plugin/pom.xml
@@ -84,11 +84,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
Part of

## Summary

- Remove redundant logging handling from Plugin API-bound code and the broad Renovate major-version exception.
- Keep dependencies explicit where source code directly imports SLF4J or Logback, with versions managed centrally and aligned with Plugin API v14.
- Preserve the standalone Vibebot SLF4J dependency and document its alignment requirement.

## Validation

- `mvn -pl java-frontend,docs/java-custom-rules-example,its/ruling -am test-compile -DskipTests`
- Custom-rules logging tests: 3 passed.
- Dependency tree resolves SLF4J 2.0.18 and Logback 1.6.3.
