### PR TITLE
SONARJAVA-6912 Recognize @Inject constructor selection

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheckSample.java
@@ -66,6 +66,20 @@ public class AutowiredOnConstructorWhenMultipleConstructorsCheckSample { // Comp
   }
 
   @Component
+  class ComponentWithInjectField { // Noncompliant {{Add @Autowired or @Inject to one of the constructors.}}
+//      ^^^^^^^^^^^^^^^^^^^^^^^^
+
+    @javax.inject.Inject
+    private String dependency;
+
+    public ComponentWithInjectField() {
+    }
+
+    public ComponentWithInjectField(int i) {
+    }
+  }
+
+  @Component
   class ComponentWithOtherAnnotations { // Noncompliant
 
     public ComponentWithOtherAnnotations() {

--- a/java-checks-test-sources/default/src/main/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheckSample.java
@@ -16,7 +16,7 @@ public class AutowiredOnConstructorWhenMultipleConstructorsCheckSample { // Comp
   }
 
   @Component
-  class SpringComponent { // Noncompliant {{Add @Autowired to one of the constructors.}}
+  class SpringComponent { // Noncompliant {{Add @Autowired or @Inject to one of the constructors.}}
 //      ^^^^^^^^^^^^^^^
 
     public SpringComponent() {
@@ -40,6 +40,28 @@ public class AutowiredOnConstructorWhenMultipleConstructorsCheckSample { // Comp
     }
 
     public CompliantSpringComponent(String s) {
+    }
+  }
+
+  @Component
+  class ComponentWithJavaxInjectConstructor { // Compliant
+
+    @javax.inject.Inject
+    public ComponentWithJavaxInjectConstructor() {
+    }
+
+    public ComponentWithJavaxInjectConstructor(int i) {
+    }
+  }
+
+  @Component
+  class ComponentWithJakartaInjectConstructor { // Compliant
+
+    @jakarta.inject.Inject
+    public ComponentWithJakartaInjectConstructor() {
+    }
+
+    public ComponentWithJakartaInjectConstructor(int i) {
     }
   }
 

--- a/java-checks-test-sources/default/src/main/java/checks/spring/SpringConfigurationWithAutowiredFieldsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/spring/SpringConfigurationWithAutowiredFieldsCheckSample.java
@@ -19,6 +19,8 @@ class SpringConfigurationWithAutowiredFieldsCheckSample {
 //                         ^^^^^^^^^^^
     @Inject private Bar jsr330; // Noncompliant {{Inject this field value directly into "jsr330", the only method that uses it.}}
 //                      ^^^^^^
+    @jakarta.inject.Inject private Bar jakartaInject; // Noncompliant {{Inject this field value directly into "jakartaInject", the only method that uses it.}}
+//                                     ^^^^^^^^^^^^^
     @Autowired private Bar multipleUsage;
     @Autowired private Bar notUsedInBeanMethod;
     @Autowired private Bar notUsed;
@@ -38,6 +40,11 @@ class SpringConfigurationWithAutowiredFieldsCheckSample {
     @Bean
     public Foo jsr330() {
       return new Foo(this.jsr330);
+    }
+
+    @Bean
+    public Foo jakartaInject() {
+      return new Foo(this.jakartaInject);
     }
 
     @Bean
@@ -149,6 +156,5 @@ class SpringConfigurationWithAutowiredFieldsCheckSample {
     }
   }
 }
-
 
 

--- a/java-checks/src/main/java/org/sonar/java/checks/helpers/SpringUtils.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/helpers/SpringUtils.java
@@ -17,6 +17,7 @@
 package org.sonar.java.checks.helpers;
 
 import java.util.List;
+import java.util.Set;
 import org.sonar.java.model.ExpressionUtils;
 import org.sonar.plugins.java.api.semantic.Symbol;
 import org.sonar.plugins.java.api.semantic.SymbolMetadata;
@@ -46,6 +47,10 @@ public final class SpringUtils {
   public static final String DATA_REPOSITORY_ANNOTATION = DATA_PACKAGE + "repository.Repository";
   public static final String REST_CONTROLLER_ANNOTATION = "org.springframework.web.bind.annotation.RestController";
   public static final String SPRING_BOOT_TEST_ANNOTATION = "org.springframework.boot.test.context.SpringBootTest";
+  public static final Set<String> INJECTION_ANNOTATIONS = Set.of(
+    AUTOWIRED_ANNOTATION,
+    "javax.inject.Inject",
+    "jakarta.inject.Inject");
 
   private SpringUtils() {
     // Utils class

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheck.java
@@ -17,6 +17,7 @@
 package org.sonar.java.checks.spring;
 
 import java.util.List;
+import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.SpringUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
@@ -26,6 +27,11 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S6829")
 public class AutowiredOnConstructorWhenMultipleConstructorsCheck extends IssuableSubscriptionVisitor {
+
+  private static final Set<String> EXPLICIT_CONSTRUCTOR_INJECTION_ANNOTATIONS = Set.of(
+    SpringUtils.AUTOWIRED_ANNOTATION,
+    "javax.inject.Inject",
+    "jakarta.inject.Inject");
 
   private final List<String> annotations = List.of(
     SpringUtils.BEAN_ANNOTATION,
@@ -56,12 +62,12 @@ public class AutowiredOnConstructorWhenMultipleConstructorsCheck extends Issuabl
       .toList();
 
     if (constructors.size() > 1) {
-      boolean anyHasAutowired = constructors.stream()
+      boolean hasExplicitConstructorInjection = constructors.stream()
         .anyMatch(constructor -> constructor.modifiers().annotations().stream()
-          .anyMatch(annotation -> annotation.symbolType().is(SpringUtils.AUTOWIRED_ANNOTATION)));
+          .anyMatch(annotation -> EXPLICIT_CONSTRUCTOR_INJECTION_ANNOTATIONS.contains(annotation.symbolType().fullyQualifiedName())));
 
-      if (!anyHasAutowired) {
-        reportIssue(classTree.simpleName(), "Add @Autowired to one of the constructors.");
+      if (!hasExplicitConstructorInjection) {
+        reportIssue(classTree.simpleName(), "Add @Autowired or @Inject to one of the constructors.");
       }
     }
   }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/AutowiredOnConstructorWhenMultipleConstructorsCheck.java
@@ -17,7 +17,6 @@
 package org.sonar.java.checks.spring;
 
 import java.util.List;
-import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.java.checks.helpers.SpringUtils;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
@@ -27,11 +26,6 @@ import org.sonar.plugins.java.api.tree.Tree;
 
 @Rule(key = "S6829")
 public class AutowiredOnConstructorWhenMultipleConstructorsCheck extends IssuableSubscriptionVisitor {
-
-  private static final Set<String> EXPLICIT_CONSTRUCTOR_INJECTION_ANNOTATIONS = Set.of(
-    SpringUtils.AUTOWIRED_ANNOTATION,
-    "javax.inject.Inject",
-    "jakarta.inject.Inject");
 
   private final List<String> annotations = List.of(
     SpringUtils.BEAN_ANNOTATION,
@@ -64,7 +58,7 @@ public class AutowiredOnConstructorWhenMultipleConstructorsCheck extends Issuabl
     if (constructors.size() > 1) {
       boolean hasExplicitConstructorInjection = constructors.stream()
         .anyMatch(constructor -> constructor.modifiers().annotations().stream()
-          .anyMatch(annotation -> EXPLICIT_CONSTRUCTOR_INJECTION_ANNOTATIONS.contains(annotation.symbolType().fullyQualifiedName())));
+          .anyMatch(annotation -> SpringUtils.INJECTION_ANNOTATIONS.contains(annotation.symbolType().fullyQualifiedName())));
 
       if (!hasExplicitConstructorInjection) {
         reportIssue(classTree.simpleName(), "Add @Autowired or @Inject to one of the constructors.");

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/FieldDependencyInjectionCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/FieldDependencyInjectionCheck.java
@@ -27,11 +27,6 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S6813")
 public class FieldDependencyInjectionCheck extends IssuableSubscriptionVisitor {
-  private static final List<String> INJECTION_ANNOTATIONS = List.of(
-    SpringUtils.AUTOWIRED_ANNOTATION,
-    "javax.inject.Inject",
-    "jakarta.inject.Inject");
-
   @Override
   public List<Tree.Kind> nodesToVisit() {
     return List.of(Tree.Kind.CLASS);
@@ -47,8 +42,7 @@ public class FieldDependencyInjectionCheck extends IssuableSubscriptionVisitor {
         var vt = (VariableTree) member;
 
         vt.modifiers().annotations().stream()
-          .filter(annotationTree -> INJECTION_ANNOTATIONS.stream()
-            .anyMatch(targetAnnotation -> annotationTree.symbolType().is(targetAnnotation)))
+          .filter(annotationTree -> SpringUtils.INJECTION_ANNOTATIONS.contains(annotationTree.symbolType().fullyQualifiedName()))
           .findFirst()
           .ifPresent(annotationTree -> reportIssue(annotationTree, "Remove this field injection and use constructor injection instead."));
       }

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/NonSingletonAutowiredInSingletonCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/NonSingletonAutowiredInSingletonCheck.java
@@ -34,9 +34,6 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 
 @Rule(key = "S6832")
 public class NonSingletonAutowiredInSingletonCheck extends IssuableSubscriptionVisitor {
-  private static final String JAVAX_INJECT_ANNOTATION = "javax.inject.Inject";
-  private static final String JAKARTA_INJECT_ANNOTATION = "jakarta.inject.Inject";
-  private static final Set<String> AUTO_WIRING_ANNOTATIONS = Set.of(SpringUtils.AUTOWIRED_ANNOTATION, JAVAX_INJECT_ANNOTATION, JAKARTA_INJECT_ANNOTATION);
   private static final Set<String> SCOPED_PROXY_MODES = Set.of("TARGET_CLASS", "INTERFACES");
 
   @Override
@@ -161,7 +158,7 @@ public class NonSingletonAutowiredInSingletonCheck extends IssuableSubscriptionV
   }
 
   private static boolean isAutoWiringAnnotation(AnnotationTree annotationTree) {
-    return AUTO_WIRING_ANNOTATIONS.contains(annotationTree.symbolType().fullyQualifiedName());
+    return SpringUtils.INJECTION_ANNOTATIONS.contains(annotationTree.symbolType().fullyQualifiedName());
   }
 
   private static boolean isSingletonBean(ClassTree classTree) {

--- a/java-checks/src/main/java/org/sonar/java/checks/spring/SpringConfigurationWithAutowiredFieldsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/spring/SpringConfigurationWithAutowiredFieldsCheck.java
@@ -17,7 +17,6 @@
 package org.sonar.java.checks.spring;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -39,10 +38,6 @@ import org.sonar.plugins.java.api.tree.VariableTree;
 public class SpringConfigurationWithAutowiredFieldsCheck extends IssuableSubscriptionVisitor {
 
   private static final String MESSAGE_FORMAT = "Inject this field value directly into \"%s\", the only method that uses it.";
-
-  private static final List<String> AUTOWIRED_ANNOTATIONS = Arrays.asList(
-    SpringUtils.AUTOWIRED_ANNOTATION,
-    "javax.inject.Inject");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {
@@ -78,7 +73,7 @@ public class SpringConfigurationWithAutowiredFieldsCheck extends IssuableSubscri
     Symbol variableSymbol = variable.symbol();
     SymbolMetadata metadata = variableSymbol.metadata();
 
-    for(String annotation: AUTOWIRED_ANNOTATIONS) {
+    for(String annotation: SpringUtils.INJECTION_ANNOTATIONS) {
       List<SymbolMetadata.AnnotationValue> annotationValues = metadata.valuesForAnnotation(annotation);
       if (annotationValues != null) {
         if (annotationValues.stream().anyMatch(SpringConfigurationWithAutowiredFieldsCheck::isRequiredFalse)

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.html
@@ -1,5 +1,6 @@
-<p>The <code>@Autowired</code> and <code>@Inject</code> annotations in Spring are used for automatic dependency injection. They allow Spring to
-resolve and inject the required beans into your bean. For example, to inject a <code>@Repository</code> object into a <code>@Service</code>.</p>
+<p>The <code>@Autowired</code> annotation in Spring, and the standard JSR-330 <code>@Inject</code> annotation (from <code>jakarta.inject</code> or
+<code>javax.inject</code>) that Spring also supports, are used for automatic dependency injection. They allow Spring to resolve and inject the
+required beans into your bean. For example, to inject a <code>@Repository</code> object into a <code>@Service</code>.</p>
 <h2>Why is this an issue?</h2>
 <p>The Spring dependency injection mechanism cannot identify which constructor to use for auto-wiring when multiple constructors are present in a
 class. This ambiguity can cause the application to crash at runtime, and it makes the code less clear to understand and more complex to extend and
@@ -46,7 +47,7 @@ public class ExampleClass {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-    @Inject
+    @Autowired // or @Inject from jakarta.inject or javax.inject
     public ExampleClass(DependencyClass1 dependency1) {
         this.dependency1 = dependency1;
     }
@@ -59,8 +60,8 @@ public class ExampleClass {
 <ul>
   <li>Spring - <a href="https://docs.spring.io/spring-framework/reference/core/beans/annotation-config/autowired.html">Annotation Config:
   Autowired</a></li>
-  <li>Spring - <a href="https://docs.spring.io/spring-framework/reference/core/beans/standard-annotations.html">Dependency Injection with @Inject and
-  @Named</a></li>
+  <li>Spring - <a href="https://docs.spring.io/spring-framework/reference/core/beans/standard-annotations.html#beans-inject-named">Dependency
+  Injection with @Inject and @Named</a></li>
 </ul>
 <h3>Articles &amp; blog posts</h3>
 <ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.html
@@ -1,5 +1,5 @@
-<p>The <code>@Autowired</code> annotation in Spring is used for automatic dependency injection. It allows Spring to resolve and inject the required
-beans into your bean. For example to inject a <code>@Repository</code> object into a <code>@Service</code>.</p>
+<p>The <code>@Autowired</code> and <code>@Inject</code> annotations in Spring are used for automatic dependency injection. They allow Spring to
+resolve and inject the required beans into your bean. For example, to inject a <code>@Repository</code> object into a <code>@Service</code>.</p>
 <h2>Why is this an issue?</h2>
 <p>The Spring dependency injection mechanism cannot identify which constructor to use for auto-wiring when multiple constructors are present in a
 class. This ambiguity can cause the application to crash at runtime, and it makes the code less clear to understand and more complex to extend and
@@ -15,12 +15,12 @@ maintain.</p>
   <li><strong>maintainability issues</strong>: adding more constructors in the future could lead to further confusion and potential bugs.</li>
 </ul>
 <h2>How to fix it</h2>
-<p>Use the <code>@Autowired</code> annotation to specify which constructor to use for auto-wiring.</p>
+<p>Use the <code>@Autowired</code> or <code>@Inject</code> annotation to specify which constructor to use for dependency injection.</p>
 <h3>Code examples</h3>
 <h4>Noncompliant code example</h4>
 <pre data-diff-id="1" data-diff-type="noncompliant">
 @Component
-public class ExampleClass { // Noncompliant: multiple constructors present and no @Autowired annotation to specify which one to use
+public class ExampleClass { // Noncompliant: multiple constructors present and no @Autowired or @Inject annotation to specify which one to use
 
     private final DependencyClass1 dependency1;
 
@@ -46,7 +46,7 @@ public class ExampleClass {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-    @Autowired
+    @Inject
     public ExampleClass(DependencyClass1 dependency1) {
         this.dependency1 = dependency1;
     }
@@ -59,6 +59,8 @@ public class ExampleClass {
 <ul>
   <li>Spring - <a href="https://docs.spring.io/spring-framework/reference/core/beans/annotation-config/autowired.html">Annotation Config:
   Autowired</a></li>
+  <li>Spring - <a href="https://docs.spring.io/spring-framework/reference/core/beans/standard-annotations.html">Dependency Injection with @Inject and
+  @Named</a></li>
 </ul>
 <h3>Articles &amp; blog posts</h3>
 <ul>

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S6829.json
@@ -1,5 +1,5 @@
 {
-  "title": "\"@Autowired\" should be used when multiple constructors are provided",
+  "title": "\"@Autowired\" or \"@Inject\" should be used when multiple constructors are provided",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
## Summary
Updates S6829 so Spring components with a constructor selected by javax.inject.Inject or jakarta.inject.Inject are compliant. The issue message and generated rule description now describe both supported annotations.
RSPEC PR: https://github.com/SonarSource/rspec/pull/8141

## Changes
- Recognize @Inject alongside @Autowired on constructors
- Cover javax.inject and jakarta.inject constructor annotations
- Regenerate the S6829 rule metadata and description