### PR TITLE
SONARJAVA-6943: Implement rule S9386 Float literals should be used instead of casting double literals to float

### DIFF
--- a/its/ruling/src/test/resources/commons-beanutils/java-S9386.json
+++ b/its/ruling/src/test/resources/commons-beanutils/java-S9386.json
@@ -1,0 +1,83 @@
+{
+"commons-beanutils:commons-beanutils:src/main/java/org/apache/commons/beanutils2/BasicDynaBean.java": [
+167
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/BasicDynaBeanTestCase.java": [
+112,
+508,
+509,
+882,
+887
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/BeanUtilsTestCase.java": [
+284,
+285,
+772,
+774,
+830,
+831
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/BenchBean.java": [
+78
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/ConvertUtilsTestCase.java": [
+164,
+165,
+169,
+170,
+258,
+435,
+436,
+440,
+441
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/DynaBeanUtilsTestCase.java": [
+119,
+372,
+374,
+503,
+816,
+818,
+869,
+870
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/DynaPropertyUtilsTestCase.java": [
+114,
+194,
+213,
+215,
+268,
+994,
+1260,
+1261,
+2106,
+2113,
+2400,
+2407
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/PropertyUtilsTestCase.java": [
+264,
+282,
+283,
+336,
+1500,
+2032,
+3383,
+3390,
+3677,
+3684
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/TestBean.java": [
+215
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/TestResultSet.java": [
+182
+],
+"commons-beanutils:commons-beanutils:src/test/java/org/apache/commons/beanutils2/locale/LocaleConvertUtilsTestCase.java": [
+302,
+485,
+486,
+490,
+491
+]
+}

--- a/its/ruling/src/test/resources/eclipse-jetty/java-S9386.json
+++ b/its/ruling/src/test/resources/eclipse-jetty/java-S9386.json
@@ -1,0 +1,5 @@
+{
+"org.eclipse.jetty:jetty-project:jetty-util/src/main/java/org/eclipse/jetty/util/PathWatcher.java": [
+737
+]
+}

