### PR TITLE
SONARJAVA-6898 S5786/S5810: stop flagging class modifiers to avoid FPs

### DIFF
--- a/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5DefaultPackageClassAndMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5DefaultPackageClassAndMethodCheckSample.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class JUnit5DefaultPackageClassAndMethodCheckSample { // Noncompliant {{Remove redundant visibility modifiers from this test class and its methods.}} [[quickfixes=qf1]]
+class JUnit5DefaultPackageClassAndMethodCheckSample { // Noncompliant {{Remove redundant visibility modifiers from the methods of this test class.}} [[quickfixes=qf1]]
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   // fix@qf1 {{Remove all redundant visibility modifiers}}
   // edit@qf1 [[sl=+12;sc=3;el=+12;ec=10]] {{}}
@@ -75,19 +75,15 @@ class JUnit5DefaultPackageClassAndMethodCheckSample { // Noncompliant {{Remove r
 
   }
 
-  protected static class PublicWithOneTest { // Noncompliant {{Remove this 'protected' modifier.}} [[quickfixes=qf2]]
-//^^^^^^^^^
-  // fix@qf2 {{Remove this 'protected' modifier.}}
-  // edit@qf2 [[sc=3;ec=13]] {{}}
+  protected static class PublicWithOneTest { // Compliant - test method is already package-private, class may legitimately need to be protected
     @Test
     void test() {}
   }
 
-  public static class WithClassAndMethodModifiers { // Noncompliant {{Remove redundant visibility modifiers from this test class and its methods.}} [[quickfixes=qf3]]
+  public static class WithClassAndMethodModifiers { // Noncompliant {{Remove redundant visibility modifiers from the methods of this test class.}} [[quickfixes=qf3]]
   //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    // fix@qf3 {{Remove all redundant visibility modifiers}}
-    // edit@qf3 [[sl=+6;sc=5;el=+6;ec=12]] {{}}
-    // edit@qf3 [[sc=3;ec=10]] {{}}
+    // fix@qf3 {{Remove this 'public' modifier.}}
+    // edit@qf3 [[sl=+5;sc=5;el=+5;ec=12]] {{}}
     @Test
     public void test() {}
   }
@@ -102,21 +98,12 @@ class JUnit5DefaultPackageClassAndMethodCheckSample { // Noncompliant {{Remove r
     void test() {}
   }
 
-  public static class TestClassWithPublicStaticMethod { // Compliant
+  public static class PublicClassWithPackagePrivateTests { // Compliant - all JUnit5 methods are already package-private
     @Test
     void test() {}
 
-    public static Object foo() { // in order to have this method visible from outside, class must be public
-      return null;
-    }
-  }
-
-  public static class TestClassWithPublicStaticField { // Compliant
-
-    public static String MY_CONSTANT = "yolo"; // in order to have this field visible from outside, class must be public
-
-    @Test
-    void test() {}
+    @BeforeEach
+    void setup() {}
   }
 
   public abstract class AbstractTest {

--- a/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheckSample.java
@@ -44,10 +44,16 @@ class JUnit5SilentlyIgnoreClassAndMethodCheckSample {
   }
 
   @Nested
-  private class PrivateWithOneTest { // Noncompliant {{Remove this 'private' modifier.}}
-//^^^^^^^
+  private class PrivateWithOneTest { // Compliant - test method is already package-private, class may legitimately need to be private
     @Test
     void test() {}
+  }
+
+  @Nested
+  private class PrivateWithPrivateMethod { // Compliant - class modifier is not flagged
+    @Test
+    private void test() {} // Noncompliant {{Remove this 'private' modifier.}}
+//  ^^^^^^^
   }
 
   @Nested
@@ -122,10 +128,7 @@ class JUnit5SilentlyIgnoreClassAndMethodCheckSample {
     // edit@qf6 [[sc=5;ec=12]] {{}}
 
     @Nested
-    private class PrivateWithOneTest { // Noncompliant [[quickfixes=qf7]]
-//  ^^^^^^^
-      // fix@qf7 {{Remove "private" modifier}}
-      // edit@qf7 [[sc=5;ec=13]] {{}}
+    private class PrivateWithOneTest { // Compliant - test method is already package-private
       @Test
       void test() {}
     }

--- a/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheckSample.java
@@ -51,7 +51,8 @@ class JUnit5SilentlyIgnoreClassAndMethodCheckSample {
   }
 
   @Nested
-  private class PrivateWithPrivateMethod { // Compliant - class modifier is not flagged, only the method is
+  private class PrivateWithPrivateMethod { // Noncompliant {{Remove this 'private' modifier.}}
+//^^^^^^^
     @Test
     private void test() {} // Noncompliant {{Remove this 'private' modifier.}}
 //  ^^^^^^^

--- a/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheckSample.java
@@ -44,13 +44,14 @@ class JUnit5SilentlyIgnoreClassAndMethodCheckSample {
   }
 
   @Nested
-  private class PrivateWithOneTest { // Compliant - test method is already package-private, class may legitimately need to be private
+  private class PrivateWithOneTest { // Noncompliant {{Remove this 'private' modifier.}}
+//^^^^^^^
     @Test
     void test() {}
   }
 
   @Nested
-  private class PrivateWithPrivateMethod { // Compliant - class modifier is not flagged
+  private class PrivateWithPrivateMethod { // Compliant - class modifier is not flagged, only the method is
     @Test
     private void test() {} // Noncompliant {{Remove this 'private' modifier.}}
 //  ^^^^^^^
@@ -128,7 +129,10 @@ class JUnit5SilentlyIgnoreClassAndMethodCheckSample {
     // edit@qf6 [[sc=5;ec=12]] {{}}
 
     @Nested
-    private class PrivateWithOneTest { // Compliant - test method is already package-private
+    private class PrivateWithOneTest { // Noncompliant [[quickfixes=qf7]]
+//  ^^^^^^^
+      // fix@qf7 {{Remove "private" modifier}}
+      // edit@qf7 [[sc=5;ec=13]] {{}}
       @Test
       void test() {}
     }

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/ClassPatternsUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/ClassPatternsUtils.java
@@ -31,22 +31,6 @@ public class ClassPatternsUtils {
   private ClassPatternsUtils() {
   }
 
-  /**
-   * Returns true if the class has any public static method or public static field that requires
-   * the class itself to be public (e.g. constants or factory methods used from outside).
-   */
-  public static boolean shouldBePublicClass(ClassTree classTree, List<MethodTree> methods) {
-    boolean hasPublicStaticMethods = methods.stream()
-      .map(MethodTree::modifiers)
-      .anyMatch(mods -> ModifiersUtils.hasAll(mods, Modifier.PUBLIC, Modifier.STATIC));
-    boolean hasPublicStaticFields = classTree.members().stream()
-      .filter(member -> member.is(Tree.Kind.VARIABLE))
-      .map(VariableTree.class::cast)
-      .map(VariableTree::modifiers)
-      .anyMatch(mods -> ModifiersUtils.hasAll(mods, Modifier.PUBLIC, Modifier.STATIC));
-    return hasPublicStaticMethods || hasPublicStaticFields;
-  }
-
   public static boolean isPrivateInnerClass(ClassTree classTree) {
     return !classTree.symbol().owner().isPackageSymbol() &&
       ModifiersUtils.hasModifier(classTree.modifiers(), Modifier.PRIVATE);

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5DefaultPackageClassAndMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5DefaultPackageClassAndMethodCheck.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.helpers.ClassPatternsUtils;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.UnitTestUtils;
 import org.sonar.java.reporting.AnalyzerMessage;
@@ -38,7 +37,7 @@ import org.sonar.plugins.java.api.tree.Tree;
 @Rule(key = "S5786")
 public class JUnit5DefaultPackageClassAndMethodCheck extends IssuableSubscriptionVisitor {
 
-  private static final String MESSAGE = "Remove redundant visibility modifiers from this test class and its methods.";
+  private static final String MESSAGE = "Remove redundant visibility modifiers from the methods of this test class.";
   private static final String MODIFIER_MESSAGE = "Remove this '%s' modifier.";
   private static final String QUICK_FIX_ALL = "Remove all redundant visibility modifiers";
 
@@ -57,28 +56,10 @@ public class JUnit5DefaultPackageClassAndMethodCheck extends IssuableSubscriptio
     UnitTestUtils.JUnit5MethodGroups groups = UnitTestUtils.groupJUnit5Methods(classTree);
     List<MethodTree> junit5ClassMethods = groups.classMethods();
     List<MethodTree> junit5InstanceMethods = groups.instanceMethods();
-    List<MethodTree> nonJunit5Methods = groups.otherMethods();
 
     List<ModifierKeywordTree> noncompliantModifiers = new ArrayList<>();
     collectNonCompliantModifiers(junit5ClassMethods, noncompliantModifiers);
     collectNonCompliantModifiers(junit5InstanceMethods, noncompliantModifiers);
-
-    if (!junit5InstanceMethods.isEmpty() && !ClassPatternsUtils.shouldBePublicClass(classTree, nonJunit5Methods)) {
-      if (noncompliantModifiers.isEmpty()) {
-        // Only the class modifier is noncompliant (no method violations): report on the modifier directly.
-        classTree.modifiers().modifiers().stream()
-          .filter(m -> isNonCompliantModifier(m.modifier()))
-          .findFirst()
-          .ifPresent(m -> QuickFixHelper.newIssue(context)
-            .forRule(this)
-            .onTree(m)
-            .withMessage(MODIFIER_MESSAGE, m.keyword().text())
-            .withQuickFixes(() -> List.of(buildQuickFix(List.of(m))))
-            .report());
-        return;
-      }
-      addNonCompliantModifier(classTree.modifiers(), noncompliantModifiers);
-    }
 
     if (!noncompliantModifiers.isEmpty()) {
       List<JavaFileScannerContext.Location> secondaries = noncompliantModifiers.stream()

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.check.Rule;
-import org.sonar.java.checks.helpers.ClassPatternsUtils;
 import org.sonar.java.checks.helpers.QuickFixHelper;
 import org.sonar.java.checks.helpers.UnitTestUtils;
 import org.sonar.java.reporting.AnalyzerMessage;
@@ -42,8 +41,6 @@ import org.sonar.plugins.java.api.tree.TypeTree;
 public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptionVisitor {
 
   private enum ModifierScope {
-    // annotation like @Nested that applies to class
-    CLASS,
     // annotation like @BeforeAll that applies to static class method
     CLASS_METHOD,
     // annotation like @BeforeEach that applies to non-static method
@@ -67,14 +64,9 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
     UnitTestUtils.JUnit5MethodGroups groups = UnitTestUtils.groupJUnit5Methods(classTree);
     List<MethodTree> junit5ClassMethods = groups.classMethods();
     List<MethodTree> junit5InstanceMethods = groups.instanceMethods();
-    List<MethodTree> nonJunit5Methods = groups.otherMethods();
 
     raiseIssueOnMethods(junit5ClassMethods, ModifierScope.CLASS_METHOD);
     raiseIssueOnMethods(junit5InstanceMethods, ModifierScope.INSTANCE_METHOD);
-    boolean classHasJunit5InstanceMethods = !junit5InstanceMethods.isEmpty();
-    if (classHasJunit5InstanceMethods) {
-      raiseIssueOnClass(nonJunit5Methods, classTree);
-    }
   }
 
   private void raiseIssueOnMethods(List<MethodTree> methods, ModifierScope scope) {
@@ -82,13 +74,6 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
       raiseIssueOnNotCompliantModifiers(method.modifiers(), scope);
       raiseIssueOnNonCompliantReturnType(method);
     }
-  }
-
-  private void raiseIssueOnClass(List<MethodTree> nonJunit5Methods, ClassTree classTree) {
-    if (ClassPatternsUtils.shouldBePublicClass(classTree, nonJunit5Methods)) {
-      return;
-    }
-    raiseIssueOnNotCompliantModifiers(classTree.modifiers(), ModifierScope.CLASS);
   }
 
   private void raiseIssueOnNotCompliantModifiers(ModifiersTree modifierTree, ModifierScope modifierScope) {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
@@ -25,6 +25,7 @@ import org.sonar.java.checks.helpers.UnitTestUtils;
 import org.sonar.java.reporting.AnalyzerMessage;
 import org.sonar.java.reporting.JavaQuickFix;
 import org.sonar.java.reporting.JavaTextEdit;
+import org.sonar.java.model.ModifiersUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
@@ -68,13 +69,9 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
     raiseIssueOnMethods(junit5ClassMethods, ModifierScope.CLASS_METHOD);
     raiseIssueOnMethods(junit5InstanceMethods, ModifierScope.INSTANCE_METHOD);
 
-    // @Nested private classes are silently ignored by JUnit5 - flag the private modifier,
-    // but only when there is at least one method that would actually run if the class was fixed
-    if (classTree.symbol().metadata().isAnnotatedWith("org.junit.jupiter.api.Nested")
+    if (UnitTestUtils.hasNestedAnnotation(classTree)
       && junit5InstanceMethods.stream().anyMatch(m -> !hasNonCompliantInstanceMethodModifier(m))) {
-      classTree.modifiers().modifiers().stream()
-        .filter(m -> m.modifier() == Modifier.PRIVATE)
-        .findFirst()
+      ModifiersUtils.findModifier(classTree.modifiers(), Modifier.PRIVATE)
         .ifPresent(this::raiseIssueOnNonCompliantModifier);
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
@@ -69,8 +69,7 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
     raiseIssueOnMethods(junit5ClassMethods, ModifierScope.CLASS_METHOD);
     raiseIssueOnMethods(junit5InstanceMethods, ModifierScope.INSTANCE_METHOD);
 
-    if (UnitTestUtils.hasNestedAnnotation(classTree)
-      && junit5InstanceMethods.stream().anyMatch(m -> !hasNonCompliantInstanceMethodModifier(m))) {
+    if (UnitTestUtils.hasNestedAnnotation(classTree) && !junit5InstanceMethods.isEmpty()) {
       ModifiersUtils.findModifier(classTree.modifiers(), Modifier.PRIVATE)
         .ifPresent(this::raiseIssueOnNonCompliantModifier);
     }
@@ -104,11 +103,6 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
 
   private static boolean isNonCompliantModifier(Modifier modifier, ModifierScope modifierScope) {
     return modifier == Modifier.PRIVATE || (modifierScope == ModifierScope.INSTANCE_METHOD && modifier == Modifier.STATIC);
-  }
-
-  private static boolean hasNonCompliantInstanceMethodModifier(MethodTree method) {
-    return method.modifiers().modifiers().stream()
-      .anyMatch(m -> isNonCompliantModifier(m.modifier(), ModifierScope.INSTANCE_METHOD));
   }
 
   private void raiseIssueOnNonCompliantReturnType(MethodTree methodTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/JUnit5SilentlyIgnoreClassAndMethodCheck.java
@@ -67,6 +67,16 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
 
     raiseIssueOnMethods(junit5ClassMethods, ModifierScope.CLASS_METHOD);
     raiseIssueOnMethods(junit5InstanceMethods, ModifierScope.INSTANCE_METHOD);
+
+    // @Nested private classes are silently ignored by JUnit5 - flag the private modifier,
+    // but only when there is at least one method that would actually run if the class was fixed
+    if (classTree.symbol().metadata().isAnnotatedWith("org.junit.jupiter.api.Nested")
+      && junit5InstanceMethods.stream().anyMatch(m -> !hasNonCompliantInstanceMethodModifier(m))) {
+      classTree.modifiers().modifiers().stream()
+        .filter(m -> m.modifier() == Modifier.PRIVATE)
+        .findFirst()
+        .ifPresent(this::raiseIssueOnNonCompliantModifier);
+    }
   }
 
   private void raiseIssueOnMethods(List<MethodTree> methods, ModifierScope scope) {
@@ -97,6 +107,11 @@ public class JUnit5SilentlyIgnoreClassAndMethodCheck extends IssuableSubscriptio
 
   private static boolean isNonCompliantModifier(Modifier modifier, ModifierScope modifierScope) {
     return modifier == Modifier.PRIVATE || (modifierScope == ModifierScope.INSTANCE_METHOD && modifier == Modifier.STATIC);
+  }
+
+  private static boolean hasNonCompliantInstanceMethodModifier(MethodTree method) {
+    return method.modifiers().modifiers().stream()
+      .anyMatch(m -> isNonCompliantModifier(m.modifier(), ModifierScope.INSTANCE_METHOD));
   }
 
   private void raiseIssueOnNonCompliantReturnType(MethodTree methodTree) {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5786.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5786.html
@@ -1,5 +1,5 @@
-<p>JUnit5 test classes and methods should generally have package visibility. To fix this issue, change their visibility to the default package
-visibility.</p>
+<p>JUnit5 test methods should generally have package visibility. To fix this issue, remove the <code>public</code> or <code>protected</code>
+visibility modifiers from the test methods.</p>
 <h2>Why is this an issue?</h2>
 <p>JUnit5 is more tolerant regarding the visibility of test classes and methods than JUnit4, which required everything to be <code>public</code>. Test
 classes and methods can have any visibility except <code>private</code>. It is however recommended to use the default package visibility to improve
@@ -14,19 +14,21 @@ readability.</p>
 <h3>What is the potential impact?</h3>
 <p>The code will be non-conventional and readability can be slightly affected.</p>
 <h3>Exceptions</h3>
-<p>This rule does not raise an issue when the visibility is set to <code>private</code>, because <code>private</code> test methods and classes are
-systematically ignored by JUnit5, without a proper warning. In this case, there is also an impact on reliability and so it is handled by the rule
+<p>This rule does not raise an issue when the visibility is set to <code>private</code>, because <code>private</code> test methods are systematically
+ignored by JUnit5, without a proper warning. In this case, there is also an impact on reliability and so it is handled by the rule
 {rule:java:S5810}.</p>
+<p>Note that this rule does not flag the visibility modifier of the test class itself, because there can be legitimate reasons to keep a test class
+public — for example, when it is referenced in a test suite or extended by a test class in another package.</p>
 <h2>How to fix it</h2>
-<p>You can simply change the visibility by removing the <code>public</code> or <code>protected</code> keywords.</p>
+<p>Remove the <code>public</code> or <code>protected</code> keywords from the test methods.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 import org.junit.jupiter.api.Test;
 
-public class MyClassTest { // Noncompliant - modifier can be removed
+class MyClassTest { // Noncompliant - test methods have redundant visibility modifiers
   @Test
-  protected void test() { // Noncompliant - modifier can be removed
+  public void test() { // secondary location
     // ...
   }
 }

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5786.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5786.json
@@ -1,5 +1,5 @@
 {
-  "title": "JUnit5 test classes and methods should have default package visibility",
+  "title": "JUnit5 test methods should have default package visibility",
   "type": "CODE_SMELL",
   "code": {
     "impacts": {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5810.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5810.html
@@ -4,12 +4,14 @@ default package, public and protected visibility, even if it is recommended to u
 code.</p>
 <p>But JUnit5 ignores without any warning:</p>
 <ul>
-  <li>private classes and private methods</li>
+  <li>private methods</li>
   <li>static methods</li>
   <li>methods returning a value without being a TestFactory</li>
+  <li><code>@Nested</code> classes with <code>private</code> visibility (the entire nested test suite is silently skipped)</li>
 </ul>
 <h3>Noncompliant code example</h3>
 <pre>
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MyClassTest {
@@ -25,8 +27,9 @@ class MyClassTest {
   boolean test3() { // Noncompliant - ignored by JUnit5
     // ...
   }
+
   @Nested
-  private class MyNestedClass { // Noncompliant - ignored by JUnit5
+  private class NestedTests { // Noncompliant - entire nested suite ignored by JUnit5
     @Test
     void test() {
       // ...
@@ -36,6 +39,7 @@ class MyClassTest {
 </pre>
 <h3>Compliant solution</h3>
 <pre>
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MyClassTest {
@@ -51,8 +55,9 @@ class MyClassTest {
   void test3() {
     // ...
   }
+
   @Nested
-  class MyNestedClass {
+  class NestedTests { // Compliant - private modifier removed
     @Test
     void test() {
       // ...

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5810.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5810.json
@@ -1,5 +1,5 @@
 {
-  "title": "JUnit5 test classes and methods should not be silently ignored",
+  "title": "JUnit5 test methods should not be silently ignored",
   "type": "BUG",
   "code": {
     "impacts": {

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5810.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S5810.json
@@ -1,5 +1,5 @@
 {
-  "title": "JUnit5 test methods should not be silently ignored",
+  "title": "JUnit5 test classes and methods should not be silently ignored",
   "type": "BUG",
   "code": {
     "impacts": {


### PR DESCRIPTION
Both rules previously attempted to flag the visibility modifier of the test class itself, but this produced false positives for classes that are legitimately public — for example, when referenced in a @Suite or extended from another package.

The fix removes class-modifier flagging from both rules entirely:
- S5786 now only reports redundant public/protected on test methods, never on the class declaration.
- S5810 now raises issues only for test methods. Exception is private @Nested class.
 
