### PR TITLE
SONARJAVA-6944: Implement rule S9387 TestNG Javadoc tags should be converted to annotations

### DIFF
--- a/java-checks-test-sources/default/src/main/java/checks/tests/TestNGJavadocTagsCheckSample.java
+++ b/java-checks-test-sources/default/src/main/java/checks/tests/TestNGJavadocTagsCheckSample.java
@@ -1,0 +1,167 @@
+package checks.tests;
+
+class TestNGJavadocTagsCheckSample {
+
+  /**
+   * @test
+   */
+  public void shouldValidateInput() { // Noncompliant {{Replace this "@test" Javadoc tag with the TestNG "@Test" annotation.}}
+  }
+
+  /**
+   * @beforeMethod
+   */
+  public void setUp() { // Noncompliant {{Replace this "@beforeMethod" Javadoc tag with the TestNG "@BeforeMethod" annotation.}}
+  }
+
+  /**
+   * @afterMethod
+   */
+  public void tearDown() { // Noncompliant {{Replace this "@afterMethod" Javadoc tag with the TestNG "@AfterMethod" annotation.}}
+  }
+
+  /**
+   * @beforeClass
+   */
+  public void classSetUp() { // Noncompliant {{Replace this "@beforeClass" Javadoc tag with the TestNG "@BeforeClass" annotation.}}
+  }
+
+  /**
+   * @afterClass
+   */
+  public void classTearDown() { // Noncompliant {{Replace this "@afterClass" Javadoc tag with the TestNG "@AfterClass" annotation.}}
+  }
+
+  /**
+   * @dataProvider
+   */
+  public Object[][] provideData() { // Noncompliant {{Replace this "@dataProvider" Javadoc tag with the TestNG "@DataProvider" annotation.}}
+    return new Object[][] {};
+  }
+
+  /**
+   * @factory
+   */
+  public Object[] createInstances() { // Noncompliant {{Replace this "@factory" Javadoc tag with the TestNG "@Factory" annotation.}}
+    return new Object[] {};
+  }
+
+  /**
+   * @beforeSuite
+   */
+  public void suiteSetUp() { // Noncompliant {{Replace this "@beforeSuite" Javadoc tag with the TestNG "@BeforeSuite" annotation.}}
+  }
+
+  /**
+   * @afterSuite
+   */
+  public void suiteTearDown() { // Noncompliant {{Replace this "@afterSuite" Javadoc tag with the TestNG "@AfterSuite" annotation.}}
+  }
+
+  /**
+   * @beforeTest
+   */
+  public void testSetUp() { // Noncompliant {{Replace this "@beforeTest" Javadoc tag with the TestNG "@BeforeTest" annotation.}}
+  }
+
+  /**
+   * @afterTest
+   */
+  public void testTearDown() { // Noncompliant {{Replace this "@afterTest" Javadoc tag with the TestNG "@AfterTest" annotation.}}
+  }
+
+  /**
+   * @beforeGroups
+   */
+  public void groupSetUp() { // Noncompliant {{Replace this "@beforeGroups" Javadoc tag with the TestNG "@BeforeGroups" annotation.}}
+  }
+
+  /**
+   * @afterGroups
+   */
+  public void groupTearDown() { // Noncompliant {{Replace this "@afterGroups" Javadoc tag with the TestNG "@AfterGroups" annotation.}}
+  }
+
+  /**
+   * @parameters
+   */
+  public void parameterized() { // Noncompliant {{Replace this "@parameters" Javadoc tag with the TestNG "@Parameters" annotation.}}
+  }
+
+  /**
+   * @listeners
+   */
+  public void withListeners() { // Noncompliant {{Replace this "@listeners" Javadoc tag with the TestNG "@Listeners" annotation.}}
+  }
+
+  /**
+   * @Test
+   */
+  public void caseInsensitiveUpperCase() { // Noncompliant {{Replace this "@Test" Javadoc tag with the TestNG "@Test" annotation.}}
+  }
+
+  /**
+   * @TEST
+   */
+  public void caseInsensitiveAllCaps() { // Noncompliant {{Replace this "@TEST" Javadoc tag with the TestNG "@Test" annotation.}}
+  }
+
+  /**
+   * Validates user input.
+   * @param input the input string
+   * @test
+   */
+  public void mixedWithStandardTags(String input) { // Noncompliant {{Replace this "@test" Javadoc tag with the TestNG "@Test" annotation.}}
+  }
+
+  /**
+   * Sets up resources.
+   * @test
+   * @beforeMethod
+   */
+  public void multipleTestNGTags() { // Noncompliant {{Replace this "@test" Javadoc tag with the TestNG "@Test" annotation.}}
+  }
+
+  // --- Compliant cases ---
+
+  /**
+   * @param input the input string
+   * @return the result
+   * @throws IllegalArgumentException if input is invalid
+   */
+  public String standardJavadocTags(String input) { // compliant
+    return input;
+  }
+
+  /**
+   * @see String
+   * @since 1.0
+   * @deprecated Use another method
+   */
+  public void otherStandardTags() { // compliant
+  }
+
+  public void noJavadoc() { // compliant
+  }
+
+  /* @test - not a Javadoc comment */
+  public void blockComment() { // compliant
+  }
+
+  // @test - not a Javadoc comment
+  public void lineComment() { // compliant
+  }
+
+  /**
+   * Processes input data.
+   */
+  public void javadocWithoutTags() { // compliant
+  }
+
+  /**
+   * @author John Doe
+   * @version 1.0
+   */
+  public void authorAndVersionTags() { // compliant
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/TestNGJavadocTagsCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/TestNGJavadocTagsCheck.java
@@ -1,0 +1,101 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.tree.SyntaxTrivia;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonarsource.analyzer.commons.collections.MapBuilder;
+
+@Rule(key = "S9387")
+public class TestNGJavadocTagsCheck extends IssuableSubscriptionVisitor {
+
+  private static final Pattern BLOCK_TAG_PATTERN = Pattern.compile("^\\s*\\*?\\s*@(\\w+)", Pattern.MULTILINE);
+
+  private static final Map<String, String> TESTNG_TAGS_TO_ANNOTATIONS = MapBuilder.<String, String>newMap()
+    .put("test", "@Test")
+    .put("beforemethod", "@BeforeMethod")
+    .put("aftermethod", "@AfterMethod")
+    .put("beforeclass", "@BeforeClass")
+    .put("afterclass", "@AfterClass")
+    .put("beforesuite", "@BeforeSuite")
+    .put("aftersuite", "@AfterSuite")
+    .put("beforetest", "@BeforeTest")
+    .put("aftertest", "@AfterTest")
+    .put("beforegroups", "@BeforeGroups")
+    .put("aftergroups", "@AfterGroups")
+    .put("dataprovider", "@DataProvider")
+    .put("factory", "@Factory")
+    .put("parameters", "@Parameters")
+    .put("listeners", "@Listeners")
+    .build();
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Arrays.asList(Tree.Kind.METHOD, Tree.Kind.CONSTRUCTOR);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    tree.firstToken().trivias().stream()
+      .filter(trivia -> trivia.isComment(SyntaxTrivia.CommentKind.JAVADOC))
+      .forEach(trivia -> checkJavadoc(tree, trivia));
+  }
+
+  private void checkJavadoc(Tree tree, SyntaxTrivia trivia) {
+    String commentText = trivia.comment();
+    Matcher matcher = BLOCK_TAG_PATTERN.matcher(commentText);
+
+    String firstTagOriginal = null;
+    String firstAnnotation = null;
+    List<JavaFileScannerContext.Location> secondaryLocations = new ArrayList<>();
+
+    while (matcher.find()) {
+      String tagName = matcher.group(1);
+      String annotation = TESTNG_TAGS_TO_ANNOTATIONS.get(tagName.toLowerCase(Locale.ROOT));
+      if (annotation != null) {
+        if (firstTagOriginal == null) {
+          firstTagOriginal = tagName;
+          firstAnnotation = annotation;
+        } else {
+          secondaryLocations.add(new JavaFileScannerContext.Location(
+            String.format("Also replace \"@%s\" with the TestNG \"%s\" annotation.",
+              tagName, TESTNG_TAGS_TO_ANNOTATIONS.get(tagName.toLowerCase(Locale.ROOT))),
+            tree));
+        }
+      }
+    }
+
+    if (firstTagOriginal != null) {
+      String message = String.format("Replace this \"@%s\" Javadoc tag with the TestNG \"%s\" annotation.", firstTagOriginal, firstAnnotation);
+      if (secondaryLocations.isEmpty()) {
+        reportIssue(tree, message);
+      } else {
+        reportIssue(tree, message, secondaryLocations, null);
+      }
+    }
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/TestNGJavadocTagsCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/TestNGJavadocTagsCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.mainCodeSourcesPath;
+
+class TestNGJavadocTagsCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/tests/TestNGJavadocTagsCheckSample.java"))
+      .withCheck(new TestNGJavadocTagsCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(mainCodeSourcesPath("checks/tests/TestNGJavadocTagsCheckSample.java"))
+      .withCheck(new TestNGJavadocTagsCheck())
+      .withoutSemantic()
+      .verifyIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9387.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9387.html
@@ -1,0 +1,69 @@
+<p>An issue is raised when a test method uses documentation comment markers (like comment-based tags) instead of proper metadata attributes or
+decorators that the testing framework requires to identify and execute tests.</p>
+<p>In Java TestNG specifically, this means using Javadoc-style tags like <code>@test</code> or <code>@beforeMethod</code> in comments instead of the
+proper Java annotations <code>@Test</code> and <code>@BeforeMethod</code>.</p>
+<h2>Why is this an issue?</h2>
+<p>Testing frameworks initially supported documentation comment tags for configuring test methods. For example, developers could write special markers
+in documentation comments to designate methods as tests. While this approach worked in older framework versions, it has significant drawbacks compared
+to modern declarative configuration mechanisms.</p>
+<p>Documentation comment tags are simply strings embedded in comments. The compiler doesn’t check them, and development environments cannot validate
+them during development. This means typos or incorrect usage won’t be caught until runtime, making bugs harder to find.</p>
+<p>Modern testing frameworks use first-class language constructs that declare test configuration directly in code. These are part of the language
+itself, so the compiler validates them at compile time. This catches errors early and makes the code more reliable.</p>
+<p>Language-native declarations also integrate better with development tools. IDEs can provide autocomplete, navigation, and refactoring support. When
+you rename a test class or reorganize code, these declarations are automatically updated, while comment-based strings remain unchanged.</p>
+<p>Using documentation comment tags in new code creates technical debt. The code appears outdated and may confuse developers who are familiar with
+standard framework practices. It also makes the codebase inconsistent if some tests use language-native declarations while others use comment
+tags.</p>
+<p>In Java, TestNG uses annotations like <code>@Test</code>, <code>@BeforeMethod</code>, and <code>@AfterMethod</code> instead of the older
+Javadoc-style tags such as <code>/** @test */</code>.</p>
+<h3>What is the potential impact?</h3>
+<p>Using documentation comments for metadata instead of structured metadata mechanisms reduces code maintainability and increases the risk of
+errors:</p>
+<ul>
+  <li><strong>Delayed error detection</strong>: Typos or configuration mistakes in comment-based metadata are only discovered at runtime, potentially
+  during test execution in production environments.</li>
+  <li><strong>Harder refactoring</strong>: When restructuring code, development tools cannot automatically update string values embedded in comments,
+  leading to broken test configurations.</li>
+  <li><strong>Reduced discoverability</strong>: New team members may not recognize comment-based test configuration, making the codebase harder to
+  understand.</li>
+  <li><strong>Limited tooling support</strong>: Build tools and test runners may have reduced functionality with comment-based configuration compared
+  to structured metadata mechanisms.</li>
+</ul>
+<h2>How to fix it</h2>
+<p>Replace Javadoc tags with the corresponding TestNG annotations. The most common conversions are:</p>
+<ul>
+  <li><code>/** @test */</code> becomes <code>@Test</code></li>
+  <li><code>/** @beforeMethod */</code> becomes <code>@BeforeMethod</code></li>
+  <li><code>/** @afterMethod */</code> becomes <code>@AfterMethod</code></li>
+  <li><code>/** @beforeClass */</code> becomes <code>@BeforeClass</code></li>
+  <li><code>/** @afterClass */</code> becomes <code>@AfterClass</code></li>
+</ul>
+<p>Import the annotation classes from <code>org.testng.annotations</code> package. Remove the Javadoc comment or keep it for documentation purposes
+without the tag.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+/**
+ * @test
+ */
+public void shouldValidateInput() { // Noncompliant
+    // test code
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+import org.testng.annotations.Test;
+
+@Test
+public void shouldValidateInput() {
+    // test code
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>TestNG Documentation - <a href="https://testng.org/doc/documentation-main.html#annotations">Annotations</a></li>
+  <li>TestNG Documentation - <a href="https://testng.org/doc/documentation-main.html#test-methods">TestNG Test Methods</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9387.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9387.json
@@ -1,0 +1,24 @@
+{
+  "title": "TestNG Javadoc tags should be converted to annotations",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "deprecated",
+    "convention"
+  ],
+  "defaultSeverity": "Major",
+  "ruleSpecification": "RSPEC-9387",
+  "sqKey": "S9387",
+  "scope": "All",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}


### PR DESCRIPTION
## Summary
- Implement new rule S9387 that detects TestNG-specific Javadoc tags (`@test`, `@beforeMethod`, `@afterMethod`, `@beforeClass`, `@afterClass`, `@dataProvider`, etc.) used as configuration markers instead of proper TestNG annotations
- Case-insensitive matching for all 15 TestNG tags with secondary locations when multiple tags appear on a single method
- Includes test sample with compliant and noncompliant examples covering edge cases (case variants, mixed standard/TestNG tags, non-Javadoc comments)

## Test plan
- [x] Unit tests pass (with and without semantic analysis)
- [ ] CI build passes
- [ ] Ruling tests updated if needed (auto-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Agent workflow

Tool link: Tool link: https://github.com/SonarSource/languages-experimental-tooling/tree/romain/my-tickets/personal/romain-brenguier
Addressed review comments in pr_report_6124.md using `uv run address_reviews.py pr_report_6124.md`