--- a/java-checks-test-sources/default/src/main/java/checks/CastDoubleToFloatCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/CastDoubleToFloatCheckSample.java
@@ -1,0 +1,80 @@
+package checks;
+
+class CastDoubleToFloatCheckSample {
+
+  double someDouble = 1.0;
+
+  double getDouble() {
+    return 1.0;
+  }
+
+  void noncompliant() {
+    float a = (float) 3.14; // Noncompliant {{Use a float literal instead of casting a double literal to float.}} [[quickfixes=qf1]]
+//            ^^^^^^^^^^^^
+    // fix@qf1 {{Replace with a float literal}}
+    // edit@qf1 [[sc=15;ec=27]] {{3.14f}}
+
+    float b = (float) 0.5; // Noncompliant [[quickfixes=qf2]]
+//            ^^^^^^^^^^^
+    // fix@qf2 {{Replace with a float literal}}
+    // edit@qf2 [[sc=15;ec=26]] {{0.5f}}
+
+    float c = (float) 1.0; // Noncompliant [[quickfixes=qf3]]
+//            ^^^^^^^^^^^
+    // fix@qf3 {{Replace with a float literal}}
+    // edit@qf3 [[sc=15;ec=26]] {{1.0f}}
+
+    float d = (float) 3.14159; // Noncompliant [[quickfixes=qf4]]
+//            ^^^^^^^^^^^^^^^
+    // fix@qf4 {{Replace with a float literal}}
+    // edit@qf4 [[sc=15;ec=30]] {{3.14159f}}
+
+    float e = (float) 1e10; // Noncompliant [[quickfixes=qf5]]
+//            ^^^^^^^^^^^^
+    // fix@qf5 {{Replace with a float literal}}
+    // edit@qf5 [[sc=15;ec=27]] {{1e10f}}
+
+    float f = (float) 1.5e-3; // Noncompliant [[quickfixes=qf6]]
+//            ^^^^^^^^^^^^^^
+    // fix@qf6 {{Replace with a float literal}}
+    // edit@qf6 [[sc=15;ec=29]] {{1.5e-3f}}
+
+    float g = (float) .5; // Noncompliant [[quickfixes=qf7]]
+//            ^^^^^^^^^^
+    // fix@qf7 {{Replace with a float literal}}
+    // edit@qf7 [[sc=15;ec=25]] {{.5f}}
+
+    float h = (float) 3.14d; // Noncompliant [[quickfixes=qf8]]
+//            ^^^^^^^^^^^^^
+    // fix@qf8 {{Replace with a float literal}}
+    // edit@qf8 [[sc=15;ec=28]] {{3.14f}}
+
+    float i = (float) 3.14D; // Noncompliant [[quickfixes=qf9]]
+//            ^^^^^^^^^^^^^
+    // fix@qf9 {{Replace with a float literal}}
+    // edit@qf9 [[sc=15;ec=28]] {{3.14f}}
+
+    float j = (float) (3.14); // Noncompliant [[quickfixes=qf10]]
+//            ^^^^^^^^^^^^^^
+    // fix@qf10 {{Replace with a float literal}}
+    // edit@qf10 [[sc=15;ec=29]] {{3.14f}}
+
+    float k = (float) 0x1.0p10; // Noncompliant [[quickfixes=qf11]]
+//            ^^^^^^^^^^^^^^^^
+    // fix@qf11 {{Replace with a float literal}}
+    // edit@qf11 [[sc=15;ec=31]] {{0x1.0p10f}}
+  }
+
+  void compliant() {
+    float a = 3.14f;
+    float b = 3.14F;
+    float c = (float) someDouble;
+    float d = (float) getDouble();
+    float e = (float) (someDouble + 1.0);
+    float f = (float) 42;
+    float g = (float) 42L;
+    int h = (int) 3.14;
+    double i = (double) 3.14f;
+    float j = (float) Math.PI;
+  }
+}

--- a/java-checks-test-sources/default/src/main/java/checks/CastDoubleToFloatCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/CastDoubleToFloatCheckSample.java
@@ -63,6 +63,21 @@ class CastDoubleToFloatCheckSample {
 //            ^^^^^^^^^^^^^^^^
     // fix@qf11 {{Replace with a float literal}}
     // edit@qf11 [[sc=15;ec=31]] {{0x1.0p10f}}
+
+    float l = (float) -0.5; // Noncompliant [[quickfixes=qf12]]
+//            ^^^^^^^^^^^^
+    // fix@qf12 {{Replace with a float literal}}
+    // edit@qf12 [[sc=15;ec=27]] {{-0.5f}}
+
+    float m = (float) +3.14; // Noncompliant [[quickfixes=qf13]]
+//            ^^^^^^^^^^^^^
+    // fix@qf13 {{Replace with a float literal}}
+    // edit@qf13 [[sc=15;ec=28]] {{3.14f}}
+
+    float n = (float) -0.0; // Noncompliant [[quickfixes=qf14]]
+//            ^^^^^^^^^^^^
+    // fix@qf14 {{Replace with a float literal}}
+    // edit@qf14 [[sc=15;ec=27]] {{-0.0f}}
   }
 
   void compliant() {
@@ -76,5 +91,8 @@ class CastDoubleToFloatCheckSample {
     int h = (int) 3.14;
     double i = (double) 3.14f;
     float j = (float) Math.PI;
+    float k = (float) 1e300; // compliant - overflow, 1e300f is not a valid float literal
+    float l = (float) 1e-46; // compliant - underflow, 1e-46f would be zero but 1e-46 is not
+    float m = (float) 1.000000059604644775390625001; // compliant - double rounding difference
   }
 }

