### PR TITLE
SONARJAVA-6942: Implemented rule S9389 - Data provider names should be unique within a class

### DIFF
--- a/java-checks-test-sources/default/src/test/java/checks/tests/DataProviderNameUniquenessCheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/DataProviderNameUniquenessCheckSample.java
@@ -1,0 +1,67 @@
+package checks.tests;
+
+import org.testng.annotations.DataProvider;
+
+public class DataProviderNameUniquenessCheckSample {
+
+  @DataProvider(name = "testData")
+  public Object[][] provideData1() {
+    return new Object[][]{{1, 2}};
+  }
+
+  @DataProvider(name = "testData") // Noncompliant {{Rename this data provider to make it unique within this class.}}
+  public Object[][] provideData2() {
+    return new Object[][]{{3, 4}};
+  }
+
+  @DataProvider(name = "testData") // Noncompliant {{Rename this data provider to make it unique within this class.}}
+  public Object[][] provideData3() {
+    return new Object[][]{{5, 6}};
+  }
+
+  @DataProvider(name = "uniqueData")
+  public Object[][] provideUnique() {
+    return new Object[][]{{7, 8}};
+  }
+
+  @DataProvider
+  public Object[][] provideDefaultName() {
+    return new Object[][]{{9, 10}};
+  }
+
+  @DataProvider(name = "alpha")
+  public Object[][] provideAlpha() {
+    return new Object[][]{{11, 12}};
+  }
+
+  @DataProvider(name = "beta")
+  public Object[][] provideBeta() {
+    return new Object[][]{{13, 14}};
+  }
+}
+
+class SecondClass {
+  @DataProvider(name = "testData")
+  public Object[][] provideData() {
+    return new Object[][]{{15, 16}};
+  }
+}
+
+class OuterClass {
+  @DataProvider(name = "outerData")
+  public Object[][] provideOuter() {
+    return new Object[][]{{17, 18}};
+  }
+
+  class InnerClass {
+    @DataProvider(name = "outerData")
+    public Object[][] provideInner() {
+      return new Object[][]{{19, 20}};
+    }
+
+    @DataProvider(name = "outerData") // Noncompliant {{Rename this data provider to make it unique within this class.}}
+    public Object[][] provideAnother() {
+      return new Object[][]{{21, 22}};
+    }
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/tests/DataProviderNameUniquenessCheck.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/tests/DataProviderNameUniquenessCheck.java
@@ -1,0 +1,121 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.ExpressionTree;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.LiteralTree;
+import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9389")
+public class DataProviderNameUniquenessCheck extends IssuableSubscriptionVisitor {
+
+  private static final String DATAPROVIDER_ANNOTATION = "org.testng.annotations.DataProvider";
+  private static final String NAME_ATTRIBUTE = "name";
+  private static final String ISSUE_MESSAGE = "Rename this data provider to make it unique within this class.";
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return List.of(Tree.Kind.CLASS, Tree.Kind.INTERFACE, Tree.Kind.ENUM);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    ClassTree classTree = (ClassTree) tree;
+    Map<String, Tree> firstOccurrences = new HashMap<>();
+
+    for (Tree member : classTree.members()) {
+      if (member.is(Tree.Kind.METHOD)) {
+        MethodTree method = (MethodTree) member;
+        String providerName = extractDataProviderName(method);
+        if (providerName != null) {
+          Tree previous = firstOccurrences.putIfAbsent(providerName, method);
+          if (previous != null) {
+            reportDuplicate(providerName, method, previous);
+          }
+        }
+      }
+    }
+  }
+
+  private String extractDataProviderName(MethodTree method) {
+    for (AnnotationTree annotation : method.modifiers().annotations()) {
+      if (isDataProviderAnnotation(annotation)) {
+        return extractNameAttribute(annotation);
+      }
+    }
+    return null;
+  }
+
+  private boolean isDataProviderAnnotation(AnnotationTree annotation) {
+    return annotation.annotationType().symbolType().is(DATAPROVIDER_ANNOTATION);
+  }
+
+  private String extractNameAttribute(AnnotationTree annotation) {
+    List<ExpressionTree> arguments = annotation.arguments();
+    if (arguments == null || arguments.isEmpty()) {
+      return null;
+    }
+
+    for (ExpressionTree argument : arguments) {
+      if (argument.is(Tree.Kind.ASSIGNMENT)) {
+        AssignmentExpressionTree assignment = (AssignmentExpressionTree) argument;
+        String attributeName = getAttributeName(assignment.variable());
+        if (NAME_ATTRIBUTE.equals(attributeName)) {
+          return extractStringValue(assignment.expression());
+        }
+      }
+    }
+    return null;
+  }
+
+  private String getAttributeName(ExpressionTree expression) {
+    if (expression.is(Tree.Kind.IDENTIFIER)) {
+      return ((IdentifierTree) expression).name();
+    } else if (expression.is(Tree.Kind.MEMBER_SELECT)) {
+      return ((MemberSelectExpressionTree) expression).identifier().name();
+    }
+    return null;
+  }
+
+  private String extractStringValue(ExpressionTree expression) {
+    if (expression.is(Tree.Kind.STRING_LITERAL)) {
+      return ((LiteralTree) expression).value();
+    }
+    return null;
+  }
+
+  private void reportDuplicate(String name, Tree duplicate, Tree first) {
+    List<JavaFileScannerContext.Location> secondaryLocations = new ArrayList<>();
+    secondaryLocations.add(new JavaFileScannerContext.Location(
+      "First data provider with this name", first));
+
+    reportIssue(duplicate, ISSUE_MESSAGE, secondaryLocations, null);
+  }
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/tests/DataProviderNameUniquenessCheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/tests/DataProviderNameUniquenessCheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks.tests;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
+
+class DataProviderNameUniquenessCheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/DataProviderNameUniquenessCheckSample.java"))
+      .withCheck(new DataProviderNameUniquenessCheck())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/DataProviderNameUniquenessCheckSample.java"))
+      .withCheck(new DataProviderNameUniquenessCheck())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/new_rule_proposal_S9389.txt
+++ b/new_rule_proposal_S9389.txt
@@ -1,0 +1,86 @@
+# Proposed Approach for S9389: Data provider names should be unique within a class
+
+## Summary
+
+This rule detects duplicate `@DataProvider` names within a single test class. When multiple methods are annotated with `@DataProvider(name = "...")` using the same name, TestNG cannot reliably determine which provider to use, leading to unpredictable test behavior. The implementation follows the pattern of `TestsStabilityCheck` for annotation detection and `MembersDifferOnlyByCapitalizationCheck` for duplicate detection within a class scope.
+
+## File Locations
+
+- Rule class: `java-checks/src/main/java/org/sonar/java/checks/tests/DataProviderNameUniquenessCheck.java`
+- Test class: `java-checks/src/test/java/org/sonar/java/checks/tests/DataProviderNameUniquenessCheckTest.java`
+- Test sample: `java-checks-test-sources/default/src/test/java/checks/tests/DataProviderNameUniquenessCheckSample.java`
+
+## Rule Behavior
+
+The rule should detect when two or more `@DataProvider` methods within the same class have the same `name` attribute value. The check should:
+
+1. **Detect**: Methods annotated with `@DataProvider` (from `org.testng.annotations.DataProvider`) that share the same `name` attribute value within the same class.
+2. **Report**: On the duplicate (second occurrence) with a secondary location on the first occurrence.
+3. **Allow**: Unique names, methods without the `name` attribute (uses method name as default), and providers in different classes.
+
+## Proposed Approach
+
+Use `IssuableSubscriptionVisitor` with `Tree.Kind.CLASS` to traverse classes. For each class, collect all `@DataProvider` methods and their names into a map, then report issues for duplicates.
+
+This approach:
+- Follows the pattern established by `TestsStabilityCheck` for TestNG annotation handling
+- Uses the same visitor pattern as other class-scoped checks
+- Leverages the semantic model to resolve the `@DataProvider` annotation type
+- Reports the second (and subsequent) duplicate with a secondary location pointing to the first occurrence
+
+## Algorithm
+
+1. Register to visit `Tree.Kind.CLASS` nodes only.
+2. For each class, iterate over its members to find `MethodTree` nodes.
+3. For each method, check if it has a `@DataProvider` annotation by looking at `method.modifiers().annotations()`.
+4. For each `@DataProvider` annotation, extract the `name` attribute value using `AnnotationTree.arguments()`.
+5. Store each (name, methodTree) pair in a `Map<String, MethodTree>` where the map tracks the first occurrence.
+6. If a name already exists in the map, report an issue on the duplicate method with a secondary location on the original.
+7. Skip methods where the `name` attribute is not explicitly set (TestNG uses the method name as default — these are handled separately by using the method name as the key).
+
+## Recommended Helpers
+
+No new helper classes are needed. The rule can use existing patterns:
+
+- `AnnotationTree.arguments()` — to access annotation arguments
+- `AssignmentExpressionTree` — to parse `name = "value"` syntax
+- `StringLiteralTree` — to extract string literal values
+- `JavaFileScannerContext.Location` — for secondary location reporting
+
+## Test Strategy
+
+The test sample should cover:
+
+### Compliant patterns
+- Each `@DataProvider` has a unique name
+- Methods without the `name` attribute (uses method name)
+- `@DataProvider` in different classes
+- `@DataProvider` without explicit `name` (uses method name as default)
+
+### Noncompliant patterns
+- Two `@DataProvider` methods with the same explicit `name`
+- Three or more `@DataProvider` methods sharing the same name (report each duplicate)
+- Same name used with different casing (should be detected — TestNG names are case-sensitive)
+
+## Expected Cases Covered
+
+### Noncompliant patterns
+- **Duplicate `name` attributes**: Two or more `@DataProvider` methods with `name = "testData"` — report on each duplicate with secondary on first.
+- **Multiple duplicates**: Three methods with the same name — report on the second and third, each with secondary on the first.
+- **Mixed explicit names**: Some methods with `name` attribute, some without — only explicit names are compared.
+- **Nested classes**: Each nested class has its own scope — duplicates are only flagged within the same class.
+
+### Compliant patterns
+- **Unique names**: All `@DataProvider` methods have distinct `name` values.
+- **No explicit name**: Methods using the default method name as provider name (unique method names are fine).
+- **Different classes**: Same provider name in different classes is allowed.
+- **Inherited methods**: `@DataProvider` in a superclass is in a different class scope.
+
+## Expected Accepted FN/FP
+
+### Accepted False Negatives
+- **Inherited providers**: Providers defined in a superclass are not detected because the rule only inspects the current class members. This is acceptable because inheritance of data providers is rare and typically intentional.
+- **Dynamic names**: Providers using a variable or expression for the `name` attribute (e.g., `@DataProvider(name = MY_NAME)`) cannot be resolved statically and are skipped.
+
+### Accepted False Positives
+- **None expected**: The rule operates on explicit string literals and method declarations within a single class, making false positives unlikely.

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9389.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9389.html
@@ -1,0 +1,80 @@
+<p>An issue is raised when two or more methods that provide test data use the same identifier value within the same test class scope.</p>
+<p>In Java with TestNG, this specifically refers to methods annotated with <code>@DataProvider</code> using the same <code>name</code> attribute
+value.</p>
+<h2>Why is this an issue?</h2>
+<p>Test framework data provider mechanisms allow you to define methods that supply test data to your test methods. Each data provider is identified by
+its name attribute, which test methods reference using configuration parameters in their test annotations.</p>
+<p>When multiple data provider methods share the same name within a class, the test framework faces ambiguity about which data provider to use. The
+framework’s behavior in this situation is undefined and implementation-dependent. It may:</p>
+<ul>
+  <li>Use the first data provider it encounters</li>
+  <li>Use the last data provider defined</li>
+  <li>Throw an exception at runtime</li>
+  <li>Produce inconsistent results across different test runs</li>
+</ul>
+<p>This ambiguity makes your tests unreliable and unpredictable. A test that passes today might fail tomorrow, or vice versa, without any changes to
+the actual code being tested. This undermines the entire purpose of automated testing.</p>
+<p>Additionally, duplicate names make it difficult for developers to understand which data is being used for which tests, reducing code
+maintainability and making debugging more challenging.</p>
+<p>In TestNG specifically, this refers to the <code>@DataProvider</code> annotation with its <code>name</code> attribute, which test methods reference
+using the <code>dataProvider</code> parameter in the <code>@Test</code> annotation.</p>
+<h3>What is the potential impact?</h3>
+<p>When test data source identifiers are duplicated, test execution becomes unpredictable. Tests may:</p>
+<ul>
+  <li>Receive incorrect test data, causing false positives or false negatives</li>
+  <li>Fail intermittently without clear cause</li>
+  <li>Behave differently across different environments or testing framework versions</li>
+</ul>
+<p>This unreliability can lead to:</p>
+<ul>
+  <li>Bugs slipping through to production because tests didn’t run as intended</li>
+  <li>Wasted developer time debugging test failures that don’t represent real issues</li>
+  <li>Loss of confidence in the test suite, potentially leading teams to ignore test results</li>
+  <li>Difficulty reproducing and fixing genuine test failures</li>
+</ul>
+<h2>How to fix it</h2>
+<p>Ensure each <code>@DataProvider</code> method in a class has a unique <code>name</code> attribute. Choose descriptive names that clearly indicate
+what data each provider supplies.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@DataProvider(name = "testData")
+public Object[][] provider1() {
+    return new Object[][] {
+        {"value1", 1},
+        {"value2", 2}
+    };
+}
+
+@DataProvider(name = "testData") // Noncompliant
+public Object[][] provider2() {
+    return new Object[][] {
+        {"value3", 3},
+        {"value4", 4}
+    };
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@DataProvider(name = "testData")
+public Object[][] provider1() {
+    return new Object[][] {
+        {"value1", 1},
+        {"value2", 2}
+    };
+}
+
+@DataProvider(name = "additionalTestData")
+public Object[][] provider2() {
+    return new Object[][] {
+        {"value3", 3},
+        {"value4", 4}
+    };
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>TestNG Documentation - <a href="https://testng.org/doc/documentation-main.html#parameters-dataproviders">Parameters - Data Providers</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9389.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9389.json
@@ -1,0 +1,26 @@
+{
+  "title": "Data provider names should be unique within a class",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5 min"
+  },
+  "tags": [
+    "testng",
+    "tests",
+    "confusing"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9389",
+  "sqKey": "S9389",
+  "scope": "Tests",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH",
+      "MAINTAINABILITY": "MEDIUM"
+    },
+    "attribute": "CLEAR"
+  }
+}


### PR DESCRIPTION
This PR implements rule S9389 which detects duplicate @DataProvider names within a single TestNG test class.

## Summary

When multiple methods are annotated with  using the same name, TestNG cannot reliably determine which provider to use, leading to unpredictable test behavior. This rule identifies such duplicates and reports them as issues.

## Implementation Details

- **Rule Class**:  extends 
- **Scope**: Checks methods within each class independently (nested classes have separate scopes)
- **Detection**: Uses semantic model to identify  annotations and extracts the  attribute value
- **Reporting**: Reports on the duplicate (second occurrence) with a secondary location pointing to the first occurrence

## Test Coverage

- Duplicate names within the same class (non-compliant)
- Three or more methods with the same name (reports each duplicate)
- Unique names (compliant)
- Methods without explicit name (compliant - uses method name as default)
- Same name in different classes (compliant - different scopes)
- Nested classes with same names (compliant - different scopes)
- No false positives when semantic is unavailable

## Files Changed

-  - Rule implementation
-  - Test class
-  - Test sample
-  - Rule description
-  - Rule metadata