### PR TITLE
SONARJAVA-6941: Implement rule S9388 TestNG data provider methods should return valid types

### DIFF
--- a/java-checks-test-sources/default/src/test/java/checks/tests/S9388CheckSample.java
+++ b/java-checks-test-sources/default/src/test/java/checks/tests/S9388CheckSample.java
@@ -1,0 +1,99 @@
+package checks.tests;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+
+class S9388CheckSample {
+
+  @DataProvider
+  public Object[][] validTwoDimensionalArray() { // Compliant
+    return new Object[][] {{"a", 1}, {"b", 2}};
+  }
+
+  @DataProvider
+  public Iterator<Object[]> validIterator() { // Compliant
+    return Arrays.asList(new Object[] {"a"}, new Object[] {"b"}).iterator();
+  }
+
+  @DataProvider
+  public Object[] validOneDimensionalArray() { // Compliant
+    return new Object[] {new Object[] {"a"}, new Object[] {"b"}};
+  }
+
+  @DataProvider
+  public List<String> returnsList() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^^^
+    return Arrays.asList("a", "b");
+  }
+
+  @DataProvider
+  public Stream<String> returnsStream() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^^^^^
+    return Stream.of("a", "b");
+  }
+
+  @DataProvider
+  public String[] returnsStringArray() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^
+    return new String[] {"a", "b"};
+  }
+
+  @DataProvider
+  public int[][] returnsIntArray2D() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^
+    return new int[][] {{1, 2}, {3, 4}};
+  }
+
+  @DataProvider
+  public String[][] returnsStringArray2D() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^
+    return new String[][] {{"a"}, {"b"}};
+  }
+
+  @DataProvider
+  public Iterator<String> returnsIteratorOfString() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^^^^^^^
+    return Arrays.asList("a", "b").iterator();
+  }
+
+  @DataProvider
+  public Iterator<Object> returnsIteratorOfObject() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^^^^^^^
+    return Arrays.<Object>asList("a", "b").iterator();
+  }
+
+  @DataProvider
+  public Object returnsObject() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^
+    return new Object();
+  }
+
+  @DataProvider
+  public void returnsVoid() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^
+  }
+
+  @DataProvider
+  public Collection<Object[]> returnsCollection() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^^^^^^^^^^^
+    return Arrays.asList(new Object[] {"a"});
+  }
+
+  @DataProvider
+  public List<Object[]> returnsListOfObjectArray() { // Noncompliant {{Change this return type to "Object[][]", "Iterator<Object[]>", or "Object[]".}}
+//       ^^^^^^^^^^^^^^
+    return Arrays.asList(new Object[] {"a"});
+  }
+
+  public List<String> notAnnotated() { // Compliant - no @DataProvider
+    return Arrays.asList("a", "b");
+  }
+
+  public String[] notAnnotatedArray() { // Compliant - no @DataProvider
+    return new String[] {"a", "b"};
+  }
+}