--- a/java-checks/src/main/java/org/sonar/java/checks/CastDoubleToFloatCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CastDoubleToFloatCheck.java
@@ -26,8 +26,10 @@ import org.sonar.java.reporting.JavaTextEdit;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.PrimitiveTypeTree;
 import org.sonar.plugins.java.api.tree.Tree;
 import org.sonar.plugins.java.api.tree.TypeCastTree;
+import org.sonar.plugins.java.api.tree.UnaryExpressionTree;
 
 @Rule(key = "S9386")
 public class CastDoubleToFloatCheck extends IssuableSubscriptionVisitor {
@@ -46,22 +48,56 @@ public class CastDoubleToFloatCheck extends IssuableSubscriptionVisitor {
       return;
     }
     ExpressionTree expression = ExpressionUtils.skipParentheses(typeCastTree.expression());
-    if (expression.is(Tree.Kind.DOUBLE_LITERAL)) {
-      String literalValue = ((LiteralTree) expression).value();
-      String replacement = stripDoubleSuffix(literalValue) + "f";
-      QuickFixHelper.newIssue(context)
-        .forRule(this)
-        .onTree(typeCastTree)
-        .withMessage(MESSAGE)
-        .withQuickFix(() -> JavaQuickFix.newQuickFix("Replace with a float literal")
-          .addTextEdit(JavaTextEdit.replaceTree(typeCastTree, replacement))
-          .build())
-        .report();
+    boolean negated = false;
+    if (expression.is(Tree.Kind.UNARY_MINUS, Tree.Kind.UNARY_PLUS)) {
+      negated = expression.is(Tree.Kind.UNARY_MINUS);
+      expression = ((UnaryExpressionTree) expression).expression();
     }
+    if (!expression.is(Tree.Kind.DOUBLE_LITERAL)) {
+      return;
+    }
+    String literalValue = ((LiteralTree) expression).value();
+    String stripped = stripDoubleSuffix(literalValue);
+    if (!isEquivalentFloatLiteral(stripped, negated)) {
+      return;
+    }
+    String replacement = (negated ? "-" : "") + stripped + "f";
+    QuickFixHelper.newIssue(context)
+      .forRule(this)
+      .onTree(typeCastTree)
+      .withMessage(MESSAGE)
+      .withQuickFix(() -> JavaQuickFix.newQuickFix("Replace with a float literal")
+        .addTextEdit(JavaTextEdit.replaceTree(typeCastTree, replacement))
+        .build())
+      .report();
   }
 
   private static boolean isFloatCast(TypeCastTree typeCastTree) {
-    return "float".equals(typeCastTree.type().firstToken().text());
+    if (typeCastTree.type() instanceof PrimitiveTypeTree primitiveType) {
+      return "float".equals(primitiveType.keyword().text());
+    }
+    return false;
+  }
+
+  private static boolean isEquivalentFloatLiteral(String stripped, boolean negated) {
+    String parseable = stripped.replace("_", "");
+    try {
+      double asDouble = Double.parseDouble(parseable);
+      float asFloat = Float.parseFloat(parseable);
+      if (!Float.isFinite(asFloat)) {
+        return false;
+      }
+      if (asFloat == 0.0f && asDouble != 0.0) {
+        return false;
+      }
+      if (negated) {
+        asDouble = -asDouble;
+        asFloat = -asFloat;
+      }
+      return asFloat == (float) asDouble;
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
 
   private static String stripDoubleSuffix(String literal) {

--- a/java-checks/src/main/java/org/sonar/java/checks/CastDoubleToFloatCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/CastDoubleToFloatCheck.java
@@ -1,0 +1,73 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.Collections;
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.java.checks.helpers.QuickFixHelper;
+import org.sonar.java.model.ExpressionUtils;
+import org.sonar.java.reporting.JavaQuickFix;
+import org.sonar.java.reporting.JavaTextEdit;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.TypeCastTree;
+
+@Rule(key = "S9386")
+public class CastDoubleToFloatCheck extends IssuableSubscriptionVisitor {
+
+  private static final String MESSAGE = "Use a float literal instead of casting a double literal to float.";
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.TYPE_CAST);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    TypeCastTree typeCastTree = (TypeCastTree) tree;
+    if (!isFloatCast(typeCastTree)) {
+      return;
+    }
+    ExpressionTree expression = ExpressionUtils.skipParentheses(typeCastTree.expression());
+    if (expression.is(Tree.Kind.DOUBLE_LITERAL)) {
+      String literalValue = ((LiteralTree) expression).value();
+      String replacement = stripDoubleSuffix(literalValue) + "f";
+      QuickFixHelper.newIssue(context)
+        .forRule(this)
+        .onTree(typeCastTree)
+        .withMessage(MESSAGE)
+        .withQuickFix(() -> JavaQuickFix.newQuickFix("Replace with a float literal")
+          .addTextEdit(JavaTextEdit.replaceTree(typeCastTree, replacement))
+          .build())
+        .report();
+    }
+  }
+
+  private static boolean isFloatCast(TypeCastTree typeCastTree) {
+    return "float".equals(typeCastTree.type().firstToken().text());
+  }
+
+  private static String stripDoubleSuffix(String literal) {
+    if (literal.endsWith("d") || literal.endsWith("D")) {
+      return literal.substring(0, literal.length() - 1);
+    }
+    return literal;
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/CastDoubleToFloatCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/CastDoubleToFloatCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class CastDoubleToFloatCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/CastDoubleToFloatCheckSample.java"))
+      .withCheck(new CastDoubleToFloatCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/CastDoubleToFloatCheckSample.java"))
+      .withCheck(new CastDoubleToFloatCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9386.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9386.html
@@ -1,22 +1,15 @@
-<p>An issue is raised when a higher-precision floating-point literal is explicitly converted to a lower-precision floating-point type using an
-explicit type conversion operation.</p>
 <h2>Why is this an issue?</h2>
-<p>In most languages, decimal number literals without a suffix are treated as a higher-precision floating-point type by default. When you need a
-lower-precision floating-point value, you have two options:</p>
+<p>In Java, decimal number literals without a suffix are treated as <code>double</code> by default. When you need a <code>float</code> value, you have
+two options:</p>
 <ul>
-  <li>Cast the default literal: using an explicit type cast operator</li>
-  <li>Use a type-specific literal directly: adding a suffix that designates the lower-precision type</li>
+  <li>Cast the literal: <code>(float) 3.14</code></li>
+  <li>Use a float literal directly: <code>3.14f</code></li>
 </ul>
 <p>Using an explicit cast adds unnecessary complexity to the code. The cast operator signals a type conversion, which typically requires careful
-attention from readers to ensure no precision loss or unexpected behavior occurs. However, when casting a literal value, this concern disappears - the
-value is known at compile time.</p>
-<p>Type-specific floating-point literals (decimal numbers with a suffix indicating the target type) were designed specifically for this purpose. They
-clearly express the intent that this is a value of the lower-precision type, not the default type being converted. This makes the code more readable
-and idiomatic.</p>
-<p>Additionally, while the performance impact is minimal in most cases, using a type-specific literal avoids the runtime cast operation entirely, as
-the compiler directly treats the value as the intended type.</p>
-<p>In Java specifically, use <code>3.14f</code> instead of <code>(float) 3.14</code>, where the <code>f</code> or <code>F</code> suffix designates a
-float literal.</p>
+attention from readers to ensure no precision loss or unexpected behavior occurs. However, when casting a literal value, this concern disappears — the
+value is known at compile time and the compiler folds the cast into a constant.</p>
+<p>Float literals with the <code>f</code> or <code>F</code> suffix were designed specifically for this purpose. They clearly express the intent that
+this is a <code>float</code> value, not a <code>double</code> being converted. This makes the code more readable and idiomatic.</p>
 <h3>What is the potential impact?</h3>
 <p>This issue affects code readability and maintainability. While it does not introduce bugs or security vulnerabilities, it makes the code slightly
 harder to read and understand. The unnecessary type conversion adds visual noise and may cause readers to spend extra time verifying that the
@@ -43,4 +36,3 @@ float half = 0.5f;
   <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.2">Floating-Point
   Literals</a></li>
 </ul>
-

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9386.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9386.html
@@ -1,0 +1,46 @@
+<p>An issue is raised when a higher-precision floating-point literal is explicitly converted to a lower-precision floating-point type using an
+explicit type conversion operation.</p>
+<h2>Why is this an issue?</h2>
+<p>In most languages, decimal number literals without a suffix are treated as a higher-precision floating-point type by default. When you need a
+lower-precision floating-point value, you have two options:</p>
+<ul>
+  <li>Cast the default literal: using an explicit type cast operator</li>
+  <li>Use a type-specific literal directly: adding a suffix that designates the lower-precision type</li>
+</ul>
+<p>Using an explicit cast adds unnecessary complexity to the code. The cast operator signals a type conversion, which typically requires careful
+attention from readers to ensure no precision loss or unexpected behavior occurs. However, when casting a literal value, this concern disappears - the
+value is known at compile time.</p>
+<p>Type-specific floating-point literals (decimal numbers with a suffix indicating the target type) were designed specifically for this purpose. They
+clearly express the intent that this is a value of the lower-precision type, not the default type being converted. This makes the code more readable
+and idiomatic.</p>
+<p>Additionally, while the performance impact is minimal in most cases, using a type-specific literal avoids the runtime cast operation entirely, as
+the compiler directly treats the value as the intended type.</p>
+<p>In Java specifically, use <code>3.14f</code> instead of <code>(float) 3.14</code>, where the <code>f</code> or <code>F</code> suffix designates a
+float literal.</p>
+<h3>What is the potential impact?</h3>
+<p>This issue affects code readability and maintainability. While it does not introduce bugs or security vulnerabilities, it makes the code slightly
+harder to read and understand. The unnecessary type conversion adds visual noise and may cause readers to spend extra time verifying that the
+conversion is intentional and safe.</p>
+<h2>How to fix it</h2>
+<p>Replace the cast expression with a float literal by adding the <code>f</code> suffix to the number and removing the cast operator.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+float value = (float) 3.14; // Noncompliant
+float pi = (float) 3.14159;
+float half = (float) 0.5;
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+float value = 3.14f;
+float pi = 3.14159f;
+float half = 0.5f;
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>Oracle Java Documentation - <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">Primitive Data Types</a></li>
+  <li>Java Language Specification - <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.2">Floating-Point
+  Literals</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9386.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9386.json
@@ -1,0 +1,23 @@
+{
+  "title": "Float literals should be used instead of casting double literals to float",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "2 min"
+  },
+  "tags": [
+    "convention"
+  ],
+  "defaultSeverity": "Minor",
+  "ruleSpecification": "RSPEC-9386",
+  "sqKey": "S9386",
+  "scope": "All",
+  "quickfix": "covered",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "LOW"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}


### PR DESCRIPTION
## Summary
- Implement new rule S9386 that detects explicit type casts of double literals to `float` (e.g. `(float) 3.14`) and suggests using a float literal suffix instead (`3.14f`)
- Includes a quick fix to automatically replace the cast expression with the equivalent float literal
- Handles scientific notation, hex floating-point literals, `d`/`D` suffixed literals, and parenthesized expressions

## Test plan
- [x] Unit tests pass with semantic analysis
- [x] Unit tests pass without semantic analysis
- [x] Check-list generator correctly discovers the new rule
- [x] Plugin metadata validation tests pass
- [ ] Ruling tests (will be validated by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)