### PR TITLE
SONARJAVA-6256: S6832 - Fix FP for non-singleton beans with scoped proxy mode

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSample.java
@@ -4,6 +4,7 @@ import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBean
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean2;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean3;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean4;
+import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean5;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.RequestBean1;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.RequestBean2;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.SessionBean1;
@@ -205,12 +206,15 @@ public class NonSingletonAutowiredInSingletonCheckSample {
 
   public class SingletonBeanWithRequestAndSessionBeans {
     @Autowired
-    private RequestBean2 requestBean2; // Noncompliant
+    private RequestBean2 requestBean2; // Noncompliant {{Don't auto-wire this non-Singleton bean into a Singleton bean (autowired field).}}
+    //      ^^^^^^^^^^^^
+
     @Autowired
     private SessionBean1 sessionBean1; // Noncompliant
 
     @Autowired
-    public void setRequestBean2(RequestBean2 requestBean2) { // Noncompliant
+    public void setRequestBean2(RequestBean2 requestBean2) { // Noncompliant {{Don't auto-wire this non-Singleton bean into a Singleton bean (autowired setter method).}}
+//                              ^^^^^^^^^^^^
       this.requestBean2 = requestBean2;
     }
 

--- a/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSample.java
@@ -3,7 +3,10 @@ package checks.spring;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean1;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean2;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean3;
+import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.PrototypeBean4;
 import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.RequestBean1;
+import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.RequestBean2;
+import checks.spring.NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.SessionBean1;
 import javax.inject.Inject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -16,18 +19,18 @@ public class NonSingletonAutowiredInSingletonCheckSample {
 
   public class SingletonBean {
     @Autowired
-    private RequestBean1 requestBean1; // Noncompliant {{Don't auto-wire this non-Singleton bean into a Singleton bean (autowired field).}}
-//          ^^^^^^^^^^^^
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     @Autowired
     private PrototypeBean1 prototypeBean1; // Noncompliant
     @Autowired
     private PrototypeBean2 prototypeBean2; // Noncompliant
     @Autowired
-    private PrototypeBean3 prototypeBean3; // Noncompliant
+    private PrototypeBean3 prototypeBean3; // Compliant, uses scoped proxy
+    @Autowired
+    private PrototypeBean4 prototypeBean4; // Compliant, uses scoped proxy
 
     @Autowired
-    public SingletonBean(RequestBean1 requestBean1) { // Noncompliant 2
-//                       ^^^^^^^^^^^^
+    public SingletonBean(RequestBean1 requestBean1) { // Compliant, uses scoped proxy
     }
 
     @Autowired // Noncompliant@+1
@@ -35,15 +38,14 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     }
 
     @Autowired
-    public SingletonBean(RequestBean1 requestBean1, // Noncompliant
+    public SingletonBean(RequestBean1 requestBean1, // Compliant, uses scoped proxy
       PrototypeBean1 prototypeBean1, // Noncompliant
       PrototypeBean2 prototypeBean2, // Noncompliant
-      PrototypeBean3 prototypeBean3) { // Noncompliant
+      PrototypeBean3 prototypeBean3) { // Compliant, uses scoped proxy
     }
 
     @Autowired
-    public void setRequestBean1(RequestBean1 requestBean1) { // Noncompliant {{Don't auto-wire this non-Singleton bean into a Singleton bean (autowired setter method).}}
-//                              ^^^^^^^^^^^^
+    public void setRequestBean1(RequestBean1 requestBean1) { // Compliant, uses scoped proxy
       this.requestBean1 = requestBean1;
     }
 
@@ -67,7 +69,7 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     @Autowired
     private SingletonBean singletonBean; // Compliant, since scope is non-Singleton
     @Autowired
-    private RequestBean1 requestBean1; // Noncompliant
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     @Autowired
     private PrototypeBean1 prototypeBean1; // Noncompliant
 
@@ -76,8 +78,8 @@ public class NonSingletonAutowiredInSingletonCheckSample {
       this.singletonBean = singletonBean;
     }
 
-    @Autowired // Noncompliant@+1
-    public SingletonBean2(RequestBean1 requestBean1) { // Noncompliant
+    @Autowired
+    public SingletonBean2(RequestBean1 requestBean1) { // Compliant, uses scoped proxy
       this.requestBean1 = requestBean1;
     }
   }
@@ -87,13 +89,12 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     @Autowired
     private SingletonBean singletonBean; // Compliant, since scope is non-Singleton
     @Autowired
-    private RequestBean1 requestBean1; // Noncompliant
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     @Autowired
     private PrototypeBean1 prototypeBean1; // Noncompliant
 
- // Noncompliant@+2
-    @Autowired // Noncompliant@+1
-    public SingletonBean3(@Autowired RequestBean1 requestBean1) { // Noncompliant
+    @Autowired
+    public SingletonBean3(@Autowired RequestBean1 requestBean1) { // Compliant, uses scoped proxy
     }
   }
 
@@ -102,7 +103,7 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     @Autowired
     private SingletonBean singletonBean; // Compliant, since scope is non-Singleton
     @Autowired
-    private RequestBean1 requestBean1; // Noncompliant
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     @Autowired
     private PrototypeBean1 prototypeBean1; // Noncompliant
   }
@@ -112,7 +113,7 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     @Autowired
     private SingletonBean singletonBean; // Compliant, since scope is non-Singleton
     @Autowired
-    private RequestBean1 requestBean1; // Noncompliant
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     @Autowired
     private PrototypeBean1 prototypeBean1; // Noncompliant
   }
@@ -122,7 +123,7 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     @Inject
     private SingletonBean5 singletonBean5; // Compliant, since scope is non-Singleton
     @Inject
-    private RequestBean1 requestBean1; // Noncompliant
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     private PrototypeBean1 prototypeBean1;
     private PrototypeBean2 prototypeBean2;
 
@@ -147,7 +148,7 @@ public class NonSingletonAutowiredInSingletonCheckSample {
     @jakarta.inject.Inject
     private SingletonBean5 singletonBean5; // Compliant, since scope is non-Singleton
     @jakarta.inject.Inject
-    private RequestBean1 requestBean1; // Noncompliant
+    private RequestBean1 requestBean1; // Compliant, uses scoped proxy
     private PrototypeBean1 prototypeBean1;
     private PrototypeBean2 prototypeBean2;
 
@@ -180,15 +181,15 @@ public class NonSingletonAutowiredInSingletonCheckSample {
 
   public class SingletonBean11 {
     @Autowired
-    private CustomBean customBean; // Noncompliant
+    private CustomBean customBean; // Compliant, uses scoped proxy
 
-    @Autowired // Noncompliant@+1
-    public SingletonBean11(CustomBean customBean) { // Noncompliant
+    @Autowired
+    public SingletonBean11(CustomBean customBean) { // Compliant, uses scoped proxy
       this.customBean = customBean;
     }
 
     @Autowired
-    public void setCustomBean(CustomBean customBean) { // Noncompliant
+    public void setCustomBean(CustomBean customBean) { // Compliant, uses scoped proxy
       this.customBean = customBean;
     }
 
@@ -199,6 +200,22 @@ public class NonSingletonAutowiredInSingletonCheckSample {
 
     public void method2(@Autowired CustomBean customBean) { // Compliant, not a setter or constructor
       // ...
+    }
+  }
+
+  public class SingletonBeanWithRequestAndSessionBeans {
+    @Autowired
+    private RequestBean2 requestBean2; // Noncompliant
+    @Autowired
+    private SessionBean1 sessionBean1; // Noncompliant
+
+    @Autowired
+    public void setRequestBean2(RequestBean2 requestBean2) { // Noncompliant
+      this.requestBean2 = requestBean2;
+    }
+
+    public SingletonBeanWithRequestAndSessionBeans(RequestBean2 requestBean2) { // Noncompliant
+      this.requestBean2 = requestBean2;
     }
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.java
@@ -31,6 +31,10 @@ public class NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinit
   public class PrototypeBean4 {
   }
 
+  @Scope(value = "prototype", proxyMode = ScopedProxyMode.NO)
+  public class PrototypeBean5 {
+  }
+
   @Scope(WebApplicationContext.SCOPE_REQUEST)
   public class RequestBean2 {
   }

--- a/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinition.java
@@ -26,4 +26,16 @@ public class NonSingletonAutowiredInSingletonCheckSampleNonSingletonBeansDefinit
   @Scope(value = PROTOTYPE_SCOPE, scopeName = "prototype", proxyMode = ScopedProxyMode.TARGET_CLASS)
   public class PrototypeBean3 {
   }
+
+  @Scope(value = "prototype", proxyMode = ScopedProxyMode.INTERFACES)
+  public class PrototypeBean4 {
+  }
+
+  @Scope(WebApplicationContext.SCOPE_REQUEST)
+  public class RequestBean2 {
+  }
+
+  @Scope(value = WebApplicationContext.SCOPE_SESSION)
+  public class SessionBean1 {
+  }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/NonSingletonAutowiredInSingletonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/NonSingletonAutowiredInSingletonCheck.java
@@ -37,6 +37,7 @@ public class NonSingletonAutowiredInSingletonCheck extends IssuableSubscriptionV
   private static final String JAVAX_INJECT_ANNOTATION = "javax.inject.Inject";
   private static final String JAKARTA_INJECT_ANNOTATION = "jakarta.inject.Inject";
   private static final Set<String> AUTO_WIRING_ANNOTATIONS = Set.of(SpringUtils.AUTOWIRED_ANNOTATION, JAVAX_INJECT_ANNOTATION, JAKARTA_INJECT_ANNOTATION);
+  private static final Set<String> SCOPED_PROXY_MODES = Set.of("TARGET_CLASS", "INTERFACES");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -148,7 +149,15 @@ public class NonSingletonAutowiredInSingletonCheck extends IssuableSubscriptionV
   }
 
   private static boolean hasTypeNotSingletonBean(VariableTree variableTree) {
-    return hasNotSingletonScopeAnnotation(variableTree.symbol().type().symbol().metadata().annotations());
+    List<SymbolMetadata.AnnotationInstance> annotations = variableTree.symbol().type().symbol().metadata().annotations();
+    return hasNotSingletonScopeAnnotation(annotations) && !hasScopedProxy(annotations);
+  }
+
+  private static boolean hasScopedProxy(List<SymbolMetadata.AnnotationInstance> annotations) {
+    return annotations.stream()
+      .filter(ai -> ai.symbol().type().is(SpringUtils.SCOPE_ANNOTATION))
+      .flatMap(ai -> ai.values().stream())
+      .anyMatch(NonSingletonAutowiredInSingletonCheck::isScopedProxyAnnotationValue);
   }
 
   private static boolean isAutoWiringAnnotation(AnnotationTree annotationTree) {
@@ -169,6 +178,12 @@ public class NonSingletonAutowiredInSingletonCheck extends IssuableSubscriptionV
       && annotationInstance.values()
         .stream()
         .anyMatch(NonSingletonAutowiredInSingletonCheck::isNotSingletonAnnotationValue);
+  }
+
+  private static boolean isScopedProxyAnnotationValue(SymbolMetadata.AnnotationValue annotationValue) {
+    return "proxyMode".equals(annotationValue.name())
+      && annotationValue.value() instanceof Symbol.VariableSymbol variableSymbol
+      && SCOPED_PROXY_MODES.contains(variableSymbol.name());
   }
 
   private static boolean isNotSingletonAnnotationValue(SymbolMetadata.AnnotationValue annotationValue) {


### PR DESCRIPTION
When a non-singleton bean is annotated with @Scope(proxyMode = ScopedProxyMode.TARGET_CLASS) or ScopedProxyMode.INTERFACES, Spring wraps it in a scoped proxy that correctly handles the scope boundary, making it safe to inject into singleton beans.