--- a/java-checks/src/main/java/org/sonar/java/checks/S9388Check.java
+++ b/java-checks/src/main/java/org/sonar/java/checks/S9388Check.java
@@ -1,0 +1,87 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import java.util.Collections;
+import java.util.List;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.semantic.Type;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+@Rule(key = "S9388")
+public class S9388Check extends IssuableSubscriptionVisitor {
+
+  private static final String DATA_PROVIDER_ANNOTATION = "org.testng.annotations.DataProvider";
+  private static final String MESSAGE = "Change this return type to \"Object[][]\", \"Iterator<Object[]>\", or \"Object[]\".";
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return Collections.singletonList(Tree.Kind.METHOD);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    MethodTree methodTree = (MethodTree) tree;
+    if (!methodTree.symbol().metadata().isAnnotatedWith(DATA_PROVIDER_ANNOTATION)) {
+      return;
+    }
+    Type returnType = methodTree.returnType().symbolType();
+    if (returnType.isUnknown()) {
+      return;
+    }
+    if (!isValidDataProviderReturnType(returnType)) {
+      reportIssue(methodTree.returnType(), MESSAGE);
+    }
+  }
+
+  private static boolean isValidDataProviderReturnType(Type returnType) {
+    return isObjectArray2D(returnType)
+      || isObjectArray1D(returnType)
+      || isIteratorOfObjectArray(returnType);
+  }
+
+  private static boolean isObjectArray2D(Type type) {
+    if (!type.isArray()) {
+      return false;
+    }
+    Type elementType = ((Type.ArrayType) type).elementType();
+    return elementType.isArray() && ((Type.ArrayType) elementType).elementType().is("java.lang.Object");
+  }
+
+  private static boolean isObjectArray1D(Type type) {
+    if (!type.isArray()) {
+      return false;
+    }
+    Type elementType = ((Type.ArrayType) type).elementType();
+    return !elementType.isArray() && elementType.is("java.lang.Object");
+  }
+
+  private static boolean isIteratorOfObjectArray(Type type) {
+    if (!type.is("java.util.Iterator") || !type.isParameterized()) {
+      return false;
+    }
+    List<Type> typeArgs = type.typeArguments();
+    if (typeArgs.size() != 1) {
+      return false;
+    }
+    Type typeArg = typeArgs.get(0);
+    return typeArg.isArray() && ((Type.ArrayType) typeArg).elementType().is("java.lang.Object");
+  }
+
+}

