### PR TITLE
SONARJAVA-6906 - Modify S8924 to raise only on inconsistent Mockito import usage

### DIFF
--- a/its/ruling/src/test/resources/sonar-server/java-S8924.json
+++ b/its/ruling/src/test/resources/sonar-server/java-S8924.json
@@ -2,12 +2,6 @@
 "org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/ce/log/CeLoggingTest.java": [
 64
 ],
-"org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/component/ws/TreeActionTest.java": [
-88
-],
-"org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/language/ws/LanguageWsTest.java": [
-51
-],
 "org.sonarsource.sonarqube:sonar-server:src/test/java/org/sonar/server/rule/ws/ShowActionTest.java": [
 150
 ]

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNoStaticImportSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNoStaticImportSample.java
@@ -1,0 +1,25 @@
+package checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class MockitoStaticImportCheckNoStaticImportSample {
+
+  interface MyService {
+    int getValue();
+  }
+
+  @Test
+  void compliant_consistent_prefixed_usage() {
+    MyService service = Mockito.mock(MyService.class); // Compliant - no static import of Mockito methods in this file
+    MyService spied = Mockito.spy(service);
+
+    Mockito.when(service.getValue()).thenReturn(42);
+    Mockito.doReturn(42).when(spied).getValue();
+
+    service.getValue();
+    Mockito.verify(service, Mockito.times(1)).getValue();
+    Mockito.verify(service, Mockito.never()).hashCode();
+  }
+
+}

--- a/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNoStaticImportSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/MockitoStaticImportCheckNoStaticImportSample.java
@@ -2,6 +2,7 @@ package checks.tests;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MockitoStaticImportCheckNoStaticImportSample {
 

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStaticImportCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/MockitoStaticImportCheck.java
@@ -50,6 +50,7 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
     .build();
 
   private Set<String> conflictingImportedNames = new HashSet<>();
+  private boolean hasStaticMockitoImport;
   private final Deque<Set<String>> classMethodsStack = new ArrayDeque<>();
 
   @Override
@@ -76,9 +77,14 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
   }
 
   private void collectConflictingImports(CompilationUnitTree compilationUnitTree) {
-    conflictingImportedNames = compilationUnitTree.imports().stream()
+    List<String> staticImportFqns = compilationUnitTree.imports().stream()
       .filter(clause -> clause instanceof ImportTree importTree && importTree.isStatic())
       .map(clause -> ExpressionsHelper.concatenate((ExpressionTree) ((ImportTree) clause).qualifiedIdentifier()))
+      .toList();
+
+    hasStaticMockitoImport = staticImportFqns.stream().anyMatch(fqn -> fqn.startsWith(MOCKITO_IMPORT_PREFIX));
+
+    conflictingImportedNames = staticImportFqns.stream()
       .filter(fqn -> !fqn.startsWith(MOCKITO_IMPORT_PREFIX) && !fqn.endsWith(".*"))
       .map(fqn -> fqn.substring(fqn.lastIndexOf('.') + 1))
       .collect(Collectors.toSet());
@@ -100,7 +106,7 @@ public class MockitoStaticImportCheck extends IssuableSubscriptionVisitor {
       return;
     }
     String methodName = mset.identifier().name();
-    if (MOCKITO_METHODS.matches(mit.methodSymbol()) && !requiresTypeWitness(mit) && !isNameInConflict(methodName)) {
+    if (hasStaticMockitoImport && MOCKITO_METHODS.matches(mit.methodSymbol()) && !requiresTypeWitness(mit) && !isNameInConflict(methodName)) {
       reportIssue(methodSelect, "Use a static import for \"%s\".".formatted(methodName));
     }
   }

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoStaticImportCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/MockitoStaticImportCheckTest.java
@@ -47,4 +47,12 @@ class MockitoStaticImportCheckTest {
       .withCheck(new MockitoStaticImportCheck())
       .verifyNoIssues();
   }
+
+  @Test
+  void test_no_static_import() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/MockitoStaticImportCheckNoStaticImportSample.java"))
+      .withCheck(new MockitoStaticImportCheck())
+      .verifyNoIssues();
+  }
 }


### PR DESCRIPTION
## Summary
- S8924 now only raises an issue when a file mixes prefixed `Mockito.xxx()` calls with at least one static import of a Mockito method, instead of flagging every prefixed call unconditionally.
- Files that consistently use the `Mockito.` prefix throughout, without any static import of a Mockito method, are no longer flagged.
- Added `MockitoStaticImportCheckNoStaticImportSample.java` and a corresponding test case covering the fully-prefixed, no-static-import scenario.

----
## Summary by Gitar

- **Rule renaming and refactoring:**
    - Renamed `CompilationOrPreparationInLoopCheck` to `PreparedStatementInsideLoopCheck` (rule S9142) and removed regex checks.
- **Documentation updates:**
    - Updated rule S9142 metadata, title, HTML description, and resources.

<sub>This will update automatically on new commits.</sub>