### PR TITLE
SONARJAVA-6892: S8989 Fix FP for class-level @Transactional when no transaction occurs

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -385,5 +385,32 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
     private void computeResult() {
     }
+
+    public void onlySavesInsideLambda() throws IOException { // Compliant - save() is in a deferred lambda, not directly executed
+      Runnable r = () -> saveOrder();
+    }
+
+    public void onlySavesInsideAnonymousClass() throws IOException { // Compliant - save() is in an anonymous class method
+      Runnable r = new Runnable() {
+        @Override
+        public void run() {
+          saveOrder();
+        }
+      };
+    }
+
+    public void onlySavesInsideLocalClass() throws IOException { // Compliant - save() is in a local class method
+      class Local {
+        void doSave() {
+          saveOrder();
+        }
+      }
+    }
+
+    public void directSaveAndLambda() throws IOException { // Noncompliant [[secondary=350]]
+//              ^^^^^^^^^^^^^^^^^^^
+      saveOrder();
+      Runnable r = () -> deleteEntity(null);
+    }
   }
 }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -22,7 +22,7 @@ class CustomCheckedException extends Exception {}
 public class TransactionalMethodCheckedExceptionCheckSample {
 
   @Transactional
-  public void processOrder(Order order) throws IOException, SQLException { // Noncompliant [[secondary=22;quickfixes=qf1,qf2]]
+  public void processOrder(Order order) throws IOException, SQLException { // Noncompliant [[secondary=24;quickfixes=qf1,qf2]]
 //            ^^^^^^^^^^^^
   // fix@qf1 {{Add rollbackFor attribute}}
   // edit@qf1 [[sl=-1;sc=3;el=-1;ec=17]] {{@Transactional(rollbackFor = {java.io.IOException.class, java.sql.SQLException.class})}}
@@ -31,19 +31,19 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   }
 
   @Transactional
-  public void importData() throws Exception { // Noncompliant [[secondary=31;quickfixes=qf3]]
+  public void importData() throws Exception { // Noncompliant [[secondary=33;quickfixes=qf3]]
 //            ^^^^^^^^^^
   // fix@qf3 {{Add rollbackFor = Exception.class}}
   // edit@qf3 [[sl=-1;sc=3;el=-1;ec=17]] {{@Transactional(rollbackFor = java.lang.Exception.class)}}
   }
 
   @Transactional(timeout = 30)
-  public void withOtherAttributes() throws SQLException { // Noncompliant [[secondary=38]]
+  public void withOtherAttributes() throws SQLException { // Noncompliant [[secondary=40]]
 //            ^^^^^^^^^^^^^^^^^^^
   }
 
   @Transactional
-  public void customException() throws CustomCheckedException { // Noncompliant [[secondary=43;quickfixes=qf7,qf8]]
+  public void customException() throws CustomCheckedException { // Noncompliant [[secondary=45;quickfixes=qf7,qf8]]
 //            ^^^^^^^^^^^^^^^
   // fix@qf7 {{Add rollbackFor attribute}}
   // edit@qf7 [[sl=-1;sc=3;el=-1;ec=17]] {{@Transactional(rollbackFor = checks.spring.CustomCheckedException.class)}}
@@ -52,7 +52,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   }
 
   @Transactional
-  public void mixedExceptions() throws IOException, RuntimeException { // Noncompliant [[secondary=52;quickfixes=qf9,qf10]]
+  public void mixedExceptions() throws IOException, RuntimeException { // Noncompliant [[secondary=54;quickfixes=qf9,qf10]]
 //            ^^^^^^^^^^^^^^^
   // fix@qf9 {{Add rollbackFor attribute}}
   // edit@qf9 [[sl=-1;sc=3;el=-1;ec=17]] {{@Transactional(rollbackFor = java.io.IOException.class)}}
@@ -134,7 +134,40 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 //              ^^^^^^^^^^^^
     }
 
+    public void insertRecord() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^
+    }
+
+    public void createEntity() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^
+    }
+
+    public void removeItem() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^
+    }
+
+    public void storeData() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^
+    }
+
+    public void executeUpdate() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^^
+    }
+
+    public void save() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^
+    }
+
     public void readData() throws IOException { // Compliant - no transactional prefix
+    }
+
+    public void savedSearch() throws IOException { // Compliant - "saved" has no word boundary after "save"
+    }
+
+    public void persisted() throws IOException { // Compliant - "persisted" has no word boundary after "persist"
+    }
+
+    public void deletion() throws IOException { // Compliant - "deletion" has no word boundary after "delete"
     }
 
     @Transactional(rollbackFor = IOException.class)