--- a/java-checks/src/test/java/org/sonar/java/checks/S9388CheckTest.java
+++ b/java-checks/src/test/java/org/sonar/java/checks/S9388CheckTest.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Java
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * You can redistribute and/or modify this program under the terms of
+ * the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.java.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.java.checks.verifier.CheckVerifier;
+
+import static org.sonar.java.checks.verifier.TestUtils.testCodeSourcesPath;
+
+class S9388CheckTest {
+
+  @Test
+  void test() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/S9388CheckSample.java"))
+      .withCheck(new S9388Check())
+      .verifyIssues();
+  }
+
+  @Test
+  void test_without_semantic() {
+    CheckVerifier.newVerifier()
+      .onFile(testCodeSourcesPath("checks/tests/S9388CheckSample.java"))
+      .withCheck(new S9388Check())
+      .withoutSemantic()
+      .verifyNoIssues();
+  }
+}

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9388.html
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9388.html
@@ -1,0 +1,97 @@
+<p>This rule raises an issue when a method annotated with TestNG’s <code>@DataProvider</code> returns a type that is not one of the supported return
+types: <code>Object[][]</code>, <code>Iterator&lt;Object[]&gt;</code>, or <code>Object[]</code>.</p>
+<h2>Why is this an issue?</h2>
+<p>TestNG relies on the <code>@DataProvider</code> annotation to supply test data for parameterized tests. For TestNG to properly execute these tests,
+<code>@DataProvider</code> methods must return one of the specifically supported types:</p>
+<ul>
+  <li><code>Object[][]</code> - a two-dimensional array where each inner array represents parameters for one test invocation</li>
+  <li><code>Iterator&lt;Object[]&gt;</code> - an iterator of arrays for lazy evaluation of test data</li>
+  <li><code>Object[]</code> - an array where each element is itself an <code>Object[]</code> (available since TestNG 6.x)</li>
+</ul>
+<p>When a <code>@DataProvider</code> method returns an incompatible type (such as <code>List</code>, <code>Stream</code>, or a simple array), TestNG
+cannot process the data correctly. This causes test failures at runtime, even though the code may compile successfully.</p>
+<p>Using the wrong return type breaks the contract between your test code and the TestNG framework, leading to:</p>
+<ul>
+  <li>Tests that fail to execute</li>
+  <li>Misleading error messages</li>
+  <li>Wasted debugging time</li>
+  <li>Reduced confidence in your test suite</li>
+</ul>
+<h3>What is the potential impact?</h3>
+<p>When a <code>@DataProvider</code> method returns an invalid type, the immediate impact is test execution failure. TestNG will throw a runtime
+exception when attempting to invoke the test method with the provided data.</p>
+<p>This has several consequences:</p>
+<ul>
+  <li><strong>Delayed feedback</strong>: The error only appears at runtime, not during compilation, making it harder to catch during development</li>
+  <li><strong>Broken test suites</strong>: Entire test classes may fail to run if the data provider is misconfigured</li>
+  <li><strong>False negatives</strong>: You might believe your code is untested when tests simply aren’t executing</li>
+  <li><strong>Maintenance burden</strong>: Team members unfamiliar with TestNG’s requirements may struggle to understand and fix the issue</li>
+</ul>
+<p>In CI/CD pipelines, this can block deployments and require emergency fixes to restore test coverage.</p>
+<h2>How to fix it in TestNG</h2>
+<p>Use <code>Object[][]</code> when you have a fixed set of test data. Each inner array represents the parameters for one test invocation.</p>
+<h3>Code examples</h3>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+@DataProvider
+public List&lt;String&gt; provideData() {  // Noncompliant
+    return Arrays.asList("value1", "value2", "value3");
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="1" data-diff-type="compliant">
+@DataProvider
+public Object[][] provideData() {
+    return new Object[][] {
+        {"value1"},
+        {"value2"},
+        {"value3"}
+    };
+}
+</pre>
+<p>Use <code>Iterator&lt;Object[]&gt;</code> when you need lazy evaluation or want to generate test data on-the-fly. This is useful for large datasets
+or when data generation is expensive.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="2" data-diff-type="noncompliant">
+@DataProvider
+public Stream&lt;String&gt; provideData() {  // Noncompliant
+    return Stream.of("value1", "value2", "value3");
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="2" data-diff-type="compliant">
+@DataProvider
+public Iterator&lt;Object[]&gt; provideData() {
+    return Arrays.asList(
+        new Object[]{"value1"},
+        new Object[]{"value2"},
+        new Object[]{"value3"}
+    ).iterator();
+}
+</pre>
+<p>Use <code>Object[]</code> where each element is itself an <code>Object[]</code> (available since TestNG 6.x). This can be useful when building data
+sets dynamically.</p>
+<h4>Noncompliant code example</h4>
+<pre data-diff-id="3" data-diff-type="noncompliant">
+@DataProvider
+public String[] provideData() {  // Noncompliant
+    return new String[]{"value1", "value2", "value3"};
+}
+</pre>
+<h4>Compliant solution</h4>
+<pre data-diff-id="3" data-diff-type="compliant">
+@DataProvider
+public Object[] provideData() {
+    return new Object[]{
+        new Object[]{"value1"},
+        new Object[]{"value2"},
+        new Object[]{"value3"}
+    };
+}
+</pre>
+<h2>Resources</h2>
+<h3>Documentation</h3>
+<ul>
+  <li>TestNG Documentation - <a href="https://testng.org/doc/documentation-main.html#parameters-dataproviders">Parameters and Data Providers</a></li>
+</ul>
+

--- a/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9388.json
+++ b/sonar-java-plugin/src/main/resources/org/sonar/l10n/java/rules/java/S9388.json
@@ -1,0 +1,25 @@
+{
+  "title": "TestNG data provider methods should return valid types",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant\/Issue",
+    "constantCost": "5min"
+  },
+  "tags": [
+    "testng",
+    "test",
+    "pitfall"
+  ],
+  "defaultSeverity": "Critical",
+  "ruleSpecification": "RSPEC-9388",
+  "sqKey": "S9388",
+  "scope": "Tests",
+  "quickfix": "unknown",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "CONVENTIONAL"
+  }
+}


### PR DESCRIPTION
## Summary
- Implement rule S9388 that detects `@DataProvider`-annotated methods in TestNG test code returning invalid types
- The rule flags methods whose return type is not `Object[][]`, `Iterator<Object[]>`, or `Object[]`
- Scoped to test sources; requires semantic analysis (no false positives without bytecode)

## Test plan
- [x] Verified with `CheckVerifier` on test sample covering all noncompliant and compliant patterns
- [x] Verified no issues raised without semantic analysis
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Agent workflow
Addressed review comments in pr_report_6126.md using `uv run address_reviews.py pr_report_6126.md`


Iterated on the PR with `uv run ci_loop.py` for 2 iterations. 
:heavy_check_mark: The PR is now ready for review.
    