@@ -147,7 +180,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   }
 
   @org.springframework.transaction.annotation.Transactional
-  public void fullyQualified() throws IOException { // Noncompliant [[secondary=121;quickfixes=qf13,qf14]]
+  public void fullyQualified() throws IOException { // Noncompliant [[secondary=182;quickfixes=qf13,qf14]]
 //            ^^^^^^^^^^^^^^
   // fix@qf13 {{Add rollbackFor attribute}}
   // edit@qf13 [[sl=-1;sc=3;el=-1;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = java.io.IOException.class)}}
@@ -160,7 +193,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   }
 
   @Transactional(value = "txManager")
-  public void withValueAttribute() throws IOException { // Noncompliant [[secondary=134]]
+  public void withValueAttribute() throws IOException { // Noncompliant [[secondary=195]]
 //            ^^^^^^^^^^^^^^^^^^
   }
 
@@ -171,7 +204,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
       public void nestedMethod() throws IOException { // Compliant - no transactional prefix
       }
 
-      public void saveNestedEntity() throws IOException { // Noncompliant [[secondary=155]]
+      public void saveNestedEntity() throws IOException { // Noncompliant [[secondary=202]]
 //                ^^^^^^^^^^^^^^^^
       }
     }
@@ -187,19 +220,19 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   interface TransactionalInterface {
     void interfaceMethod() throws IOException; // Compliant - no transactional prefix
 
-    void saveEntity() throws IOException; // Noncompliant [[secondary=169]]
+    void saveEntity() throws IOException; // Noncompliant [[secondary=219]]
 //       ^^^^^^^^^^ {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes on the class-level @Transactional.}}
   }
 
   // Test meta-annotated (composed) annotation
   @MyTransactional
-  public void metaAnnotated() throws IOException { // Noncompliant [[secondary=162]]
+  public void metaAnnotated() throws IOException { // Noncompliant [[secondary=228]]
 //            ^^^^^^^^^^^^^
   }
 
   // Test annotation with value attribute (transaction manager name)
   @Transactional("txManager")
-  public void valueShorthand() throws IOException { // Noncompliant [[secondary=168]]
+  public void valueShorthand() throws IOException { // Noncompliant [[secondary=234]]
 //            ^^^^^^^^^^^^^^
     // Has value attribute but no rollback configuration
   }
@@ -235,7 +268,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     public void publicInClassLevel() throws IOException { // Compliant - no transactional prefix
     }
 
-    public void savePublicInClassLevel() throws IOException { // Noncompliant [[secondary=207]]
+    public void savePublicInClassLevel() throws IOException { // Noncompliant [[secondary=257]]
 //              ^^^^^^^^^^^^^^^^^^^^^^
     }
   }
@@ -262,13 +295,13 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
   // readOnly = false with default propagation is still noncompliant
   @Transactional(readOnly = false)
-  public void readOnlyFalse() throws IOException { // Noncompliant [[secondary=228]]
+  public void readOnlyFalse() throws IOException { // Noncompliant [[secondary=297]]
 //            ^^^^^^^^^^^^^
   }
 
   // Explicit REQUIRED propagation still needs rollback config
   @Transactional(propagation = Propagation.REQUIRED)
-  public void requiredPropagation() throws IOException { // Noncompliant [[secondary=234]]
+  public void requiredPropagation() throws IOException { // Noncompliant [[secondary=303]]
 //            ^^^^^^^^^^^^^^^^^^^
   }
 
@@ -309,14 +342,14 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     }
 
     @Deprecated
-    public void deleteWithAnnotations() throws IOException { // Noncompliant [[secondary=290]]
+    public void deleteWithAnnotations() throws IOException { // Noncompliant [[secondary=337]]
 //              ^^^^^^^^^^^^^^^^^^^^^
     }
   }
 
   @Transactional
   static class ClassLevelWithMethodCalls {
-    public void processOrder(Object repository) throws IOException { // Noncompliant [[secondary=297]]
+    public void processOrder(Object repository) throws IOException { // Noncompliant [[secondary=350]]
 //              ^^^^^^^^^^^^
       repository.toString();
       saveOrder();
@@ -329,7 +362,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     private void saveOrder() {
     }
 
-    public void delegateToFlush() throws IOException { // Noncompliant [[secondary=297]]
+    public void delegateToFlush() throws IOException { // Noncompliant [[secondary=350]]
 //              ^^^^^^^^^^^^^^^
       flushAll();
     }
@@ -337,7 +370,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     private void flushAll() {
     }
 
-    public void delegateToDelete(Object entity) throws IOException { // Noncompliant [[secondary=297]]
+    public void delegateToDelete(Object entity) throws IOException { // Noncompliant [[secondary=350]]
 //              ^^^^^^^^^^^^^^^^
       deleteEntity(entity);
     }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -138,20 +138,16 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 //              ^^^^^^^^^^^^
     }
 
-    public void createEntity() throws IOException { // Noncompliant [[secondary=108]]
-//              ^^^^^^^^^^^^
+    public void createEntity() throws IOException { // Compliant - "create" is not a transactional prefix
     }
 
-    public void removeItem() throws IOException { // Noncompliant [[secondary=108]]
-//              ^^^^^^^^^^
+    public void removeItem() throws IOException { // Compliant - "remove" is not a transactional prefix
     }
 
-    public void storeData() throws IOException { // Noncompliant [[secondary=108]]
-//              ^^^^^^^^^
+    public void storeData() throws IOException { // Compliant - "store" is not a transactional prefix
     }
 
-    public void executeUpdate() throws IOException { // Noncompliant [[secondary=108]]
-//              ^^^^^^^^^^^^^
+    public void executeUpdate() throws IOException { // Compliant - "execute" is not a transactional prefix
     }
 
     public void save() throws IOException { // Noncompliant [[secondary=108]]
@@ -167,7 +163,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     public void persisted() throws IOException { // Compliant - "persisted" has no word boundary after "persist"
     }
 
-    public void deletion() throws IOException { // Compliant - "deletion" has no word boundary after "delete"
+    public void deletes() throws IOException { // Compliant - "deletes" has no word boundary after "delete"
     }
 
     @Transactional(rollbackFor = IOException.class)
@@ -180,7 +176,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   }
 
   @org.springframework.transaction.annotation.Transactional
-  public void fullyQualified() throws IOException { // Noncompliant [[secondary=182;quickfixes=qf13,qf14]]
+  public void fullyQualified() throws IOException { // Noncompliant [[secondary=178;quickfixes=qf13,qf14]]
 //            ^^^^^^^^^^^^^^
   // fix@qf13 {{Add rollbackFor attribute}}
   // edit@qf13 [[sl=-1;sc=3;el=-1;ec=60]] {{@org.springframework.transaction.annotation.Transactional(rollbackFor = java.io.IOException.class)}}
@@ -193,7 +189,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   }
 
   @Transactional(value = "txManager")
-  public void withValueAttribute() throws IOException { // Noncompliant [[secondary=195]]
+  public void withValueAttribute() throws IOException { // Noncompliant [[secondary=191]]
 //            ^^^^^^^^^^^^^^^^^^
   }
 
@@ -204,7 +200,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
       public void nestedMethod() throws IOException { // Compliant - no transactional prefix
       }
 
-      public void saveNestedEntity() throws IOException { // Noncompliant [[secondary=202]]
+      public void saveNestedEntity() throws IOException { // Noncompliant [[secondary=198]]
 //                ^^^^^^^^^^^^^^^^
       }
     }
@@ -220,19 +216,19 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   interface TransactionalInterface {
     void interfaceMethod() throws IOException; // Compliant - no transactional prefix
 
-    void saveEntity() throws IOException; // Noncompliant [[secondary=219]]
+    void saveEntity() throws IOException; // Noncompliant [[secondary=215]]
 //       ^^^^^^^^^^ {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes on the class-level @Transactional.}}
   }
 
   // Test meta-annotated (composed) annotation
   @MyTransactional
-  public void metaAnnotated() throws IOException { // Noncompliant [[secondary=228]]
+  public void metaAnnotated() throws IOException { // Noncompliant [[secondary=224]]
 //            ^^^^^^^^^^^^^
   }
 
   // Test annotation with value attribute (transaction manager name)
   @Transactional("txManager")
-  public void valueShorthand() throws IOException { // Noncompliant [[secondary=234]]
+  public void valueShorthand() throws IOException { // Noncompliant [[secondary=230]]
 //            ^^^^^^^^^^^^^^
     // Has value attribute but no rollback configuration
   }
@@ -268,7 +264,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     public void publicInClassLevel() throws IOException { // Compliant - no transactional prefix
     }
 
-    public void savePublicInClassLevel() throws IOException { // Noncompliant [[secondary=257]]
+    public void savePublicInClassLevel() throws IOException { // Noncompliant [[secondary=253]]
 //              ^^^^^^^^^^^^^^^^^^^^^^
     }
   }
@@ -295,13 +291,13 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
   // readOnly = false with default propagation is still noncompliant
   @Transactional(readOnly = false)
-  public void readOnlyFalse() throws IOException { // Noncompliant [[secondary=297]]
+  public void readOnlyFalse() throws IOException { // Noncompliant [[secondary=293]]
 //            ^^^^^^^^^^^^^
   }
 
   // Explicit REQUIRED propagation still needs rollback config
   @Transactional(propagation = Propagation.REQUIRED)
-  public void requiredPropagation() throws IOException { // Noncompliant [[secondary=303]]
+  public void requiredPropagation() throws IOException { // Noncompliant [[secondary=299]]
 //            ^^^^^^^^^^^^^^^^^^^
   }
 
@@ -342,14 +338,14 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     }
 
     @Deprecated
-    public void deleteWithAnnotations() throws IOException { // Noncompliant [[secondary=337]]
+    public void deleteWithAnnotations() throws IOException { // Noncompliant [[secondary=333]]
 //              ^^^^^^^^^^^^^^^^^^^^^
     }
   }
 
   @Transactional
   static class ClassLevelWithMethodCalls {
-    public void processOrder(Object repository) throws IOException { // Noncompliant [[secondary=350]]
+    public void processOrder(Object repository) throws IOException { // Noncompliant [[secondary=346]]
 //              ^^^^^^^^^^^^
       repository.toString();
       saveOrder();
@@ -362,7 +358,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     private void saveOrder() {
     }
 
-    public void delegateToFlush() throws IOException { // Noncompliant [[secondary=350]]
+    public void delegateToFlush() throws IOException { // Noncompliant [[secondary=346]]
 //              ^^^^^^^^^^^^^^^
       flushAll();
     }
@@ -370,7 +366,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     private void flushAll() {
     }
 
-    public void delegateToDelete(Object entity) throws IOException { // Noncompliant [[secondary=350]]
+    public void delegateToDelete(Object entity) throws IOException { // Noncompliant [[secondary=346]]
 //              ^^^^^^^^^^^^^^^^
       deleteEntity(entity);
     }
@@ -386,8 +382,13 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     private void computeResult() {
     }
 
-    public void onlySavesInsideLambda() throws IOException { // Compliant - save() is in a deferred lambda, not directly executed
+    public void onlySavesInsideLambda() throws IOException { // Compliant - save() is in a lambda assigned to a variable, not directly executed
       Runnable r = () -> saveOrder();
+    }
+
+    public void savesInsideLambdaArgument() throws IOException { // Noncompliant [[secondary=346]]
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^
+      java.util.List.of().forEach(o -> saveOrder());
     }
 
     public void onlySavesInsideAnonymousClass() throws IOException { // Compliant - save() is in an anonymous class method
@@ -407,7 +408,7 @@ public class TransactionalMethodCheckedExceptionCheckSample {
       }
     }
 
-    public void directSaveAndLambda() throws IOException { // Noncompliant [[secondary=350]]
+    public void directSaveAndLambda() throws IOException { // Noncompliant [[secondary=346]]
 //              ^^^^^^^^^^^^^^^^^^^
       saveOrder();
       Runnable r = () -> deleteEntity(null);

--- a/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/TransactionalMethodCheckedExceptionCheckSample.java
@@ -107,8 +107,34 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
   @Transactional
   static class ClassLevelNoConfig {
-    public void noConfig() throws IOException { // Noncompliant [[secondary=106]]
-//              ^^^^^^^^ {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes on the class-level @Transactional.}}
+    public void noConfig() throws IOException { // Compliant - method name does not suggest a transactional operation
+    }
+
+    public void saveOrder() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^
+    }
+
+    public void deleteRecord() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^
+    }
+
+    public void updateStatus() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^
+    }
+
+    public void persistEntity() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^^
+    }
+
+    public void mergeData() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^
+    }
+
+    public void flushChanges() throws IOException { // Noncompliant [[secondary=108]]
+//              ^^^^^^^^^^^^
+    }
+
+    public void readData() throws IOException { // Compliant - no transactional prefix
     }
 
     @Transactional(rollbackFor = IOException.class)
@@ -142,8 +168,11 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   static class OuterClass {
     @Transactional
     static class InnerClassWithAnnotation {
-      public void nestedMethod() throws IOException { // Noncompliant [[secondary=141]]
-//                ^^^^^^^^^^^^ {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes on the class-level @Transactional.}}
+      public void nestedMethod() throws IOException { // Compliant - no transactional prefix
+      }
+
+      public void saveNestedEntity() throws IOException { // Noncompliant [[secondary=155]]
+//                ^^^^^^^^^^^^^^^^
       }
     }
 
@@ -156,8 +185,10 @@ public class TransactionalMethodCheckedExceptionCheckSample {
 
   @Transactional
   interface TransactionalInterface {
-    void interfaceMethod() throws IOException; // Noncompliant [[secondary=155]]
-//       ^^^^^^^^^^^^^^^ {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes on the class-level @Transactional.}}
+    void interfaceMethod() throws IOException; // Compliant - no transactional prefix
+
+    void saveEntity() throws IOException; // Noncompliant [[secondary=169]]
+//       ^^^^^^^^^^ {{Specify rollback behavior for checked exceptions using "rollbackFor" or "noRollbackFor" attributes on the class-level @Transactional.}}
   }
 
   // Test meta-annotated (composed) annotation
@@ -201,8 +232,11 @@ public class TransactionalMethodCheckedExceptionCheckSample {
     void packagePrivateInClassLevel() throws IOException { // Compliant - package-private methods are not proxied
     }
 
-    public void publicInClassLevel() throws IOException { // Noncompliant [[secondary=191]]
-//              ^^^^^^^^^^^^^^^^^^
+    public void publicInClassLevel() throws IOException { // Compliant - no transactional prefix
+    }
+
+    public void savePublicInClassLevel() throws IOException { // Noncompliant [[secondary=207]]
+//              ^^^^^^^^^^^^^^^^^^^^^^
     }
   }
 
@@ -271,8 +305,52 @@ public class TransactionalMethodCheckedExceptionCheckSample {
   static class ClassWithMultipleAnnotations {
     @Deprecated
     @SuppressWarnings("unused")
-    public void methodWithOtherAnnotations() throws IOException { // Noncompliant [[secondary=270]]
-//              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    public void methodWithOtherAnnotations() throws IOException { // Compliant - no transactional prefix
+    }
+
+    @Deprecated
+    public void deleteWithAnnotations() throws IOException { // Noncompliant [[secondary=290]]
+//              ^^^^^^^^^^^^^^^^^^^^^
+    }
+  }
+
+  @Transactional
+  static class ClassLevelWithMethodCalls {
+    public void processOrder(Object repository) throws IOException { // Noncompliant [[secondary=297]]
+//              ^^^^^^^^^^^^
+      repository.toString();
+      saveOrder();
+    }
+
+    public void doWork() throws IOException { // Compliant - no transactional prefix and no transactional calls
+      System.out.println("work");
+    }
+
+    private void saveOrder() {
+    }
+
+    public void delegateToFlush() throws IOException { // Noncompliant [[secondary=297]]
+//              ^^^^^^^^^^^^^^^
+      flushAll();
+    }
+
+    private void flushAll() {
+    }
+
+    public void delegateToDelete(Object entity) throws IOException { // Noncompliant [[secondary=297]]
+//              ^^^^^^^^^^^^^^^^
+      deleteEntity(entity);
+    }
+
+    private void deleteEntity(Object entity) {
+    }
+
+    public void noTransactionalCalls() throws IOException { // Compliant - no transactional method calls
+      System.out.println("no transaction");
+      computeResult();
+    }
+
+    private void computeResult() {
     }
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -42,10 +42,12 @@ import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.LambdaExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.NewClassTree;
 import org.sonar.plugins.java.api.tree.Modifier;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
 import org.sonar.plugins.java.api.tree.Tree;
@@ -318,6 +320,22 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
         }
       }
       super.visitMethodInvocation(tree);
+    }
+
+    @Override
+    public void visitLambdaExpression(LambdaExpressionTree tree) {
+      // Do not traverse into lambda bodies: they are deferred and may not execute within the transaction
+    }
+
+    @Override
+    public void visitClass(ClassTree tree) {
+      // Do not traverse into anonymous or local class declarations
+    }
+
+    @Override
+    public void visitNewClass(NewClassTree tree) {
+      // Do not traverse into anonymous class bodies, but visit constructor arguments
+      scan(tree.arguments());
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -54,7 +54,9 @@ import org.sonar.plugins.java.api.tree.TypeTree;
 @Rule(key = "S8989")
 public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
 
-  private static final List<String> TRANSACTIONAL_PREFIXES = List.of("save", "delete", "update", "persist", "merge", "flush");
+  private static final List<String> TRANSACTIONAL_PREFIXES = List.of(
+    "save", "delete", "update", "persist", "merge", "flush",
+    "insert", "create", "remove", "store", "execute");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -295,7 +297,12 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
 
   private static boolean hasTransactionalPrefix(String name) {
     String lowerName = name.toLowerCase(Locale.ROOT);
-    return TRANSACTIONAL_PREFIXES.stream().anyMatch(lowerName::startsWith);
+    return TRANSACTIONAL_PREFIXES.stream().anyMatch(prefix -> {
+      if (!lowerName.startsWith(prefix)) {
+        return false;
+      }
+      return name.length() == prefix.length() || Character.isUpperCase(name.charAt(prefix.length()));
+    });
   }
 
   private static class MethodInvocationVisitor extends BaseTreeVisitor {

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -57,8 +57,7 @@ import org.sonar.plugins.java.api.tree.TypeTree;
 public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
 
   private static final List<String> TRANSACTIONAL_PREFIXES = List.of(
-    "save", "delete", "update", "persist", "merge", "flush",
-    "insert", "create", "remove", "store", "execute");
+    "save", "delete", "update", "persist", "merge", "flush", "insert");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -303,7 +302,11 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
       if (!lowerName.startsWith(prefix)) {
         return false;
       }
-      return name.length() == prefix.length() || Character.isUpperCase(name.charAt(prefix.length()));
+      if (name.length() == prefix.length()) {
+        return true;
+      }
+      char next = name.charAt(prefix.length());
+      return Character.isUpperCase(next) || Character.isDigit(next) || next == '_';
     });
   }
 
@@ -324,7 +327,9 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
 
     @Override
     public void visitLambdaExpression(LambdaExpressionTree tree) {
-      // Do not traverse into lambda bodies: they are deferred and may not execute within the transaction
+      if (isMethodArgument(tree)) {
+        super.visitLambdaExpression(tree);
+      }
     }
 
     @Override
@@ -332,10 +337,18 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
       // Do not traverse into anonymous or local class declarations
     }
 
-    @Override
-    public void visitNewClass(NewClassTree tree) {
-      // Do not traverse into anonymous class bodies, but visit constructor arguments
-      scan(tree.arguments());
+    private static boolean isMethodArgument(LambdaExpressionTree lambda) {
+      Tree parent = lambda.parent();
+      while (parent != null) {
+        if (parent instanceof MethodInvocationTree || parent instanceof NewClassTree) {
+          return true;
+        }
+        if (!(parent instanceof Arguments)) {
+          return false;
+        }
+        parent = parent.parent();
+      }
+      return false;
     }
   }
 

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/TransactionalMethodCheckedExceptionCheck.java
@@ -19,12 +19,14 @@ package org.sonar.java.checks.spring;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.SpringUtils;
+import org.sonar.java.model.ExpressionUtils;
 import org.sonar.java.model.ModifiersUtils;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
@@ -36,11 +38,13 @@ import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.AnnotationTree;
 import org.sonar.plugins.java.api.tree.Arguments;
 import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
 import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.MethodTree;
 import org.sonar.plugins.java.api.tree.Modifier;
 import org.sonar.plugins.java.api.tree.SyntaxToken;
@@ -49,6 +53,8 @@ import org.sonar.plugins.java.api.tree.TypeTree;
 
 @Rule(key = "S8989")
 public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscriptionVisitor implements DependencyVersionAware {
+
+  private static final List<String> TRANSACTIONAL_PREFIXES = List.of("save", "delete", "update", "persist", "merge", "flush");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -99,6 +105,10 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
     }
 
     boolean isClassLevel = isClassLevelAnnotation(method, transactionalAnnotation);
+
+    if (isClassLevel && !looksTransactional(method)) {
+      return;
+    }
 
     var issueBuilder = QuickFixHelper.newIssue(context)
       .forRule(this)
@@ -272,6 +282,36 @@ public class TransactionalMethodCheckedExceptionCheck extends IssuableSubscripti
         }
         return false;
       });
+  }
+
+  private static boolean looksTransactional(MethodTree method) {
+    if (hasTransactionalPrefix(method.simpleName().name())) {
+      return true;
+    }
+    var visitor = new MethodInvocationVisitor();
+    method.accept(visitor);
+    return visitor.foundTransactionalCall;
+  }
+
+  private static boolean hasTransactionalPrefix(String name) {
+    String lowerName = name.toLowerCase(Locale.ROOT);
+    return TRANSACTIONAL_PREFIXES.stream().anyMatch(lowerName::startsWith);
+  }
+
+  private static class MethodInvocationVisitor extends BaseTreeVisitor {
+    boolean foundTransactionalCall = false;
+
+    @Override
+    public void visitMethodInvocation(MethodInvocationTree tree) {
+      if (!foundTransactionalCall) {
+        String calledMethodName = ExpressionUtils.methodName(tree).name();
+        if (hasTransactionalPrefix(calledMethodName)) {
+          foundTransactionalCall = true;
+          return;
+        }
+      }
+      super.visitMethodInvocation(tree);
+    }
   }
 
   private static boolean isNonPublicMethod(MethodTree method) {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S8989.html
@@ -53,6 +53,10 @@ exceptions), but the database state doesn’t match expectations.</p>
   the method without any transaction context, so there is no transaction to roll back.</li>
   <li><code>@Transactional(readOnly = true)</code> - Read-only transactions do not perform write operations, so there is no risk of committing partial
   or inconsistent data.</li>
+  <li>When <code>@Transactional</code> is applied at the class level, the rule only raises an issue if the method name or one of the directly called
+  methods starts with a persistence-related prefix (such as <code>save</code>, <code>delete</code>, <code>update</code>, <code>persist</code>,
+  <code>merge</code>, <code>flush</code>, or <code>insert</code>). Methods that do not appear to perform transactional write operations are not
+  flagged.</li>
 </ul>
 <h2>How to fix it in Spring</h2>
 <p>Explicitly specify <code>rollbackFor</code> to include the checked exceptions that should trigger a rollback. This is the most common fix, as most


### PR DESCRIPTION
## Summary
- When `@Transactional` is at the class level, only raise S8989 when the method likely performs a transactional operation
- A method is considered transactional if its name or the name of any method it calls starts with: `save`, `delete`, `update`, `persist`, `merge`, or `flush`
- Methods with method-level `@Transactional` are unaffected and always raise as before

## Test plan
- [x] Existing tests for method-level `@Transactional` still pass
- [x] Class-level `@Transactional` with transactional method names (e.g., `saveOrder`, `deleteRecord`) raises issues
- [x] Class-level `@Transactional` with non-transactional method names (e.g., `noConfig`, `readData`) no longer raises
- [x] Class-level `@Transactional` with transactional method calls (e.g., calling `saveOrder()` inside body) raises issues
- [x] `test_without_semantic` and `test_noDependencies` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)